### PR TITLE
fix(builder): incorrect asset URL in windows

### DIFF
--- a/.changeset/cuddly-singers-explode.md
+++ b/.changeset/cuddly-singers-explode.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): incorrect asset URL in windows
+
+fix(builder): 修复 windows 上生成静态资源 URL 错误的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/output.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/output.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { posix } from 'path';
 import {
   getDistPath,
   getFilename,
@@ -23,8 +23,8 @@ export const builderPluginOutput = (): BuilderPlugin => ({
         const cssPath = getDistPath(config.output, 'css');
         const cssFilename = getFilename(config.output, 'css', isProd);
 
-        rspackConfig.output.cssFilename = join(cssPath, cssFilename);
-        rspackConfig.output.cssChunkFilename = join(
+        rspackConfig.output.cssFilename = posix.join(cssPath, cssFilename);
+        rspackConfig.output.cssChunkFilename = posix.join(
           cssPath,
           `async/${cssFilename}`,
         );

--- a/packages/builder/builder-shared/src/apply/output.ts
+++ b/packages/builder/builder-shared/src/apply/output.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { posix } from 'path';
 import type {
   BuilderContext,
   SharedBuilderPluginAPI,
@@ -26,8 +26,8 @@ export function applyBuilderOutputPlugin(api: SharedBuilderPluginAPI) {
 
       chain.output
         .path(api.context.distPath)
-        .filename(join(jsPath, jsFilename))
-        .chunkFilename(join(jsPath, `async/${jsFilename}`))
+        .filename(posix.join(jsPath, jsFilename))
+        .chunkFilename(posix.join(jsPath, `async/${jsFilename}`))
         .publicPath(publicPath)
         // disable pathinfo to improve compile performance
         // the path info is useless in most cases
@@ -39,7 +39,7 @@ export function applyBuilderOutputPlugin(api: SharedBuilderPluginAPI) {
 
       if (isServer) {
         const serverPath = getDistPath(config.output, 'server');
-        const filename = join(serverPath, `[name].js`);
+        const filename = posix.join(serverPath, `[name].js`);
 
         chain.output
           .filename(filename)
@@ -49,7 +49,7 @@ export function applyBuilderOutputPlugin(api: SharedBuilderPluginAPI) {
 
       if (isServiceWorker) {
         const workerPath = getDistPath(config.output, 'worker');
-        const filename = join(workerPath, `[name].js`);
+        const filename = posix.join(workerPath, `[name].js`);
 
         chain.output
           .filename(filename)

--- a/packages/builder/builder-webpack-provider/src/plugins/output.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/output.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { posix } from 'path';
 import { CSSExtractOptions } from '../types/thirdParty/css';
 import {
   getDistPath,
@@ -36,8 +36,8 @@ export const builderPluginOutput = (): BuilderPlugin => ({
           .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)
           .use(MiniCssExtractPlugin, [
             {
-              filename: join(cssPath, cssFilename),
-              chunkFilename: join(cssPath, `async/${cssFilename}`),
+              filename: posix.join(cssPath, cssFilename),
+              chunkFilename: posix.join(cssPath, `async/${cssFilename}`),
               ignoreOrder: true,
               ...extractPluginOptions,
             },


### PR DESCRIPTION
## Description

Fix incorrect asset URL in windows.

![image](https://user-images.githubusercontent.com/7237365/228439604-eb8b7a2d-6e82-4c19-a338-42d2261b902d.png)

## Related PR

https://github.com/web-infra-dev/modern.js/pull/3265

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
