### PR TITLE
fix: referenceCssAssets should not include publicPath in bundle

### DIFF
--- a/.changeset/blue-feet-fold.md
+++ b/.changeset/blue-feet-fold.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: referenceCssAssets should not include publicPath in bundle
+fix: referenceCssAssets 不应该包含 publicPath 字段在 bundle 中

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -103,7 +103,10 @@ export class RouterPlugin {
           const injectedContent = `
             ;(function(){
               window.${ROUTE_MANIFEST} = ${JSON.stringify(manifest, (k, v) => {
-            if (k === 'assets' && Array.isArray(v)) {
+            if (
+              (k === 'assets' || k === 'referenceCssAssets') &&
+              Array.isArray(v)
+            ) {
               // should hide publicPath in browser
               return v.map(item => {
                 return item.replace(publicPath, '');


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
