### PR TITLE
feat(builder): add assetsRetry.inlineScript config

### DIFF
--- a/.changeset/tidy-pumas-train.md
+++ b/.changeset/tidy-pumas-train.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-doc': patch
+'@modern-js/builder': patch
+---
+
+feat(builder): add assetsRetry.inlineScript config
+
+feat(builder): 新增 assetsRetry.inlineScript 配置项

--- a/packages/builder/builder-shared/src/plugins/AssetsRetryPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/AssetsRetryPlugin.ts
@@ -1,51 +1,127 @@
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import fs from 'fs/promises';
+import { fs } from '@modern-js/utils';
+// @ts-expect-error
+import { RawSource } from 'webpack-sources';
 import { getSharedPkgCompiledPath } from '../utils';
-import type { WebpackPluginInstance, Compiler } from 'webpack';
+import { COMPILATION_PROCESS_STAGE } from './util';
+import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type { WebpackPluginInstance, Compiler, Compilation } from 'webpack';
 import type { AssetsRetryOptions } from '../types';
+import path from 'path';
+import { withPublicPath } from '../url';
 
 export class AssetsRetryPlugin implements WebpackPluginInstance {
   readonly name: string;
 
-  HtmlPlugin: typeof HtmlWebpackPlugin;
+  readonly distDir: string;
 
-  #retryOptions: AssetsRetryOptions;
+  readonly inlineScript: boolean;
+
+  readonly HtmlPlugin: typeof HtmlWebpackPlugin;
+
+  readonly #retryOptions: AssetsRetryOptions;
+
+  scriptPath: string;
 
   constructor(
     options: AssetsRetryOptions & {
+      distDir: string;
       HtmlPlugin: typeof HtmlWebpackPlugin;
     },
   ) {
-    const { HtmlPlugin, ...retryOptions } = options;
+    const {
+      distDir,
+      HtmlPlugin,
+      inlineScript = true,
+      ...retryOptions
+    } = options;
     this.name = 'AssetsRetryPlugin';
     this.#retryOptions = retryOptions;
+    this.distDir = distDir;
     this.HtmlPlugin = HtmlPlugin;
+    this.inlineScript = inlineScript;
+    this.scriptPath = '';
+  }
+
+  async getRetryCode() {
+    const { default: serialize } = await import(
+      '../../compiled/serialize-javascript'
+    );
+    const runtimeFilePath = getSharedPkgCompiledPath('assetsRetry.js');
+    const runtimeCode = await fs.readFile(runtimeFilePath, 'utf-8');
+    // Runtime code will include `Object.defineProperty(exports,"__esModule",{value:!0})` after compiled by tsc
+    // So we inject `var exports={}` to avoid `exports is not defined` error
+    return `var exports={};${runtimeCode}init(${serialize(
+      this.#retryOptions,
+    )})`;
+  }
+
+  async getScriptPath() {
+    if (!this.scriptPath) {
+      const pkgJson = await fs.readJSON(
+        path.join(__dirname, '../../package.json'),
+      );
+      const version = pkgJson.version.replace(/\./g, '_');
+      this.scriptPath = path.join(this.distDir, `assets-retry.${version}.js`);
+    }
+
+    return this.scriptPath;
   }
 
   apply(compiler: Compiler): void {
+    if (!this.inlineScript) {
+      compiler.hooks.thisCompilation.tap(
+        this.name,
+        (compilation: Compilation) => {
+          compilation.hooks.processAssets.tapPromise(
+            {
+              name: this.name,
+              stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_PRE_PROCESS,
+            },
+            async assets => {
+              const scriptPath = await this.getScriptPath();
+              assets[scriptPath] = new RawSource(
+                await this.getRetryCode(),
+                false,
+              );
+            },
+          );
+        },
+      );
+    }
+
     compiler.hooks.compilation.tap(this.name, compilation => {
       this.HtmlPlugin.getHooks(compilation).afterTemplateExecution.tapPromise(
         this.name,
         async data => {
-          const { default: serialize } = await import(
-            '../../compiled/serialize-javascript'
-          );
-          const runtimeFilePath = getSharedPkgCompiledPath('assetsRetry.js');
-          const runtimeCode = await fs.readFile(runtimeFilePath, 'utf-8');
-
-          data.headTags.unshift({
+          const scriptTag = {
             tagName: 'script',
             attributes: {
               type: 'text/javascript',
             },
             voidTag: false,
-            // Runtime code will include `Object.defineProperty(exports,"__esModule",{value:!0})` after compiled by tsc
-            // So we inject `var exports={}` to avoid `exports is not defined` error
-            innerHTML: `var exports={};${runtimeCode}init(${serialize(
-              this.#retryOptions,
-            )})`,
             meta: {},
-          });
+          };
+
+          if (this.inlineScript) {
+            data.headTags.unshift({
+              ...scriptTag,
+              innerHTML: await this.getRetryCode(),
+            });
+          } else {
+            const publicPath =
+              typeof compiler.options.output.publicPath === 'string'
+                ? compiler.options.output.publicPath
+                : '/';
+            const url = withPublicPath(await this.getScriptPath(), publicPath);
+            data.headTags.unshift({
+              ...scriptTag,
+              attributes: {
+                ...scriptTag.attributes,
+                src: url,
+              },
+            });
+          }
+
           return data;
         },
       );

--- a/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlTagsPlugin.ts
@@ -1,13 +1,12 @@
 import _ from '@modern-js/utils/lodash';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { Compiler } from 'webpack';
-import { URL } from 'url';
+import { withPublicPath } from '../url';
 import {
   HtmlInjectTag,
   HtmlInjectTagDescriptor,
   HtmlInjectTagUtils,
 } from '../types';
-import path from 'path';
 
 export interface HtmlTagsPluginOptions {
   hash?: HtmlInjectTag['hash'];
@@ -60,37 +59,6 @@ export const HEAD_TAGS = [
 export const FILE_ATTRS = {
   link: 'href',
   script: 'src',
-};
-
-export const withPublicPath = (str: string, base: string) => {
-  // The use of an absolute URL without a protocol is technically legal,
-  // however it cannot be parsed as a URL instance.
-  // Just return it.
-  // e.g. str is //example.com/foo.js
-  if (str.startsWith('//')) {
-    return str;
-  }
-
-  // Only absolute url with hostname & protocol can be parsed into URL instance.
-  // e.g. str is https://example.com/foo.js
-  try {
-    return new URL(str).toString();
-  } catch {}
-
-  // Or it should be a relative path.
-  // Let's join the publicPath.
-  // e.g. str is ./foo.js
-  try {
-    // `base` is a url with hostname & protocol.
-    // e.g. base is https://example.com/static
-    const url = new URL(base);
-    url.pathname = path.posix.resolve(url.pathname, str);
-    return url.toString();
-  } catch {
-    // without hostname & protocol.
-    // e.g. base is /
-    return path.posix.resolve(base, str);
-  }
 };
 
 const withHash = (url: string, hash: string) => `${url}?${hash}`;

--- a/packages/builder/builder-shared/src/types/config/output.ts
+++ b/packages/builder/builder-shared/src/types/config/output.ts
@@ -64,6 +64,7 @@ export type AssetsRetryOptions = {
   test?: string | ((url: string) => boolean);
   domain?: string[];
   crossOrigin?: boolean;
+  inlineScript?: boolean;
   onFail?: (options: AssetsRetryHookContext) => void;
   onRetry?: (options: AssetsRetryHookContext) => void;
   onSuccess?: (options: AssetsRetryHookContext) => void;

--- a/packages/builder/builder-shared/src/url.ts
+++ b/packages/builder/builder-shared/src/url.ts
@@ -1,0 +1,33 @@
+import { URL } from 'url';
+import path from 'path';
+
+export const withPublicPath = (str: string, base: string) => {
+  // The use of an absolute URL without a protocol is technically legal,
+  // however it cannot be parsed as a URL instance.
+  // Just return it.
+  // e.g. str is //example.com/foo.js
+  if (str.startsWith('//')) {
+    return str;
+  }
+
+  // Only absolute url with hostname & protocol can be parsed into URL instance.
+  // e.g. str is https://example.com/foo.js
+  try {
+    return new URL(str).toString();
+  } catch {}
+
+  // Or it should be a relative path.
+  // Let's join the publicPath.
+  // e.g. str is ./foo.js
+  try {
+    // `base` is a url with hostname & protocol.
+    // e.g. base is https://example.com/static
+    const url = new URL(base);
+    url.pathname = path.posix.resolve(url.pathname, str);
+    return url.toString();
+  } catch {
+    // without hostname & protocol.
+    // e.g. base is /
+    return path.posix.resolve(base, str);
+  }
+};

--- a/packages/builder/builder-shared/tests/url.test.ts
+++ b/packages/builder/builder-shared/tests/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { withPublicPath } from '@/plugins/HtmlTagsPlugin';
+import { withPublicPath } from '@/url';
 
 const PUBLIC_PATH = 'https://www.example.com/static';
 

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/assetsRetry.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/assetsRetry.test.ts.snap
@@ -5,7 +5,10 @@ exports[`plugins/assetsRetry > should add assets retry plugin 1`] = `
   "plugins": [
     AssetsRetryPlugin {
       "HtmlPlugin": [Function],
+      "distDir": "static/js",
+      "inlineScript": true,
       "name": "AssetsRetryPlugin",
+      "scriptPath": "",
     },
   ],
 }

--- a/packages/builder/builder/src/plugins/assetsRetry.ts
+++ b/packages/builder/builder/src/plugins/assetsRetry.ts
@@ -1,6 +1,7 @@
 import {
-  DefaultBuilderPlugin,
+  getDistPath,
   isHtmlDisabled,
+  DefaultBuilderPlugin,
 } from '@modern-js/builder-shared';
 
 export function builderPluginAssetsRetry(): DefaultBuilderPlugin {
@@ -18,9 +19,12 @@ export function builderPluginAssetsRetry(): DefaultBuilderPlugin {
           const { AssetsRetryPlugin } = await import(
             '@modern-js/builder-shared'
           );
+          const distDir = getDistPath(config.output, 'js');
+
           chain.plugin(CHAIN_ID.PLUGIN.ASSETS_RETRY).use(AssetsRetryPlugin, [
             {
               ...(config.output.assetsRetry || {}),
+              distDir,
               HtmlPlugin,
             },
           ]);

--- a/packages/document/builder-doc/docs/en/config/output/assetsRetry.md
+++ b/packages/document/builder-doc/docs/en/config/output/assetsRetry.md
@@ -47,7 +47,7 @@ export const defaultAssetsRetryOptions: AssetsRetryOptions = {
 };
 ```
 
-At the same time, you can also customize your retry logic according to the following config instructions.
+At the same time, you can also customize your retry logic using the following configurations.
 
 ### assetsRetry.max
 
@@ -193,3 +193,26 @@ export default {
   },
 };
 ```
+
+### assetsRetry.inlineScript
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to inline the runtime JavaScript code of `assetsRetry` into the HTML file.
+
+If you don't want to insert the code in the HTML file, you can set `assetsRetry.inlineScript` to `false`:
+
+```js
+export default {
+  output: {
+    assetsRetry: {
+      inlineScript: false,
+    },
+  },
+};
+```
+
+After adding the above configuration, the runtime code of `assetsRetry` will be extracted into a separate `assets-retry.[version].js` file and output to the dist directory.
+
+The downside is that `assets-retry.[version].js` itself may fail to load. If this happens, the assets retry will not work. Therefore, we prefer to inline the runtime code into the HTML file.

--- a/packages/document/builder-doc/docs/zh/config/output/assetsRetry.md
+++ b/packages/document/builder-doc/docs/zh/config/output/assetsRetry.md
@@ -22,7 +22,7 @@ export type AssetsRetryOptions = {
 };
 ```
 
-由于该能力会往 HTML 中注入额外的一些运行时代码，因此我们默认关闭了该能力，如果需要开启该能力，你可以配置成对象的形式，比如：
+由于该能力会往 HTML 中注入额外的一些运行时代码，因此我们默认关闭了该能力，如果需要开启该能力，你可以添加以下配置：
 
 ```js
 export default {
@@ -47,7 +47,7 @@ export const defaultAssetsRetryOptions: AssetsRetryOptions = {
 };
 ```
 
-同时你也可以根据接下来的一些配置说明，来定制你的重试逻辑。
+同时你也可以使用以下的配置项，来定制你的重试逻辑。
 
 ### assetsRetry.max
 
@@ -193,3 +193,26 @@ export default {
   },
 };
 ```
+
+### assetsRetry.inlineScript
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+是否将 `assetsRetry` 的运行时 JavaScript 代码内联到 HTML 文件中。
+
+如果你不希望在 HTML 文件中插入相关代码，可以将 `assetsRetry.inlineScript` 设置为 `false`：
+
+```js
+export default {
+  output: {
+    assetsRetry: {
+      inlineScript: false,
+    },
+  },
+};
+```
+
+添加以上配置后，`assetsRetry` 的运行时代码会被抽取为一个独立的 `assets-retry.[version].js` 文件，并输出到产物目录下。
+
+这种方式的弊端在于，`assets-retry.[version].js` 自身有加载失败的可能性。如果出现这种情况，静态资源重试的逻辑就无法生效。因此，我们更推荐将运行时代码内联到 HTML 文件中。

--- a/tests/e2e/builder/cases/assets-retry/index.test.ts
+++ b/tests/e2e/builder/cases/assets-retry/index.test.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+
+test('should inline assets retry runtime code to html by default', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
+      output: {
+        assetsRetry: {},
+      },
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+  const htmlFile = Object.keys(files).find(file => file.endsWith('.html'));
+
+  expect(htmlFile).toBeTruthy();
+  expect(files[htmlFile!].includes('function retry')).toBeTruthy();
+});
+
+test('should extract assets retry runtime code when inlineScript is false', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
+      output: {
+        assetsRetry: {
+          inlineScript: false,
+        },
+      },
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+
+  const htmlFile = Object.keys(files).find(file => file.endsWith('.html'));
+  const retryFile = Object.keys(files).find(
+    file => file.includes('/assets-retry') && file.endsWith('.js'),
+  );
+
+  expect(htmlFile).toBeTruthy();
+  expect(retryFile).toBeTruthy();
+  expect(files[htmlFile!].includes('function retry')).toBeFalsy();
+});

--- a/tests/e2e/builder/cases/assets-retry/src/index.js
+++ b/tests/e2e/builder/cases/assets-retry/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27bd1e1</samp>

This pull request enhances the assets retry feature in `@modern-js/builder`, which allows the web app to retry loading assets when they fail due to network errors. It adds a new configuration option `inlineScript` to control the injection of the assets retry runtime code, refactors some common logic to a shared `url` module, and updates the documentation and tests accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27bd1e1</samp>

*  Add a markdown file to the `.changeset` directory for changelog and version bump generation ([link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-a424b31176617b824cf7277175c206ddde2a5c103f0a2f90c22d011304fb8366R1-R9))
*  Implement the `inlineScript` option for the assets retry feature, which allows users to choose whether to inline the assets retry runtime code into the HTML file or extract it into a separate JS file ([link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-f7251431a9415646b2aaff8fd5921ef1b06ecdec7e75408378257584de6fbee3L42-R124), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-42e9c77fc1a6c3a3d3cecbfed0575b9b07c1b9dec393e5dabeef20b3c68ce516R67), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-a868b60233b4d36d15bf447af101d812de6ecf81068b97f07d6d23282e7cfb95L21-R27), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-b083e6bd389c3e6fc06ffb05aa535e2a0d88171d408b0ade21f83251d9a3e266R196-R218), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-abbf766f5f76c3f4d5227a3598eb3810e795660140ba9d8048d5addafcb3acbaR196-R218), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-6e00febeaee53fda833a162d55c4f0cf29aa1340376053f064d4003868a7b75bR1-R44))
*  Refactor the `withPublicPath` function from `HtmlTagsPlugin.ts` to a separate module `url.ts`, and use it in both `HtmlTagsPlugin.ts` and `AssetsRetryPlugin.ts` to generate the correct URLs for the injected tags ([link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-f7251431a9415646b2aaff8fd5921ef1b06ecdec7e75408378257584de6fbee3L1-R96), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-aed6897e522b09d9410cf4eea144778fe795efe3189ae42c04e426ed15e06650L4-R4), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-aed6897e522b09d9410cf4eea144778fe795efe3189ae42c04e426ed15e06650L10), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-aed6897e522b09d9410cf4eea144778fe795efe3189ae42c04e426ed15e06650L65-L95), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-ad14255930bb4d5c7ddf1a40506cde183fb39cb1c4c9e2bfda63b6d69d24a3b4R1-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-309cb00a4a31269d1cb11d77950425cd1686c11ac1abe083682e98e17d5a614aL2-R2))
*  Use the `getDistPath` function from `@modern-js/builder-shared` to get the dist directory for the output files based on the output configuration, and pass it to the `AssetsRetryPlugin` constructor ([link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-a868b60233b4d36d15bf447af101d812de6ecf81068b97f07d6d23282e7cfb95L2-R4))
*  Improve the wording of the documentation for the assets retry feature in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-b083e6bd389c3e6fc06ffb05aa535e2a0d88171d408b0ade21f83251d9a3e266L50-R50), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-abbf766f5f76c3f4d5227a3598eb3810e795660140ba9d8048d5addafcb3acbaL25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-abbf766f5f76c3f4d5227a3598eb3810e795660140ba9d8048d5addafcb3acbaL50-R50))
*  Add a simple source file `index.js` as the entry point for the test case of the assets retry feature ([link](https://github.com/web-infra-dev/modern.js/pull/3431/files?diff=unified&w=0#diff-7d1c3a1af2e4fe26d4aa9da11900023569585f1c82d92253092840764517f2b3R1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
