### PR TITLE
fix(app-tools): distPath.root not take effect when run serve

### DIFF
--- a/.changeset/itchy-ties-act.md
+++ b/.changeset/itchy-ties-act.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: distpath.root not take effect when serve
+
+fix: 修复 distpath.root 在 run serve 时不生效的问题

--- a/packages/solutions/app-tools/src/commands/serve.ts
+++ b/packages/solutions/app-tools/src/commands/serve.ts
@@ -22,7 +22,14 @@ export const start = async (api: PluginAPI<AppTools<'shared'>>) => {
 
   const app = await server({
     pwd: appDirectory,
-    config: userConfig as any,
+    config: {
+      ...userConfig,
+      dev: userConfig.dev as any,
+      output: {
+        path: userConfig.output.distPath?.root,
+        ...(userConfig.output || {}),
+      },
+    },
     appContext: {
       sharedDirectory: getTargetDir(
         appContext.sharedDirectory,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
