### PR TITLE
chore(builder): fix SVG minify e2e case when using Rspack

### DIFF
--- a/tests/e2e/builder/cases/svg/svg.test.ts
+++ b/tests/e2e/builder/cases/svg/svg.test.ts
@@ -17,7 +17,7 @@ allProviderTest('should preserve viewBox after svgo minification', async () => {
 
   const files = await builder.unwrapOutputJSON();
   const mainJs = Object.keys(files).find(
-    file => file.includes('main') && file.endsWith('.js'),
+    file => file.includes('/main.') && file.endsWith('.js'),
   );
   const content = readFileSync(mainJs!, 'utf-8');
 


### PR DESCRIPTION
## Description

Fix SVG minify e2e case when using Rspack.

The test cases failed because the generated files of webpack and Rspack is different, **we need to make the dist files consistent in the future.**

webpack:

<img width="326" alt="Screen Shot 2023-03-30 at 10 59 38" src="https://user-images.githubusercontent.com/7237365/228717181-22aed448-c2a3-431b-bed6-92251dd1de1c.png">

Rspack:

<img width="527" alt="Screen Shot 2023-03-30 at 10 59 57" src="https://user-images.githubusercontent.com/7237365/228717199-d0186ca9-fd29-493a-8cda-c686d58e8d97.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
