### PR TITLE
fix(builder): set camel2dashName properly

### DIFF
--- a/.changeset/many-guests-help.md
+++ b/.changeset/many-guests-help.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): set camel2dashName properly
+
+fix(builder): 正确配置 transformImport babel 插件的 camel2dashName

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -209,13 +209,28 @@ function applyPluginImport(
     for (const item of pluginImport) {
       const name = item.libraryName;
 
+      const option: TransformImport & {
+        camel2DashComponentName?: boolean;
+      } = {
+        ...item,
+      };
+
+      if (
+        option.camelToDashComponentName !== undefined ||
+        option.camel2DashComponentName !== undefined
+      ) {
+        option.camel2DashComponentName =
+          option.camel2DashComponentName ?? option.camelToDashComponentName;
+        delete option.camelToDashComponentName;
+      }
+
       chain
         .plugin(`plugin-import-${name}`)
         .use(
           require.resolve(
             '@modern-js/babel-preset-base/compiled/babel-plugin-import',
           ),
-          [item, name],
+          [option, name],
         );
     }
   }

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -182,3 +182,247 @@ exports[`webpackConfig > should provide mergeConfig util in tools.webpack functi
   },
 }
 `;
+
+exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
+[
+  {
+    "include": [
+      {
+        "and": [
+          "<ROOT>",
+          {
+            "not": /node_modules/,
+          },
+        ],
+      },
+    ],
+    "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+    "use": [
+      {
+        "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/babel-loader",
+        "options": {
+          "babelrc": false,
+          "compact": false,
+          "configFile": false,
+          "plugins": [
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+              {
+                "camel2DashComponentName": true,
+                "libraryName": "foo",
+              },
+              "foo",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+              {},
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+              {
+                "legacy": true,
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+              {
+                "helpers": false,
+                "regenerator": true,
+                "useESModules": true,
+                "version": "7.18.6",
+              },
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+              {
+                "proposal": "minimal",
+              },
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+              {
+                "displayName": true,
+                "pure": false,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
+              "styled-components",
+            ],
+          ],
+          "presets": [
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+              {
+                "bugfixes": false,
+                "corejs": {
+                  "proposals": true,
+                  "version": "3.30",
+                },
+                "exclude": [
+                  "transform-typeof-symbol",
+                ],
+                "modules": false,
+                "shippedProposals": false,
+                "targets": [
+                  "> 0.01%",
+                  "not dead",
+                  "not op_mini all",
+                ],
+                "useBuiltIns": "entry",
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-react/lib/index.js",
+              {
+                "development": true,
+                "runtime": "classic",
+                "useBuiltIns": true,
+                "useSpread": false,
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+              {
+                "allExtensions": true,
+                "allowDeclareFields": true,
+                "allowNamespaces": true,
+                "isTSX": true,
+                "optimizeConstEnums": true,
+              },
+            ],
+          ],
+        },
+      },
+    ],
+  },
+  {
+    "mimetype": {
+      "or": [
+        "text/javascript",
+        "application/javascript",
+      ],
+    },
+    "use": [
+      {
+        "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/babel-loader",
+        "options": {
+          "babelrc": false,
+          "compact": false,
+          "configFile": false,
+          "plugins": [
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+              {
+                "camel2DashComponentName": true,
+                "libraryName": "foo",
+              },
+              "foo",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+              {},
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+              {
+                "legacy": true,
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+              {
+                "helpers": false,
+                "regenerator": true,
+                "useESModules": true,
+                "version": "7.18.6",
+              },
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+              {
+                "proposal": "minimal",
+              },
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+            ],
+            [
+              "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+              {
+                "displayName": true,
+                "pure": false,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
+              "styled-components",
+            ],
+          ],
+          "presets": [
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+              {
+                "bugfixes": false,
+                "corejs": {
+                  "proposals": true,
+                  "version": "3.30",
+                },
+                "exclude": [
+                  "transform-typeof-symbol",
+                ],
+                "modules": false,
+                "shippedProposals": false,
+                "targets": [
+                  "> 0.01%",
+                  "not dead",
+                  "not op_mini all",
+                ],
+                "useBuiltIns": "entry",
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-react/lib/index.js",
+              {
+                "development": true,
+                "runtime": "classic",
+                "useBuiltIns": true,
+                "useSpread": false,
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+              {
+                "allExtensions": true,
+                "allowDeclareFields": true,
+                "allowNamespaces": true,
+                "isTSX": true,
+                "optimizeConstEnums": true,
+              },
+            ],
+          ],
+        },
+      },
+    ],
+  },
+]
+`;

--- a/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import { builderPluginBasic } from '@/plugins/basic';
 import { createStubBuilder } from '@/stub';
+import { builderPluginBabel } from '@/plugins/babel';
 
 describe('webpackConfig', () => {
   it('should allow tools.webpack to return config', async () => {
@@ -197,5 +198,31 @@ describe('webpackConfig', () => {
 
     const config = await builder.unwrapWebpackConfig();
     expect(config.module?.rules).toEqual([newRule]);
+  });
+
+  it('should set proper pluginImport option in Babel', async () => {
+    // camelToDashComponentName
+    const builder = await createStubBuilder({
+      plugins: [builderPluginBabel()],
+      builderConfig: {
+        source: {
+          transformImport: [
+            {
+              libraryName: 'foo',
+              camelToDashComponentName: true,
+            },
+          ],
+        },
+      },
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    const babelRules = config.module!.rules?.filter(item => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error item has use
+      return item?.use?.[0].loader.includes('babel-loader');
+    });
+
+    expect(babelRules).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a2920c</samp>

This pull request fixes a bug and adds a test for the `transformImport` babel plugin in the `@modern-js/builder-webpack-provider` package. The plugin allows importing components from libraries like `antd` and `@alifd/next` with dash case names.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a2920c</samp>

* Fix camel case to dash case conversion for component names when using transformImport plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-c96036f113c05fef287b38eb6b8410b7e7b945ce699dc3f17a717e91cd5ce09dR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aR212-R220), [link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL218-R227))
  - Add a changeset file to document the patch update for `@modern-js/builder-webpack-provider` ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-c96036f113c05fef287b38eb6b8410b7e7b945ce699dc3f17a717e91cd5ce09dR1-R7))
  - Add a new variable `option` to copy and modify the pluginImport item in `applyPluginImport` function in `babel.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aR212-R220))
  - Pass `option` instead of `item` to the babel plugin for transformImport in `babel.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL218-R227))
* Add a test case to verify the correct pluginImport option in babel configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3R4), [link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3R202-R227))
  - Import `builderPluginBabel` function from `babel` module in `webpackConfig.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3R4))
  - Use `builderPluginBabel` to create a stub builder with babel plugin enabled ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3R202-R227))
  - Check the expected babel rules using a snapshot ([link](https://github.com/web-infra-dev/modern.js/pull/3442/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3R202-R227))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
