### PR TITLE
feat: support use node api run dev & build & deploy command

### DIFF
--- a/.changeset/four-lions-battle.md
+++ b/.changeset/four-lions-battle.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/utils': patch
+'@modern-js/core': patch
+---
+
+feat: support use node api run dev & build & deploy command
+feat: 支持通过 node api 运行 dev & build & deploy 命令

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -24,6 +24,11 @@
       },
       "default": "./dist/index.js"
     },
+    "./node": {
+      "jsnext:source": "./src/node-api.ts",
+      "types": "./dist/node-api.d.ts",
+      "default": "./dist/node-api.js"
+    },
     "./bin": {
       "jsnext:source": "./src/bin.ts",
       "default": "./dist/bin.js"
@@ -50,6 +55,9 @@
       ],
       "types": [
         "./dist/types/index.d.ts"
+      ],
+      "node": [
+        "./dist/node-api.d.ts"
       ],
       "runBin": [
         "./dist/runBin.d.ts"

--- a/packages/cli/core/src/config/createLoadedConfig.ts
+++ b/packages/cli/core/src/config/createLoadedConfig.ts
@@ -85,6 +85,7 @@ export async function createLoadedConfig(
   appDirectory: string,
   filePath?: string,
   packageJsonConfig?: string,
+  loadedConfig?: UserConfig,
   // eslint-disable-next-line @typescript-eslint/ban-types
 ): Promise<LoadedConfig<{}>> {
   const configFile = getConfigFilePath(appDirectory, filePath);
@@ -93,6 +94,7 @@ export async function createLoadedConfig(
     appDirectory,
     configFile,
     packageJsonConfig,
+    loadedConfig,
   );
 
   if (!loaded.config && !loaded.pkgConfig) {

--- a/packages/cli/core/src/config/loadConfig.ts
+++ b/packages/cli/core/src/config/loadConfig.ts
@@ -140,6 +140,7 @@ export const loadConfig = async <T>(
   appDirectory: string,
   configFile: string | false,
   packageJsonConfig?: string,
+  loadedConfig?: T,
 ): Promise<{
   path: string | false;
   config?: T;
@@ -154,7 +155,9 @@ export const loadConfig = async <T>(
     ? [path.resolve(appDirectory, './package.json')]
     : [];
 
-  if (configFile) {
+  if (loadedConfig) {
+    config = loadedConfig;
+  } else if (configFile) {
     delete require.cache[configFile];
 
     const mod = await bundleRequireWithCatch(configFile, { appDirectory });

--- a/packages/cli/core/src/node-api.ts
+++ b/packages/cli/core/src/node-api.ts
@@ -1,0 +1,16 @@
+import { cli, CoreOptions } from '.';
+
+export const dev = (options?: CoreOptions, commandOptions: string[] = []) => {
+  cli.runCommand('dev', commandOptions, options);
+};
+
+export const build = (options?: CoreOptions, commandOptions: string[] = []) => {
+  cli.runCommand('build', commandOptions, options);
+};
+
+export const deploy = (
+  options?: CoreOptions,
+  commandOptions: string[] = [],
+) => {
+  cli.runCommand('deploy', commandOptions, options);
+};

--- a/packages/cli/core/tests/loadConfigs.test.ts
+++ b/packages/cli/core/tests/loadConfigs.test.ts
@@ -118,6 +118,23 @@ describe('load user config file', () => {
     expect(userConfig.path).toBe(false);
     expect(userConfig.config).toBeUndefined();
   });
+
+  test('should support pass config', async () => {
+    const fixturePath = path.resolve(__dirname, './fixtures/config/no-config');
+    const loadedConfig = {
+      server: {
+        baseUrl: '/base',
+      },
+    };
+    const userConfig = await loadConfig<any>(
+      fixturePath,
+      getConfigFilePath(fixturePath),
+      undefined,
+      loadedConfig,
+    );
+
+    expect(userConfig.config).toEqual(loadedConfig);
+  });
 });
 
 describe('get file dependencies', () => {

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -7,6 +7,7 @@ import {
   minimist,
   getCommand,
   isDevCommand,
+  getArgv,
 } from '@modern-js/utils';
 import type { CliPlugin } from '@modern-js/core';
 import { cloneDeep } from '@modern-js/utils/lodash';
@@ -132,7 +133,7 @@ export default ({
 
         let checkedEntries = entrypoints.map(point => point.entryName);
         if (isDevCommand()) {
-          const { entry } = minimist(process.argv.slice(2));
+          const { entry } = minimist(getArgv());
           checkedEntries = await getSelectedEntries(
             typeof entry === 'string' ? entry.split(',') : entry,
             entrypoints,

--- a/packages/solutions/app-tools/src/utils/restart.ts
+++ b/packages/solutions/app-tools/src/utils/restart.ts
@@ -1,5 +1,11 @@
 import { cli, ToRunners } from '@modern-js/core';
-import { chalk, clearConsole, logger, program } from '@modern-js/utils';
+import {
+  chalk,
+  clearConsole,
+  getArgv,
+  logger,
+  program,
+} from '@modern-js/utils';
 import { AppToolsHooks } from '../types/hooks';
 
 export async function restart(
@@ -20,7 +26,7 @@ export async function restart(
     hasGetError = true;
   } finally {
     if (!hasGetError) {
-      program.parse(process.argv);
+      program.parse(getArgv());
     }
   }
 }

--- a/packages/toolkit/utils/src/analyzeProject.ts
+++ b/packages/toolkit/utils/src/analyzeProject.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { getArgv } from './commands';
 import { fs, minimist } from './compiled';
 
 export const isApiOnly = async (
@@ -7,11 +8,11 @@ export const isApiOnly = async (
 ): Promise<boolean> => {
   const srcDir = path.join(appDirectory, entryDir ?? 'src');
   const existSrc = await fs.pathExists(srcDir);
-  const options = minimist(process.argv.slice(2));
+  const options = minimist(getArgv());
   return !existSrc || Boolean(options['api-only']);
 };
 
 export const isWebOnly = async () => {
-  const options = minimist(process.argv.slice(2));
+  const options = minimist(getArgv());
   return Boolean(options['web-only']);
 };

--- a/packages/toolkit/utils/src/commands.ts
+++ b/packages/toolkit/utils/src/commands.ts
@@ -1,5 +1,9 @@
+export const getArgv = () => {
+  return (process.env.MODERN_ARGV?.split(' ') || process.argv).slice(2);
+};
+
 export const getCommand = () => {
-  const args = process.argv.slice(2);
+  const args = getArgv();
   const command = args[0];
   return command;
 };

--- a/packages/toolkit/utils/tests/commands.test.ts
+++ b/packages/toolkit/utils/tests/commands.test.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import { getArgv, getCommand, isDevCommand } from '../src/commands';
+
+describe('test commands utils', () => {
+  test('should get command correctly', () => {
+    process.argv = ['', '', 'dev'];
+    expect(getCommand()).toBe('dev');
+
+    process.env.MODERN_ARGV = ['', '', 'start'].join(' ');
+    expect(getCommand()).toBe('start');
+  });
+
+  test('should get argv correctly', () => {
+    delete process.env.MODERN_ARGV;
+    process.argv = ['', '', 'dev'];
+    expect(getArgv()).toEqual(['dev']);
+
+    process.env.MODERN_ARGV = ['', '', 'start'].join(' ');
+    expect(getArgv()).toEqual(['start']);
+  });
+
+  test('should detect dev command correctly', () => {
+    delete process.env.MODERN_ARGV;
+    process.argv = ['', '', 'dev'];
+    expect(isDevCommand()).toBeTruthy();
+
+    process.env.MODERN_ARGV = ['', '', 'build'].join(' ');
+    expect(isDevCommand()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Description

An experimental feature, most likely to change, now you can start modern.js by node api:

```ts
import { dev } from '@modern-js/core/node';
import appTools, { defineConfig } from '@modern-js/app-tools';
import runtimeCli from '@modern-js/runtime/cli';

const main = () => {
  dev({
    loadedConfig: defineConfig({
      runtime: {
        router: true,
      },
      plugins: [runtimeCli(), appTools()],
    }),
  });
};

main();
```

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
