### PR TITLE
docs(main): update dynamic router data fetch import package error

### DIFF
--- a/.changeset/blue-months-stare.md
+++ b/.changeset/blue-months-stare.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/main-doc': major
+---
+
+docs(main): update dynamic router import package error

--- a/.变更集/blue-months-stare.md
+++ b/.变更集/blue-months-stare.md
@@ -1,5 +1,5 @@
 ---
-'@modern-js/main-doc': major
+'@modern-js/main-doc': path
 ---
 
 docs(main): update dynamic router import package error

--- a/packages/document/main-doc/docs/en/guides/basic-features/data-fetch.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/data-fetch.mdx
@@ -223,7 +223,7 @@ Currently, only CSR is supported, so stay tuned for Streaming SSR.
 Add the following code to `user/layout.loader.ts`:
 
 ```ts title="routes/user/layout.loader.ts"
-import { defer } from "@edenx/runtime/router"
+import { defer } from "@modern-js/runtime/router"
 
 const loader = () =>
 defer({

--- a/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
@@ -230,7 +230,7 @@ When a route jumps from `/` to `/blog`, if the JS Chunk of the `<Blog>` componen
 You can redirect routes by creating a [`data loader`](/guides/basic-features/data-fetch) file, Suppose you have the file `routes/user/page.tsx` and you want to redirect the route corresponding to this file, you can create the file `routes/user/page.loader.ts`:
 
 ```ts title="routes/user/page.loader.ts"
-import { redirect } from "@edenx/runtime/router"
+import { redirect } from "@modern-js/runtime/router"
 
 export default () => {
   const user = await getUser();

--- a/packages/document/main-doc/docs/zh/guides/basic-features/data-fetch.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/data-fetch.mdx
@@ -224,7 +224,7 @@ export default function UserLayout() {
 创建 `user/layout.loader.ts`，并添加以下代码：
 
 ```ts title="routes/user/layout.loader.ts"
-import { defer } from "@edenx/runtime/router"
+import { defer } from "@modern-js/runtime/router"
 
 const loader = () =>
 defer({

--- a/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
@@ -297,7 +297,7 @@ Modern.js 建议必须有根 layout 和根 loading。
 可以通过创建 [`data loader`](/guides/basic-features/data-fetch) 文件做路由的重定向，如有文件 `routes/user/page.tsx`，想对这个文件对应的路由做重定向，可以创建 `routes/user/page.loader.ts` 文件：
 
 ```ts title="routes/user/page.loader.ts"
-import { redirect } from "@edenx/runtime/router"
+import { redirect } from "@modern-js/runtime/router"
 
 export default () => {
   const user = await getUser();


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
The packet introduced by the document route redirection route should be @ modem js/runtime/router instead of @ edenx/runtime/router
## Related Issue

<!--- Provide link of related issues -->
https://modernjs.dev/guides/basic-features/routes.html#%E8%B7%AF%E7%94%B1%E9%87%8D%E5%AE%9A%E5%90%91
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [x] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
