### PR TITLE
fix: nodeApi type export in modern-js/core

### DIFF
--- a/.changeset/large-birds-play.md
+++ b/.changeset/large-birds-play.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/core': patch
+---
+
+fix: nodeApi type export in modern-js/core
+
+fix: 修复 nodeApi 在 modern-js/core 中的类型导出

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -57,7 +57,7 @@
         "./dist/types/index.d.ts"
       ],
       "node": [
-        "./dist/node-api.d.ts"
+        "./dist/nodeApi.d.ts"
       ],
       "runBin": [
         "./dist/runBin.d.ts"


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7069eb3</samp>

This pull request fixes the nodeApi type export in the `@modern-js/core` package and adds a changeset file to document the patch update. The fix resolves a type mismatch issue that affected TypeScript and other tools.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7069eb3</samp>

*  Fix nodeApi type export in `@modern-js/core` package ([link](https://github.com/web-infra-dev/modern.js/pull/3430/files?diff=unified&w=0#diff-798858f913da3d6488150ae284b7aabc6d387db02c3db2d9953bcc119991860bL60-R60), [link](https://github.com/web-infra-dev/modern.js/pull/3430/files?diff=unified&w=0#diff-4a1e522e27b5e125ecc43c0346cfecde78a7494d83b5a128255a227a6f74a79fR1-R7))
  - Rename `node-api.d.ts` to `nodeApi.d.ts` in `package.json` to match actual file name in `dist` folder ([link](https://github.com/web-infra-dev/modern.js/pull/3430/files?diff=unified&w=0#diff-798858f913da3d6488150ae284b7aabc6d387db02c3db2d9953bcc119991860bL60-R60))
  - Add changeset file to document patch update and explain the fix in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3430/files?diff=unified&w=0#diff-4a1e522e27b5e125ecc43c0346cfecde78a7494d83b5a128255a227a6f74a79fR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
