### PR TITLE
fix(core): beforeExit should be sync workflow

### DIFF
--- a/.changeset/sour-pots-hug.md
+++ b/.changeset/sour-pots-hug.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/core': patch
+---
+
+fix(core): beforeExit should be sync workflow
+
+fix(core): beforeExit 需要使用同步的 workflow

--- a/packages/cli/core/src/index.ts
+++ b/packages/cli/core/src/index.ts
@@ -149,7 +149,7 @@ const createCli = () => {
     ['SIGINT', 'SIGTERM', 'unhandledRejection', 'uncaughtException'].forEach(
       event => {
         process.on(event, async err => {
-          await hooksRunner.beforeExit();
+          hooksRunner.beforeExit();
           if (err instanceof Error) {
             logger.error(err.stack);
           }

--- a/packages/cli/core/src/manager.ts
+++ b/packages/cli/core/src/manager.ts
@@ -1,4 +1,5 @@
 import {
+  createWorkflow,
   createAsyncManager,
   createAsyncWorkflow,
   createAsyncWaterfall,
@@ -23,7 +24,7 @@ const baseHooks: BaseHooks<{}> = {
   commands: createAsyncWorkflow(),
   watchFiles: createParallelWorkflow(),
   fileChange: createAsyncWorkflow(),
-  beforeExit: createAsyncWorkflow(),
+  beforeExit: createWorkflow(),
   addRuntimeExports: createAsyncWaterfall(),
 };
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/cli/core/src/types/hooks.ts
+++ b/packages/cli/core/src/types/hooks.ts
@@ -1,4 +1,5 @@
 import {
+  Workflow,
   ParallelWorkflow,
   AsyncWaterfall,
   AsyncWorkflow,
@@ -34,7 +35,7 @@ export type BaseHooks<
     void
   >;
   commands: AsyncWorkflow<{ program: Command }, void>;
-  beforeExit: AsyncWorkflow<void, void>;
+  beforeExit: Workflow<void, void>;
   addRuntimeExports: AsyncWaterfall<void>;
 };
 

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -209,6 +209,10 @@ export default (): CliPlugin => ({
 });
 ```
 
+:::tip
+Since the callback function when exiting the process in Node.js is synchronous, the type of `beforeExit` Hook is `Workflow` and cannot perform asynchronous operations.
+:::
+
 ### `beforeDev`
 
 - Functionality: Tasks before running the main dev process.

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -191,8 +191,8 @@ foo
 
 - Functionality: Reset some file states before exiting the process.
 - Execution phase: Before the process exits.
-- Hook model: AsyncWorkflow
-- Type: `AsyncWorkflow<void, void>`
+- Hook model: Workflow
+- Type: `Workflow<void, void>`
 - Example usage:
 
 ```ts

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -191,8 +191,8 @@ foo
 
 - 功能：在退出进程前，重置一些文件状态
 - 执行阶段：进程退出之前
-- Hook 模型：AsyncWorkflow
-- 类型：`AsyncWorkflow<void, void>`
+- Hook 模型：Workflow
+- 类型：`Workflow<void, void>`
 - 使用示例：
 
 ```ts

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -209,6 +209,10 @@ export default (): CliPlugin => ({
 });
 ```
 
+:::tip
+由于 Node.js 中退出进程时的回调函数是同步的，所以 `beforeExit` Hook 的类型是 `Workflow`，不能执行异步操作。
+:::
+
 ### `beforeDev`
 
 - 功能：运行 dev 主流程的之前的任务


### PR DESCRIPTION
## Description

Since the callback function when exiting the process in Node.js is synchronous, the type of `beforeExit` Hook should be `Workflow` and cannot perform asynchronous operations.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
