### PR TITLE
docs(doc-tools): improve builderConfig guides

### DIFF
--- a/packages/document/doc-tools-doc/docs/en/advanced/extend-build.mdx
+++ b/packages/document/doc-tools-doc/docs/en/advanced/extend-build.mdx
@@ -2,23 +2,34 @@
 
 ## Modern.js Builder
 
-Modern.js Doc builds projects based on [Modern.js Builder](https://modernjs.dev/builder/), you can use `builderConfig` to customize the build config. For example:
+Modern.js Doc builds documents based on the Rspack mode of [Modern.js Builder](https://modernjs.dev/builder/en/).
+
+Modern.js Builder provides flexible build configurations, you can use [doc.builderConfig](/api/config-build.html#builderconfig) to customize these configurations. For example, change the output directory to `doc_dist`:
 
 ```ts title="modern.config.ts"
 import docTools, { defineConfig } from '@modern-js/doc-tools';
-import path from 'path';
 
 export default defineConfig({
   doc: {
     builderConfig: {
-      dev: {
-        startUrl: false,
+      output: {
+        distPath: {
+          root: 'doc_dist',
+        },
       },
     },
   },
   plugins: [docTools()],
 });
 ```
+
+:::tip
+
+You can learn more configurations through the [Modern.js Builder - API](https://modernjs.dev/builder/en/api/index.html) documentation.
+
+Note that Modern.js Doc only supports Rspack bundler, so some configurations related to webpack will not work, such as `tools.webpack`.
+
+:::
 
 ## MDX Compilation
 

--- a/packages/document/doc-tools-doc/docs/en/api/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config-build.mdx
@@ -2,7 +2,37 @@
 
 ## builderConfig
 
-Customize Modern.js Builder configuration, see [official website configuration](https://modernjs.dev/builder/api/index.html) for details.
+- Type: `Object`
+
+Used to customize the configurations of Modern.js Builder. For complete configurations, please refer to [Modern.js Builder - API](https://modernjs.dev/builder/en/api/index.html).
+
+For example, change the output directory to `doc_dist`:
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  doc: {
+    builderConfig: {
+      output: {
+        distPath: {
+          root: 'doc_dist',
+        },
+      },
+    },
+  },
+});
+```
+
+### Default Config
+
+If you need to see the default `builderConfig`, you can add the `DEBUG=builder` parameter when running the `modern dev` or `modern build` command:
+
+```bash
+DEBUG=builder modern dev
+```
+
+After execution, the `builder.config.js` file is created in the `doc_build` directory, which contains the complete `builderConfig`.
+
+> Please refer to [Modern.js Builder - Debug Mode](https://modernjs.dev/builder/en/guide/debug/debug-mode.html) for more information on how to debug the Builder.
 
 ## markdown
 

--- a/packages/document/doc-tools-doc/docs/zh/advanced/extend-build.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/advanced/extend-build.mdx
@@ -2,23 +2,34 @@
 
 ## Modern.js Builder
 
-Modern.js Doc 基于 [Modern.js Builder](https://modernjs.dev/builder/) 来进行项目构建，你可以使用 `builderConfig` 来自定义构建配置。比如:
+Modern.js Doc 底层基于 [Modern.js Builder](https://modernjs.dev/builder/) 的 Rspack 模式来进行文档构建。
+
+Modern.js Builder 提供了丰富的构建配置，你可以使用 [doc.builderConfig](/api/config-build.html#builderconfig) 来自定义这些配置项。比如，将产物目录修改为 `doc_dist`：
 
 ```ts title="modern.config.ts"
 import docTools, { defineConfig } from '@modern-js/doc-tools';
-import path from 'path';
 
 export default defineConfig({
   doc: {
     builderConfig: {
-      dev: {
-        startUrl: false,
+      output: {
+        distPath: {
+          root: 'doc_dist',
+        },
       },
     },
   },
   plugins: [docTools()],
 });
 ```
+
+:::tip
+
+你可以通过 [Modern.js Builder - API](https://modernjs.dev/builder/api/index.html) 的文档来了解更多的配置项。
+
+注意，Modern.js Doc 仅支持 Rspack 打包工具，因此一些与 webpack 相关的配置项将无法生效，比如 `tools.webpack`。
+
+:::
 
 ## MDX 编译插件
 

--- a/packages/document/doc-tools-doc/docs/zh/api/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config-build.mdx
@@ -2,7 +2,37 @@
 
 ## builderConfig
 
-自定义 Modern.js Builder 配置，详见 [官网配置](https://modernjs.dev/builder/api/index.html)。
+- Type: `Object`
+
+用于自定义 Modern.js Builder 的配置项，完整配置项请查看 [Modern.js Builder - API](https://modernjs.dev/builder/api/index.html)。
+
+比如，将产物目录修改为 `doc_dist`：
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  doc: {
+    builderConfig: {
+      output: {
+        distPath: {
+          root: 'doc_dist',
+        },
+      },
+    },
+  },
+});
+```
+
+### 默认配置
+
+如果你需要查看默认的 `builderConfig`，可以在执行 `modern dev` 或 `modern build` 命令时，添加 `DEBUG=builder` 参数：
+
+```bash
+DEBUG=builder modern dev
+```
+
+在执行后，`doc_build` 目录下会生成 `builder.config.js` 文件，里面包含了完整的 `builderConfig`。
+
+> 请查看 [Modern.js Builder - 调试模式](https://modernjs.dev/builder/guide/debug/debug-mode.html) 来了解更多调试 Builder 的方法。
 
 ## markdown
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45bf672</samp>

This pull request updates and improves the documentation of Modern.js Doc's `extend-build` feature in both English and Chinese. It also moves the documentation of the `builderConfig` option from the `config-build.mdx` file to the `extend-build.mdx` file, where it is more relevant and easier to find.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
