### PR TITLE
fix(doc-core): search broken when search keyword is null

### DIFF
--- a/.changeset/spotty-monkeys-impress.md
+++ b/.changeset/spotty-monkeys-impress.md
@@ -3,3 +3,5 @@
 ---
 
 fix: search broken when search keyword is null
+
+fix: 搜索关键字为空时搜索过程卡住

--- a/.changeset/spotty-monkeys-impress.md
+++ b/.changeset/spotty-monkeys-impress.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: search broken when search keyword is null

--- a/packages/cli/doc-core/src/theme-default/components/Search/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Search/index.tsx
@@ -143,8 +143,10 @@ export function Search() {
   const onQueryChanged = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const newQuery = e.target.value;
     setQuery(newQuery);
-    const matched = await pageSearcherRef.current?.match(newQuery);
-    setSearchResult(matched || { current: [], others: [] });
+    if (newQuery) {
+      const matched = await pageSearcherRef.current?.match(newQuery);
+      setSearchResult(matched || { current: [], others: [] });
+    }
   };
 
   const normalizeSuggestions = (suggestions: MatchResultItem[]) =>
@@ -171,7 +173,7 @@ export function Search() {
       const indexItem = normalizeSearchIndexes(
         searchOptions.searchIndexes || [],
       ).find(indexInfo => indexInfo.value === item.index);
-      return indexItem!.label;
+      return indexItem.label;
     }) as string[];
 
     return (


### PR DESCRIPTION
## Description

搜索关键字为空时，跳过搜索过程

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
