### PR TITLE
chore(doc-tools): add border-radius to nav item

### DIFF
--- a/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
@@ -162,6 +162,7 @@ export function SidebarGroupComp(props: SidebarItemProps) {
       <div
         flex="~"
         justify="between"
+        border="rounded-md"
         items-start="~"
         cursor={collapsible ? 'pointer' : 'none'}
         className={`items-center ${
@@ -188,6 +189,7 @@ export function SidebarGroupComp(props: SidebarItemProps) {
         {collapsible && (
           <div
             p="2"
+            border="rounded-md"
             className={styles.collapseContainer}
             onClick={toggleCollapse}
           >


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
I think the border of the nav item(such as "核心概念") is too sharp and does not match the sub-item(such as "介绍") very well, so I tried to make some style changes.
<img width="324" alt="image" src="https://user-images.githubusercontent.com/69381867/224397677-f2ef93c8-4559-4025-8ec7-ea8b853d3dc8.png">


## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
