### PR TITLE
fix(builder): should preserve viewBox after minify SVG

### DIFF
--- a/.changeset/gentle-actors-boil.md
+++ b/.changeset/gentle-actors-boil.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder': patch
+---
+
+fix(builder): should preserve viewBox when minify svg
+
+fix(builder): 修复压缩 svg 导致 viewBox 丢失的问题

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -229,6 +229,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -875,6 +887,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -1528,6 +1552,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -1918,6 +1954,18 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {

--- a/packages/builder/builder-shared/src/index.ts
+++ b/packages/builder/builder-shared/src/index.ts
@@ -23,3 +23,4 @@ export * from './openBrowser';
 export * from './apply';
 export * from './fallback';
 export * from './getLoaderOptions';
+export * from './svgo';

--- a/packages/builder/builder-shared/src/svgo.ts
+++ b/packages/builder/builder-shared/src/svgo.ts
@@ -1,0 +1,16 @@
+export function getSvgoDefaultConfig() {
+  return {
+    plugins: [
+      {
+        name: 'preset-default',
+        params: {
+          overrides: {
+            // viewBox is required to resize SVGs with CSS.
+            // @see https://github.com/svg/svgo/issues/1128
+            removeViewBox: false,
+          },
+        },
+      },
+    ],
+  };
+}

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -112,6 +112,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -965,6 +977,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -1866,6 +1890,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -2588,6 +2624,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {

--- a/packages/builder/builder/src/plugins/svg.ts
+++ b/packages/builder/builder/src/plugins/svg.ts
@@ -6,6 +6,7 @@ import {
   getDistPath,
   getFilename,
   chainStaticAssetRule,
+  getSvgoDefaultConfig,
 } from '@modern-js/builder-shared';
 import type { DefaultBuilderPlugin } from '@modern-js/builder-shared';
 
@@ -67,7 +68,10 @@ export const builderPluginSvg = (): DefaultBuilderPlugin => {
           .type('javascript/auto')
           .use(CHAIN_ID.USE.SVGR)
           .loader(require.resolve('@svgr/webpack'))
-          .options({ svgo: true })
+          .options({
+            svgo: true,
+            svgoConfig: getSvgoDefaultConfig(),
+          })
           .end()
           .when(defaultExport === 'url', c =>
             c

--- a/packages/builder/builder/tests/plugins/__snapshots__/svg.test.ts.snap
+++ b/packages/builder/builder/tests/plugins/__snapshots__/svg.test.ts.snap
@@ -84,6 +84,18 @@ exports[`plugins/svg > export default Component 1`] = `
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
             ],
@@ -180,6 +192,18 @@ exports[`plugins/svg > export default url 1`] = `
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -283,6 +307,18 @@ exports[`plugins/svg > should allow to use distPath.svg to modify dist path 1`] 
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -386,6 +422,18 @@ exports[`plugins/svg > should allow to use filename.svg to modify filename 1`] =
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {
@@ -489,6 +537,18 @@ exports[`plugins/svg > should allow using output.dataUriLimit.svg to custom data
                 "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@svgr/webpack/dist/index.js",
                 "options": {
                   "svgo": true,
+                  "svgoConfig": {
+                    "plugins": [
+                      {
+                        "name": "preset-default",
+                        "params": {
+                          "overrides": {
+                            "removeViewBox": false,
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
               {

--- a/tests/e2e/builder/cases/svg/svg.test.ts
+++ b/tests/e2e/builder/cases/svg/svg.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { expect } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import { allProviderTest } from '@scripts/helper';
+
+allProviderTest('should preserve viewBox after svgo minification', async () => {
+  const fixture = join(__dirname, 'svgo-minify');
+  const buildOpts = {
+    cwd: fixture,
+    entry: {
+      main: join(fixture, 'src/index.jsx'),
+    },
+  };
+
+  const builder = await build(buildOpts);
+
+  const files = await builder.unwrapOutputJSON();
+  const mainJs = Object.keys(files).find(
+    file => file.includes('main') && file.endsWith('.js'),
+  );
+  const content = readFileSync(mainJs!, 'utf-8');
+
+  expect(
+    content.includes('width:120,height:120,viewBox:"0 0 120 120"'),
+  ).toBeTruthy();
+});

--- a/tests/e2e/builder/cases/svg/svgo-minify/src/image.svg
+++ b/tests/e2e/builder/cases/svg/svgo-minify/src/image.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+    width="120px" height="120px" viewBox="0 0 120 120"
+    enable-background="new 0 0 120 120" xml:space="preserve"
+>
+</svg>

--- a/tests/e2e/builder/cases/svg/svgo-minify/src/index.jsx
+++ b/tests/e2e/builder/cases/svg/svgo-minify/src/index.jsx
@@ -1,0 +1,3 @@
+import { ReactComponent } from './image.svg';
+
+console.log(ReactComponent);


### PR DESCRIPTION
## Description

Should preserve viewBox after minify SVG, because viewBox is required to resize SVGs with CSS.

## Related Issue

- https://github.com/web-infra-dev/modern.js/issues/3254
- https://github.com/svg/svgo/issues/1128

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
