### PR TITLE
feat(module-tools): enable isolatedModules

### DIFF
--- a/.changeset/unlucky-steaks-notice.md
+++ b/.changeset/unlucky-steaks-notice.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-generator': patch
+---
+
+feat: enable isolatedModules
+feat: 开启isolatedModules

--- a/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
@@ -4,7 +4,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "isolatedModules": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description
Setting the isolatedModules flag tells TypeScript to warn you if you write certain code that can’t be correctly interpreted by a single-file transpilation process.

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
