### PR TITLE
fix: load chunk while can not load all css asset, when streaming ssr

### DIFF
--- a/.changeset/chatty-panthers-compare.md
+++ b/.changeset/chatty-panthers-compare.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: load chunk while can not load all css asset, when streaming ssr.
+fix: 使用 streaming ssr 时，不能加载当前 chunk 的所有 css 资源

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/bulidTemplate.before.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/bulidTemplate.before.ts
@@ -55,8 +55,10 @@ function getHeadTemplate(beforeEntryTemplate: string, context: RuntimeContext) {
         if (routeId) {
           const routeManifest = routeAssets[routeId];
           if (routeManifest) {
-            const { assets = [] } = routeManifest;
-            const _cssChunks = assets.filter((asset?: string) =>
+            const { referenceCssAssets = [] } = routeManifest as {
+              referenceCssAssets?: string[];
+            };
+            const _cssChunks = referenceCssAssets.filter((asset?: string) =>
               asset?.endsWith('.css'),
             );
             cssChunks.push(..._cssChunks);

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -11,6 +11,7 @@ interface RouteAssets {
   [routeId: string]: {
     chunkIds?: (string | number)[];
     assets?: string[];
+    referenceCssAssets?: string[];
   };
 }
 
@@ -61,11 +62,11 @@ export class RouterPlugin {
             chunkGroups: true,
             chunks: true,
           });
-          const { publicPath, chunks = [] } = stats;
+          const { publicPath, chunks = [], assetsByChunkName } = stats;
           const routeAssets: RouteAssets = {};
           const { namedChunkGroups } = stats;
 
-          if (!namedChunkGroups) {
+          if (!namedChunkGroups || !assetsByChunkName) {
             logger.warn(
               'Route manifest does not exist, performance will be affected',
             );
@@ -78,7 +79,7 @@ export class RouterPlugin {
               [prop: string]: any;
             };
 
-            const assets = (chunkGroup as ChunkGroupLike).assets
+            const referenceCssAssets = (chunkGroup as ChunkGroupLike).assets
               .filter(asset => /\.css$/.test(asset.name))
               .map(asset => {
                 const item = asset.name;
@@ -87,7 +88,10 @@ export class RouterPlugin {
 
             routeAssets[name] = {
               chunkIds: chunkGroup.chunks,
-              assets,
+              assets: assetsByChunkName[name].map(item =>
+                publicPath ? normalizePath(publicPath) + item : item,
+              ),
+              referenceCssAssets,
             };
           }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
If the user css split many chunks, the `assetsByChunkName` can not get all chunks messages.
So we use the  chunkGroup to filter the css assets

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
