### PR TITLE
fix(doc-core): run string-replace-loader before mdx-loader

### DIFF
--- a/.changeset/tasty-tables-mate.md
+++ b/.changeset/tasty-tables-mate.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): run string-replace-loader before mdx-loader
+
+fix(doc-core): 在 mdx-loader 之前执行 string-replace-loader

--- a/packages/cli/doc-core/README.md
+++ b/packages/cli/doc-core/README.md
@@ -10,12 +10,12 @@
 
 ## Getting Started
 
-Please follow [Quick Start](https://modernjs.dev/en/guides/get-started/quick-start) to get started with Modern.js.
+Please follow [Quick Start](https://modernjs.dev/doc-tools/guide/getting-started.html) to get started with Modern.js Doc.
 
 ## Documentation
 
-- [English Documentation](https://modernjs.dev/en/)
-- [中文文档](https://modernjs.dev)
+- [English Documentation](https://modernjs.dev/doc-tools/)
+- [中文文档](https://modernjs.dev/doc-tools/zh/)
 
 ## Contributing
 

--- a/packages/cli/doc-core/package.json
+++ b/packages/cli/doc-core/package.json
@@ -2,7 +2,7 @@
   "name": "@modern-js/doc-core",
   "version": "2.10.0",
   "description": "The Documentation Framework of Modern.js.",
-  "homepage": "https://modernjs.dev",
+  "homepage": "https://modernjs.dev/doc-tools/",
   "bugs": "https://github.com/web-infra-dev/modern.js/issues",
   "repository": "web-infra-dev/modern.js",
   "license": "MIT",

--- a/packages/cli/doc-core/src/node/createBuilder.ts
+++ b/packages/cli/doc-core/src/node/createBuilder.ts
@@ -130,15 +130,15 @@ async function createInternalBuildConfig(
         chain.module
           .rule('MDX')
           .test(/\.mdx?$/)
+          .use('mdx-loader')
+          .loader(require.resolve('@mdx-js/loader'))
+          .options(mdxOptions)
+          .end()
           .use('string-replace-loader')
           .loader(require.resolve('string-replace-loader'))
           .options({
             multiple: config.doc?.replaceRules || [],
           })
-          .end()
-          .use('mdx-loader')
-          .loader(require.resolve('@mdx-js/loader'))
-          .options(mdxOptions)
           .end();
 
         chain.resolve.extensions.prepend('.md').prepend('.mdx');

--- a/packages/cli/doc-plugin-auto-sidebar/README.md
+++ b/packages/cli/doc-plugin-auto-sidebar/README.md
@@ -10,12 +10,12 @@
 
 ## Getting Started
 
-Please follow [Quick Start](https://modernjs.dev/en/guides/get-started/quick-start) to get started with Modern.js.
+Please follow [Quick Start](https://modernjs.dev/doc-tools/guide/getting-started.html) to get started with Modern.js Doc.
 
 ## Documentation
 
-- [English Documentation](https://modernjs.dev/en/)
-- [中文文档](https://modernjs.dev)
+- [English Documentation](https://modernjs.dev/doc-tools/)
+- [中文文档](https://modernjs.dev/doc-tools/zh/)
 
 ## Contributing
 

--- a/packages/cli/doc-plugin-auto-sidebar/package.json
+++ b/packages/cli/doc-plugin-auto-sidebar/package.json
@@ -2,7 +2,7 @@
   "name": "@modern-js/doc-plugin-auto-sidebar",
   "version": "2.10.0",
   "description": "The Documentation Framework of Modern.js.",
-  "homepage": "https://modernjs.dev",
+  "homepage": "https://modernjs.dev/doc-tools/",
   "bugs": "https://github.com/web-infra-dev/modern.js/issues",
   "repository": "web-infra-dev/modern.js",
   "license": "MIT",

--- a/packages/document/builder-doc/docs/en/plugins/plugin-esbuild.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-esbuild.mdx
@@ -30,7 +30,7 @@ pnpm add @modern-js/builder-plugin-esbuild -D
 
 ### Register
 
-In upper-level frameworks such as {MODERN_JS} or EdenX, you can register esbuild plugins through the `builderPlugins` config:
+In upper-level frameworks such as Modern.js, you can register esbuild plugins through the `builderPlugins` config:
 
 ```ts
 import { builderPluginEsbuild } from '@modern-js/builder-plugin-esbuild';

--- a/packages/document/builder-doc/docs/en/plugins/plugin-image-compress.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-image-compress.mdx
@@ -25,7 +25,7 @@ pnpm add @modern-js/builder-plugin-image-compress -D
 
 ### Register
 
-In upper-level frameworks such as {MODERN_JS} or EdenX, you can register image compress plugins through the `builderPlugins` config:
+In upper-level frameworks such as Modern.js, you can register image compress plugins through the `builderPlugins` config:
 
 ```ts
 import { builderPluginImageCompress } from '@modern-js/builder-plugin-image-compress';

--- a/packages/document/builder-doc/docs/en/plugins/plugin-node-polyfill.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-node-polyfill.mdx
@@ -25,7 +25,7 @@ pnpm add @modern-js/builder-plugin-node-polyfill -D
 
 ### Register
 
-In upper-level frameworks such as {MODERN_JS} or EdenX, you can register node polyfill plugins through the `builderPlugins` config:
+In upper-level frameworks such as Modern.js, you can register node polyfill plugins through the `builderPlugins` config:
 
 ```ts
 import { builderPluginNodePolyfill } from '@modern-js/builder-plugin-node-polyfill';

--- a/packages/document/builder-doc/docs/en/plugins/plugin-stylus.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-stylus.mdx
@@ -25,7 +25,7 @@ pnpm install @modern-js/builder-plugin-stylus -D
 
 ### Register
 
-In upper-level frameworks such as {MODERN_JS} or EdenX, you can register Stylus plugins through the `builderPlugins` config:
+In upper-level frameworks such as Modern.js, you can register Stylus plugins through the `builderPlugins` config:
 
 ```ts
 import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';

--- a/packages/document/builder-doc/docs/en/plugins/plugin-swc.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-swc.mdx
@@ -27,7 +27,7 @@ pnpm add @modern-js/builder-plugin-swc -D
 
 ### Register
 
-In upper-level frameworks such as {MODERN_JS} or EdenX, you can register SWC plugin through the `builderPlugins` config:
+In upper-level frameworks such as Modern.js, you can register SWC plugin through the `builderPlugins` config:
 
 ```ts
 import { builderPluginSwc } from '@modern-js/builder-plugin-swc';

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-esbuild.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-esbuild.mdx
@@ -30,7 +30,7 @@ pnpm add @modern-js/builder-plugin-esbuild -D
 
 ### 注册插件
 
-在 {MODERN_JS} / EdenX 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 esbuild 插件：
+在 Modern.js 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 esbuild 插件：
 
 ```ts
 import { builderPluginEsbuild } from '@modern-js/builder-plugin-esbuild';

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-image-compress.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-image-compress.mdx
@@ -25,7 +25,7 @@ pnpm add @modern-js/builder-plugin-image-compress -D
 
 ### 注册插件
 
-在 {MODERN_JS} / EdenX 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 Image Compress 插件：
+在 Modern.js 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 Image Compress 插件：
 
 ```ts
 import { builderPluginImageCompress } from '@modern-js/builder-plugin-image-compress';

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-node-polyfill.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-node-polyfill.mdx
@@ -25,7 +25,7 @@ pnpm add @modern-js/builder-plugin-node-polyfill -D
 
 ### 注册插件
 
-在 {MODERN_JS} / EdenX 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 node polyfill 插件：
+在 Modern.js 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 node polyfill 插件：
 
 ```ts
 import { builderPluginNodePolyfill } from '@modern-js/builder-plugin-node-polyfill';

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-stylus.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-stylus.mdx
@@ -25,7 +25,7 @@ pnpm install @modern-js/builder-plugin-stylus -D
 
 ### 注册插件
 
-在 {MODERN_JS} / EdenX 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 Stylus 插件：
+在 Modern.js 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 Stylus 插件：
 
 ```ts
 import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-swc.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-swc.mdx
@@ -27,7 +27,7 @@ pnpm add @modern-js/builder-plugin-swc -D
 
 ### 注册插件
 
-在 {MODERN_JS} / EdenX 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 SWC 插件：
+在 Modern.js 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 SWC 插件：
 
 ```ts
 import { builderPluginSwc } from '@modern-js/builder-plugin-swc';

--- a/packages/document/builder-doc/modern.config.ts
+++ b/packages/document/builder-doc/modern.config.ts
@@ -144,9 +144,7 @@ function getSidebar(lang: 'zh' | 'en'): Sidebar {
       {
         collapsible: false,
         text: getText('指南', 'Guide'),
-        items: [
-          getLink('/plugins/introduction'),
-        ],
+        items: [getLink('/plugins/introduction')],
       },
       {
         collapsible: false,
@@ -209,16 +207,22 @@ export default defineConfig({
         },
       ],
     },
+    replaceRules: [
+      {
+        search: /{MODERN_JS}/g,
+        replace: 'Modern.js',
+      },
+      {
+        search: /{MODERN_JS_CONFIG}/g,
+        replace: 'modern.config.ts',
+      },
+    ],
     builderConfig: {
       source: {
         alias: {
           '@components': path.join(__dirname, 'src/components'),
           '@en': path.join(__dirname, 'docs/en'),
           '@zh': path.join(__dirname, 'docs/zh'),
-        },
-        globalVars: {
-          MODERN_JS: 'Modern.js',
-          MODERN_JS_CONFIG: 'modern.config.ts',
         },
       },
       dev: {

--- a/packages/solutions/doc-tools/README.md
+++ b/packages/solutions/doc-tools/README.md
@@ -10,12 +10,12 @@
 
 ## Getting Started
 
-Please follow [Quick Start](https://modernjs.dev/en/guides/get-started/quick-start) to get started with Modern.js.
+Please follow [Quick Start](https://modernjs.dev/doc-tools/guide/getting-started.html) to get started with Modern.js Doc.
 
 ## Documentation
 
-- [English Documentation](https://modernjs.dev/en/)
-- [中文文档](https://modernjs.dev)
+- [English Documentation](https://modernjs.dev/doc-tools/)
+- [中文文档](https://modernjs.dev/doc-tools/zh/)
 
 ## Contributing
 

--- a/packages/solutions/doc-tools/package.json
+++ b/packages/solutions/doc-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@modern-js/doc-tools",
   "description": "The Documentation Framework of Modern.js.",
-  "homepage": "https://modernjs.dev",
+  "homepage": "https://modernjs.dev/doc-tools",
   "bugs": "https://github.com/web-infra-dev/modern.js/issues",
   "repository": "web-infra-dev/modern.js",
   "license": "MIT",


### PR DESCRIPTION
## Description

- Run `string-replace-loader` before `mdx-loader`, so we can using `string-replace-loader` to replace variables, such as `{MODERN_JS}`.
- Fix some doc-tools links.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
