### PR TITLE
fix(module-tools): missing postcss dependency

### DIFF
--- a/.changeset/fair-planets-behave.md
+++ b/.changeset/fair-planets-behave.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): missing postcss dependency
+
+fix(module-tools): 修复缺少 postcss 依赖的问题

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -55,7 +55,8 @@
     "@modern-js/plugin-i18n": "workspace:*",
     "@modern-js/plugin-lint": "workspace:*",
     "@modern-js/upgrade": "workspace:*",
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "postcss": "8.4.6"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
@@ -69,7 +70,6 @@
     "fs-extra": "10.1.0",
     "jest": "^29",
     "path-browserify": "1.0.1",
-    "postcss": "8.4.6",
     "postcss-alias": "2.0.0",
     "react": "17",
     "typescript": "^4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3429,6 +3429,7 @@ importers:
       '@modern-js/plugin-lint': link:../../cli/plugin-lint
       '@modern-js/upgrade': link:../../toolkit/upgrade
       '@modern-js/utils': link:../../toolkit/utils
+      postcss: 8.4.6
     devDependencies:
       '@modern-js/builder-webpack-provider': link:../../builder/builder-webpack-provider
       '@modern-js/self': 'link:'
@@ -3441,7 +3442,6 @@ importers:
       fs-extra: 10.1.0
       jest: 29.5.0_@types+node@14.18.35
       path-browserify: 1.0.1
-      postcss: 8.4.6
       postcss-alias: 2.0.0
       react: 17.0.2
       typescript: 4.9.3


### PR DESCRIPTION
## Summary

The `module-tools/compiled/postcss-custom-properties/index.js` file will require postcss, so postcss should be a dependency rather than devDependencey.

![image](https://user-images.githubusercontent.com/7237365/231720101-ac2236ee-2012-4a43-8b2c-32370cf093d7.png)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
