### PR TITLE
fix(builder-plugin-swc): remove default env.mode

### DIFF
--- a/.changeset/tidy-squids-wash.md
+++ b/.changeset/tidy-squids-wash.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc-base': patch
+---
+
+fix(builder-plugin-swc): remove default env.mode
+
+fix(builder-plugin-swc): 删除 env.mod 的默认值

--- a/packages/builder/plugin-swc-base/src/apply.ts
+++ b/packages/builder/plugin-swc-base/src/apply.ts
@@ -193,7 +193,6 @@ export function getDefaultSwcConfig(): TransformConfig {
     sourceMaps: true,
     env: {
       targets: '> 0.01%, not dead, not op_mini all',
-      mode: 'usage',
     },
     exclude: [],
     inlineSourcesContent: true,

--- a/packages/builder/plugin-swc/tests/fixtures/compat/cjs-no-preserve-dyn-import/expected.js
+++ b/packages/builder/plugin-swc/tests/fixtures/compat/cjs-no-preserve-dyn-import/expected.js
@@ -1,7 +1,5 @@
 "use strict";
 var _interop_require_wildcard = require("<SWC_HELPER>/_/_interop_require_wildcard");
-require("<CORE_JS>/modules/es.promise.js");
-require("<CORE_JS>/modules/es.object.to-string.js");
 var a = require("foo");
 console.log(a);
 Promise.resolve().then(function() {

--- a/packages/builder/plugin-swc/tests/fixtures/compat/cjs-preserve-dyn-import/expected.js
+++ b/packages/builder/plugin-swc/tests/fixtures/compat/cjs-preserve-dyn-import/expected.js
@@ -1,6 +1,4 @@
 "use strict";
-require("<CORE_JS>/modules/es.promise.js");
-require("<CORE_JS>/modules/es.object.to-string.js");
 var a = require("foo");
 console.log(a);
 import("other");


### PR DESCRIPTION
## Description

Remove default `usage` option for presetEnv

<!--- Describe your changes -->

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
