### PR TITLE
feat: generator plugin support relative path

### DIFF
--- a/.changeset/chatty-ducks-heal.md
+++ b/.changeset/chatty-ducks-heal.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/generator-plugin': patch
+---
+
+feat: generator plugin support relative path
+
+feat: 生成器插件支持相对路径

--- a/packages/generator/generator-plugin/src/index.ts
+++ b/packages/generator/generator-plugin/src/index.ts
@@ -55,7 +55,11 @@ export class GeneratorPlugin {
     await Promise.all(
       plugins.map(async plugin => {
         let pkgJSON;
-        if (path.isAbsolute(plugin)) {
+        if (plugin.startsWith('file:')) {
+          pkgJSON = await fs.readJSON(
+            path.join(process.cwd(), plugin.slice(5), 'package.json'),
+          );
+        } else if (path.isAbsolute(plugin)) {
           pkgJSON = await fs.readJSON(path.join(plugin, 'package.json'));
         } else {
           const { name, version: pkgVersion } = getPackageInfo(plugin);

--- a/packages/generator/generator-plugin/src/utils/index.ts
+++ b/packages/generator/generator-plugin/src/utils/index.ts
@@ -7,22 +7,28 @@ export { getPackageMeta } from './getPackageMeta';
 export async function installPlugins(plugins: string[], registryUrl?: string) {
   return Promise.all(
     plugins.map(async plugin => {
-      if (path.isAbsolute(plugin)) {
-        return {
-          templatePath: plugin,
-          module: requireModule(plugin),
-        };
-      } else {
-        const { name, version } = getPackageInfo(plugin);
-        const pluginPath = await downloadPackage(name, version, {
-          registryUrl,
-          install: true,
-        });
+      if (plugin.startsWith('file:')) {
+        const pluginPath = path.join(process.cwd(), plugin.slice(5));
         return {
           templatePath: pluginPath,
           module: requireModule(pluginPath),
         };
       }
+      if (path.isAbsolute(plugin)) {
+        return {
+          templatePath: plugin,
+          module: requireModule(plugin),
+        };
+      }
+      const { name, version } = getPackageInfo(plugin);
+      const pluginPath = await downloadPackage(name, version, {
+        registryUrl,
+        install: true,
+      });
+      return {
+        templatePath: pluginPath,
+        module: requireModule(pluginPath),
+      };
     }),
   );
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0832ec</samp>

This pull request adds support for local plugins in the `@modern-js/generator-plugin` package. It allows users to specify relative paths to local plugins in the `modern.config.js` file and load them without installing or downloading them.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0832ec</samp>

*  Add changeset file for `@modern-js/generator-plugin` package ([link](https://github.com/web-infra-dev/modern.js/pull/3423/files?diff=unified&w=0#diff-19afd13377f373c977e42e0b69dac5bb855cbe5390c27cb206b1e6ed178400e2R1-R7))
*  Enable relative paths for local plugins in `GeneratorPlugin` class ([link](https://github.com/web-infra-dev/modern.js/pull/3423/files?diff=unified&w=0#diff-2ce24445e82d9206eb3e124dbbc8841f578f9832292333c7877edaaf4c5db466L58-R62))
*  Skip downloading and installing local plugins in `installPlugins` function ([link](https://github.com/web-infra-dev/modern.js/pull/3423/files?diff=unified&w=0#diff-ec69bf28a64cae9d599b762b8d113ee3c411553d78133e56f4b56b9688a39f4dR10-R16))
*  Simplify logic by removing redundant `else` clause in `installPlugins` function ([link](https://github.com/web-infra-dev/modern.js/pull/3423/files?diff=unified&w=0#diff-ec69bf28a64cae9d599b762b8d113ee3c411553d78133e56f4b56b9688a39f4dL15-R31))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
