### PR TITLE
feat(doc-tools): print dev server URLs with base

### DIFF
--- a/.changeset/eighty-trainers-love.md
+++ b/.changeset/eighty-trainers-love.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/utils': patch
+'@modern-js/doc-core': patch
+---
+
+feat(doc-tools): print dev server URLs with base
+
+feat(doc-tools): 输出 dev server 的 URLs 时补全 base 信息

--- a/packages/builder/builder-shared/src/types/provider.ts
+++ b/packages/builder/builder-shared/src/types/provider.ts
@@ -8,9 +8,11 @@ export type Bundler = 'webpack' | 'rspack';
 
 export type CreateCompilerOptions = { watch?: boolean };
 
+export type PrintUrl = { label: string; url: string };
+
 export type StartDevServerOptions = {
   compiler?: Compiler | MultiCompiler;
-  printURLs?: boolean;
+  printURLs?: boolean | ((urls: PrintUrl[]) => PrintUrl[]);
   strictPort?: boolean;
   serverOptions?: Partial<Omit<ModernDevServerOptions, 'config'>> & {
     config?: Partial<ModernDevServerOptions['config']>;

--- a/packages/builder/builder-shared/src/types/provider.ts
+++ b/packages/builder/builder-shared/src/types/provider.ts
@@ -3,16 +3,15 @@ import type { BuilderContext } from './context';
 import type { Compiler, MultiCompiler } from 'webpack';
 import type { BuilderMode, CreateBuilderOptions } from './builder';
 import type { Server, ModernDevServerOptions } from '@modern-js/server';
+import type { AddressUrl } from '@modern-js/utils';
 
 export type Bundler = 'webpack' | 'rspack';
 
 export type CreateCompilerOptions = { watch?: boolean };
 
-export type PrintUrl = { label: string; url: string };
-
 export type StartDevServerOptions = {
   compiler?: Compiler | MultiCompiler;
-  printURLs?: boolean | ((urls: PrintUrl[]) => PrintUrl[]);
+  printURLs?: boolean | ((urls: AddressUrl[]) => AddressUrl[]);
   strictPort?: boolean;
   serverOptions?: Partial<Omit<ModernDevServerOptions, 'config'>> & {
     config?: Partial<ModernDevServerOptions['config']>;

--- a/packages/document/builder-doc/docs/en/api/builder-instance.mdx
+++ b/packages/document/builder-doc/docs/en/api/builder-instance.mdx
@@ -192,7 +192,7 @@ Start the local Dev Server, based on the Modern.js Dev Server.
 ```ts
 type StartDevServerOptions = {
   // Whether to output URL infos, the default is true
-  printURLs?: boolean;
+  printURLs?: boolean | Function;
   // Whether to throw an exception when the port is occupied, the default is false
   strictPort?: boolean;
   // custom Compiler object
@@ -245,13 +245,26 @@ console.log(port); // 8080
 await server.close();
 ```
 
-### Disable print URLs
+### Disable Print URLs
 
 Setting `printURLs` to `false` to disable the default URL output, so you can custom the logs.
 
 ```ts
 await builder.startDevServer({
   printURLs: false,
+});
+```
+
+You can also directly configure `printURLs` as a function to modify URLs, such as adding a subpath to each URL:
+
+```ts
+await builder.startDevServer({
+  printURLs: urls => {
+    return urls.map(({ label, url }) => ({
+      label,
+      url: `${url}/path`,
+    }));
+  },
 });
 ```
 

--- a/packages/document/builder-doc/docs/zh/api/builder-instance.mdx
+++ b/packages/document/builder-doc/docs/zh/api/builder-instance.mdx
@@ -192,7 +192,7 @@ await builder.build({
 ```ts
 type StartDevServerOptions = {
   // 是否输出 URL 信息，默认为 true
-  printURLs?: boolean;
+  printURLs?: boolean | Function;
   // 是否在端口被占用时抛出异常，默认为 false
   strictPort?: boolean;
   // 自定义 Compiler 对象
@@ -252,6 +252,19 @@ await server.close();
 ```ts
 await builder.startDevServer({
   printURLs: false,
+});
+```
+
+你也可以直接将 `printURLs` 配置为一个函数来修改 URL，比如给每个 URL 增加一个子路径：
+
+```ts
+await builder.startDevServer({
+  printURLs: urls => {
+    return urls.map(({ label, url }) => ({
+      label,
+      url: `${url}/path`,
+    }));
+  },
 });
 ```
 

--- a/packages/toolkit/utils/src/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/prettyInstructions.ts
@@ -35,15 +35,15 @@ export const getIpv4Interfaces = () => {
 export const getAddressUrls = (protocol = 'http', port: number) => {
   const ipv4Interfaces = getIpv4Interfaces();
   return ipv4Interfaces.reduce(
-    (memo: { type: string; url: string }[], detail) => {
-      let type = 'Network:  ';
+    (memo: { label: string; url: string }[], detail) => {
+      let label = 'Network:  ';
       let url = `${protocol}://${detail.address}:${port}`;
       if (detail.address.includes(`localhost`) || detail.internal) {
-        type = 'Local:  ';
+        label = 'Local:  ';
         url = `${protocol}://localhost:${port}`;
       }
 
-      memo.push({ type, url });
+      memo.push({ label, url });
       return memo;
     },
     [],
@@ -74,8 +74,8 @@ export const prettyInstructions = (appContext: any, config: any) => {
   if (isSingleEntry(entrypoints) || apiOnly) {
     message += urls
       .map(
-        ({ type, url }) =>
-          `  ${chalk.bold(`> ${type.padEnd(10)}`)}${chalk.cyanBright(
+        ({ label, url }) =>
+          `  ${chalk.bold(`> ${label.padEnd(10)}`)}${chalk.cyanBright(
             normalizeUrl(`${url}/${routes[0].urlPath}`),
           )}\n`,
       )
@@ -83,8 +83,8 @@ export const prettyInstructions = (appContext: any, config: any) => {
   } else {
     const maxNameLength = Math.max(...routes.map(r => r.entryName.length));
 
-    urls.forEach(({ type, url }) => {
-      message += `  ${chalk.bold(`> ${type}`)}\n`;
+    urls.forEach(({ label, url }) => {
+      message += `  ${chalk.bold(`> ${label}`)}\n`;
       routes.forEach(({ entryName, urlPath, isSSR }) => {
         if (!checkedEntries.includes(entryName)) {
           return;

--- a/packages/toolkit/utils/src/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/prettyInstructions.ts
@@ -32,22 +32,21 @@ export const getIpv4Interfaces = () => {
   return ipv4Interfaces;
 };
 
+export type AddressUrl = { label: string; url: string };
+
 export const getAddressUrls = (protocol = 'http', port: number) => {
   const ipv4Interfaces = getIpv4Interfaces();
-  return ipv4Interfaces.reduce(
-    (memo: { label: string; url: string }[], detail) => {
-      let label = 'Network:  ';
-      let url = `${protocol}://${detail.address}:${port}`;
-      if (detail.address.includes(`localhost`) || detail.internal) {
-        label = 'Local:  ';
-        url = `${protocol}://localhost:${port}`;
-      }
+  return ipv4Interfaces.reduce((memo: AddressUrl[], detail) => {
+    let label = 'Network:  ';
+    let url = `${protocol}://${detail.address}:${port}`;
+    if (detail.address.includes(`localhost`) || detail.internal) {
+      label = 'Local:  ';
+      url = `${protocol}://localhost:${port}`;
+    }
 
-      memo.push({ label, url });
-      return memo;
-    },
-    [],
-  );
+    memo.push({ label, url });
+    return memo;
+  }, []);
 };
 
 export const prettyInstructions = (appContext: any, config: any) => {


### PR DESCRIPTION
## Description

Print dev server URLs with base.

before:

<img width="422" alt="Screen Shot 2023-03-30 at 14 23 10" src="https://user-images.githubusercontent.com/7237365/228756561-77ca18eb-1441-4c7b-98ed-ab16644dd9d5.png">

after:

<img width="479" alt="Screen Shot 2023-03-30 at 14 56 48" src="https://user-images.githubusercontent.com/7237365/228756581-bdb3fb1d-ef01-4e3d-9564-e5d435bd807a.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
