### PR TITLE
feat(devServer): using current host and port to create HMR connection

### DIFF
--- a/.changeset/rare-spoons-tan.md
+++ b/.changeset/rare-spoons-tan.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/server': patch
+---
+
+fix(devServer): using current host and port to create HMR connection
+
+fix(devServer): 建立 HMR 连接时默认使用当前 host 和 port

--- a/packages/document/builder-doc/docs/en/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/en/config/tools/devServer.md
@@ -92,11 +92,11 @@ export default {
 ```js
 const defaultConfig = {
   path: '/webpack-hmr',
-  // Equivalent to location.hostname
-  host: '',
-  // Equivalent to location.port
+  // By default it is set to the port number of the dev server
   port: '',
-  // Equivalent to location.protocol === 'https:' ? 'wss' : 'ws'
+  // By default it is set to "location.hostname"
+  host: '',
+  // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""
   protocol: '',
 };
 ```

--- a/packages/document/builder-doc/docs/en/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/en/config/tools/devServer.md
@@ -91,11 +91,13 @@ export default {
 
 ```js
 const defaultConfig = {
-  // use the host of the current page
-  host: '',
-  // use the port of the current page
-  port: '',
   path: '/webpack-hmr',
+  // Equivalent to location.hostname
+  host: '',
+  // Equivalent to location.port
+  port: '',
+  // Equivalent to location.protocol === 'https:' ? 'wss' : 'ws'
+  protocol: '',
 };
 ```
 

--- a/packages/document/builder-doc/docs/en/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/en/config/tools/devServer.md
@@ -90,14 +90,16 @@ export default {
 - **Default:**
 
 ```js
-{
-    path: '/webpack-hmr',
-    port: '8080',
-    host: networkAddress || 'localhost',
-}
+const defaultConfig = {
+  // use the host of the current page
+  host: '',
+  // use the port of the current page
+  port: '',
+  path: '/webpack-hmr',
+};
 ```
 
-The config of hmr client.
+The config of HMR client, which are usually used to set the WebSocket URL of HMR.
 
 #### devMiddleware
 

--- a/packages/document/builder-doc/docs/en/guide/advanced/hmr.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/hmr.md
@@ -22,11 +22,13 @@ export default {
 
 ## Specify HMR URL
 
-By default, builder get HMR client URL by local-ip and current port.
+By default, Builder uses the host and port number of the current page to splice the WebSocket URL of HMR.
 
-In the event of a connection failure you can specify an available URL by custom configuration.
+When the HMR connection fails, you can specify the WebSocket URL by customizing `devServer.client` configuration.
 
-For example, set HMR client and port empty to auto derived from browser:
+### Default Config
+
+The default config are as follows, Builder will automatically deduce the URL of the WebSocket request according to the current page:
 
 ```ts
 export default {
@@ -35,6 +37,24 @@ export default {
       client: {
         host: '',
         port: '',
+        path: '/webpack-hmr',
+      },
+    },
+  },
+};
+```
+
+### Proxy
+
+If you are proxying an online page to local development, WebSocket requests will fail to connect. You can try configuring `devServer.client` to the following values so that HMR requests can reach the local Dev Server.
+
+```ts
+export default {
+  tools: {
+    devServer: {
+      client: {
+        host: 'localhost',
+        protocol: 'ws',
       },
     },
   },

--- a/packages/document/builder-doc/docs/en/guide/advanced/hmr.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/hmr.md
@@ -36,10 +36,10 @@ export default {
     devServer: {
       client: {
         path: '/webpack-hmr',
+        // Equivalent to port of the dev server
+        port: '',
         // Equivalent to location.hostname
         host: '',
-        // Equivalent to location.port
-        port: '',
         // Equivalent to location.protocol === 'https:' ? 'wss' : 'ws'
         protocol: '',
       },

--- a/packages/document/builder-doc/docs/en/guide/advanced/hmr.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/hmr.md
@@ -28,16 +28,20 @@ When the HMR connection fails, you can specify the WebSocket URL by customizing 
 
 ### Default Config
 
-The default config are as follows, Builder will automatically deduce the URL of the WebSocket request according to the current page:
+The default config are as follows, Builder will automatically deduce the URL of the WebSocket request according to the current location:
 
 ```ts
 export default {
   tools: {
     devServer: {
       client: {
-        host: '',
-        port: '',
         path: '/webpack-hmr',
+        // Equivalent to location.hostname
+        host: '',
+        // Equivalent to location.port
+        port: '',
+        // Equivalent to location.protocol === 'https:' ? 'wss' : 'ws'
+        protocol: '',
       },
     },
   },

--- a/packages/document/builder-doc/docs/zh/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/devServer.md
@@ -92,11 +92,11 @@ export default {
 ```js
 const defaultConfig = {
   path: '/webpack-hmr',
-  // 等价于 location.hostname
-  host: '',
-  // 等价于 location.port
+  // By default it is set to the port number of the dev server
   port: '',
-  // 等价于 location.protocol === 'https:' ? 'wss' : 'ws'
+  // By default it is set to "location.hostname"
+  host: '',
+  // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""
   protocol: '',
 };
 ```

--- a/packages/document/builder-doc/docs/zh/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/devServer.md
@@ -90,14 +90,16 @@ export default {
 - **默认值：**
 
 ```js
-{
-    path: '/webpack-hmr',
-    port: '8080',
-    host: networkAddress || 'localhost',
-}
+const defaultConfig = {
+  // 使用当前页面的 host
+  host: '',
+  // 使用当前页面的端口号
+  port: '',
+  path: '/webpack-hmr',
+};
 ```
 
-配置 hmr 客户端相关功能。
+对应 HMR 客户端的配置，通常用于设置 HMR 对应的 WebSocket URL。
 
 #### devMiddleware
 

--- a/packages/document/builder-doc/docs/zh/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/devServer.md
@@ -91,11 +91,13 @@ export default {
 
 ```js
 const defaultConfig = {
-  // 使用当前页面的 host
-  host: '',
-  // 使用当前页面的端口号
-  port: '',
   path: '/webpack-hmr',
+  // 等价于 location.hostname
+  host: '',
+  // 等价于 location.port
+  port: '',
+  // 等价于 location.protocol === 'https:' ? 'wss' : 'ws'
+  protocol: '',
 };
 ```
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/hmr.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/hmr.md
@@ -36,11 +36,11 @@ export default {
     devServer: {
       client: {
         path: '/webpack-hmr',
-        // 等价于 location.hostname
-        host: '',
-        // 等价于 location.port
+        // 默认设置为 dev server 的端口号
         port: '',
-        // 等价于 location.protocol === 'https:' ? 'wss' : 'ws'
+        // 默认设置为 location.hostname
+        host: '',
+        // 默认设置为 location.protocol === 'https:' ? 'wss' : 'ws'
         protocol: '',
       },
     },

--- a/packages/document/builder-doc/docs/zh/guide/advanced/hmr.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/hmr.md
@@ -22,17 +22,39 @@ export default {
 
 ## 自定义 HMR URL
 
-Builder 默认使用 local-ip 和当前端口号拼接 HMR 客户端的 URL，当出现连接失败的情况，可以通过自定义配置的方式指定可用的 URL。
+在默认情况下，Builder 使用当前页面的 host 和端口号来拼接 HMR 对应的 WebSocket URL。
 
-例如，通过将 host 和 path 设置为空将根据当前客户端情况自动推导 HMR 客户端 URL：
+当出现 HMR 连接失败的情况时，你可以通过自定义 `devServer.client` 配置的方式来指定 WebSocket URL。
+
+### 默认配置
+
+默认配置如下，Builder 会根据当前页面自动推导 WebSocket 请求的 URL：
 
 ```ts
 export default {
   tools: {
     devServer: {
       client: {
-        port: '',
         host: '',
+        port: '',
+        path: '/webpack-hmr',
+      },
+    },
+  },
+};
+```
+
+### 线上代理
+
+如果你将一个线上页面代理到本地进行开发，WebSocket 请求将会连接失败。此时你可以尝试将 `devServer.client` 配置成如下值，使 HMR 请求能打到本地的 Dev Server。
+
+```ts
+export default {
+  tools: {
+    devServer: {
+      client: {
+        host: 'localhost',
+        protocol: 'ws',
       },
     },
   },

--- a/packages/document/builder-doc/docs/zh/guide/advanced/hmr.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/hmr.md
@@ -28,16 +28,20 @@ export default {
 
 ### 默认配置
 
-默认配置如下，Builder 会根据当前页面自动推导 WebSocket 请求的 URL：
+默认配置如下，Builder 会根据当前页面的 location 自动推导 WebSocket 请求的 URL：
 
 ```ts
 export default {
   tools: {
     devServer: {
       client: {
-        host: '',
-        port: '',
         path: '/webpack-hmr',
+        // 等价于 location.hostname
+        host: '',
+        // 等价于 location.port
+        port: '',
+        // 等价于 location.protocol === 'https:' ? 'wss' : 'ws'
+        protocol: '',
       },
     },
   },

--- a/packages/server/server/src/constants.ts
+++ b/packages/server/server/src/constants.ts
@@ -4,11 +4,13 @@ import { DevServerOptions } from './types';
 export const getDefaultDevOptions = (): DevServerOptions => {
   return {
     client: {
-      // using current port
-      port: '',
-      // using current hostname
-      host: '',
       path: HMR_SOCK_PATH,
+      // This will fallback to "location.port"
+      port: '',
+      // This will fallback to "location.hostname"
+      host: '',
+      // This will fallback to "location.protocol === 'https:' ? 'wss' : 'ws'"
+      protocol: '',
     },
     https: false,
     devMiddleware: { writeToDisk: true },

--- a/packages/server/server/src/constants.ts
+++ b/packages/server/server/src/constants.ts
@@ -5,11 +5,11 @@ export const getDefaultDevOptions = (): DevServerOptions => {
   return {
     client: {
       path: HMR_SOCK_PATH,
-      // This will fallback to "location.port"
+      // By default it is set to the port number of the dev server
       port: '',
-      // This will fallback to "location.hostname"
+      // By default it is set to "location.hostname"
       host: '',
-      // This will fallback to "location.protocol === 'https:' ? 'wss' : 'ws'"
+      // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""
       protocol: '',
     },
     https: false,

--- a/packages/server/server/src/constants.ts
+++ b/packages/server/server/src/constants.ts
@@ -1,14 +1,14 @@
-import { getIpv4Interfaces } from '@modern-js/utils';
 import { HMR_SOCK_PATH } from '@modern-js/utils/universal/constants';
 import { DevServerOptions } from './types';
 
 export const getDefaultDevOptions = (): DevServerOptions => {
-  const network = getIpv4Interfaces().find(item => !item.internal);
   return {
     client: {
-      port: '8080',
+      // using current port
+      port: '',
+      // using current hostname
+      host: '',
       path: HMR_SOCK_PATH,
-      host: network?.address || 'localhost',
     },
     https: false,
     devMiddleware: { writeToDisk: true },

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -21,6 +21,7 @@ import type {
   ExposeServerApis,
 } from '@modern-js/types';
 import { LOADABLE_STATS_FILE } from '@modern-js/utils/constants';
+import { merge as deepMerge } from '@modern-js/utils/lodash';
 import { getDefaultDevOptions } from '../constants';
 import { createMockHandler } from '../dev-tools/mock';
 import { enableRegister } from '../dev-tools/register';
@@ -61,15 +62,7 @@ export class ModernDevServer extends ModernServer {
   private getDevOptions(options: ModernDevServerOptions) {
     const devOptions = typeof options.dev === 'boolean' ? {} : options.dev;
     const defaultOptions = getDefaultDevOptions();
-
-    return {
-      ...defaultOptions,
-      ...devOptions,
-      client: {
-        ...defaultOptions.client,
-        ...devOptions?.client,
-      },
-    };
+    return deepMerge(defaultOptions, devOptions);
   }
 
   private addMiddlewareHandler(handlers: RequestHandler[]) {


### PR DESCRIPTION
## Summary

**Make default behavior consistent with rspack-cli / webpack-cli / vite.**

```ts
const defaultDevClientConfig = {
  path: '/webpack-hmr',
  // By default it is set to the port number of the dev server
  port: '',
  // By default it is set to "location.hostname"
  host: '',
  // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""
  protocol: '',
};
```

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1942edf</samp>

This pull request improves the HMR (hot module replacement) feature of the `modern.js` framework by making the `devServer.client` configuration more flexible and consistent. It updates the code in the `server` package to use the current host and port of the page for the HMR connection by default. It also updates the documentation in the `builder-doc` package for both English and Chinese languages, with examples and tips for different scenarios. It adds a changeset file to record the changes for the next release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1942edf</samp>

*  Add a changeset file to generate changelogs and version bumps for the affected packages ([link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-cd3b61c422dfe81db4fb287450bbb4161355f1789563ce4e63a5a3100b9b15c6R1-R8))
*  Update the documentation and the code for the `devServer.client` configuration in the `builder-doc` and `server` packages to use the current host and port of the page for the HMR connection by default ([link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-0a714ddc474c7a425c13ae672e264ac547893c9283cc43e155d06d121f6329beL93-R102), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-cb8ff06e7e8ed89bcbac155c9b6b07f3761cf7cded35192d19719de729b30e3fL25-R32), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-cb8ff06e7e8ed89bcbac155c9b6b07f3761cf7cded35192d19719de729b30e3fR40), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-cb8ff06e7e8ed89bcbac155c9b6b07f3761cf7cded35192d19719de729b30e3fR47-R63), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-69d3b93a9b57afe8f5e9d592ac1aac80306d6ba8399f930dffd1c3aa7aa6f606L93-R102), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-096ca420d00cc2c9cd58ba0e6f4a0ed4d3ed0150a78386bb2aae3b91186b1edeL25-R32), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-096ca420d00cc2c9cd58ba0e6f4a0ed4d3ed0150a78386bb2aae3b91186b1edeL34-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-096ca420d00cc2c9cd58ba0e6f4a0ed4d3ed0150a78386bb2aae3b91186b1edeR47-R63), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-30d4bc97dac1a007a0823ed2ff4d87a3ab9cc90c2d1b2f52002a4befc1357448L1-R11))
*  Add a new section to the documentation for the `devServer.client` configuration in the `guide/advanced/hmr` pages to explain how to handle proxying an online page to local development ([link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-cb8ff06e7e8ed89bcbac155c9b6b07f3761cf7cded35192d19719de729b30e3fR47-R63), [link](https://github.com/web-infra-dev/modern.js/pull/3445/files?diff=unified&w=0#diff-096ca420d00cc2c9cd58ba0e6f4a0ed4d3ed0150a78386bb2aae3b91186b1edeR47-R63))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
