### PR TITLE
fix: remove get & delete & apply api in hook or middleware api

### DIFF
--- a/.changeset/curvy-vans-relate.md
+++ b/.changeset/curvy-vans-relate.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-shared': patch
+'@modern-js/prod-server': patch
+'@modern-js/main-doc': patch
+'@modern-js/server': patch
+'@modern-js/types': patch
+---
+
+fix: support tools.devServer.header include string[] type, remove get & delete & apply api in hook or middleware api
+fix: 支持 tools.devServer.header 包含字符串数组类型，移除 Hook 和 Middleware 中对 响应 Cookie 的获取、删除操作

--- a/packages/builder/builder-shared/src/schema/tools.ts
+++ b/packages/builder/builder-shared/src/schema/tools.ts
@@ -27,7 +27,7 @@ const sharedDevServerConfigSchema = z.partialObj({
   https: DevServerHttpsOptionsSchema,
   liveReload: z.boolean(),
   setupMiddlewares: z.array(z.function()),
-  headers: z.record(z.string()),
+  headers: z.record(z.union([z.string(), z.array(z.string())])),
   proxy: z.record(z.unknown()),
   watch: z.boolean(),
 });

--- a/packages/builder/builder-webpack-provider/src/core/devMiddleware.ts
+++ b/packages/builder/builder-webpack-provider/src/core/devMiddleware.ts
@@ -3,6 +3,7 @@ import webpackDevMiddleware from '@modern-js/utils/webpack-dev-middleware';
 import type { Compiler, MultiCompiler } from 'webpack';
 import type { ModernDevServerOptions } from '@modern-js/server';
 import { setupServerHooks, isClientCompiler } from '@modern-js/builder-shared';
+import { IncomingMessage, ServerResponse } from 'http';
 
 type DevMiddlewareOptions = ModernDevServerOptions['devMiddleware'];
 
@@ -56,5 +57,11 @@ export const getDevMiddleware: (
   // register hooks for each compilation, update socket stats if recompiled
   setupHooks(compiler, callbacks);
 
-  return webpackDevMiddleware(compiler, restOptions as any);
+  return webpackDevMiddleware(
+    compiler,
+    restOptions as webpackDevMiddleware.Options<
+      IncomingMessage,
+      ServerResponse
+    >,
+  );
 };

--- a/packages/builder/builder-webpack-provider/src/core/devMiddleware.ts
+++ b/packages/builder/builder-webpack-provider/src/core/devMiddleware.ts
@@ -56,5 +56,5 @@ export const getDevMiddleware: (
   // register hooks for each compilation, update socket stats if recompiled
   setupHooks(compiler, callbacks);
 
-  return webpackDevMiddleware(compiler, restOptions);
+  return webpackDevMiddleware(compiler, restOptions as any);
 };

--- a/packages/document/main-doc/docs/en/apis/app/runtime/web-server/hook.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/web-server/hook.mdx
@@ -38,9 +38,7 @@ type HookContext = {
     set: (key: string, value: string) => void;
     status: (code: number) => void;
     cookies: {
-      get: (key: string) => string;
-      set: (key: string, value: string) => void;
-      delete: () => void;
+      set: (key: string, value: string, options?: any) => void;
       clear: () => void;
     };
     raw: (

--- a/packages/document/main-doc/docs/en/apis/app/runtime/web-server/middleware.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/web-server/middleware.mdx
@@ -46,11 +46,8 @@ type MiddlewareContext = {
     set: (key: string, value: string) => void;
     status: (code: number) => void;
     cookies: {
-      get: (key: string) => string;
-      set: (key: string, value: string) => void;
-      delete: () => void;
+      set: (key: string, value: string, options?: any) => void;
       clear: () => void;
-      apply: () => void;
     };
     raw: (
       body: string,

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/web-server/hook.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/web-server/hook.mdx
@@ -36,9 +36,7 @@ type HookContext = {
     set: (key: string, value: string) => void;
     status: (code: number) => void;
     cookies: {
-      get: (key: string) => string;
-      set: (key: string, value: string) => void;
-      delete: () => void;
+      set: (key: string, value: string, options?: any) => void;
       clear: () => void;
     };
     raw: (

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/web-server/middleware.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/web-server/middleware.mdx
@@ -45,11 +45,8 @@ type MiddlewareContext = {
     set: (key: string, value: string) => void;
     status: (code: number) => void;
     cookies: {
-      get: (key: string) => string;
-      set: (key: string, value: string) => void;
-      delete: () => void;
+      set: (key: string, value: string, options?: any) => void;
       clear: () => void;
-      apply: () => void;
     };
     raw: (
       body: string,

--- a/packages/server/prod-server/tests/hook.test.ts
+++ b/packages/server/prod-server/tests/hook.test.ts
@@ -28,22 +28,18 @@ describe('test hook api', () => {
 
     // request data
     expect(request.cookie).toBe(cookie);
-    expect(request.cookies.get('a')).toBe('b');
+    expect(request.cookies.get!('a')).toBe('b');
     expect(request.headers.host).toBe('modernjs.com');
     expect(request.pathname).toBe('/home');
     expect(request.query.id).toBe('12345');
 
     // response data
     response.cookies.set('name', 'modern');
-    expect(response.cookies.get('name')).toBe('modern');
-    response.cookies.delete('name');
-    expect(response.cookies.get('name')).toBeUndefined();
-    response.cookies.set('name', 'modern');
-    expect(res.getHeader('set-cookie')).toBeUndefined();
-    response.cookies.apply();
-    expect(res.getHeader('set-cookie')).toBe('name=modern');
+    expect(res.getHeader('set-cookie')).toMatch('name=modern');
+    response.cookies.set('age', '18');
+    expect(res.getHeader('set-cookie')).toEqual(['name=modern', 'age=18']);
+
     response.cookies.clear();
-    response.cookies.apply();
     expect(res.getHeader('set-cookie')).toBeUndefined();
 
     response.set('x-modern-test', 'foo');

--- a/packages/server/server/src/types.ts
+++ b/packages/server/server/src/types.ts
@@ -28,7 +28,7 @@ export type DevMiddlewareOptions = {
   hmrClientPath?: string;
 
   /** The options need by compiler middleware (like webpackMiddleware) */
-  headers?: Record<string, string>;
+  headers?: Record<string, string | string[]>;
   writeToDisk?: boolean | ((filename: string) => boolean);
   stats?: boolean;
 

--- a/packages/toolkit/types/server/devServer.d.ts
+++ b/packages/toolkit/types/server/devServer.d.ts
@@ -29,7 +29,7 @@ export type DevServerOptions = {
     outputFileSystem?: Record<string, any>;
   };
   proxy?: BffProxyOptions;
-  headers?: Record<string, string>;
+  headers?: Record<string, string | string[]>;
   before?: RequestHandler[];
   after?: RequestHandler[];
   /** Provides the ability to execute a custom function and apply custom middlewares */

--- a/packages/toolkit/types/server/hook.d.ts
+++ b/packages/toolkit/types/server/hook.d.ts
@@ -1,11 +1,13 @@
 import { IncomingMessage, ServerResponse } from 'http';
 
 export type CookieAPI = {
-  get: (key: string) => string;
-  set: (key: string, value: string) => void;
-  delete: (key: string) => void;
+  /**
+   * @deprecated Using set empty cookie instead.
+   */
+  delete?: (key: string) => void;
+  get?: (key: string) => string;
+  set: (key: string, value: string, options?: any) => void;
   clear: () => void;
-  apply: () => void;
 };
 
 export interface ModernResponse {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15607,10 +15607,8 @@ packages:
       ajv: 6.12.6
     dev: false
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -32310,7 +32308,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:


### PR DESCRIPTION
## Description

support `string[]` type for `tools.devServer.headers`.

```ts
import AppToolsPlugin, { defineConfig } from '@modern-js/app-tools';
export default defineConfig({
  tools: {
    devServer: {
      headers: {
        'Set-Cookie': process.env.COOKIE.split('; ').map(
          item => `${item}; path=/; Max-Age=8640000;`,
        ),
      },
    },
  },
  plugins: [
    AppToolsPlugin({}),
  ],
});
```

remove `get`、`set`、`apply` in Hook or Middleware `response.cookies` API. For Most libraries or frameworks do not provide such API.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
