### PR TITLE
fix: should empty dist dir when execute deploy command

### DIFF
--- a/.changeset/afraid-rice-hang.md
+++ b/.changeset/afraid-rice-hang.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: should empty dist dir when execute deploy command
+fix: 应该清空 dist 目录，当执行 deploy 命令时

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -235,7 +235,12 @@ export default (
 
       async prepare() {
         const command = getCommand();
-        if (command === 'dev' || command === 'start' || command === 'build') {
+        if (
+          command === 'dev' ||
+          command === 'start' ||
+          command === 'build' ||
+          command === 'deploy'
+        ) {
           const appContext = api.useAppContext();
           await emptyDir(appContext.distDirectory);
         }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f75eac1</samp>

This pull request fixes a bug in the `@modern-js/app-tools` package that could cause stale files to be deployed. It updates the changeset file and the `prepare` method of the `AppToolsSolution` class to ensure the dist directory is emptied before deploying.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f75eac1</samp>

* Fix dist directory not being emptied when deploying `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/3447/files?diff=unified&w=0#diff-647e6380ca6183f0ebfbbbfd6cc0c9abc3d2d23b25c9ff1f59c768d2c303f859R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3447/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL238-R243))
  - Update changeset file to include patch version bump and fix message in `.changeset/afraid-rice-hang.md` ([link](https://github.com/web-infra-dev/modern.js/pull/3447/files?diff=unified&w=0#diff-647e6380ca6183f0ebfbbbfd6cc0c9abc3d2d23b25c9ff1f59c768d2c303f859R1-R6))
  - Add `deploy` command to the condition that triggers the emptying of the dist directory in `packages/solutions/app-tools/src/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3447/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL238-R243))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
