### PR TITLE
fix: plugin config hook can not get bundlerType,

### DIFF
--- a/.changeset/funny-lizards-cover.md
+++ b/.changeset/funny-lizards-cover.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/app-tools': patch
+'@modern-js/core': patch
+---
+
+fix: plugin config hook can not get bundlerType, so we can't set babelConfig correctly in ssr plugin
+fix: 插件的 config 钩子不能获得 bundlerType，所以我们在 ssr 插件不能正确的设置 babelConfig

--- a/packages/cli/core/src/types/context.ts
+++ b/packages/cli/core/src/types/context.ts
@@ -38,4 +38,5 @@ export interface IAppContext {
   internalDirAlias: string;
   internalSrcAlias: string;
   builder?: BuilderInstance;
+  bundlerType?: 'webpack' | 'rspack' | 'esbuild';
 }

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -54,8 +54,7 @@ export default (): CliPlugin<AppTools> => ({
           'plugins',
         );
 
-        const { builder } = api.useAppContext();
-        const bundlerType = builder?.context.bundlerType || 'webpack';
+        const { bundlerType = 'webpack' } = api.useAppContext();
         const babelConfig =
           bundlerType === 'webpack'
             ? (config: any) => {

--- a/packages/solutions/app-tools/src/initialize/index.ts
+++ b/packages/solutions/app-tools/src/initialize/index.ts
@@ -26,10 +26,25 @@ export default ({
 }): CliPlugin<AppTools<'shared'>> => ({
   name: '@modern-js/plugin-initialize',
 
+  post: [
+    '@modern-js/plugin-ssr',
+    '@modern-js/plugin-document',
+    '@modern-js/plugin-state',
+    '@modern-js/plugin-router',
+    '@modern-js/plugin-router-v5',
+    '@modern-js/plugin-polyfill',
+  ],
+
   setup(api) {
     const config = () => {
       const appContext = api.useAppContext();
       const userConfig = api.useConfigContext();
+
+      // set bundlerType to appContext
+      api.setAppContext({
+        ...appContext,
+        bundlerType: bundler,
+      });
 
       return checkIsLegacyConfig(userConfig)
         ? (createLegacyDefaultConfig(appContext) as unknown as AppUserConfig)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Plugin config hook can not get bundler type,so we can not set babelConfig correctly in ssr plugin.

1. Set bundler type in `initial plugin`
2. Ensure initial plugin run before ssr plugin.

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
