### PR TITLE
fix(builder): `normalizeConfig` will merge arrays when filling default values for config

### DIFF
--- a/.changeset/clever-dryers-happen.md
+++ b/.changeset/clever-dryers-happen.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): `normalizeConfig` will merge arrays when filling default values for config
+fix(builder): `normalizeConfig` 填充默认值时会将数组合并

--- a/packages/builder/builder-rspack-provider/src/config/normalize.ts
+++ b/packages/builder/builder-rspack-provider/src/config/normalize.ts
@@ -1,4 +1,7 @@
-import { extendsType, mergeBuilderConfig } from '@modern-js/builder-shared';
+import {
+  extendsType,
+  defaultsToBuilderConfig,
+} from '@modern-js/builder-shared';
 import { BuilderConfig, NormalizedConfig } from '../types';
 import { createDefaultConfig } from './defaults';
 
@@ -15,7 +18,7 @@ const createNormalizedDefaultConfig = () =>
  * 3. Meaningful and can be filled by constant value.
  */
 export const normalizeConfig = (config: BuilderConfig): NormalizedConfig =>
-  mergeBuilderConfig<NormalizedConfig>(
+  defaultsToBuilderConfig<NormalizedConfig>(
     createNormalizedDefaultConfig(),
     config as NormalizedConfig,
   );

--- a/packages/builder/builder-shared/src/mergeBuilderConfig.ts
+++ b/packages/builder/builder-shared/src/mergeBuilderConfig.ts
@@ -1,29 +1,37 @@
 import _ from '@modern-js/utils/lodash';
 
+export const defaultsToBuilderConfig = <T>(...configs: T[]): T =>
+  _.mergeWith({}, ...configs, (target: unknown, source: unknown) => {
+    const pair = [target, source];
+
+    // Use the defined one.
+    if (pair.some(_.isUndefined)) {
+      return target ?? source;
+    }
+
+    // Handle on each properties.
+    if (_.every(pair, _.isPlainObject)) {
+      return undefined;
+    }
+
+    return target;
+  });
+
 export const mergeBuilderConfig = <T>(...configs: T[]): T =>
-  _.mergeWith(
-    {},
-    ...configs,
-    (target: unknown, source: unknown, key: string) => {
-      const pair = [target, source];
-      if (pair.some(_.isUndefined)) {
-        // fallback to lodash default merge behavior
-        return undefined;
-      }
-
-      // source maybe array，should not merge source & target
-      if (key === 'removeConsole') {
-        return source ?? target;
-      }
-
-      if (pair.some(_.isArray)) {
-        return [..._.castArray(target), ..._.castArray(source)];
-      }
-      // convert function to chained function
-      if (pair.some(_.isFunction)) {
-        return [target, source];
-      }
+  _.mergeWith({}, ...configs, (target: unknown, source: unknown) => {
+    const pair = [target, source];
+    if (pair.some(_.isUndefined)) {
       // fallback to lodash default merge behavior
       return undefined;
-    },
-  );
+    }
+
+    if (pair.some(_.isArray)) {
+      return [..._.castArray(target), ..._.castArray(source)];
+    }
+    // convert function to chained function
+    if (pair.some(_.isFunction)) {
+      return [target, source];
+    }
+    // fallback to lodash default merge behavior
+    return undefined;
+  });

--- a/packages/builder/builder-webpack-provider/src/config/normalize.ts
+++ b/packages/builder/builder-webpack-provider/src/config/normalize.ts
@@ -1,4 +1,7 @@
-import { extendsType, mergeBuilderConfig } from '@modern-js/builder-shared';
+import {
+  extendsType,
+  defaultsToBuilderConfig,
+} from '@modern-js/builder-shared';
 import { BuilderConfig, NormalizedConfig } from '../types';
 import { createDefaultConfig } from './defaults';
 
@@ -15,7 +18,7 @@ const createNormalizedDefaultConfig = () =>
  * 3. Meaningful and can be filled by constant value.
  */
 export const normalizeConfig = (config: BuilderConfig): NormalizedConfig =>
-  mergeBuilderConfig<NormalizedConfig>(
+  defaultsToBuilderConfig<NormalizedConfig>(
     createNormalizedDefaultConfig(),
     config as NormalizedConfig,
   );


### PR DESCRIPTION
## Description

Add new util function`defaultsToBuilderConfig`, which is used to replace `mergeBuilderConfig` in filling the default config.

## Related Issue

The new option `source.transformImports` can be an array. The `mergeBuilderConfig` function will be executed twice and the default values will be filled in two times:

```ts
const config = api.getNormalizedConfig().source.transformImports;
//        ^? EXPECT: ['a', 'b']
//           ACTUAL: ['a', 'b', 'a', 'b']
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
