### PR TITLE
fix(doc-core): fix code background color in containers

### DIFF
--- a/.changeset/proud-rats-rescue.md
+++ b/.changeset/proud-rats-rescue.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): fix code background color in containers
+
+fix(doc-core): 修复 container 中的代码块背景色

--- a/packages/cli/doc-core/src/theme-default/styles/doc/container.css
+++ b/packages/cli/doc-core/src/theme-default/styles/doc/container.css
@@ -6,17 +6,17 @@
   --modern-container-info-border: rgba(7, 156, 112, 0.3);
   --modern-container-info-text: #399c70;
   --modern-container-info-bg: rgba(7, 156, 112, 0.02);
-  --modern-container-info-code-bg: var(--modern-container-info-bg);
+  --modern-container-info-code-bg: rgba(7, 156, 112, 0.1);
 
   --modern-container-warning-border: rgba(255, 197, 23, 0.5);
   --modern-container-warning-text: #ad850e;
   --modern-container-warning-bg: rgba(255, 197, 23, 0.02);
-  --modern-container-warning-code-bg: var(--modern-container-warning-bg);
+  --modern-container-warning-code-bg: rgba(255, 197, 23, 0.1);
 
   --modern-container-danger-border: rgba(237, 60, 80, 0.5);
   --modern-container-danger-text: #ab2131;
   --modern-container-danger-bg: rgba(237, 60, 80, 0.02);
-  --modern-container-danger-code-bg: var(--modern-container-danger-bg);
+  --modern-container-danger-code-bg: rgba(237, 60, 80, 0.1);
 }
 
 .dark {
@@ -73,7 +73,7 @@
 
 .modern-doc .modern-directive.tip code,
 .modern-doc .modern-directive.note code {
-  background-color: var(--modern-container-tip-code-bg);
+  background-color: var(--modern-container-info-code-bg);
 }
 
 .modern-doc .modern-directive.info code {


### PR DESCRIPTION
## Description

Fix code background color in containers.

before:

<img width="794" alt="Screen Shot 2023-03-23 at 13 00 19" src="https://user-images.githubusercontent.com/7237365/227107827-badcf89c-85c2-4417-a086-60dcd994bc98.png">

after:

<img width="791" alt="Screen Shot 2023-03-23 at 13 00 07" src="https://user-images.githubusercontent.com/7237365/227107835-de5eb575-34b2-4f15-bd7f-db64ff3a60e8.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
