### PR TITLE
fix(utils): the esm format files should be generate for the client

### DIFF
--- a/.changeset/chilled-dragons-wash.md
+++ b/.changeset/chilled-dragons-wash.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/server': patch
+'@modern-js/utils': patch
+---
+
+fix(utils): the esm format files should be generate for the client
+
+fix(utils): 应该为客户端使用，生成 esm 格式的文件

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -25,7 +25,14 @@
       },
       "default": "./dist/esm/index.js"
     },
-    "./hmr-client": "./dist/esm/dev-tools/dev-middleware/hmr-client/index.js"
+    "./hmr-client": {
+      "node": {
+        "jsnext:source": "./src/dev-tools/dev-middleware/hmr-client/index.ts",
+        "import": "./dist/esm/dev-tools/dev-middleware/hmr-client/index.js",
+        "require": "./dist/cjs/dev-tools/dev-middleware/hmr-client/index.js"
+      },
+      "default": "./dist/esm/dev-tools/dev-middleware/hmr-client/index.js"
+    }
   },
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -24,7 +24,8 @@
         "require": "./dist/cjs/index.js"
       },
       "default": "./dist/esm/index.js"
-    }
+    },
+    "./hmr-client": "./dist/esm/dev-tools/dev-middleware/hmr-client/index.js"
   },
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",

--- a/packages/server/server/src/dev-tools/dev-middleware/index.ts
+++ b/packages/server/server/src/dev-tools/dev-middleware/index.ts
@@ -23,7 +23,7 @@ function getHMRClientPath(client: DevServerOptions['client']) {
   const port = client?.port ? `&port=${client.port}` : '';
 
   const clientEntry = `${require.resolve(
-    './hmr-client',
+    '@modern-js/server/hmr-client',
   )}?${host}${path}${port}${protocol}`;
 
   return clientEntry;

--- a/packages/toolkit/utils/.npmignore
+++ b/packages/toolkit/utils/.npmignore
@@ -36,6 +36,7 @@ tests/
 
 **/*/api/typings/auto-generated
 src/
+compiled/
 
 modern.config.js
 modern.config.ts

--- a/packages/toolkit/utils/modern.config.js
+++ b/packages/toolkit/utils/modern.config.js
@@ -1,5 +1,34 @@
-export default {
-  buildConfig: {
-    buildType: 'bundleless',
-  },
+module.exports = {
+  buildConfig: [
+    {
+      buildType: 'bundleless',
+      format: 'cjs',
+      target: 'es2019',
+      dts: false,
+      outDir: './dist/cjs',
+      copy: {
+        patterns: [
+          {
+            from: './compiled',
+            context: __dirname,
+            to: '../compiled',
+          },
+        ],
+      },
+    },
+    {
+      buildType: 'bundleless',
+      format: 'esm',
+      target: 'es2019',
+      dts: false,
+      outDir: './dist/esm',
+    },
+    {
+      buildType: 'bundleless',
+      dts: {
+        only: true,
+      },
+      outDir: './dist/types',
+    },
+  ],
 };

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -20,23 +20,28 @@
   "exports": {
     ".": {
       "jsnext:source": "./src/index.ts",
-      "default": "./dist/index.js"
+      "import": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
     },
     "./ssr": {
       "jsnext:source": "./src/ssr.ts",
-      "default": "./dist/ssr.js"
+      "import": "./dist/esm/ssr.js",
+      "default": "./dist/cjs/ssr.js"
     },
     "./logger": {
       "jsnext:source": "./src/logger.ts",
-      "default": "./dist/logger.js"
+      "import": "./dist/esm/logger.js",
+      "default": "./dist/cjs/logger.js"
     },
     "./constants": {
       "jsnext:source": "./src/constants.ts",
-      "default": "./dist/constants.js"
+      "import": "./dist/esm/constants.js",
+      "default": "./dist/cjs/constants.js"
     },
     "./babel": {
       "jsnext:source": "./src/babel.ts",
-      "default": "./dist/babel.js"
+      "import": "./dist/esm/babel.js",
+      "default": "./dist/cjs/babel.js"
     },
     "./ajv": "./compiled/ajv/index.js",
     "./glob": "./compiled/glob/index.js",
@@ -58,27 +63,32 @@
     "./webpack-dev-middleware": "./compiled/webpack-dev-middleware/index.js",
     "./chain-id": {
       "jsnext:source": "./src/chainId.ts",
-      "default": "./dist/chainId.js"
+      "default": "./dist/cjs/chainId.js"
     },
     "./universal/constants": {
       "jsnext:source": "./src/universal/constants.ts",
-      "default": "./dist/universal/constants.js"
+      "import": "./dist/esm/universal/constants.js",
+      "default": "./dist/cjs/universal/constants.js"
     },
     "./universal/serialize": {
       "jsnext:source": "./src/universal/serialize.ts",
-      "default": "./dist/universal/serialize.js"
+      "import": "./dist/esm/universal/serialize.js",
+      "default": "./dist/cjs/universal/serialize.js"
     },
     "./universal/remix-router": {
       "jsnext:source": "./src/universal/remixRouter.ts",
-      "default": "./dist/universal/remixRouter.js"
+      "import": "./dist/esm/universal/remixRouter.js",
+      "default": "./dist/cjs/universal/remixRouter.js"
     },
     "./universal/format-webpack": {
       "jsnext:source": "./src/universal/formatWebpack.ts",
-      "default": "./dist/universal/formatWebpack.js"
+      "import": "./dist/esm/universal/formatWebpack.js",
+      "default": "./dist/cjs/universal/formatWebpack.js"
     },
     "./universal/nestedRoutes": {
       "jsnext:source": "./src/universal/nestedRoutes.tsx",
-      "default": "./dist/universal/nestedRoutes.js"
+      "import": "./dist/esm/universal/nestedRoutes.js",
+      "default": "./dist/cjs/universal/nestedRoutes.js"
     }
   },
   "publishConfig": {
@@ -86,12 +96,26 @@
     "access": "public",
     "types": "./dist/index.d.ts",
     "exports": {
-      ".": "./dist/index.js",
-      "./ssr": "./dist/ssr.js",
-      "./babel": "./dist/babel.js",
-      "./logger": "./dist/logger.js",
-      "./chain-id": "./dist/chainId.js",
-      "./constants": "./dist/constants.js",
+      ".": {
+        "import": "./dist/esm/index.js",
+        "default": "./dist/cjs/index.js"
+      },
+      "./ssr": {
+        "import": "./dist/esm/ssr.js",
+        "default": "./dist/cjs/ssr.js"
+      },
+      "./logger": {
+        "import": "./dist/esm/logger.js",
+        "default": "./dist/cjs/logger.js"
+      },
+      "./constants": {
+        "import": "./dist/esm/constants.js",
+        "default": "./dist/cjs/constants.js"
+      },
+      "./babel": {
+        "import": "./dist/esm/babel.js",
+        "default": "./dist/cjs/babel.js"
+      },
       "./ajv": "./compiled/ajv/index.js",
       "./glob": "./compiled/glob/index.js",
       "./chalk": "./compiled/chalk/index.js",
@@ -110,26 +134,44 @@
       "./tsconfig-paths": "./compiled/tsconfig-paths/index.js",
       "./better-ajv-errors": "./compiled/better-ajv-errors/index.js",
       "./webpack-dev-middleware": "./compiled/webpack-dev-middleware/index.js",
-      "./universal/constants": "./dist/universal/constants.js",
-      "./universal/serialize": "./dist/universal/serialize.js",
-      "./universal/remix-router": "./dist/universal/remixRouter.js",
-      "./universal/format-webpack": "./dist/universal/formatWebpack.js",
-      "./universal/nestedRoutes": "./dist/universal/nestedRoutes.js"
+      "./chain-id": {
+        "default": "./dist/cjs/chainId.js"
+      },
+      "./universal/constants": {
+        "import": "./dist/esm/universal/constants.js",
+        "default": "./dist/cjs/universal/constants.js"
+      },
+      "./universal/serialize": {
+        "import": "./dist/esm/universal/serialize.js",
+        "default": "./dist/cjs/universal/serialize.js"
+      },
+      "./universal/remix-router": {
+        "import": "./dist/esm/universal/remixRouter.js",
+        "default": "./dist/cjs/universal/remixRouter.js"
+      },
+      "./universal/format-webpack": {
+        "import": "./dist/esm/universal/formatWebpack.js",
+        "default": "./dist/cjs/universal/formatWebpack.js"
+      },
+      "./universal/nestedRoutes": {
+        "import": "./dist/esm/universal/nestedRoutes.js",
+        "default": "./dist/cjs/universal/nestedRoutes.js"
+      }
     }
   },
   "typesVersions": {
     "*": {
       "ssr": [
-        "./dist/ssr.d.ts"
+        "./dist/types/ssr.d.ts"
       ],
       "logger": [
-        "./dist/logger.d.ts"
+        "./dist/types/logger.d.ts"
       ],
       "constants": [
-        "./dist/constants.d.ts"
+        "./dist/types/constants.d.ts"
       ],
       "babel": [
-        "./dist/babel.d.ts"
+        "./dist/types/babel.d.ts"
       ],
       "ajv": [
         "./compiled/ajv/types/ajv.d.ts"
@@ -147,7 +189,7 @@
         "./compiled/json5/index.d.ts"
       ],
       "chain-id": [
-        "./dist/chainId.d.ts"
+        "./dist/types/chainId.d.ts"
       ],
       "semver": [
         "./compiled/semver/index.d.ts"
@@ -192,19 +234,19 @@
         "./compiled/webpack-dev-middleware/types/index.d.ts"
       ],
       "universal/constants": [
-        "./dist/universal/constants.d.ts"
+        "./dist/types/universal/constants.d.ts"
       ],
       "universal/serialize": [
-        "./dist/universal/serialize.d.ts"
+        "./dist/types/universal/serialize.d.ts"
       ],
       "universal/remix-router": [
-        "./dist/universal/remixRouter.d.ts"
+        "./dist/types/universal/remixRouter.d.ts"
       ],
       "universal/format-webpack": [
-        "./dist/universal/formatWebpack.d.ts"
+        "./dist/types/universal/formatWebpack.d.ts"
       ],
       "universal/nestedRoutes": [
-        "./dist/universal/nestedRoutes.d.ts"
+        "./dist/types/universal/nestedRoutes.d.ts"
       ]
     }
   },
@@ -219,7 +261,7 @@
     "caniuse-lite": "^1.0.30001451",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0",
-    "@remix-run/router": "^1.3.2"
+     "@remix-run/router": "^1.3.2"
   },
   "peerDependencies": {
     "react": ">=17.0.0",

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -98,63 +98,74 @@
     "exports": {
       ".": {
         "import": "./dist/esm/index.js",
+        "types": "./dist/types/index.d.ts",
         "default": "./dist/cjs/index.js"
       },
       "./ssr": {
         "import": "./dist/esm/ssr.js",
+        "types": "./dist/types/ssr.d.ts",
         "default": "./dist/cjs/ssr.js"
       },
       "./logger": {
         "import": "./dist/esm/logger.js",
+        "types": "./dist/types/logger.d.ts",
         "default": "./dist/cjs/logger.js"
       },
       "./constants": {
         "import": "./dist/esm/constants.js",
+        "types": "./dist/types/constants.d.ts",
         "default": "./dist/cjs/constants.js"
       },
       "./babel": {
         "import": "./dist/esm/babel.js",
+        "types": "./dist/types/babel.d.ts",
         "default": "./dist/cjs/babel.js"
       },
-      "./ajv": "./compiled/ajv/index.js",
-      "./glob": "./compiled/glob/index.js",
-      "./chalk": "./compiled/chalk/index.js",
-      "./json5": "./compiled/json5/index.js",
-      "./semver": "./compiled/semver/index.js",
-      "./lodash": "./compiled/lodash/index.js",
-      "./globby": "./compiled/globby/index.js",
-      "./fs-extra": "./compiled/fs-extra/index.js",
-      "./fast-glob": "./compiled/fast-glob/index.js",
-      "./gzip-size": "./compiled/gzip-size/index.js",
-      "./mime-types": "./compiled/mime-types/index.js",
-      "./strip-ansi": "./compiled/strip-ansi/index.js",
-      "./ajv-keywords": "./compiled/ajv-keywords/index.js",
-      "./browserslist": "./compiled/browserslist/index.js",
-      "./webpack-chain": "./compiled/webpack-chain/index.js",
-      "./tsconfig-paths": "./compiled/tsconfig-paths/index.js",
-      "./better-ajv-errors": "./compiled/better-ajv-errors/index.js",
-      "./webpack-dev-middleware": "./compiled/webpack-dev-middleware/index.js",
+      "./ajv": "./dist/compiled/ajv/index.js",
+      "./glob": "./dist/compiled/glob/index.js",
+      "./chalk": "./dist/compiled/chalk/index.js",
+      "./json5": "./dist/compiled/json5/index.js",
+      "./semver": "./dist/compiled/semver/index.js",
+      "./lodash": "./dist/compiled/lodash/index.js",
+      "./globby": "./dist/compiled/globby/index.js",
+      "./fs-extra": "./dist/compiled/fs-extra/index.js",
+      "./fast-glob": "./dist/compiled/fast-glob/index.js",
+      "./gzip-size": "./dist/compiled/gzip-size/index.js",
+      "./mime-types": "./dist/compiled/mime-types/index.js",
+      "./strip-ansi": "./dist/compiled/strip-ansi/index.js",
+      "./ajv-keywords": "./dist/compiled/ajv-keywords/index.js",
+      "./browserslist": "./dist/compiled/browserslist/index.js",
+      "./webpack-chain": "./dist/compiled/webpack-chain/index.js",
+      "./tsconfig-paths": "./dist/compiled/tsconfig-paths/index.js",
+      "./better-ajv-errors": "./dist/compiled/better-ajv-errors/index.js",
+      "./webpack-dev-middleware": "./dist/compiled/webpack-dev-middleware/index.js",
       "./chain-id": {
+        "types": "./dist/types/chainId.d.ts",
         "default": "./dist/cjs/chainId.js"
       },
       "./universal/constants": {
         "import": "./dist/esm/universal/constants.js",
+        "types": "./dist/types/universal/constants.d.ts",
         "default": "./dist/cjs/universal/constants.js"
       },
       "./universal/serialize": {
         "import": "./dist/esm/universal/serialize.js",
+        "types": "./dist/types/universal/serialize.d.ts",
         "default": "./dist/cjs/universal/serialize.js"
       },
       "./universal/remix-router": {
         "import": "./dist/esm/universal/remixRouter.js",
+        "types": "./dist/types/universal/remix-router.d.ts",
         "default": "./dist/cjs/universal/remixRouter.js"
       },
       "./universal/format-webpack": {
         "import": "./dist/esm/universal/formatWebpack.js",
+        "types": "./dist/types/universal/format-webpack.d.ts",
         "default": "./dist/cjs/universal/formatWebpack.js"
       },
       "./universal/nestedRoutes": {
         "import": "./dist/esm/universal/nestedRoutes.js",
+        "types": "./dist/types/universal/nestedRoutes.d.ts",
         "default": "./dist/cjs/universal/nestedRoutes.js"
       }
     }
@@ -174,64 +185,64 @@
         "./dist/types/babel.d.ts"
       ],
       "ajv": [
-        "./compiled/ajv/types/ajv.d.ts"
+        "./dist/compiled/ajv/types/ajv.d.ts"
       ],
       "ajv/json-schema": [
-        "./compiled/ajv/types/types/json-schema.d.ts"
+        "./dist/compiled/ajv/types/types/json-schema.d.ts"
       ],
       "glob": [
-        "./compiled/glob/index.d.ts"
+        "./dist/compiled/glob/index.d.ts"
       ],
       "chalk": [
-        "./compiled/chalk/index.d.ts"
+        "./dist/compiled/chalk/index.d.ts"
       ],
       "json5": [
-        "./compiled/json5/index.d.ts"
+        "./dist/compiled/json5/index.d.ts"
       ],
       "chain-id": [
         "./dist/types/chainId.d.ts"
       ],
       "semver": [
-        "./compiled/semver/index.d.ts"
+        "./dist/compiled/semver/index.d.ts"
       ],
       "lodash": [
-        "./compiled/lodash/index.d.ts"
+        "./dist/compiled/lodash/index.d.ts"
       ],
       "globby": [
-        "./compiled/globby/index.d.ts"
+        "./dist/compiled/globby/index.d.ts"
       ],
       "fs-extra": [
-        "./compiled/fs-extra/index.d.ts"
+        "./dist/compiled/fs-extra/index.d.ts"
       ],
       "fast-glob": [
-        "./compiled/fast-glob/index.d.ts"
+        "./dist/compiled/fast-glob/index.d.ts"
       ],
       "gzip-size": [
-        "./compiled/gzip-size/index.d.ts"
+        "./dist/compiled/gzip-size/index.d.ts"
       ],
       "mime-types": [
-        "./compiled/mime-types/index.d.ts"
+        "./dist/compiled/mime-types/index.d.ts"
       ],
       "strip-ansi": [
-        "./compiled/strip-ansi/index.d.ts"
+        "./dist/compiled/strip-ansi/index.d.ts"
       ],
       "ajv-keywords": [
-        "./compiled/ajv-keywords/index.d.ts"
+        "./dist/compiled/ajv-keywords/index.d.ts"
       ],
       "browserslist": [
-        "./compiled/browserslist/index.d.ts"
+        "./dist/compiled/browserslist/index.d.ts"
       ],
       "webpack-chain": [
-        "./compiled/webpack-chain/types/index.d.ts"
+        "./dist/compiled/webpack-chain/types/index.d.ts"
       ],
       "tsconfig-paths": [
-        "./compiled/tsconfig-paths/lib/index.d.ts"
+        "./dist/compiled/tsconfig-paths/lib/index.d.ts"
       ],
       "better-ajv-errors": [
-        "./compiled/better-ajv-errors/index.d.ts"
+        "./dist/compiled/better-ajv-errors/index.d.ts"
       ],
       "webpack-dev-middleware": [
-        "./compiled/webpack-dev-middleware/types/index.d.ts"
+        "./dist/compiled/webpack-dev-middleware/types/index.d.ts"
       ],
       "universal/constants": [
         "./dist/types/universal/constants.d.ts"

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -94,7 +94,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/index.d.ts",
+    "types": "./dist/types/index.d.ts",
     "exports": {
       ".": {
         "import": "./dist/esm/index.js",

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -261,7 +261,7 @@
     "caniuse-lite": "^1.0.30001451",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0",
-     "@remix-run/router": "^1.3.2"
+    "@remix-run/router": "^1.3.2"
   },
   "peerDependencies": {
     "react": ">=17.0.0",


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
On the client side, we need to use the code in esm format.
### <samp>🤖 Generated by Copilot at 1bb1196</samp>

This pull request improves the build and export configuration of the `@modern-js/utils` and `@modern-js/server` packages to support different module formats and TypeScript types.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1bb1196</samp>

*  Add a changeset file to generate changelogs and version updates for the affected packages ([link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-23c4a84549cfa0f630c779d9777044d45a4f28f9a15f4bd3f00f18ca1d299de6R1-R8))
*  Add a new export entry for the `hmr-client` module in the `@modern-js/server` package, which enables hot module replacement for the client-side code ([link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-4e5229a5eda5177170934d4faa8f34e6413ab98d6652b8173bbc236a97251b31L27-R28))
*  Update the `getHMRClientPath` function in the `@modern-js/server` package to use the new export entry for the `hmr-client` module instead of the relative path ([link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-41827dd1b71ffd0db31f0208e70b641560a52d8fdbcd7a80d431aa44d802ea91L26-R26))
*  Update the `modern.config.js` file in the `@modern-js/utils` package to use an array of build configurations for different output formats and targets, and to copy the `compiled` folder from the source to the output directory ([link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-996a62832a3c6c0414c444d29befd9665393f063b528e6005e8f15cf9c4576eaL1-R33))
*  Update the export map entries, the `exports` property, and the `typesVersions` property in the `package.json` file of the `@modern-js/utils` package to point to the appropriate format and type declaration files in the `dist` subfolders, and to fix a JSON syntax error ([link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L23-R44), [link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L61-R91), [link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L89-R118), [link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L113-R159), [link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L123-R174), [link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L150-R192), [link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L195-R249), [link](https://github.com/web-infra-dev/modern.js/pull/3427/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L222-R264))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
