### PR TITLE
feat(builder): print total file size after build

### DIFF
--- a/.changeset/nice-walls-cover.md
+++ b/.changeset/nice-walls-cover.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': patch
+---
+
+feat(builder): print total file size after build
+
+feat(builder): 构建后输出文件体积的总和

--- a/packages/builder/builder/src/plugins/fileSize.ts
+++ b/packages/builder/builder/src/plugins/fileSize.ts
@@ -40,7 +40,7 @@ async function printHeader(
     return `${prev + curLabel}    `;
   }, '  ');
 
-  logger.log(chalk.bold(chalk.blue(headerRow)));
+  logger.log(chalk.bold.blue(headerRow));
 }
 
 async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
@@ -100,11 +100,17 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
 
   printHeader(longestFileLength, longestLabelLength);
 
+  let totalSize = 0;
+  let totalGzipSize = 0;
+
   assets.forEach(asset => {
     let { sizeLabel } = asset;
     const { name, folder, gzipSizeLabel } = asset;
     const fileNameLength = stripAnsi(folder + path.sep + name).length;
     const sizeLength = stripAnsi(sizeLabel).length;
+
+    totalSize += asset.size;
+    totalGzipSize += asset.gzippedSize;
 
     if (sizeLength < longestLabelLength) {
       const rightPadding = ' '.repeat(longestLabelLength - sizeLength);
@@ -122,7 +128,13 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
     logger.log(`  ${fileNameLabel}    ${sizeLabel}    ${gzipSizeLabel}`);
   });
 
-  logger.log('');
+  const totalSizeLabel = `${chalk.bold.blue('Total size:')}  ${filesize(
+    totalSize,
+  )}`;
+  const gzippedSizeLabel = `${chalk.bold.blue('Gzipped size:')}  ${filesize(
+    totalGzipSize,
+  )}`;
+  logger.log(`\n  ${totalSizeLabel}\n  ${gzippedSizeLabel}\n`);
 }
 
 export const builderPluginFileSize = (): DefaultBuilderPlugin => ({


### PR DESCRIPTION
## Description

Print total file size after build:

<img width="649" alt="Screen Shot 2023-03-24 at 14 07 03" src="https://user-images.githubusercontent.com/7237365/227438746-ff8961cb-d322-42a7-8e43-ea3817af3aae.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
