### PR TITLE
fix(builder): `HtmlTagsPlugin` failed to join public path with absolute url

### DIFF
--- a/.changeset/five-weeks-approve.md
+++ b/.changeset/five-weeks-approve.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): `HtmlTagsPlugin` failed to join public path with absolute url
+fix(builder): `HtmlTagsPlugin` 为绝对路径拼接 public path 会导致格式错误

--- a/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
@@ -1,13 +1,12 @@
+import _ from '@modern-js/utils/lodash';
+import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type { Compiler } from 'webpack';
+import { URL } from 'url';
 import {
   HtmlInjectTag,
   HtmlInjectTagDescriptor,
   HtmlInjectTagUtils,
 } from '../types';
-import _ from '@modern-js/utils/lodash';
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import path from 'path';
-import type { Compiler } from 'webpack';
-import { isURL } from '../utils';
 
 export interface HtmlTagsPluginOptions {
   hash?: HtmlInjectTag['hash'];
@@ -63,10 +62,20 @@ export const FILE_ATTRS = {
 };
 
 const withPublicPath = (str: string, base: string) => {
-  if (isURL(str)) {
+  // The use of an absolute URL without a protocol is technically legal,
+  // however it cannot be parsed as a URL instance.
+  // Just return it.
+  if (str.startsWith('//')) {
     return str;
   }
-  return path.posix.join(base, str);
+  try {
+    // Only absolute url can be parsed into URL instance.
+    return new URL(str).toString();
+  } catch {
+    // Or it should be a relative path.
+    // Let's join the publicPath.
+    return new URL(str, base).toString();
+  }
 };
 
 const withHash = (url: string, hash: string) => `${url}?${hash}`;

--- a/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
@@ -7,6 +7,7 @@ import {
   HtmlInjectTagDescriptor,
   HtmlInjectTagUtils,
 } from '../types';
+import path from 'path';
 
 export interface HtmlTagsPluginOptions {
   hash?: HtmlInjectTag['hash'];
@@ -61,20 +62,34 @@ export const FILE_ATTRS = {
   script: 'src',
 };
 
-const withPublicPath = (str: string, base: string) => {
+export const withPublicPath = (str: string, base: string) => {
   // The use of an absolute URL without a protocol is technically legal,
   // however it cannot be parsed as a URL instance.
   // Just return it.
+  // e.g. str is //example.com/foo.js
   if (str.startsWith('//')) {
     return str;
   }
+
+  // Only absolute url can be parsed into URL instance.
+  // e.g. str is https://example.com/foo.js
   try {
-    // Only absolute url can be parsed into URL instance.
     return new URL(str).toString();
+  } catch {}
+
+  // Or it should be a relative path.
+  // Let's join the publicPath.
+  // e.g. str is ./foo.js
+  try {
+    // `base` is a url with hostname & protocol.
+    // e.g. base is https://example.com/static
+    const url = new URL(base);
+    url.pathname = path.posix.resolve(url.pathname, str);
+    return url.toString();
   } catch {
-    // Or it should be a relative path.
-    // Let's join the publicPath.
-    return new URL(str, base).toString();
+    // without hostname & protocol.
+    // e.g. base is /
+    return path.posix.resolve(base, str);
   }
 };
 

--- a/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
@@ -71,7 +71,7 @@ export const withPublicPath = (str: string, base: string) => {
     return str;
   }
 
-  // Only absolute url can be parsed into URL instance.
+  // Only absolute url with hostname & protocol can be parsed into URL instance.
   // e.g. str is https://example.com/foo.js
   try {
     return new URL(str).toString();

--- a/packages/builder/builder-shared/tests/plugins/HtmlTagsPlugin.test.ts
+++ b/packages/builder/builder-shared/tests/plugins/HtmlTagsPlugin.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { withPublicPath } from '@/plugins/HtmlTagsPlugin';
+
+const PUBLIC_PATH = 'https://www.example.com/static';
+
+describe('withPublicPath', () => {
+  it('should handle relative url', () => {
+    expect(withPublicPath('foo/bar.js', PUBLIC_PATH)).toBe(
+      'https://www.example.com/static/foo/bar.js',
+    );
+    expect(withPublicPath('foo/bar.js', '/')).toBe('/foo/bar.js');
+    expect(withPublicPath('./foo/bar.js', PUBLIC_PATH)).toBe(
+      'https://www.example.com/static/foo/bar.js',
+    );
+    expect(withPublicPath('./foo/bar.js', '/')).toBe('/foo/bar.js');
+  });
+
+  it('should handle absolute url', () => {
+    expect(withPublicPath('/foo/bar.js', PUBLIC_PATH)).toBe(
+      'https://www.example.com/foo/bar.js',
+    );
+    expect(withPublicPath('/foo/bar.js', '/')).toBe('/foo/bar.js');
+  });
+
+  it('should handle absolute url with hostname & protocol', () => {
+    expect(withPublicPath('http://foo.com/bar.js', PUBLIC_PATH)).toBe(
+      'http://foo.com/bar.js',
+    );
+    expect(withPublicPath('http://foo.com/bar.js', '/')).toBe(
+      'http://foo.com/bar.js',
+    );
+  });
+
+  it('should handle absolute url with double slash', () => {
+    expect(withPublicPath('//foo.com/bar.js', PUBLIC_PATH)).toBe(
+      '//foo.com/bar.js',
+    );
+    expect(withPublicPath('//foo.com/bar.js', '/')).toBe('//foo.com/bar.js');
+  });
+});

--- a/packages/builder/builder-shared/tests/tsconfig.json
+++ b/packages/builder/builder-shared/tests/tsconfig.json
@@ -6,6 +6,9 @@
     "jsx": "preserve",
     "baseUrl": "./",
     "isolatedModules": true,
-    "paths": {}
-  },
+    "paths": {
+      "@/*": ["../src/*"],
+      "~/*": ["../*"]
+    }
+  }
 }

--- a/packages/builder/builder-shared/vitest.config.ts
+++ b/packages/builder/builder-shared/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 import { withTestPreset } from '@scripts/vitest-config';
 
@@ -6,6 +7,12 @@ const config = defineConfig({
     root: __dirname,
     environment: 'node',
   },
+  resolve: {
+    alias: {
+      '~': path.resolve(__dirname),
+      '@': path.resolve(__dirname, 'src'),
+    }
+  }
 });
 
 export default withTestPreset(config);


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
