### PR TITLE
feat(builder): support using RegExp to inline part of chunks

### DIFF
--- a/.changeset/few-mails-dress.md
+++ b/.changeset/few-mails-dress.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-doc': patch
+'@modern-js/builder': patch
+---
+
+feat(builder): support using RegExp to inline part of chunks
+
+feat(builder): 支持通过正则来内联部分资源

--- a/packages/builder/builder-shared/src/schema/output.ts
+++ b/packages/builder/builder-shared/src/schema/output.ts
@@ -99,8 +99,8 @@ export const sharedOutputConfigSchema = z.partialObj({
   enableAssetFallback: z.boolean(),
   enableLatestDecorators: z.boolean(),
   enableCssModuleTSDeclaration: z.boolean(),
-  enableInlineScripts: z.boolean(),
-  enableInlineStyles: z.boolean(),
+  enableInlineScripts: z.union([z.boolean(), z.instanceof(RegExp)]),
+  enableInlineStyles: z.union([z.boolean(), z.instanceof(RegExp)]),
   overrideBrowserslist: z.union([
     z.array(z.string()),
     z.record(BuilderTargetSchema, z.array(z.string())),

--- a/packages/builder/builder-shared/src/types/config/output.ts
+++ b/packages/builder/builder-shared/src/types/config/output.ts
@@ -219,11 +219,11 @@ export interface SharedOutputConfig {
   /**
    * Whether to inline output scripts files (.js files) into HTML with `<script>` tags.
    */
-  enableInlineScripts?: boolean;
+  enableInlineScripts?: boolean | RegExp;
   /**
    * Whether to inline output style files (.css files) into html with `<style>` tags.
    */
-  enableInlineStyles?: boolean;
+  enableInlineStyles?: boolean | RegExp;
   /**
    * Specifies the range of target browsers that the project is compatible with.
    * This value will be used by [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env) and
@@ -254,7 +254,7 @@ export interface NormalizedSharedOutputConfig extends SharedOutputConfig {
   enableAssetFallback: boolean;
   enableLatestDecorators: boolean;
   enableCssModuleTSDeclaration: boolean;
-  enableInlineScripts: boolean;
-  enableInlineStyles: boolean;
+  enableInlineScripts: boolean | RegExp;
+  enableInlineStyles: boolean | RegExp;
   svgDefaultExport: SvgDefaultExport;
 }

--- a/packages/builder/builder/src/plugins/inlineChunk.ts
+++ b/packages/builder/builder/src/plugins/inlineChunk.ts
@@ -28,17 +28,32 @@ export const builderPluginInlineChunk = (): DefaultBuilderPlugin => ({
           enableInlineScripts,
         } = config.output;
 
+        const tests: RegExp[] = [];
+
+        if (enableInlineScripts) {
+          tests.push(
+            enableInlineScripts === true ? /\.js$/ : enableInlineScripts,
+          );
+        }
+
+        if (enableInlineStyles) {
+          tests.push(
+            enableInlineStyles === true ? /\.css$/ : enableInlineStyles,
+          );
+        }
+
+        if (!disableInlineRuntimeChunk) {
+          tests.push(
+            // RegExp like /builder-runtime([.].+)?\.js$/
+            // matches builder-runtime.js and builder-runtime.123456.js
+            new RegExp(`${RUNTIME_CHUNK_NAME}([.].+)?\\.js$`),
+          );
+        }
+
         chain.plugin(CHAIN_ID.PLUGIN.INLINE_HTML).use(InlineChunkHtmlPlugin, [
           HtmlPlugin,
           {
-            tests: [
-              enableInlineScripts && /\.js$/,
-              enableInlineStyles && /\.css$/,
-              !disableInlineRuntimeChunk &&
-                // RegExp like /builder-runtime([.].+)?\.js$/
-                // matches builder-runtime.js and builder-runtime.123456.js
-                new RegExp(`${RUNTIME_CHUNK_NAME}([.].+)?\\.js$`),
-            ].filter(Boolean) as RegExp[],
+            tests,
             distPath: pick(config.output.distPath, ['js', 'css']),
           },
         ]);

--- a/packages/document/builder-doc/docs/en/config/output/enableInlineScripts.md
+++ b/packages/document/builder-doc/docs/en/config/output/enableInlineScripts.md
@@ -48,3 +48,21 @@ And `dist/static/js/main.js` will be inlined in `index.html`:
   </body>
 </html>
 ```
+
+### Using RegExp
+
+If you need to inline part of the JS files, you can set `enableInlineScripts` to a regular expression that matches the URL of the JS file that needs to be inlined.
+
+For example, to inline `main.js` into HTML, you can add the following configuration:
+
+```js
+export default {
+  output: {
+    enableInlineScripts: /\/main\.\w+\.js$/,
+  },
+};
+```
+
+:::tip
+The production filename will contains a hash by default, such as `/main.18a568e5.js`.
+:::

--- a/packages/document/builder-doc/docs/en/config/output/enableInlineStyles.md
+++ b/packages/document/builder-doc/docs/en/config/output/enableInlineStyles.md
@@ -48,3 +48,21 @@ And `dist/static/css/style.css` will be inlined in `index.html`:
   <body></body>
 </html>
 ```
+
+### Using RegExp
+
+If you need to inline part of the CSS files, you can set `enableInlineStyles` to a regular expression that matches the URL of the CSS file that needs to be inlined.
+
+For example, to inline `main.css` into HTML, you can add the following configuration:
+
+```js
+export default {
+  output: {
+    enableInlineStyles: /\/main\.\w+\.css$/,
+  },
+};
+```
+
+:::tip
+The production filename will contains a hash by default, such as `/main.18a568e5.css`.
+:::

--- a/packages/document/builder-doc/docs/zh/config/output/enableInlineScripts.md
+++ b/packages/document/builder-doc/docs/zh/config/output/enableInlineScripts.md
@@ -1,4 +1,4 @@
-- **类型：** `boolean`
+- **类型：** `boolean | RegExp`
 - **默认值：** `false`
 - **打包工具：** `仅支持 webpack`
 
@@ -48,3 +48,21 @@ dist/static/css/style.css
   </body>
 </html>
 ```
+
+### 通过正则匹配
+
+当你需要内联产物中的一部分 JS 文件时，你可以将 `enableInlineScripts` 设置为一个正则表达式，匹配需要内联的 JS 文件的 URL。
+
+比如，将产物中的 `main.js` 内联到 HTML 中，你可以添加如下配置：
+
+```js
+export default {
+  output: {
+    enableInlineScripts: /\/main\.\w+\.js$/,
+  },
+};
+```
+
+:::tip
+生产环境的文件名中默认包含了一个 hash 值，比如 `/main.18a568e5.js`。
+:::

--- a/packages/document/builder-doc/docs/zh/config/output/enableInlineStyles.md
+++ b/packages/document/builder-doc/docs/zh/config/output/enableInlineStyles.md
@@ -1,4 +1,4 @@
-- **类型：** `boolean`
+- **类型：** `boolean | RegExp`
 - **默认值：** `false`
 
 用来控制生产环境中是否用 `<style>` 标签将产物中的 style 文件（.css 文件）inline 到 HTML 中。
@@ -48,3 +48,21 @@ dist/static/js/main.js
   <body></body>
 </html>
 ```
+
+### 通过正则匹配
+
+当你需要内联产物中的一部分 CSS 文件时，你可以将 `enableInlineStyles` 设置为一个正则表达式，匹配需要内联的 CSS 文件的 URL。
+
+比如，将产物中的 `main.css` 内联到 HTML 中，你可以添加如下配置：
+
+```js
+export default {
+  output: {
+    enableInlineStyles: /\/main\.\w+\.css$/,
+  },
+};
+```
+
+:::tip
+生产环境的文件名中默认包含了一个 hash 值，比如 `/main.18a568e5.css`。
+:::

--- a/tests/e2e/builder/cases/inline-chunk/build.test.ts
+++ b/tests/e2e/builder/cases/inline-chunk/build.test.ts
@@ -124,3 +124,60 @@ webpackOnlyTest('inline all scripts and emit all source maps', async () => {
     Object.keys(files).filter(fileName => fileName.endsWith('.js.map')).length,
   ).toEqual(5);
 });
+
+webpackOnlyTest('using RegExp to inline scripts', async () => {
+  const builder = await build(
+    {
+      cwd: __dirname,
+      entry: {
+        index: path.resolve(__dirname, './src/index.js'),
+      },
+    },
+    {
+      output: {
+        enableInlineScripts: /\/main\.\w+\.js$/,
+      },
+      tools: toolsConfig,
+    },
+    false,
+  );
+  const files = await builder.unwrapOutputJSON(false);
+
+  // no main.js in output
+  expect(
+    Object.keys(files).filter(
+      fileName => fileName.endsWith('.js') && fileName.includes('/main.'),
+    ).length,
+  ).toEqual(0);
+
+  // all source maps in output
+  expect(
+    Object.keys(files).filter(fileName => fileName.endsWith('.js.map')).length,
+  ).toEqual(4);
+});
+
+webpackOnlyTest('using RegExp to inline styles', async () => {
+  const builder = await build(
+    {
+      cwd: __dirname,
+      entry: {
+        index: path.resolve(__dirname, './src/index.js'),
+      },
+    },
+    {
+      output: {
+        enableInlineStyles: /\/main\.\w+\.css$/,
+      },
+      tools: toolsConfig,
+    },
+    false,
+  );
+  const files = await builder.unwrapOutputJSON(false);
+
+  // no main.css in output
+  expect(
+    Object.keys(files).filter(
+      fileName => fileName.endsWith('.css') && fileName.includes('/main.'),
+    ).length,
+  ).toEqual(0);
+});


### PR DESCRIPTION
## Description

Support using RegExp to inline part of chunks.

For example, only inline `main.js` into HTML:

```js
export default {
  output: {
    enableInlineScripts: /\/main\.\w+\.js$/,
  },
};
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
