### PR TITLE
fix(builder): missing some type in tools.cssExtract

### DIFF
--- a/.changeset/breezy-wolves-walk.md
+++ b/.changeset/breezy-wolves-walk.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): missing some type in tools.cssExtract
+
+fix(builder): 修复 tools.cssExtract 缺少部分类型的问题

--- a/packages/builder/builder-webpack-provider/src/types/thirdParty/css.ts
+++ b/packages/builder/builder-webpack-provider/src/types/thirdParty/css.ts
@@ -5,6 +5,10 @@ import type {
   AcceptedPlugin,
   SourceMapOptions,
 } from 'postcss';
+import type {
+  PluginOptions as MiniCSSExtractPluginOptions,
+  LoaderOptions as MiniCSSExtractLoaderOptions,
+} from 'mini-css-extract-plugin';
 
 export interface CSSModulesOptions {
   compileType?: string;
@@ -43,63 +47,7 @@ export interface StyleLoaderOptions {
   insert?: string | ((element: HTMLElement) => void);
 }
 
-export interface MiniCSSExtractLoaderOptions {
-  /**
-   * Overrides [`output.publicPath`](https://webpack.js.org/configuration/output/#outputpublicpath).
-   * @default output.publicPath
-   */
-  publicPath?: string | ((resourcePath: string, context: string) => string);
-  /**
-   * If false, the plugin will extract the CSS but **will not** emit the file
-   * @default true
-   */
-  emit?: boolean | undefined;
-  /**
-   * By default, `mini-css-extract-plugin` generates JS modules that use the ES modules syntax.
-   * There are some cases in which using ES modules is beneficial,
-   * like in the case of module concatenation and tree shaking.
-   * @default true
-   */
-  esModule?: boolean;
-}
-
-export interface MiniCSSExtractPluginOptions {
-  /**
-   * This option determines the name of each output CSS file.
-   * @link https://github.com/webpack-contrib/mini-css-extract-plugin#filename
-   * @default '[name].css'
-   */
-  filename?: string | undefined;
-  /**
-   * This option determines the name of non-entry chunk files.
-   * @link https://github.com/webpack-contrib/mini-css-extract-plugin#chunkfilename
-   */
-  chunkFilename?: string | undefined;
-  /**
-   * Remove Order Warnings.
-   * @link https://github.com/webpack-contrib/mini-css-extract-plugin#ignoreorder
-   * @default false
-   */
-  ignoreOrder?: boolean | undefined;
-  /**
-   * Inserts `<link>` at the given position.
-   * @link https://github.com/webpack-contrib/mini-css-extract-plugin#insert
-   * @default document.head.appendChild(linkTag)
-   */
-  insert?: string | ((linkTag: any) => void) | undefined;
-  /**
-   * Adds custom attributes to tag.
-   * @link https://github.com/webpack-contrib/mini-css-extract-plugin#attributes
-   * @default {}
-   */
-  attributes?: Record<string, string> | undefined;
-  /**
-   * This option allows loading asynchronous chunks with a custom link type
-   * @link https://github.com/webpack-contrib/mini-css-extract-plugin#linktype
-   * @default 'text/css'
-   */
-  linkType?: string | false | 'text/css' | undefined;
-}
+export { MiniCSSExtractPluginOptions, MiniCSSExtractLoaderOptions };
 
 export interface CSSExtractOptions {
   pluginOptions?: MiniCSSExtractPluginOptions;


### PR DESCRIPTION
## Description

Fix missing some type in `tools.cssExtract`, import the type directly from `mini-css-extract-plugin` package.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
