### PR TITLE
fix: url parsed cursh should be catched

### DIFF
--- a/packages/server/prod-server/src/libs/context/context.ts
+++ b/packages/server/prod-server/src/libs/context/context.ts
@@ -171,7 +171,7 @@ export class ModernServerContext implements ModernServerContextInterface {
     this.logger.error(
       `Web Server Error - ${dig}, error = %s, req.url = %s, req.headers = %o`,
       e instanceof Error ? e.stack || e.message : e,
-      this.path,
+      this.req.url,
       this.headers,
     );
   }

--- a/tests/integration/server-prod/test/index.test.js
+++ b/tests/integration/server-prod/test/index.test.js
@@ -11,6 +11,7 @@ const {
 
 const appPath = path.resolve(__dirname, '../');
 const successStatus = 200;
+const internalServerErrorStatus = 500;
 let app, appPort;
 
 beforeAll(async () => {
@@ -86,5 +87,10 @@ describe('test basic usage', () => {
     );
     expect(status).toBe(successStatus);
     expect(headers['content-type']).toBe('image/png');
+  });
+
+  it(`should show the 500 page when get wrong url parse`, async () => {
+    const { status } = await axios.get(`http://localhost:${appPort}//`);
+    expect(status).toBe(internalServerErrorStatus);
   });
 });


### PR DESCRIPTION
# PR Details

修复访问「unNormal」路径出现，服务 crash

## Description

url 解析出错时，抛错被 service catch 住，但 logger.errer 又引用了错误的 url，导致没有 被 server 最终 catch。
只需要改成原始 req.url 即可。

## Motivation and Context

路径解析失败，不应该 crash

## How Has This Been Tested


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated changeset
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
