### PR TITLE
feat(doc-tools): support --config CLI option

### DIFF
--- a/.changeset/chilled-lobsters-destroy.md
+++ b/.changeset/chilled-lobsters-destroy.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/doc-tools': patch
+'@modern-js/doc-core': patch
+---
+
+feat(doc-tools): support --config CLI option
+
+feat(doc-tools): 支持 --config CLI 选项

--- a/packages/cli/doc-core/src/theme-default/styles/doc/container.css
+++ b/packages/cli/doc-core/src/theme-default/styles/doc/container.css
@@ -30,7 +30,7 @@
 .modern-doc .modern-directive {
   border: 1px solid transparent;
   border-radius: 16px;
-  padding: 20px 24px 14px;
+  padding: 20px 24px 12px;
   line-height: 1.7;
   font-size: 14px;
   font-weight: 500;

--- a/packages/document/doc-tools-doc/docs/en/api/commands.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/commands.mdx
@@ -1,0 +1,41 @@
+# Commands
+
+Through this chapter, you can learn about the built-in commands of Modern.js Doc and how to use them.
+
+## modern dev
+
+The `modern dev` command is used to start a local development server to preview and debug documentation site locally.
+
+```bash
+Usage: modern dev [options]
+
+Options:
+   -c --config <config> specify config file path, which can be a relative path or an absolute path
+   -h, --help show command help
+```
+
+## modern build
+
+The `modern build` command is used to build documentation site for production.
+
+```bash
+Usage: modern build [options]
+
+Options:
+   -c --config <config> specify config file path, which can be a relative path or an absolute path
+   -h, --help show command help
+```
+
+## modern serve
+
+The `modern serve` command is used to preview the output files of the `modern build` command locally.
+
+```bash
+Usage: modern serve [options]
+
+Options:
+   -c --config <config> specify config file path, which can be a relative path or an absolute path
+   --port <port> specify port number
+   --host <host> specify host
+   -h, --help show command help
+```

--- a/packages/document/doc-tools-doc/docs/en/api/commands.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/commands.mdx
@@ -4,7 +4,7 @@ Through this chapter, you can learn about the built-in commands of Modern.js Doc
 
 ## modern dev
 
-The `modern dev` command is used to start a local development server to preview and debug documentation site locally.
+The `modern dev` command is used to start a local development server, providing a development environment for document preview and debugging.
 
 ```bash
 Usage: modern dev [options]

--- a/packages/document/doc-tools-doc/docs/zh/api/commands.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/commands.mdx
@@ -4,7 +4,7 @@
 
 ## modern dev
 
-`modern dev` 命令用于启动一个本地开发服务器，在本地预览和调试文档效果。
+`modern dev` 命令用于启动一个本地开发服务器，提供一个文档进行预览和调试的开发环境。
 
 ```bash
 Usage: modern dev [options]

--- a/packages/document/doc-tools-doc/docs/zh/api/commands.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/commands.mdx
@@ -1,0 +1,41 @@
+# 命令
+
+通过本章节，你可以了解到 Modern.js Doc 内置的命令有哪些，以及如何使用这些命令。
+
+## modern dev
+
+`modern dev` 命令用于启动一个本地开发服务器，在本地预览和调试文档效果。
+
+```bash
+Usage: modern dev [options]
+
+Options:
+  -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
+  -h, --help            显示命令帮助
+```
+
+## modern build
+
+`modern build` 命令用于构建出针对生产环境的文档产物。
+
+```bash
+Usage: modern build [options]
+
+Options:
+  -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
+  -h, --help  显示命令帮助
+```
+
+## modern serve
+
+`modern serve` 命令用于在本地预览 `modern build` 命令构建出的产物。
+
+```bash
+Usage: modern serve [options]
+
+Options:
+  -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
+  --port <port>         指定端口号
+  --host <host>         指定 host
+  -h, --help  显示命令帮助
+```

--- a/packages/document/doc-tools-doc/modern.config.ts
+++ b/packages/document/doc-tools-doc/modern.config.ts
@@ -113,6 +113,7 @@ function getSidebar(lang: 'zh' | 'en'): Sidebar {
         text: getText('Client API', 'Client API'),
         items: [getLink('/api/api-runtime'), getLink('/api/api-components')],
       },
+      getLink('/api/commands'),
     ],
   };
 }

--- a/packages/solutions/doc-tools/src/index.ts
+++ b/packages/solutions/doc-tools/src/index.ts
@@ -66,6 +66,7 @@ export default (): CliPlugin => ({
         program
           .command('dev [root]')
           .description('start dev server')
+          .option('-c --config <config>', 'specify config file')
           .action(async (root?: string) => {
             startServer = async (isFristStart = false) => {
               if (!isFristStart) {
@@ -85,6 +86,7 @@ export default (): CliPlugin => ({
         program
           .command('build [root]')
           .description('build in production')
+          .option('-c --config <config>', 'specify config file')
           .action(async (root?: string) => {
             const config = api.useConfigContext() as UserConfig;
             await build(root || '', config);
@@ -93,6 +95,7 @@ export default (): CliPlugin => ({
         program
           .command('preview [root]')
           .description('preview in production')
+          .option('-c --config <config>', 'specify config file')
           .option('--port [port]', 'port number')
           .option('--host [host]', 'hostname')
           .action(async (root?: string) => {


### PR DESCRIPTION
## Description

Support `--config` CLI option.

## Related Issue

https://github.com/web-infra-dev/modern.js/issues/3151

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
