### PR TITLE
fix: export node-api to nodeApi

### DIFF
--- a/.changeset/young-eyes-suffer.md
+++ b/.changeset/young-eyes-suffer.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/core': patch
+---
+
+fix: use nodeApi instead node-api in @modern-js/core exports
+修复: 使用 nodeApi 代替 node-api 作为 @modern-js/core 的导出

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -25,9 +25,9 @@
       "default": "./dist/index.js"
     },
     "./node": {
-      "jsnext:source": "./src/node-api.ts",
-      "types": "./dist/node-api.d.ts",
-      "default": "./dist/node-api.js"
+      "jsnext:source": "./src/nodeApi.ts",
+      "types": "./dist/nodeApi.d.ts",
+      "default": "./dist/nodeApi.js"
     },
     "./bin": {
       "jsnext:source": "./src/bin.ts",


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87a270f</samp>

This pull request fixes the export name of the node API module in the `@modern-js/core` package to follow the camelCase convention. It also updates the `.changeset` file and the `package.json` file to reflect the name change and provide a fix message in English and Chinese.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87a270f</samp>

* Change export name of node API module from `node-api` to `nodeApi` to follow camelCase convention ([link](https://github.com/web-infra-dev/modern.js/pull/3426/files?diff=unified&w=0#diff-fa6ba679c32d34314139ff99ed42732d9a35ce9a3208728555d52929cb21749cR1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3426/files?diff=unified&w=0#diff-798858f913da3d6488150ae284b7aabc6d387db02c3db2d9953bcc119991860bL28-R30))
* Update `.changeset/young-eyes-suffer.md` file to include patch version bump and fix message for `@modern-js/core` package in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3426/files?diff=unified&w=0#diff-fa6ba679c32d34314139ff99ed42732d9a35ce9a3208728555d52929cb21749cR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
