### PR TITLE
feat: print the version of rspack in the console

### DIFF
--- a/.changeset/few-tomatoes-sparkle.md
+++ b/.changeset/few-tomatoes-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/app-tools': patch
+---
+
+feat: 控制台输出 rspack 版本
+feat: Print the version of rspack in the console.

--- a/packages/builder/builder-rspack-provider/src/index.ts
+++ b/packages/builder/builder-rspack-provider/src/index.ts
@@ -1,3 +1,4 @@
+export { getRspackVersion } from './shared/getRspackVersion';
 export { builderRspackProvider } from './provider';
 export type { BuilderRspackProvider } from './provider';
 

--- a/packages/builder/builder-rspack-provider/src/shared/getRspackVersion.ts
+++ b/packages/builder/builder-rspack-provider/src/shared/getRspackVersion.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+
+export const getRspackVersion = async (): Promise<string> => {
+  try {
+    const core = require.resolve('@rspack/core');
+    const pkg = await import(path.join(core, '../../package.json'));
+    return pkg?.version;
+  } catch (err) {
+    // don't block build process
+    console.error(err);
+    return '';
+  }
+};

--- a/packages/builder/builder-rspack-provider/src/shared/index.ts
+++ b/packages/builder/builder-rspack-provider/src/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './fs';
 export * from './config';
 export * from './constants';
+export * from './getRspackVersion';

--- a/packages/solutions/app-tools/src/builder/index.ts
+++ b/packages/solutions/app-tools/src/builder/index.ts
@@ -1,10 +1,12 @@
 import { logger } from '@modern-js/utils';
+import { getRspackVersion } from '@modern-js/builder-rspack-provider';
 
 export async function createBuilderGenerator(bundler: 'webpack' | 'rspack') {
   if (bundler === 'rspack') {
     try {
       const { createRspackBuilderForModern } = await import('./builder-rspack');
-      logger.info('Using Rspack ✨');
+      const version = await getRspackVersion();
+      logger.info(`Using Rspack v${version} 🦀`);
       return createRspackBuilderForModern;
     } catch (_) {
       throw new Error(


### PR DESCRIPTION
## Description

I want to output the version of rspack, which is very useful during debugging, especially when there may be multiple rspack versions in a monorepo.

before: 
```sh
info    Using Rspack  ✨
info    Create a production build...
```

after: 
```sh
info    Using Rspack 0.1.1  ✨
info    Create a production build...
```

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
