### PR TITLE
fix(builder): asset url using incorrect path separator in windows

### DIFF
--- a/.changeset/twelve-gorillas-grin.md
+++ b/.changeset/twelve-gorillas-grin.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': patch
+---
+
+fix: asset url using incorrect path seperator in windows
+
+fix: 修复 windows 中 asset url 使用错误的路径分隔符

--- a/packages/builder/builder/src/plugins/asset.ts
+++ b/packages/builder/builder/src/plugins/asset.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import path from 'path';
 import {
   getRegExpForExts,
   getDistPath,
@@ -27,7 +27,7 @@ export const builderAssetPlugin = (
       chainStaticAssetRule({
         rule,
         maxSize,
-        filename: join(distDir, filename),
+        filename: path.posix.join(distDir, filename),
         assetType,
       });
     });

--- a/packages/builder/builder/src/plugins/svg.ts
+++ b/packages/builder/builder/src/plugins/svg.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import path from 'path';
 import {
   JS_REGEX,
   TS_REGEX,
@@ -10,7 +10,7 @@ import {
 import type { DefaultBuilderPlugin } from '@modern-js/builder-shared';
 
 export const getCompiledPath = (packageName: string) =>
-  join(__dirname, '../../compiled', packageName);
+  path.join(__dirname, '../../compiled', packageName);
 
 export const builderPluginSvg = (): DefaultBuilderPlugin => {
   return {
@@ -23,7 +23,7 @@ export const builderPluginSvg = (): DefaultBuilderPlugin => {
 
         const distDir = getDistPath(config.output, 'svg');
         const filename = getFilename(config.output, 'svg', isProd);
-        const outputName = join(distDir, filename);
+        const outputName = path.posix.join(distDir, filename);
         const maxSize = config.output.dataUriLimit[assetType];
 
         const rule = chain.module.rule(CHAIN_ID.RULE.SVG).test(SVG_REGEX);
@@ -32,7 +32,7 @@ export const builderPluginSvg = (): DefaultBuilderPlugin => {
         chainStaticAssetRule({
           rule,
           maxSize,
-          filename: join(distDir, filename),
+          filename: path.posix.join(distDir, filename),
           assetType,
           issuer: {
             // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.


### PR DESCRIPTION
## Description

修复 windows 中 asset url 使用错误的路径分隔符

<!--- Describe your changes -->

## Related Issue

#2981 

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
