### PR TITLE
fix(plugin-module-babel): add right export name

### DIFF
--- a/.changeset/khaki-cooks-act.md
+++ b/.changeset/khaki-cooks-act.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-babel': patch
+---
+
+fix(plugin-module-babel): export right name
+fix(plugin-module-babel): 导出正确的模块名称

--- a/packages/cli/plugin-module-babel/src/index.ts
+++ b/packages/cli/plugin-module-babel/src/index.ts
@@ -5,6 +5,7 @@ export type Options = typeof babelPlugin extends (arg1: infer P) => void
   ? P
   : never;
 
+// deprecated export name
 export const ModulePluginBabel = (
   options?: Options,
 ): CliPlugin<ModuleTools> => ({
@@ -16,3 +17,6 @@ export const ModulePluginBabel = (
     },
   }),
 });
+
+// right export name
+export { ModulePluginBabel as modulePluginBabel };


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

add right export name for `@modern-js/plugin-module-babel`

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
