### PR TITLE
Fix: fix duplicate re-exports of reduck

### DIFF
--- a/.changeset/weak-kings-roll.md
+++ b/.changeset/weak-kings-roll.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: fix duplicate re-exports of reduck
+fix: 修复从 reduck 重复导出的 API

--- a/packages/runtime/plugin-runtime/src/state/runtime/index.tsx
+++ b/packages/runtime/plugin-runtime/src/state/runtime/index.tsx
@@ -1,4 +1,3 @@
 export * from '@modern-js-reduck/react';
-export { model, createStore } from '@modern-js-reduck/store';
 export { default } from './plugin';
 export * from './plugin';


### PR DESCRIPTION
## Description

`@modern-js-reduck/react` currently exports `model` and `createStore`,  so we don't need to export these two API from `@modern-js-reduck/store`.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
