### PR TITLE
fix(swc): can not find object_destructuring_empty.mjs

### DIFF
--- a/.changeset/clean-jokes-dream.md
+++ b/.changeset/clean-jokes-dream.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc-base': patch
+---
+
+fix(swc): can not find object_destructuring_empty.mjs
+
+fix(swc): 修复找不到 object_destructuring_empty.mjs 的问题

--- a/packages/builder/plugin-swc-base/package.json
+++ b/packages/builder/plugin-swc-base/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-typescript": "^7.17.12",
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@swc/helpers": "0.4.12",
+    "@swc/helpers": "0.4.14",
     "core-js": "^3.26.0"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
       '@modern-js/builder-webpack-provider': workspace:*
       '@modern-js/utils': workspace:*
       '@scripts/vitest-config': workspace:*
-      '@swc/helpers': 0.4.12
+      '@swc/helpers': 0.4.14
       '@types/babel__core': ^7.1.20
       core-js: ^3.26.0
       magic-string: ^0.26.2
@@ -371,7 +371,7 @@ importers:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.5
       '@modern-js/builder-shared': link:../builder-shared
       '@modern-js/utils': link:../../toolkit/utils
-      '@swc/helpers': 0.4.12
+      '@swc/helpers': 0.4.14
       core-js: 3.26.0
     devDependencies:
       '@modern-js/builder-webpack-provider': link:../builder-webpack-provider
@@ -14456,14 +14456,14 @@ packages:
       '@swc/core-win32-ia32-msvc': 1.3.42
       '@swc/core-win32-x64-msvc': 1.3.42
 
-  /@swc/helpers/0.4.12:
-    resolution: {integrity: sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==}
+  /@swc/helpers/0.4.13:
+    resolution: {integrity: sha512-WOoZMSqpmUgL72xOeaWcU9IG7C6t5Wh1e8NGpSyBvmN5BSCXleK4/PLS6Oko1i/Lvn/yGYOv62bxlfsDvmRurg==}
     dependencies:
       tslib: 2.4.0
     dev: false
 
-  /@swc/helpers/0.4.13:
-    resolution: {integrity: sha512-WOoZMSqpmUgL72xOeaWcU9IG7C6t5Wh1e8NGpSyBvmN5BSCXleK4/PLS6Oko1i/Lvn/yGYOv62bxlfsDvmRurg==}
+  /@swc/helpers/0.4.14:
+    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
     dependencies:
       tslib: 2.4.0
     dev: false
@@ -16040,8 +16040,10 @@ packages:
       ajv: 6.12.6
     dev: false
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -33790,7 +33792,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scmp/2.1.0:


### PR DESCRIPTION
## Description

The `@swc/heplers` version is lower than SWC version, and some helpers can not be found.

```bash
Module not found: Can't resolve '/node_modules/.pnpm/@swc+helpers@0.4.12/node_modules/@swc/helpers/src/_object_destructuring_empty.mjs' in 'xxx'
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
