### PR TITLE
fix(app-tools): inline-loader match path error in windows

### DIFF
--- a/.changeset/tame-tips-juggle.md
+++ b/.changeset/tame-tips-juggle.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: inline-loader match path error in windows
+fix: inline-loader 在 windows 里路径匹配错误。

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -234,6 +234,8 @@ function applySSRDataLoader<B extends Bundler>(
 
   const { entriesDir = './src' } = normalizedConfig.source;
 
+  // Both match in Windows and Unix(Linux, Mac)
+  // docs: https://github.com/webpack/webpack/issues/2073
   const absolutePath = path
     .resolve(appDirectory, entriesDir)
     .split(path.sep)

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -234,7 +234,10 @@ function applySSRDataLoader<B extends Bundler>(
 
   const { entriesDir = './src' } = normalizedConfig.source;
 
-  const absolutePath = path.resolve(appDirectory, entriesDir);
+  const absolutePath = path
+    .resolve(appDirectory, entriesDir)
+    .split(path.sep)
+    .join('(\\\\|/)');
 
   const reg = new RegExp(`${absolutePath}.*\\.loader\\.[t|j]s$`);
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da2b838</samp>

This pull request fixes a bug that prevented the inline-loader from working properly in Windows environments. It updates the `@modern-js/app-tools` package with a patch version and a changelog entry, and changes the path matching logic in `adapterSSR.ts`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da2b838</samp>

*  Fix inline-loader path matching for Windows in `adapterSSR.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3440/files?diff=unified&w=0#diff-d019db18fbb5169d98250c217097e90337f356e26121269d691b402495334186L237-R242), [link](https://github.com/web-infra-dev/modern.js/pull/3440/files?diff=unified&w=0#diff-716000dc174aabf493a50b869103e7263590d08e50935c53bbb671391dd3106cR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
