### PR TITLE
fix(plugin-swc): missing @modern-js/builder-shared dependency

### DIFF
--- a/.changeset/serious-squids-bow.md
+++ b/.changeset/serious-squids-bow.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc': patch
+---
+
+fix(plugin-swc): missing @modern-js/builder-shared dependency
+
+fix(plugin-swc): 修复缺少 @modern-js/builder-shared 依赖的问题

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -48,7 +48,6 @@
   "license": "MIT",
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
-    "@modern-js/builder-shared": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/babel__core": "^7.1.20",
@@ -62,6 +61,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.17.12",
     "@babel/preset-typescript": "^7.17.12",
+    "@modern-js/builder-shared": "workspace:*",
     "@modern-js/swc-plugins": "0.0.16",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.4.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,12 +358,12 @@ importers:
       '@babel/preset-env': 7.20.2_@babel+core@7.20.5
       '@babel/preset-react': 7.18.6_@babel+core@7.20.5
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.5
+      '@modern-js/builder-shared': link:../builder-shared
       '@modern-js/swc-plugins': 0.0.16
       '@modern-js/utils': link:../../toolkit/utils
       '@swc/helpers': 0.4.12
       core-js: 3.26.0
     devDependencies:
-      '@modern-js/builder-shared': link:../builder-shared
       '@modern-js/builder-webpack-provider': link:../builder-webpack-provider
       '@scripts/vitest-config': link:../../../scripts/vitest-config
       '@types/babel__core': 7.1.20
@@ -15176,10 +15176,8 @@ packages:
       ajv: 6.12.6
     dev: false
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -30908,7 +30906,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:


### PR DESCRIPTION
## Description

Fix missing `@modern-js/builder-shared` dependency.

<img width="610" alt="Screen Shot 2023-03-06 at 14 04 15" src="https://user-images.githubusercontent.com/7237365/223031906-1c43be99-9285-4bf3-acf9-6bd53d2e51c2.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
