### PR TITLE
feat(plugin-module-doc): change global css,fix dark theme and upgrade overview component

### DIFF
--- a/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Siderbar/index.tsx
@@ -6,7 +6,7 @@ import { Link } from '../Link';
 import { isActive } from '../../logic';
 import ArrowRight from '../../assets/arrow-right.svg';
 import styles from './index.module.scss';
-import { removeBase, normalizeHref } from '@/runtime';
+import { removeBase, normalizeHref, withBase } from '@/runtime';
 
 interface Props {
   isSidebarOpen?: boolean;
@@ -166,20 +166,20 @@ export function SidebarGroupComp(props: SidebarItemProps) {
     >
       <div
         style={{
-          cursor: collapsible ? 'pointer' : 'normal',
+          cursor: collapsible || item.link ? 'pointer' : 'normal',
         }}
         className={`flex justify-between items-center rounded-xl ${
           // eslint-disable-next-line no-nested-ternary
           active
             ? styles.menuItemActive
-            : collapsible
+            : collapsible || item.link
             ? styles.menuItem
             : styles.menuItemStatic
         }`}
         onMouseEnter={() => item.link && props.preloadLink(item.link)}
         onClick={e => {
           if (item.link) {
-            navigate(normalizeHref(item.link));
+            navigate(withBase(normalizeHref(item.link)));
             collapsed && toggleCollapse(e);
           } else {
             collapsible && toggleCollapse(e);

--- a/packages/module/plugin-module-doc/src/components/codeContainer/index.tsx
+++ b/packages/module/plugin-module-doc/src/components/codeContainer/index.tsx
@@ -7,7 +7,7 @@ import '@arco-design/web-react/es/Card/style';
 import '@arco-design/web-react/es/Space/style';
 
 import './index.scss';
-import { normalizeRoutePath } from '../../utils';
+import { normalizeRoutePath } from '@modern-js/doc-core/runtime';
 import { locales } from '../../locales';
 
 type CodeContainerProps = {

--- a/packages/module/plugin-module-doc/src/components/overview/index.module.scss
+++ b/packages/module/plugin-module-doc/src/components/overview/index.module.scss
@@ -1,6 +1,4 @@
 @media (max-width: 640px) {
-  .grid-2,
-  .grid-3,
   .grid-4,
   .grid-6 {
     width: calc(100%);
@@ -8,22 +6,41 @@
 }
 
 @media (min-width: 640px) {
-  .grid-2,
-  .grid-3,
   .grid-4,
   .grid-6 {
     width: calc(100% / 2);
   }
 }
 
+@media (min-width: 1280px) {
+  .grid-4,
+  .grid-6 {
+    width: calc(100% / 3);
+  }
+}
+
+
 
 .featureCard {
-  background: var(--modern-home-feature-bg);
-  border: 1px solid transparent;
+  background-color: transparent;
+  border-radius: 8px;
+  border: 1px solid rgb(229, 231, 235);
   transition: all 0.3s;
+  font-size: 20px;
+  font-weight: 500;
+  color: initial;
 }
 
 .featureCard:hover {
-  background: var(--modern-home-feature-hover-bg);
-  border: 1px solid var(--modern-c-brand);
+  background: rgba(248,250,252,1);
+}
+
+.featureCard svg {
+  width: 24px;
+  height: 24px;
+  color: rgba(0,0,0,0.2);
+}
+
+.featureCard:hover svg {
+  color: currentColor;
 }

--- a/packages/module/plugin-module-doc/src/components/overview/index.tsx
+++ b/packages/module/plugin-module-doc/src/components/overview/index.tsx
@@ -1,4 +1,5 @@
 import { usePageData } from '@modern-js/doc-core/runtime';
+import { Link } from '@modern-js/doc-core/theme';
 import { PageData } from '@modern-js/doc-core';
 import { IconRight } from '@arco-design/web-react/icon';
 import { Divider } from '@arco-design/web-react';
@@ -7,76 +8,70 @@ import { locales } from '../../locales';
 
 import styles from './index.module.scss';
 
-type ModuleList = {
+type List = {
+  icon?: React.ReactNode;
   text: string;
   link: string;
+  arrow?: boolean;
 };
-
-const PRESET_COUNT = [2, 3, 4];
 
 const getGridClass = (count?: number): string => {
   if (!count) {
     return '';
-  } else if (PRESET_COUNT.includes(count)) {
-    return `grid-${12 / count}`;
   } else if (count % 3 === 0) {
     return 'grid-4';
   } else if (count % 2 === 0) {
     return 'grid-6';
   }
-  return '';
+  return 'grid-6';
 };
 
-export default () => {
+export default ({ list, ...props }: { list?: List[] }) => {
   const pageData = usePageData() as PageData;
   const { siteData, lang } = pageData;
-  const moduleList: ModuleList[] = [];
+  const moduleList = list ?? [];
 
-  siteData.themeConfig.locales?.forEach(locale => {
-    if (locale.lang === lang) {
-      Object.values(locale.sidebar!)[0].forEach((sidebarItem: any) => {
-        sidebarItem.items.forEach((item: ModuleList) => {
-          moduleList.push({
-            text: item.text,
-            link: item.link,
+  if (moduleList.length === 0) {
+    // default list, from sidebar
+    siteData.themeConfig.locales?.forEach(locale => {
+      if (locale.lang === lang) {
+        Object.values(locale.sidebar!)[0].forEach((sidebarItem: any) => {
+          sidebarItem.items.forEach((item: List) => {
+            moduleList.push({
+              text: item.text,
+              link: item.link,
+              arrow: true,
+            });
           });
         });
-      });
-    }
-  });
+      }
+    });
+  }
   const gridClass = getGridClass(moduleList?.length);
-
   return (
-    <div>
+    <div {...props}>
       <h1>{locales[lang as 'zh' | 'en']?.overview}</h1>
-      <Divider></Divider>
-      <div className="overflow-hidden m-auto flex flex-wrap justify-between max-w-6xl">
-        {moduleList?.map(({ text, link }) => {
+      <Divider />
+      <div className="overflow-hidden m-auto flex flex-wrap max-w-6xl">
+        {moduleList.map(({ text, link, icon, arrow }) => {
           return (
             <div
               key={link + text}
-              className={`${
-                gridClass ? styles[gridClass] : 'w-full'
-              } rounded hover:var(--modern-c-brand)`}
+              className={`${gridClass ? styles[gridClass] : 'w-full'} rounded `}
             >
               <div className="h-full p-2">
-                <article
-                  key={link + text}
-                  className={`${styles.featureCard} h-full p-2 pl-4 border-transparent flex items-center justify-between`}
-                  style={{
-                    cursor: link ? 'pointer' : 'auto',
-                  }}
-                  onClick={() => {
-                    if (link) {
-                      window.location.href = link;
-                    }
-                  }}
-                >
-                  <h2 className=" text-center" style={{ fontSize: '24px' }}>
-                    {text}
-                  </h2>
-                  <IconRight style={{ height: '24px', marginRight: '4px' }} />
-                </article>
+                <Link href={link}>
+                  <span
+                    key={link + text}
+                    className={`${styles.featureCard} h-full p-3 flex items-center justify-between text-center`}
+                  >
+                    <span className="flex items-center gap-2">
+                      {icon}
+                      {text}
+                    </span>
+                    {arrow && <IconRight />}
+                  </span>
+                </Link>
               </div>
             </div>
           );

--- a/packages/module/plugin-module-doc/src/features/lanchDoc.ts
+++ b/packages/module/plugin-module-doc/src/features/lanchDoc.ts
@@ -74,6 +74,13 @@ export async function launchDoc({
             [remarkTsxToReact, { appDir, defaultLang: DEFAULT_LANG }],
           ],
         },
+        head: [
+          `
+          <script>
+            window.MODERN_THEME = 'light';
+          </script>
+          `,
+        ],
       },
     },
     {

--- a/packages/module/plugin-module-doc/src/utils.ts
+++ b/packages/module/plugin-module-doc/src/utils.ts
@@ -1,3 +1,0 @@
-export function normalizeRoutePath(routePath: string) {
-  return routePath.replace(/\.html$/, '').replace(/\/index$/, '/');
-}

--- a/packages/module/plugin-module-doc/static/index.css
+++ b/packages/module/plugin-module-doc/static/index.css
@@ -1,7 +1,9 @@
 :root {
-  --modern-c-brand: #FF9933;
-  --modern-c-brand-dark: #FF9933;
-  --modern-c-brand-darker: #FF9933;
-  --modern-c-brand-light: #FF9933;
-  --modern-c-brand-lighter: #FF9933;
+  --modern-c-brand: #165DFF;
+  --modern-c-brand-dark: #165DFF;
+  --modern-c-brand-darker: #165DFF;
+  --modern-c-brand-light: #165DFF;
+  --modern-c-brand-lighter: #165DFF;
+  --modern-sidebar-width: 210px;
+  --modern-aside-width: 192px;
 }

--- a/tests/integration/module-doc/docs/zh/index.mdx
+++ b/tests/integration/module-doc/docs/zh/index.mdx
@@ -1,1 +1,4 @@
-<Overview/>
+<Overview list={[
+  {arrow: true, link: '/Alert', text: 'Alert', icon: <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path d="M16 8a5.99 5.99 0 0 0 9.471 4.885L28.586 16L30 14.586l-3.115-3.115A5.997 5.997 0 1 0 16 8zm2 0a4 4 0 1 1 4 4a4.005 4.005 0 0 1-4-4z" fill="currentColor"/><path d="M11 24h10v2H11z" fill="currentColor"/><path d="M13 28h6v2h-6z" fill="currentColor"/><path d="M10.815 18.14A7.185 7.185 0 0 1 8 12a8.005 8.005 0 0 1 6-7.737L13.614 2.3A10.009 10.009 0 0 0 6 12a9.18 9.18 0 0 0 3.46 7.616C10.472 20.551 11 21.081 11 22h2c0-1.84-1.11-2.866-2.185-3.86z" fill="currentColor"/><path d="M23.05 16a9.6 9.6 0 0 1-1.872 2.143C20.107 19.135 19 20.16 19 22h2c0-.92.526-1.45 1.535-2.386a10.966 10.966 0 0 0 2.369-2.833z" fill="currentColor"/></svg>},
+   {arrow: true, link: '/Button', text: 'Button', icon: <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="currentColor" d="M4 2H2v26a2 2 0 0 0 2 2h26v-2H4Z"/><path fill="currentColor" d="M30 9h-7v2h3.59L19 18.59l-4.29-4.3a1 1 0 0 0-1.42 0L6 21.59L7.41 23L14 16.41l4.29 4.3a1 1 0 0 0 1.42 0l8.29-8.3V16h2Z"/></svg>},
+    ]}/>


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8fb1212</samp>

This pull request improves the appearance and functionality of the doc-core and plugin-module-doc packages. It refactors the `Overview` component to use a custom prop and the doc theme `Link` component, simplifies the style sheets and adds CSS variables, fixes the theme switching issue in development mode, and updates the usage of the `Overview` component in the `index.mdx` file. It also removes some unused or duplicated code and imports.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8fb1212</samp>

* Change the brand color and the sidebar and aside width using CSS variables ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-5048a325a5021f553899aa020c1f1b0762963c12e71ff6b81e73d26ebf039e5dL2-R8))
* Import and use the `withBase` function to prepend the base path to the sidebar links ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-c7d6b72a0b8cfe40e924cabadf2aed35c8b9ba509c11ed59b2d5ab8bcc57a2b6L9-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-c7d6b72a0b8cfe40e924cabadf2aed35c8b9ba509c11ed59b2d5ab8bcc57a2b6L182-R182))
* Add the `item.link` condition to style and navigate the sidebar groups with links ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-c7d6b72a0b8cfe40e924cabadf2aed35c8b9ba509c11ed59b2d5ab8bcc57a2b6L169-R169), [link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-c7d6b72a0b8cfe40e924cabadf2aed35c8b9ba509c11ed59b2d5ab8bcc57a2b6L175-R175))
* Update the `featureCard` class to use transparent background, rounded border, and consistent font size and weight ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-41daae5ffbf7721c2e4840f5abccb74ab2dbb1478b08e804d5ce77abf812c843L19-R46))
* Change the hover effect of the feature cards to use a lighter background and the same border color as the text ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-41daae5ffbf7721c2e4840f5abccb74ab2dbb1478b08e804d5ce77abf812c843L19-R46))
* Style the svg icon of the feature cards to match the text color and size ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-41daae5ffbf7721c2e4840f5abccb74ab2dbb1478b08e804d5ce77abf812c843L19-R46))
* Import and use the `Link` component to render the overview items with icons and arrows ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fR2), [link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fL27-R74))
* Change the `Overview` component props to accept an optional `list` prop that contains the icon, text, link, and arrow properties for each overview item ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fL10-R20))
* Simplify the grid class of the `Overview` component to use either `grid-4` or `grid-6` depending on the count ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fL10-R20))
* Remove the unused and redundant `.grid-2` and `.grid-3` classes from the overview component style sheet ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-41daae5ffbf7721c2e4840f5abccb74ab2dbb1478b08e804d5ce77abf812c843L2-L3), [link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-41daae5ffbf7721c2e4840f5abccb74ab2dbb1478b08e804d5ce77abf812c843L11-L12))
* Import the `normalizeRoutePath` function from `@modern-js/doc-core/runtime` instead of `../../utils` to avoid duplication and use the shared utility function ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-3eefe432bee8373a4c5b570fac5904d753133128be87e7a25cfa386d2bad9aa7L10-R10))
* Inject a script tag that sets the `window.MODERN_THEME` variable to `light` in the `head` property of the `launchDoc` function to fix the theme switching issue in development mode ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9R77-R83))
* Delete the `utils.ts` file as it was no longer needed ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-a42fef309c4851be5e4185d33ea84a2fad4f04acf4a8b90f8241ca5ee78f7902))
* Pass a custom `list` prop to the `Overview` component in the `index.mdx` file to customize the overview items without relying on the sidebar configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3464/files?diff=unified&w=0#diff-91d5eb1643d99c51a3c5fd065f29dba85fb44593198493e57f62e533e514c4c6L1-R4))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
