### PR TITLE
fix(builder): failed to set empty distPath.js/css

### DIFF
--- a/.changeset/smart-hotels-fry.md
+++ b/.changeset/smart-hotels-fry.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): failed to set empty distPath.js/css
+
+fix(builder): 修复设置 distPath.js/css 为空时报错的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/output.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/output.ts
@@ -1,10 +1,10 @@
+import { join } from 'path';
 import {
   getDistPath,
   getFilename,
   applyBuilderOutputPlugin,
   setConfig,
 } from '@modern-js/builder-shared';
-
 import type { BuilderPlugin } from '../types';
 import { isUseCssExtract } from '../shared';
 
@@ -23,8 +23,11 @@ export const builderPluginOutput = (): BuilderPlugin => ({
         const cssPath = getDistPath(config.output, 'css');
         const cssFilename = getFilename(config.output, 'css', isProd);
 
-        rspackConfig.output.cssFilename = `${cssPath}/${cssFilename}`;
-        rspackConfig.output.cssChunkFilename = `${cssPath}/async/${cssFilename}`;
+        rspackConfig.output.cssFilename = join(cssPath, cssFilename);
+        rspackConfig.output.cssChunkFilename = join(
+          cssPath,
+          `async/${cssFilename}`,
+        );
       }
 
       if (config.output.copy) {

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/output.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/output.test.ts.snap
@@ -17,6 +17,22 @@ exports[`plugins/output > should allow to custom server directory with distPath.
 }
 `;
 
+exports[`plugins/output > should allow to set distPath.js and distPath.css to empty string 1`] = `
+{
+  "module": {},
+  "output": {
+    "chunkFilename": "async/[name].js",
+    "cssChunkFilename": "async/[name].css",
+    "cssFilename": "[name].css",
+    "filename": "[name].js",
+    "hashFunction": "xxhash64",
+    "path": "<ROOT>/dist",
+    "pathinfo": false,
+    "publicPath": "/",
+  },
+}
+`;
+
 exports[`plugins/output > should allow to use copy plugin 1`] = `
 {
   "builtins": {

--- a/packages/builder/builder-rspack-provider/tests/plugins/output.test.ts
+++ b/packages/builder/builder-rspack-provider/tests/plugins/output.test.ts
@@ -33,6 +33,25 @@ describe('plugins/output', () => {
     expect(bundlerConfigs[0]).toMatchSnapshot();
   });
 
+  it('should allow to set distPath.js and distPath.css to empty string', async () => {
+    const builder = await createBuilder({
+      plugins: [builderPluginOutput()],
+      builderConfig: {
+        output: {
+          distPath: {
+            js: '',
+            css: '',
+          },
+        },
+      },
+    });
+
+    const {
+      origin: { bundlerConfigs },
+    } = await builder.inspectConfig();
+    expect(bundlerConfigs[0]).toMatchSnapshot();
+  });
+
   it('should allow to use filename.js to modify filename', async () => {
     const builder = await createBuilder({
       plugins: [builderPluginOutput()],

--- a/packages/builder/builder-shared/src/apply/output.ts
+++ b/packages/builder/builder-shared/src/apply/output.ts
@@ -1,4 +1,5 @@
-import {
+import { join } from 'path';
+import type {
   BuilderContext,
   SharedBuilderPluginAPI,
   SharedNormalizedConfig,
@@ -25,8 +26,8 @@ export function applyBuilderOutputPlugin(api: SharedBuilderPluginAPI) {
 
       chain.output
         .path(api.context.distPath)
-        .filename(`${jsPath}/${jsFilename}`)
-        .chunkFilename(`${jsPath}/async/${jsFilename}`)
+        .filename(join(jsPath, jsFilename))
+        .chunkFilename(join(jsPath, `async/${jsFilename}`))
         .publicPath(publicPath)
         // disable pathinfo to improve compile performance
         // the path info is useless in most cases
@@ -38,7 +39,7 @@ export function applyBuilderOutputPlugin(api: SharedBuilderPluginAPI) {
 
       if (isServer) {
         const serverPath = getDistPath(config.output, 'server');
-        const filename = `${serverPath}/[name].js`;
+        const filename = join(serverPath, `[name].js`);
 
         chain.output
           .filename(filename)
@@ -48,7 +49,7 @@ export function applyBuilderOutputPlugin(api: SharedBuilderPluginAPI) {
 
       if (isServiceWorker) {
         const workerPath = getDistPath(config.output, 'worker');
-        const filename = `${workerPath}/[name].js`;
+        const filename = join(workerPath, `[name].js`);
 
         chain.output
           .filename(filename)

--- a/packages/builder/builder-webpack-provider/src/plugins/output.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/output.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { CSSExtractOptions } from '../types/thirdParty/css';
 import {
   getDistPath,
@@ -35,8 +36,8 @@ export const builderPluginOutput = (): BuilderPlugin => ({
           .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)
           .use(MiniCssExtractPlugin, [
             {
-              filename: `${cssPath}/${cssFilename}`,
-              chunkFilename: `${cssPath}/async/${cssFilename}`,
+              filename: join(cssPath, cssFilename),
+              chunkFilename: join(cssPath, `async/${cssFilename}`),
               ignoreOrder: true,
               ...extractPluginOptions,
             },

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/output.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/output.test.ts.snap
@@ -14,6 +14,36 @@ exports[`plugins/output > should allow to custom server directory with distPath.
 }
 `;
 
+exports[`plugins/output > should allow to set distPath.js and distPath.css to empty string 1`] = `
+{
+  "output": {
+    "chunkFilename": "async/[name].js",
+    "filename": "[name].js",
+    "hashFunction": "xxhash64",
+    "path": "<ROOT>/dist",
+    "pathinfo": false,
+    "publicPath": "/",
+  },
+  "plugins": [
+    MiniCssExtractPlugin {
+      "_sortedModulesCache": WeakMap {},
+      "options": {
+        "chunkFilename": "async/[name].css",
+        "experimentalUseImportModule": undefined,
+        "filename": "[name].css",
+        "ignoreOrder": true,
+        "runtime": true,
+      },
+      "runtimeOptions": {
+        "attributes": undefined,
+        "insert": undefined,
+        "linkType": "text/css",
+      },
+    },
+  ],
+}
+`;
+
 exports[`plugins/output > should allow to use filename.js to modify filename 1`] = `
 {
   "output": {

--- a/packages/builder/builder-webpack-provider/tests/plugins/output.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/plugins/output.test.ts
@@ -29,6 +29,23 @@ describe('plugins/output', () => {
     expect(config).toMatchSnapshot();
   });
 
+  it('should allow to set distPath.js and distPath.css to empty string', async () => {
+    const builder = await createStubBuilder({
+      plugins: [builderPluginOutput()],
+      builderConfig: {
+        output: {
+          distPath: {
+            js: '',
+            css: '',
+          },
+        },
+      },
+    });
+
+    const config = await builder.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+  });
+
   it('should allow to use filename.js to modify filename', async () => {
     const builder = await createStubBuilder({
       plugins: [builderPluginOutput()],


### PR DESCRIPTION
## Description

FIx failed to set empty distPath.js/css.

```ts
export default {
  distPath: {
    js: '',
    css: '',
  }
}
```

<img width="1050" alt="Screen Shot 2023-03-28 at 15 01 21" src="https://user-images.githubusercontent.com/7237365/228155621-d110653b-b585-4e1d-bd4c-8ba10e0f26df.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
