### PR TITLE
fix(transform-import): :bug: remove check for babel transform-import

### DIFF
--- a/.changeset/sixty-dryers-attend.md
+++ b/.changeset/sixty-dryers-attend.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix: 移除 babel plugin-import 对于非法函数参数的校验
+
+fix: remove babel plugin-import invalid function type options checking

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -12,7 +12,6 @@ import {
   getBrowserslistWithDefault,
   getSharedPkgCompiledPath,
   applyScriptCondition,
-  logger,
 } from '@modern-js/builder-shared';
 
 import type {
@@ -200,26 +199,8 @@ function applyPluginImport(
   pluginImport?: TransformImport[],
 ) {
   if (pluginImport) {
-    for (let i = 0; i < pluginImport.length; i++) {
-      const item = pluginImport[i];
+    for (const item of pluginImport) {
       const name = item.libraryName;
-
-      if (
-        ['customName', 'customStyleName'].some(key => {
-          // @ts-expect-error
-          if (item[key] && typeof item[key] === 'string') {
-            logger.error(
-              `Can't use template string config in \`source.transformImport[${i}].${key}\`, if you are not using Rspack or SWC plugin`,
-            );
-            return true;
-          }
-          return false;
-        })
-      ) {
-        throw new Error(
-          "Can't use template string config in `source.transformImport` in webpack without SWC plugin",
-        );
-      }
 
       chain
         .plugin(`plugin-import-${name}`)


### PR DESCRIPTION
## Description

之前在 Babel 中检测了是否 transformImport 配置中有字符串参数，如果有报错，但是不应该这样因为可能会使用 SWC 插件

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
