### PR TITLE
feat: use `declarationDir` instead of `outDir`

### DIFF
--- a/.changeset/swift-rivers-hear.md
+++ b/.changeset/swift-rivers-hear.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+feat: use `declarationDir` instead of `outDir`
+feat: 使用 `declarationDir` 替换 `outDir`

--- a/packages/solutions/module-tools/src/types/dts.ts
+++ b/packages/solutions/module-tools/src/types/dts.ts
@@ -16,6 +16,7 @@ export interface ITsconfig {
         rootDir?: string;
         baseUrl?: string;
         declaration?: boolean;
+        declarationDir?: string;
         emitDeclarationOnly?: boolean;
         emitDecoratorMetadata?: boolean;
         isolatedModules?: boolean;

--- a/packages/solutions/module-tools/src/utils/dts.ts
+++ b/packages/solutions/module-tools/src/utils/dts.ts
@@ -44,7 +44,12 @@ export const generatorTsConfig = async (
       // Ensure that .d.ts files are created by tsc, but not .js files
       declaration: true,
       emitDeclarationOnly: true,
-      outDir: tempDistAbsOurDir,
+      // when `outDir` is './dist', `declarationDir` is `./types`
+      // tsc will emit:
+      // - ./dist/index.js
+      // - ./types/index.d.ts
+      // we only want to emit declarations
+      declarationDir: tempDistAbsOurDir,
     },
   };
 


### PR DESCRIPTION
## Summary

This pull request modifies some files to improve the generation and publishing of declaration files for the module-tools package. It adds the `declarationDir` option to the TypeScript compiler options instead of `outDir`.

## Details

## Related Issue

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
