### PR TITLE
fix(builder): remove duplicated babel-plugin-import

### DIFF
--- a/.changeset/cold-pens-give.md
+++ b/.changeset/cold-pens-give.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/babel-preset-base': patch
+'@modern-js/babel-preset-app': patch
+'@modern-js/builder': patch
+'@modern-js/utils': patch
+---
+
+fix(builder): remove duplicated babel-plugin-import
+
+fix(builder): 移除重复注册的 babel-plugin-import

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -112,6 +112,7 @@ export const builderPluginBabel = (): BuilderPlugin => ({
               userBabelConfig: config.tools.babel,
               userBabelConfigUtils: babelUtils,
               overrideBrowserslist: browserslist,
+              importAntd: false,
             }),
           };
 

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -40,15 +40,6 @@ exports[`plugins/babel > should add rule to compile Data URI when enable source.
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -156,15 +147,6 @@ exports[`plugins/babel > should add rule to compile Data URI when enable source.
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -290,15 +272,6 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "lib",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -401,15 +374,6 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "lib",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -533,15 +497,6 @@ exports[`plugins/babel > should apply exclude condition when using source.exclud
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -649,15 +604,6 @@ exports[`plugins/babel > should apply exclude condition when using source.exclud
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -791,15 +737,6 @@ exports[`plugins/babel > should override targets of babel-preset-env when using 
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -905,15 +842,6 @@ exports[`plugins/babel > should override targets of babel-preset-env when using 
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -1037,15 +965,6 @@ exports[`plugins/babel > should set babel-loader 1`] = `
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -1153,15 +1072,6 @@ exports[`plugins/babel > should set babel-loader 1`] = `
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -1291,15 +1201,6 @@ exports[`plugins/babel > should set include/exclude 1`] = `
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -1407,15 +1308,6 @@ exports[`plugins/babel > should set include/exclude 1`] = `
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -462,15 +462,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -589,15 +580,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -1333,15 +1315,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -1466,15 +1439,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -2153,15 +2117,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "lib",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -2284,15 +2239,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "lib",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -2890,15 +2836,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -3023,15 +2960,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
@@ -31,15 +31,6 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
-                ],
-                [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
                   {},
                 ],
@@ -153,15 +144,6 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
-                ],
-                [
-                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "import-antd",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",

--- a/packages/builder/builder/src/plugins/antd.ts
+++ b/packages/builder/builder/src/plugins/antd.ts
@@ -1,3 +1,4 @@
+import { getAntdMajorVersion } from '@modern-js/utils';
 import type {
   BuilderTarget,
   DefaultBuilderPlugin,
@@ -9,6 +10,7 @@ export const builderAntdPlugin = (): DefaultBuilderPlugin => ({
   setup(api) {
     api.modifyBuilderConfig(builderConfig => {
       builderConfig.source ??= {};
+
       if (
         builderConfig.source.transformImport?.some(
           item => item.libraryName === 'antd',
@@ -39,16 +41,4 @@ function useSSR(target: BuilderTarget | BuilderTarget[]) {
   return (Array.isArray(target) ? target : [target]).some(item =>
     ['node', 'service-worker'].includes(item),
   );
-}
-
-function getAntdMajorVersion(appDirectory: string) {
-  try {
-    const pkgJsonPath = require.resolve('antd/package.json', {
-      paths: [appDirectory],
-    });
-    const { version } = require(pkgJsonPath);
-    return Number(version.split('.')[0]);
-  } catch (err) {
-    return null;
-  }
 }

--- a/packages/cli/babel-preset-app/src/common.ts
+++ b/packages/cli/babel-preset-app/src/common.ts
@@ -47,6 +47,7 @@ export const genCommon = (options: Options): BabelChain => {
     styledComponents,
     useTsLoader,
     overrideBrowserslist,
+    importAntd,
   } = options;
 
   const useSSR = target === 'server';
@@ -84,7 +85,13 @@ export const genCommon = (options: Options): BabelChain => {
     },
     plugins: {
       lodashOptions,
-      import: { antd: { libraryDirectory: useSSR ? 'lib' : 'es' } },
+      import: {
+        antd: importAntd
+          ? {
+              libraryDirectory: useSSR ? 'lib' : 'es',
+            }
+          : false,
+      },
       transformRuntime: {
         // version, regenerator 在 base config 里已配置
         // https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules

--- a/packages/cli/babel-preset-app/src/index.ts
+++ b/packages/cli/babel-preset-app/src/index.ts
@@ -24,6 +24,7 @@ const defaultOptions: Options = {
   useTsLoader: false,
   lodash: {},
   styledComponents: {},
+  importAntd: true,
 };
 
 export const getBabelConfig = (options?: Options): BabelOptions => {

--- a/packages/cli/babel-preset-app/src/type.ts
+++ b/packages/cli/babel-preset-app/src/type.ts
@@ -24,4 +24,5 @@ export type Options = {
   userBabelConfig?: BabelConfig | BabelConfig[];
   userBabelConfigUtils?: Partial<BabelConfigUtils>;
   overrideBrowserslist?: string[];
+  importAntd?: boolean;
 };

--- a/packages/cli/babel-preset-base/src/index.ts
+++ b/packages/cli/babel-preset-base/src/index.ts
@@ -15,9 +15,11 @@ export interface IBaseBabelConfigOption {
   plugins?: {
     transformRuntime?: any;
     import?: {
-      antd?: {
-        libraryDirectory: string;
-      };
+      antd?:
+        | {
+            libraryDirectory: string;
+          }
+        | false;
     };
     transformReactRemovePropTypes?: false | Record<string, any>;
     styledComponentsOptions?: IStyledComponentOptions;

--- a/packages/toolkit/utils/src/index.ts
+++ b/packages/toolkit/utils/src/index.ts
@@ -31,7 +31,7 @@ export * from './nodeEnv';
 export * from './wait';
 export * from './emptyDir';
 export * from './getServerConfig';
-export * from './tryResolve';
+export * from './resolve';
 export * from './analyzeProject';
 export * from './chainId';
 export * from './version';

--- a/packages/toolkit/utils/src/resolve.ts
+++ b/packages/toolkit/utils/src/resolve.ts
@@ -34,3 +34,15 @@ export const isPackageInstalled = (
     return false;
   }
 };
+
+export const getAntdMajorVersion = (appDirectory: string) => {
+  try {
+    const pkgJsonPath = require.resolve('antd/package.json', {
+      paths: [appDirectory],
+    });
+    const { version } = require(pkgJsonPath);
+    return Number(version.split('.')[0]);
+  } catch (err) {
+    return null;
+  }
+};

--- a/packages/toolkit/utils/tests/isPackageInstalled.test.ts
+++ b/packages/toolkit/utils/tests/isPackageInstalled.test.ts
@@ -1,4 +1,4 @@
-import { isPackageInstalled } from '../src/tryResolve';
+import { isPackageInstalled } from '../src/resolve';
 
 describe('isPackageInstalled', () => {
   it('should return false if the package not is resolved', () => {


### PR DESCRIPTION
## Description

Remove duplicated babel-plugin-import.

Currently, there are two `babel-plugin-import` to import antd in Builder:

- The `@modern-js/babel-preset-base` will register one.
- The `@modern-js/builder` will register another one.

So we should disable the antd of babel-preset-base when using Builder.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
