### PR TITLE
feat(rspack-provider): add @babel/preset-typescript to handle ts syntax

### DIFF
--- a/.changeset/tough-hats-explode.md
+++ b/.changeset/tough-hats-explode.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/babel-preset-base': patch
+'@modern-js/utils': patch
+---
+
+fix: For rspack-provider can use `tools.babel` configuration, inline the `@babel/preset-typescript` to handle ts syntax in rspack-provider.
+fix: 为了 rspack-provider 能给使用 `tools.babel` 配置项，将 `@babel/preset-typescript` 内置进 rspack-provider 去处理 ts 语法。

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -39,6 +39,7 @@
     "@modern-js/server": "workspace:*",
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@babel/preset-typescript": "^7.17.12",
     "@rspack/core": "0.1.1",
     "@rspack/dev-client": "0.1.1",
     "@rspack/dev-middleware": "0.1.1",

--- a/packages/builder/builder-rspack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/babel.ts
@@ -7,12 +7,14 @@ import {
 } from '@modern-js/builder-shared';
 import { BuilderPlugin, NormalizedConfig } from '../types';
 import type { BabelOptions } from '@modern-js/types';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { DEFAULT_BABEL_PRESET_TYPESCRIPT_OPTIONS } from '@modern-js/utils/constants';
 
 export const builderPluginBabel = (): BuilderPlugin => ({
   name: 'builder-plugin-babel',
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {
-      const config = api.getNormalizedConfig() as any;
+      const config = api.getNormalizedConfig();
       if (!config.tools.babel) {
         // we would not use babel loader in rspack, unless user need to use.
         return;
@@ -49,9 +51,14 @@ export const builderPluginBabel = (): BuilderPlugin => ({
           ...applyUserBabelConfig(
             {
               plugins: [],
-              presets: [],
+              presets: [
+                [
+                  require.resolve('@babel/preset-typescript'),
+                  DEFAULT_BABEL_PRESET_TYPESCRIPT_OPTIONS,
+                ],
+              ],
             },
-            (config.tools as any).babel,
+            config.tools.babel,
             babelUtils,
           ),
         };

--- a/packages/builder/builder-rspack-provider/src/shared/plugin.ts
+++ b/packages/builder/builder-rspack-provider/src/shared/plugin.ts
@@ -21,7 +21,7 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
     plugins.html(),
     // TODO: the babel can't parser ts/react syntax without @babel/presets-env, @babel/presets-react ...
     // Temporary removal
-    // import('../plugins/babel').then(m => m.builderPluginBabel()),
+    import('../plugins/babel').then(m => m.builderPluginBabel()),
     import('../plugins/define').then(m => m.builderPluginDefine()),
     import('../plugins/css').then(m => m.builderPluginCss()),
     import('../plugins/less').then(m => m.builderPluginLess()),

--- a/packages/builder/builder-rspack-provider/src/shared/plugin.ts
+++ b/packages/builder/builder-rspack-provider/src/shared/plugin.ts
@@ -19,8 +19,6 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
     plugins.media(),
     plugins.svg(),
     plugins.html(),
-    // TODO: the babel can't parser ts/react syntax without @babel/presets-env, @babel/presets-react ...
-    // Temporary removal
     import('../plugins/babel').then(m => m.builderPluginBabel()),
     import('../plugins/define').then(m => m.builderPluginDefine()),
     import('../plugins/css').then(m => m.builderPluginCss()),

--- a/packages/builder/builder-rspack-provider/src/types/config/tools.ts
+++ b/packages/builder/builder-rspack-provider/src/types/config/tools.ts
@@ -29,7 +29,7 @@ export type ToolsRspackConfig = ChainedConfig<
   ModifyRspackConfigUtils
 >;
 
-export interface ToolsConfig extends Omit<SharedToolsConfig, 'babel'> {
+export interface ToolsConfig extends SharedToolsConfig {
   htmlPlugin?: false | ToolsHtmlPluginConfig;
   postcss?: ToolsPostCSSLoaderConfig;
   rspack?: ToolsRspackConfig;

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -29,6 +29,19 @@ exports[`plugins/babel > should set babel-loader 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
+              "plugins": [],
+              "presets": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+              ],
             },
           },
         ],

--- a/packages/builder/builder-rspack-provider/tests/plugins/babel.test.ts
+++ b/packages/builder/builder-rspack-provider/tests/plugins/babel.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { createBuilder } from '../helper';
 import { builderPluginBabel } from '@/plugins/babel';
 
-describe.skip('plugins/babel', () => {
+describe('plugins/babel', () => {
   it('should set babel-loader', async () => {
     const builder = await createBuilder({
       plugins: [builderPluginBabel()],

--- a/packages/cli/babel-preset-base/src/presets.ts
+++ b/packages/cli/babel-preset-base/src/presets.ts
@@ -1,4 +1,5 @@
 import { getBrowserslist } from '@modern-js/utils';
+import { DEFAULT_BABEL_PRESET_TYPESCRIPT_OPTIONS } from '@modern-js/utils/constants';
 import { createBabelChain } from './babel-chain';
 import { IBaseBabelConfigOption } from '.';
 
@@ -68,13 +69,7 @@ export const getPresetChain = (option: IBaseBabelConfigOption) => {
 
   if (!(useTsLoader || disableTypescriptPreset)) {
     const typescriptPresetOptions = {
-      allowNamespaces: true,
-      allExtensions: true,
-      allowDeclareFields: true,
-      // aligns Babel's behavior with TypeScript's default behavior.
-      // https://babeljs.io/docs/en/babel-preset-typescript#optimizeconstenums
-      optimizeConstEnums: true,
-      isTSX: true,
+      ...DEFAULT_BABEL_PRESET_TYPESCRIPT_OPTIONS,
       ...getPresetOptions(typescriptOptions),
     };
     chain

--- a/packages/document/builder-doc/docs/en/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/en/config/tools/babel.md
@@ -1,12 +1,11 @@
 - **Type:** `Object | Function`
 - **Default:** `undefined`
-- **Bundler:** `only support Webpack`
 
 By `tools.babel` you can modify the options of [babel-loader](https://github.com/babel/babel-loader).
 
-<!-- :::warningd
+:::warningd
 When using Rspack as a packaging tool, using this configuration item will slow down Rspack builds a bit.
-::: -->
+:::
 
 ### Function Type
 

--- a/packages/document/builder-doc/docs/en/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/en/config/tools/babel.md
@@ -3,7 +3,7 @@
 
 By `tools.babel` you can modify the options of [babel-loader](https://github.com/babel/babel-loader).
 
-:::warningd
+:::warning
 When using Rspack as a packaging tool, using this configuration item will slow down Rspack builds a bit.
 :::
 

--- a/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -137,7 +137,6 @@ Unsupported configurations and capabilities include:
 Unsupported configurations and capabilities include:
 
 - [tools.terser](/api/config-tools.html#toolsterser)
-- [tools.babel](/api/config-tools.html#toolsbabel)
 - [tools.cssExtract](/api/config-tools.html#toolscssextract)
 - [tools.cssLoader](/api/config-tools.html#toolscssloader)
 - [tools.inspector](/api/config-tools.html#toolsinspector)

--- a/packages/document/builder-doc/docs/zh/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/babel.md
@@ -1,13 +1,11 @@
 - **类型：** `Object | Function`
 - **默认值：** `undefined`
-- **打包工具：** `仅支持 Webpack`
 
 通过 `tools.babel` 可以修改 [babel-loader](https://github.com/babel/babel-loader) 的配置项。
 
-<!--
 :::warning
 在使用 Rspack 作为打包工具时，使用该配置项将在一定程度上拖慢 Rspack 构建速度。
-::: -->
+:::
 
 ### Function 类型
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -136,7 +136,6 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 不支持的配置项包括：
 
 - [tools.terser](/api/config-tools.html#toolsterser)
-- [tools.babel](/api/config-tools.html#toolsbabel)
 - [tools.cssExtract](/api/config-tools.html#toolscssextract)
 - [tools.cssLoader](/api/config-tools.html#toolscssloader)
 - [tools.inspector](/api/config-tools.html#toolsinspector)

--- a/packages/toolkit/utils/src/constants.ts
+++ b/packages/toolkit/utils/src/constants.ts
@@ -308,3 +308,20 @@ export const PLUGIN_SCHEMAS = {
   ],
   '@modern-js/plugin-nocode': [],
 };
+
+/**
+ * The `@babel/preset-typescript` default options.
+ *
+ * for:
+ * - `@modern-js/builder-rspack-provider`
+ * - `@modern-js/babel-preset-base`
+ */
+export const DEFAULT_BABEL_PRESET_TYPESCRIPT_OPTIONS = {
+  allowNamespaces: true,
+  allExtensions: true,
+  allowDeclareFields: true,
+  // aligns Babel's behavior with TypeScript's default behavior.
+  // https://babeljs.io/docs/en/babel-preset-typescript#optimizeconstenums
+  optimizeConstEnums: true,
+  isTSX: true,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,7 @@ importers:
 
   packages/builder/builder-rspack-provider:
     specifiers:
+      '@babel/preset-typescript': ^7.17.12
       '@modern-js/builder-shared': workspace:*
       '@modern-js/e2e': workspace:*
       '@modern-js/server': workspace:*
@@ -94,6 +95,7 @@ importers:
       postcss: 8.4.21
       typescript: ^4
     dependencies:
+      '@babel/preset-typescript': 7.18.6
       '@modern-js/builder-shared': link:../builder-shared
       '@modern-js/server': link:../../server/server
       '@modern-js/types': link:../../toolkit/types
@@ -6757,6 +6759,23 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-create-class-features-plugin/7.18.6:
+    resolution: {integrity: sha512-YfDzdnoxHGV8CzqHGyCbFvXg5QESPFkXlHtvdCkesLjjVMT2Adxe4FGUR5ChIb3DxSaXO12iIOCWoXdsUVwnqw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-member-expression-to-functions': 7.18.9
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.19.1
+      '@babel/helper-split-export-declaration': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/helper-create-class-features-plugin/7.18.6_@babel+core@7.18.0:
     resolution: {integrity: sha512-YfDzdnoxHGV8CzqHGyCbFvXg5QESPFkXlHtvdCkesLjjVMT2Adxe4FGUR5ChIb3DxSaXO12iIOCWoXdsUVwnqw==}
     engines: {node: '>=6.9.0'}
@@ -8806,6 +8825,19 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
+  /@babel/plugin-transform-typescript/7.18.6:
+    resolution: {integrity: sha512-ijHNhzIrLj5lQCnI6aaNVRtGVuUZhOXFLRVFs7lLrkXTHip4FKty5oAuQdk4tywG0/WjXmjTfQCWmuzrvFer1w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-typescript': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-typescript/7.18.6_@babel+core@7.20.5:
     resolution: {integrity: sha512-ijHNhzIrLj5lQCnI6aaNVRtGVuUZhOXFLRVFs7lLrkXTHip4FKty5oAuQdk4tywG0/WjXmjTfQCWmuzrvFer1w==}
     engines: {node: '>=6.9.0'}
@@ -9084,6 +9116,19 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.5
       '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.20.5
       '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.20.5
+    dev: false
+
+  /@babel/preset-typescript/7.18.6:
+    resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-transform-typescript': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/preset-typescript/7.18.6_@babel+core@7.20.5:

--- a/tests/e2e/builder/cases/babel/build.test.ts
+++ b/tests/e2e/builder/cases/babel/build.test.ts
@@ -1,9 +1,8 @@
 import path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { webpackOnlyTest } from '@scripts/helper';
 
-webpackOnlyTest('babel', async ({ page }) => {
+test('babel', async ({ page }) => {
   const builder = await build(
     {
       cwd: __dirname,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
The babel can't parser `tsx/jsx` syntax without `@babel/preset-typescript`.

For rspack-provider can use `tools.babel` configuration, inline the `@babel/preset-typescript` to handle ts syntax in rspack-provider.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
