### PR TITLE
fix: the streaming ssr may add repeated css assets

### DIFF
--- a/.changeset/giant-seahorses-help.md
+++ b/.changeset/giant-seahorses-help.md
@@ -3,3 +3,4 @@
 ---
 
 fix: the streaming ssr may add repeated css assets, because the route-manifets would product all css link
+fix: 因为 route-manifets 会生成所有 css link 信息，导致 streaming ssr 可能添加重复的 css 资源，

--- a/.changeset/giant-seahorses-help.md
+++ b/.changeset/giant-seahorses-help.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: the streaming ssr may add repeated css assets, because the route-manifets would product all css link

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/bulidTemplate.before.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/bulidTemplate.before.ts
@@ -58,8 +58,9 @@ function getHeadTemplate(beforeEntryTemplate: string, context: RuntimeContext) {
             const { referenceCssAssets = [] } = routeManifest as {
               referenceCssAssets?: string[];
             };
-            const _cssChunks = referenceCssAssets.filter((asset?: string) =>
-              asset?.endsWith('.css'),
+            const _cssChunks = referenceCssAssets.filter(
+              (asset?: string) =>
+                asset?.endsWith('.css') && !headTemplate.includes(asset),
             );
             cssChunks.push(..._cssChunks);
           }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 800d24a</samp>

This pull request fixes a bug in the `@modern-js/runtime` package that caused streaming SSR to inject duplicate CSS assets into the HTML head. It updates the `getCssChunks` function and adds a changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 800d24a</samp>

*  Fix bug of repeated CSS assets in streaming SSR ([link](https://github.com/web-infra-dev/modern.js/pull/3458/files?diff=unified&w=0#diff-e46db1354625d59674c90a56f42f6aa62c618a89994685c2b50c35a0470d9b59R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/3458/files?diff=unified&w=0#diff-a2bf57dfb80cf787cf6b866e09c202590ccd1863dc995b4d56353e69478d9f8cL61-R63))
   * Add changeset file for patch update of `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/3458/files?diff=unified&w=0#diff-e46db1354625d59674c90a56f42f6aa62c618a89994685c2b50c35a0470d9b59R1-R5))
   * Filter out existing CSS assets in `getCssChunks` function in `plugin-runtime/src/ssr/serverRender/renderToStream/bulidTemplate.before.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3458/files?diff=unified&w=0#diff-a2bf57dfb80cf787cf6b866e09c202590ccd1863dc995b4d56353e69478d9f8cL61-R63))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
