### PR TITLE
chore(utils): fix jest haste module map error

### DIFF
--- a/packages/solutions/module-tools/tests/fixtures/sideEffects/package.json
+++ b/packages/solutions/module-tools/tests/fixtures/sideEffects/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "source-dir-test",
+  "name": "module-tools-side-effects-test",
   "sideEffects": true
 }

--- a/packages/toolkit/utils/jest.config.js
+++ b/packages/toolkit/utils/jest.config.js
@@ -4,4 +4,5 @@ const sharedConfig = require('@scripts/jest-config');
 module.exports = {
   ...sharedConfig,
   rootDir: __dirname,
+  modulePathIgnorePatterns: ['<rootDir>/compiled/'],
 };

--- a/tests/jest-ut.config.js
+++ b/tests/jest-ut.config.js
@@ -51,6 +51,7 @@ module.exports = {
     '<rootDir>/packages/toolkit/remark-container',
     '<rootDir>/packages/solutions/module-tools-v2/compiled/',
     '<rootDir>/packages/solutions/module-tools/compiled/',
+    '<rootDir>/packages/toolkit/utils/compiled/',
   ],
   testPathIgnorePatterns: [
     '<rootDir>/packages/builder/',


### PR DESCRIPTION
## Summary

Fix jest haste module map error.

<img width="1053" alt="Screen Shot 2023-04-17 at 19 49 01" src="https://user-images.githubusercontent.com/7237365/232476243-92f46666-39b5-4ee6-947e-2a99b342ffc7.png">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 075f8f8</samp>

This pull request fixes some issues with the Jest configuration and the test fixtures for the `module-tools` solution and the `toolkit/utils` package. It ensures that the test names, paths, and coverage are consistent and accurate.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 075f8f8</samp>

*  Exclude compiled files from Jest tests and coverage ([link](https://github.com/web-infra-dev/modern.js/pull/3466/files?diff=unified&w=0#diff-2e4a53a4c6c39b9a1a58a320739a82dab71c0abb3d02a6d8a7f12ba7b57f0b5dR7), [link](https://github.com/web-infra-dev/modern.js/pull/3466/files?diff=unified&w=0#diff-93582d322926c96a6d34101b4c200bdde48d82a5af07be294c41bd757ccb53e4R54))
* Rename test fixture package to match test suite ([link](https://github.com/web-infra-dev/modern.js/pull/3466/files?diff=unified&w=0#diff-02ebc6f105acffa2e1da06a1ea1a0ec4526b3f780b0e8a09167245c7a5fb2620L2-R2))

## Related Issue

- https://github.com/facebook/jest/issues/8114#issuecomment-475068766

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
