### PR TITLE
fix(app-tools): failed to restart CLI

### DIFF
--- a/.changeset/big-dots-worry.md
+++ b/.changeset/big-dots-worry.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/utils': patch
+---
+
+fix(app-tools): failed to restart CLI
+
+fix(app-tools): 修复 CLI 重启失败的问题

--- a/packages/solutions/app-tools/src/utils/restart.ts
+++ b/packages/solutions/app-tools/src/utils/restart.ts
@@ -2,7 +2,7 @@ import { cli, ToRunners } from '@modern-js/core';
 import {
   chalk,
   clearConsole,
-  getArgv,
+  getFullArgv,
   logger,
   program,
 } from '@modern-js/utils';
@@ -26,7 +26,7 @@ export async function restart(
     hasGetError = true;
   } finally {
     if (!hasGetError) {
-      program.parse(getArgv());
+      program.parse(getFullArgv());
     }
   }
 }

--- a/packages/toolkit/utils/src/commands.ts
+++ b/packages/toolkit/utils/src/commands.ts
@@ -1,5 +1,9 @@
+export const getFullArgv = () => {
+  return process.env.MODERN_ARGV?.split(' ') || process.argv;
+};
+
 export const getArgv = () => {
-  return (process.env.MODERN_ARGV?.split(' ') || process.argv).slice(2);
+  return getFullArgv().slice(2);
 };
 
 export const getCommand = () => {


### PR DESCRIPTION
## Description

Fix failed to restart CLI, because `program.parse` should accept a full argv array.

## Related PR

https://github.com/web-infra-dev/modern.js/pull/3295

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
