### PR TITLE
fix(swc-integration): change the way to test swc css minify

### DIFF
--- a/tests/integration/swc/test/index.test.ts
+++ b/tests/integration/swc/test/index.test.ts
@@ -55,6 +55,12 @@ describe('swc minify', () => {
     await modernBuild(appDir);
 
     const cssFile = getCssFiles(appDir)[0];
-    expect(cssFile).toMatchSnapshot('swc minified css');
+    const content = readFileSync(
+      path.resolve(appDir, `dist/static/css/${cssFile}`),
+      'utf8',
+    );
+    expect(content).toContain(
+      '@charset "UTF-8";:root{--bs-blue:#0d6efd;--bs-indigo:#6610f2;',
+    );
   });
 });


### PR DESCRIPTION
## Description

Fix integration test failure because of different hash between different platforms

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
