### PR TITLE
feat(app-tools): the modern.js ssr loader support rspack

### DIFF
--- a/.changeset/warm-pandas-complain.md
+++ b/.changeset/warm-pandas-complain.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: move the analyze webpackChain config to app-tools builder shared
+fix: 将 anylyze 的 `webpackChain` 配置项移植进 app-tools builder shared

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -29,7 +29,11 @@ import {
   ENTRY_POINT_FILE_NAME,
   ENTRY_BOOTSTRAP_FILE_NAME,
 } from './constants';
-import { getDefaultImports, getServerLoadersFile } from './utils';
+import {
+  getDefaultImports,
+  getServerLoadersFile,
+  getServerCombinedModueFile,
+} from './utils';
 import { walk } from './nestedRoutes';
 
 const createImportSpecifier = (specifiers: ImportSpecifier[]): string => {
@@ -202,6 +206,21 @@ export const generateCode = async (
 
           await fs.ensureFile(routesServerFile);
           await fs.writeFile(routesServerFile, code);
+        }
+
+        const serverLoaderCombined = templates.ssrLoaderCombinedModule(
+          entrypoints,
+          entrypoint,
+          config,
+          appContext,
+        );
+        if (serverLoaderCombined) {
+          const serverLoaderFile = getServerCombinedModueFile(
+            internalDirectory,
+            entryName,
+          );
+          await fs.ensureFile(serverLoaderFile);
+          await fs.writeFile(serverLoaderFile, serverLoaderCombined);
         }
 
         fs.outputFileSync(

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -219,8 +219,8 @@ export const generateCode = async (
             internalDirectory,
             entryName,
           );
-          await fs.ensureFile(serverLoaderFile);
-          await fs.writeFile(serverLoaderFile, serverLoaderCombined);
+
+          await fs.outputFile(serverLoaderFile, serverLoaderCombined);
         }
 
         fs.outputFileSync(

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -3,16 +3,13 @@ import {
   createDebugger,
   findExists,
   fs,
-  getEntryOptions,
   isApiOnly,
   minimist,
   getCommand,
   isDevCommand,
-  isSSGEntry,
 } from '@modern-js/utils';
 import type { CliPlugin } from '@modern-js/core';
 import { cloneDeep } from '@modern-js/utils/lodash';
-import { createVirtualModule } from '@modern-js/builder-shared';
 import { printInstructions } from '../utils/printInstructions';
 import { generateRoutes } from '../utils/routes';
 import { emitResolvedConfig } from '../utils/config';
@@ -20,12 +17,7 @@ import { getSelectedEntries } from '../utils/getSelectedEntries';
 import { AppTools, webpack } from '../types';
 import { initialNormalizedConfig } from '../config';
 import { createBuilderGenerator } from '../builder';
-import {
-  getServerLoadersFile,
-  isPageComponentFile,
-  parseModule,
-  replaceWithAlias,
-} from './utils';
+import { isPageComponentFile, parseModule, replaceWithAlias } from './utils';
 import {
   APP_CONFIG_NAME,
   APP_INIT_EXPORTED,
@@ -226,53 +218,53 @@ export default ({
       watchFiles() {
         return pagesDir;
       },
-      config() {
-        return {
-          tools: {
-            webpackChain: (chain: any, { name }: any) => {
-              const appContext = api.useAppContext();
-              const resolvedConfig = api.useResolvedConfigContext();
-              const { entrypoints, internalDirectory, packageName } =
-                appContext;
-              entrypoints.forEach(entrypoint => {
-                const { entryName } = entrypoint;
-                const ssr = getEntryOptions(
-                  entryName,
-                  resolvedConfig.server.ssr,
-                  resolvedConfig.server.ssrByEntries,
-                  packageName,
-                );
+      // config() {
+      //   return {
+      //     tools: {
+      //       webpackChain: (chain: any, { name }: any) => {
+      //         const appContext = api.useAppContext();
+      //         const resolvedConfig = api.useResolvedConfigContext();
+      //         const { entrypoints, internalDirectory, packageName } =
+      //           appContext;
+      //         entrypoints.forEach(entrypoint => {
+      //           const { entryName } = entrypoint;
+      //           const ssr = getEntryOptions(
+      //             entryName,
+      //             resolvedConfig.server.ssr,
+      //             resolvedConfig.server.ssrByEntries,
+      //             packageName,
+      //           );
 
-                const useSSG = isSSGEntry(
-                  resolvedConfig,
-                  entryName,
-                  entrypoints,
-                );
+      //           const useSSG = isSSGEntry(
+      //             resolvedConfig,
+      //             entryName,
+      //             entrypoints,
+      //           );
 
-                if (
-                  entrypoint.nestedRoutesEntry &&
-                  (ssr || useSSG) &&
-                  name === 'server'
-                ) {
-                  const serverLoaderRuntime = require.resolve(
-                    '@modern-js/plugin-data-loader/runtime',
-                  );
-                  const serverLoadersFile = getServerLoadersFile(
-                    internalDirectory,
-                    entryName,
-                  );
-                  const combinedModule = createVirtualModule(
-                    `export * from "${serverLoaderRuntime}"; export * from "${serverLoadersFile}"`,
-                  );
-                  chain
-                    .entry(`${entryName}-server-loaders`)
-                    .add(combinedModule);
-                }
-              });
-            },
-          },
-        } as any;
-      },
+      //           if (
+      //             entrypoint.nestedRoutesEntry &&
+      //             (ssr || useSSG) &&
+      //             name === 'server'
+      //           ) {
+      //             const serverLoaderRuntime = require.resolve(
+      //               '@modern-js/plugin-data-loader/runtime',
+      //             );
+      //             const serverLoadersFile = getServerLoadersFile(
+      //               internalDirectory,
+      //               entryName,
+      //             );
+      //             const combinedModule = createVirtualModule(
+      //               `export * from "${serverLoaderRuntime}"; export * from "${serverLoadersFile}"`,
+      //             );
+      //             chain
+      //               .entry(`${entryName}-server-loaders`)
+      //               .add(combinedModule);
+      //           }
+      //         });
+      //       },
+      //     },
+      //   } as any;
+      // },
 
       resolvedConfig({ resolved }) {
         const appContext = api.useAppContext();

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -218,53 +218,6 @@ export default ({
       watchFiles() {
         return pagesDir;
       },
-      // config() {
-      //   return {
-      //     tools: {
-      //       webpackChain: (chain: any, { name }: any) => {
-      //         const appContext = api.useAppContext();
-      //         const resolvedConfig = api.useResolvedConfigContext();
-      //         const { entrypoints, internalDirectory, packageName } =
-      //           appContext;
-      //         entrypoints.forEach(entrypoint => {
-      //           const { entryName } = entrypoint;
-      //           const ssr = getEntryOptions(
-      //             entryName,
-      //             resolvedConfig.server.ssr,
-      //             resolvedConfig.server.ssrByEntries,
-      //             packageName,
-      //           );
-
-      //           const useSSG = isSSGEntry(
-      //             resolvedConfig,
-      //             entryName,
-      //             entrypoints,
-      //           );
-
-      //           if (
-      //             entrypoint.nestedRoutesEntry &&
-      //             (ssr || useSSG) &&
-      //             name === 'server'
-      //           ) {
-      //             const serverLoaderRuntime = require.resolve(
-      //               '@modern-js/plugin-data-loader/runtime',
-      //             );
-      //             const serverLoadersFile = getServerLoadersFile(
-      //               internalDirectory,
-      //               entryName,
-      //             );
-      //             const combinedModule = createVirtualModule(
-      //               `export * from "${serverLoaderRuntime}"; export * from "${serverLoadersFile}"`,
-      //             );
-      //             chain
-      //               .entry(`${entryName}-server-loaders`)
-      //               .add(combinedModule);
-      //           }
-      //         });
-      //       },
-      //     },
-      //   } as any;
-      // },
 
       resolvedConfig({ resolved }) {
         const appContext = api.useAppContext();

--- a/packages/solutions/app-tools/src/analyze/utils.ts
+++ b/packages/solutions/app-tools/src/analyze/utils.ts
@@ -147,3 +147,10 @@ export const getServerLoadersFile = (
 ) => {
   return path.join(internalDirectory, entryName, 'route-server-loaders.js');
 };
+
+export const getServerCombinedModueFile = (
+  internalDirectory: string,
+  entryName: string,
+) => {
+  return path.join(internalDirectory, entryName, 'server-loader-combined.js');
+};

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -199,7 +199,7 @@ function applySSRLoaderEntry<B extends Bundler>(
     );
     // the rspack is not support virtualModule
     // so we write the combinedModule in filesystem;
-    // then we load it from dist;
+    // then we load it from disk;
     if (isServer && fs.existsSync(serverLoadersFile)) {
       chain.entry(`${entryName}-server-loaders`).add(serverLoadersFile);
     }


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
improvement: the modern.js ssr loader support rspack            

the `rspack` is not support virtualModule
so we write the `ssr` loader combinedModule in filesystem;  
then we load it from disk.                          

It is temporary.Once `rspack` support it, we will use   
virtualModule to implement it.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
