### PR TITLE
fix(builder): schema parser error, tools.devServer.proxy can be a array

### DIFF
--- a/.changeset/nervous-ducks-dress.md
+++ b/.changeset/nervous-ducks-dress.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix: schema parser error, builder tools.devServer.proxy can be a array
+fix: schema 解析错误，builder `tools.devSerer.proxy' 可以是个数组。

--- a/packages/builder/builder-shared/src/schema/tools.ts
+++ b/packages/builder/builder-shared/src/schema/tools.ts
@@ -28,7 +28,7 @@ const sharedDevServerConfigSchema = z.partialObj({
   liveReload: z.boolean(),
   setupMiddlewares: z.array(z.function()),
   headers: z.record(z.union([z.string(), z.array(z.string())])),
-  proxy: z.record(z.unknown()),
+  proxy: z.union([z.record(z.unknown()), z.array(z.any())]),
   watch: z.boolean(),
 });
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
The builder `tools.devServer.proxy` can be a array.
But user pass a array would occur a error, because the schema parse error.


## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
