### PR TITLE
fix(integration-test): should await killApp

### DIFF
--- a/.changeset/great-laws-judge.md
+++ b/.changeset/great-laws-judge.md
@@ -1,0 +1,8 @@
+---
+'integration-asset-prefix': patch
+'integration-load-config': patch
+---
+
+fix(integration-test): should await killApp
+
+fix(integration-test): killApp 应该被 await

--- a/tests/integration/asset-prefix/test/index.test.ts
+++ b/tests/integration/asset-prefix/test/index.test.ts
@@ -20,7 +20,7 @@ describe('asset prefix', () => {
     );
     expect(HTML.includes(`//${DEFAULT_DEV_HOST}:3333/static/js/`)).toBeTruthy();
 
-    killApp(app);
+    await killApp(app);
   });
 
   it(`should inject window.__assetPrefix__ global variable`, async () => {
@@ -48,6 +48,6 @@ describe('asset prefix', () => {
 
     expect(assetPrefix).toEqual(expected);
 
-    killApp(app);
+    await killApp(app);
   });
 });

--- a/tests/integration/load-config/test/index.test.ts
+++ b/tests/integration/load-config/test/index.test.ts
@@ -17,7 +17,7 @@ describe('local config', () => {
       existsSync(path.join(appDir, 'dist/bar/html/main/index.html')),
     ).toBeTruthy();
 
-    killApp(app);
+    await killApp(app);
   });
 
   it(`should not load local config when running build command`, async () => {
@@ -37,7 +37,7 @@ describe('local config', () => {
       existsSync(path.join(appDir, 'dist/bar/html/main/index.html')),
     ).toBeTruthy();
 
-    killApp(app);
+    await killApp(app);
   });
 
   it(`should passing correct config params when running dev command`, async () => {
@@ -53,7 +53,7 @@ describe('local config', () => {
       command: 'dev',
     });
 
-    killApp(app);
+    await killApp(app);
   });
 
   it(`should passing correct config params when running build command`, async () => {


### PR DESCRIPTION
## Summary

Tests should finish after app be killed

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53296e5</samp>

Fix integration tests for asset prefix and load config features in `next.js` framework. Add a changeset file to document the fixes and prepare for publishing.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53296e5</samp>

*  Add a changeset file to document the fixes for the integration tests ([link](https://github.com/web-infra-dev/modern.js/pull/3452/files?diff=unified&w=0#diff-699d019374255454b5d640724f25b342d5e37a2efba8cb865c7207c43221aaa3R1-R8))
*  Await the killApp function in the integration tests for the asset prefix and load config features, to prevent server interference ([link](https://github.com/web-infra-dev/modern.js/pull/3452/files?diff=unified&w=0#diff-1f176658b2041da3513c5609802ebb998a0320326340449f955df1f048555eabL23-R23), [link](https://github.com/web-infra-dev/modern.js/pull/3452/files?diff=unified&w=0#diff-1f176658b2041da3513c5609802ebb998a0320326340449f955df1f048555eabL51-R51), [link](https://github.com/web-infra-dev/modern.js/pull/3452/files?diff=unified&w=0#diff-a2e5a79f7876d6c1a958345f5dcdee057329eda7243d3b4e75ec2540356b5ddbL20-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3452/files?diff=unified&w=0#diff-a2e5a79f7876d6c1a958345f5dcdee057329eda7243d3b4e75ec2540356b5ddbL40-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3452/files?diff=unified&w=0#diff-a2e5a79f7876d6c1a958345f5dcdee057329eda7243d3b4e75ec2540356b5ddbL56-R56))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
