### PR TITLE
fix(server): use mock host instead real url host for url parse

### DIFF
--- a/.changeset/light-dragons-grin.md
+++ b/.changeset/light-dragons-grin.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/types': patch
+---
+
+fix: use mock host instead real url host for url parse, for new URL not support ipv6, and we only need parse url path & search
+fix: 使用虚拟的域名代替真实的主机名，因为 new URL 不支持解析 ipv6 的域名，并且我们只需要解析 url 的路径和查询字符串

--- a/packages/server/prod-server/src/libs/context/context.ts
+++ b/packages/server/prod-server/src/libs/context/context.ts
@@ -7,6 +7,8 @@ import createEtag from 'etag';
 import fresh from 'fresh';
 import { headersWithoutCookie } from '../../utils';
 
+const MOCK_URL_BASE = 'https://modernjs.dev/';
+
 export type ContextOptions = {
   etag?: boolean;
 };
@@ -52,6 +54,12 @@ export class ModernServerContext implements ModernServerContextInterface {
     this.serverData = {};
 
     this.bind();
+  }
+
+  private get parsedURL() {
+    // only for parse url, use mock
+    const url = new URL(this.req.url!, MOCK_URL_BASE);
+    return url;
   }
 
   private bind() {
@@ -166,29 +174,21 @@ export class ModernServerContext implements ModernServerContextInterface {
     return this.origin + this.url;
   }
 
-  public get parsedURL() {
-    const url = new URL(this.req.url!, this.origin);
-    return url;
-  }
-
   public get path() {
     return this.parsedURL.pathname;
   }
 
   public set path(p) {
-    const url = new URL(this.req.url!, this.origin);
     // this should never happened
-    if (!url || !p) {
+    if (!p) {
       return;
     }
 
-    if (url.pathname === p) {
+    if (this.path === p) {
       return;
     }
 
-    url.pathname = p;
-
-    this.url = url.toString();
+    this.url = p + this.parsedURL.search;
   }
 
   public get querystring() {

--- a/packages/toolkit/types/server/context.d.ts
+++ b/packages/toolkit/types/server/context.d.ts
@@ -33,8 +33,6 @@ export interface ModernServerContext {
 
   href: string;
 
-  parsedURL: URL;
-
   path: string;
 
   querystring: string;


### PR DESCRIPTION
## Description

For `new url.URL(path, base)` not support ipv6 host, and we only need parse url path & search.

So use mock host 'https://modern.dev' instead real host.

Koa use `url.parse` to parse url path, but the api has deprecated.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
