### PR TITLE
fix(app-tools): should not print all addresses when custom dev.host

### DIFF
--- a/.changeset/plenty-shirts-sniff.md
+++ b/.changeset/plenty-shirts-sniff.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/utils': patch
+---
+
+fix(app-tools): should not print all addresses when custom dev.host
+
+fix(app-tools): 修复自定义 dev.host 时会输出多余的 URL 地址的问题

--- a/packages/builder/builder-shared/src/devServer.ts
+++ b/packages/builder/builder-shared/src/devServer.ts
@@ -177,7 +177,7 @@ export async function startDevServer<
 
         const { getAddressUrls } = await import('@modern-js/utils');
         const protocol = builderConfig.dev?.https ? 'https' : 'http';
-        let urls = getAddressUrls(protocol, port);
+        let urls = getAddressUrls(protocol, port, builderConfig.dev?.host);
 
         if (printURLs) {
           if (isFunction(printURLs)) {

--- a/packages/toolkit/utils/tests/getAddressUrls.test.ts
+++ b/packages/toolkit/utils/tests/getAddressUrls.test.ts
@@ -1,0 +1,19 @@
+import { getAddressUrls } from '../src/prettyInstructions';
+
+describe('getAddressUrls', () => {
+  test('should allow to custom host', () => {
+    expect(getAddressUrls('http', 3000, 'localhost')).toEqual([
+      { label: 'Local:  ', url: 'http://localhost:3000' },
+    ]);
+    expect(getAddressUrls('http', 3000, '192.168.0.1')).toEqual([
+      { label: 'Network:  ', url: 'http://192.168.0.1:3000' },
+    ]);
+    expect(getAddressUrls('https', 3001, '192.168.0.1')).toEqual([
+      { label: 'Network:  ', url: 'https://192.168.0.1:3001' },
+    ]);
+  });
+
+  test('should get multiple addresses when host is 0.0.0.0', () => {
+    expect(getAddressUrls('https', 3001, '0.0.0.0').length > 1).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

When set `dev.host` to `localhost`, will should not print the ip address URL:

```ts
export default {
  dev: {
    host: 'localhost'
  }
}
```

Current:


<img width="401" alt="Screen Shot 2023-04-16 at 10 04 12" src="https://user-images.githubusercontent.com/7237365/232262226-ea70344c-1e7b-42cb-99b1-da5a2cb8bd5e.png">

Expected:

<img width="392" alt="Screen Shot 2023-04-16 at 09 59 35" src="https://user-images.githubusercontent.com/7237365/232262223-58e15d0f-be6e-40b0-9ee9-a0734e2cab6a.png">



<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00ff533</samp>

This pull request adds support for custom host settings for the development server in the `@modern-js/builder-shared` and `@modern-js/utils` packages. It also fixes a bug in the `@modern-js/app-tools` package that printed unnecessary URLs. It updates the `prettyInstructions` function and adds tests for the `getAddressUrls` function.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00ff533</samp>

*  Add changeset file to document patch updates and fix for app-tools package ([link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-313295e145a2c9d2afcce6a0c8b30872f1f320eb987914889080ebdaefd8cc4aR1-R8))
*  Respect custom dev.host setting in builder config and print correct URLs for dev server ([link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-1876b89358da5214f40c6a33a70fd6ca415b4222d9ae36cbe1f701dfa4fe083aL180-R180), [link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-63743c3db3c6c363678055d158e8c1dee6eeffed09c4b0bfc4bc0f07654c412bR4), [link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-63743c3db3c6c363678055d158e8c1dee6eeffed09c4b0bfc4bc0f07654c412bL37-R69), [link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-63743c3db3c6c363678055d158e8c1dee6eeffed09c4b0bfc4bc0f07654c412bR87))
   * Modify `startDevServer` function in `devServer.ts` and pass `builderConfig.dev?.host` to `getAddressUrls` function ([link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-1876b89358da5214f40c6a33a70fd6ca415b4222d9ae36cbe1f701dfa4fe083aL180-R180))
   * Refactor `getAddressUrls` function in `prettyInstructions.ts` and add `host` parameter and helper function `isLocalhost` ([link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-63743c3db3c6c363678055d158e8c1dee6eeffed09c4b0bfc4bc0f07654c412bL37-R69))
   * Import `DEFAULT_DEV_HOST` constant from `constants.ts` and use it in `getAddressUrls` function ([link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-63743c3db3c6c363678055d158e8c1dee6eeffed09c4b0bfc4bc0f07654c412bR4))
   * Pass `config.dev?.host` to `getAddressUrls` function in `prettyInstructions` function ([link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-63743c3db3c6c363678055d158e8c1dee6eeffed09c4b0bfc4bc0f07654c412bR87))
   * Add test file `getAddressUrls.test.ts` and test cases for `getAddressUrls` function ([link](https://github.com/web-infra-dev/modern.js/pull/3455/files?diff=unified&w=0#diff-1b9c05b4fdd2499e2e5426d1f7b756684e6ddc0025c3c65669753705a64d94cbR1-R19))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
