### PR TITLE
fix: router missing App static property

### DIFF
--- a/.changeset/proud-icons-brush.md
+++ b/.changeset/proud-icons-brush.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: router missing App static property
+fix: router 确实 App 的静态属性

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -121,7 +121,11 @@ export const routerPlugin = ({
               );
             }) as React.FC<any>;
           };
-          const RouteApp = getRouteApp();
+          let RouteApp = getRouteApp();
+
+          if (App) {
+            RouteApp = hoistNonReactStatics(RouteApp, App);
+          }
 
           if (routesConfig?.globalApp) {
             return next({


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

补全 react-router plugin hoc 逻辑

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c17c5a2</samp>

* Add a changeset file to describe the patch updates for `@modern-js/runtime` and the fix messages for the router plugin issue (.changeset/proud-icons-brush.md)
* Fix the router plugin issue by hoisting the static properties of the App component to the RouteApp component ([link](https://github.com/web-infra-dev/modern.js/pull/3477/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L124-R129))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
