### PR TITLE
chore(CI): disable codecov patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 coverage:
   branch: main
   status:
+    patch: off
     project:
       default:
         target: 55%


### PR DESCRIPTION
## Description

Disable the codecov patch check because it is always inaccurate.

For example, #3324 only updated a dependency, but the `codecov/patch` is failed and we get some irrelavant annotations.

![image](https://user-images.githubusercontent.com/7237365/229402661-ace25769-5632-4717-a2e8-9426043c665d.png)

![image](https://user-images.githubusercontent.com/7237365/229402806-7dd07162-b44e-421a-b6bb-5fea60c8330d.png)

https://docs.codecov.com/docs/commit-status#disabling-a-status

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
