### PR TITLE
fix: upgrade libuild version to fix tailwind plugin in watch mode

### DIFF
--- a/.changeset/four-hornets-nail.md
+++ b/.changeset/four-hornets-nail.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+'@modern-js/plugin-tailwindcss': patch
+---
+
+fix: upgrade libuild version to support tailwind in watch mode
+fix: 更新libuild版本以支持tailwindcss在watch模式下生效

--- a/packages/cli/plugin-tailwind/src/cli.ts
+++ b/packages/cli/plugin-tailwind/src/cli.ts
@@ -173,6 +173,10 @@ export default (
 
         return config;
       },
+      modifyLibuild(config, next) {
+        config.transformCache = false;
+        return next(config);
+      },
     };
   },
 });

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -46,9 +46,9 @@
   },
   "dependencies": {
     "@modern-js/core": "workspace:*",
-    "@modern-js/libuild": "~0.11.9",
-    "@modern-js/libuild-plugin-svgr": "~0.11.9",
-    "@modern-js/libuild-plugin-swc": "~0.11.9",
+    "@modern-js/libuild": "~0.11.11",
+    "@modern-js/libuild-plugin-svgr": "~0.11.11",
+    "@modern-js/libuild-plugin-swc": "~0.11.11",
     "@modern-js/new-action": "workspace:*",
     "@modern-js/plugin": "workspace:*",
     "@modern-js/plugin-changeset": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3393,9 +3393,9 @@ importers:
     specifiers:
       '@modern-js/builder-webpack-provider': workspace:*
       '@modern-js/core': workspace:*
-      '@modern-js/libuild': ~0.11.9
-      '@modern-js/libuild-plugin-svgr': ~0.11.9
-      '@modern-js/libuild-plugin-swc': ~0.11.9
+      '@modern-js/libuild': ~0.11.11
+      '@modern-js/libuild-plugin-svgr': ~0.11.11
+      '@modern-js/libuild-plugin-swc': ~0.11.11
       '@modern-js/new-action': workspace:*
       '@modern-js/plugin': workspace:*
       '@modern-js/plugin-changeset': workspace:*
@@ -3419,9 +3419,9 @@ importers:
       typescript: ^4
     dependencies:
       '@modern-js/core': link:../../cli/core
-      '@modern-js/libuild': 0.11.9
-      '@modern-js/libuild-plugin-svgr': 0.11.9
-      '@modern-js/libuild-plugin-swc': 0.11.9
+      '@modern-js/libuild': 0.11.11
+      '@modern-js/libuild-plugin-svgr': 0.11.11
+      '@modern-js/libuild-plugin-swc': 0.11.11
       '@modern-js/new-action': link:../../generator/new-action
       '@modern-js/plugin': link:../../toolkit/plugin
       '@modern-js/plugin-changeset': link:../../cli/plugin-changeset
@@ -11118,8 +11118,8 @@ packages:
       vm-browserify: 1.1.2
     dev: false
 
-  /@modern-js/libuild-plugin-svgr/0.11.9:
-    resolution: {integrity: sha512-FvKlKyRzQRwmj4qFZiFJS+CUqzOFUlhvgTVYwia1oPI1TPr6IW1/1s8I5bddr8r4t96ANcxfLXjtUoFluSKv/w==}
+  /@modern-js/libuild-plugin-svgr/0.11.11:
+    resolution: {integrity: sha512-3vqJiBZKk0JC1BZmU5Vsf0y3cabMFcfrTeOhg8SDgryiX7FsVbNh5gkB8KqKNzW0Qg8Xbp+BNSM7yj9gz/mxlQ==}
     dependencies:
       '@svgr/core': 6.2.0
       '@svgr/plugin-jsx': 6.2.0_@svgr+core@6.2.0
@@ -11129,16 +11129,30 @@ packages:
       - supports-color
     dev: false
 
+  /@modern-js/libuild-plugin-swc/0.11.11:
+    resolution: {integrity: sha512-sjcV/93s0jKCmjJmH71nBIBd2z9OdyCGY09DoyA3a/NebKY9IBJ8wMgE3YBCVZkslW1uV6mFAM2skj9QIZCP8Q==}
+    dependencies:
+      '@modern-js/swc-plugins': 0.2.0
+    dev: false
+
   /@modern-js/libuild-plugin-swc/0.11.8:
     resolution: {integrity: sha512-T+EDlCzVH9OO/4jm3OYZ7g76jOoOcsOjYk+oIyvRDD/Yzw6zZpizYMpmRSxSk4gzzJeFybb/mnXGgddIFa+mRQ==}
     dependencies:
       '@modern-js/swc-plugins': 0.2.0
     dev: false
 
-  /@modern-js/libuild-plugin-swc/0.11.9:
-    resolution: {integrity: sha512-MwAq6U/2BVu9niKunyUt6NIpepSS+DhrysxzwhjH8cz6pShivIK1B6Itap64Z9phQneII9xR3n7SqqyziDgcKA==}
+  /@modern-js/libuild/0.11.11:
+    resolution: {integrity: sha512-BKs8CAScqDfQloO/UhAeoU9dwi/FVqoMiXMskLzra9yZTKbqTOePGaheqWpUF/3TZfn22YQtOeg7M2LJ1ooFjg==}
+    hasBin: true
     dependencies:
-      '@modern-js/swc-plugins': 0.2.0
+      '@ast-grep/napi': 0.1.13
+      esbuild: 0.17.7
+      postcss: 8.4.6
+      source-map: 0.7.4
+      source-map-support: 0.5.20
+      style-inject: 0.3.0
+      sucrase: 3.29.0
+      terser: 5.15.0
     dev: false
 
   /@modern-js/libuild/0.11.8:
@@ -11153,20 +11167,6 @@ packages:
       sucrase: 3.29.0
       terser: 5.15.0
     dev: true
-
-  /@modern-js/libuild/0.11.9:
-    resolution: {integrity: sha512-5l7+SZ/LLdZBJlD4hCOEfLvy/X18voRZpCmQQSbWT/52lNJvLvU06aBdHPshlaPbIDv7z5gUSgnbRCJRY5DDoQ==}
-    hasBin: true
-    dependencies:
-      '@ast-grep/napi': 0.1.13
-      esbuild: 0.17.7
-      postcss: 8.4.6
-      source-map: 0.7.4
-      source-map-support: 0.5.20
-      style-inject: 0.3.0
-      sucrase: 3.29.0
-      terser: 5.15.0
-    dev: false
 
   /@modern-js/mdx-rs-binding-darwin-arm64/0.1.3:
     resolution: {integrity: sha512-fv+jRfwjy0URRL+l8cMH43blFU/6kPdB2YmNbEwnKs/TONknJ8Eu4FXKLJTX5aYXXv9MYQOauikCEhFxdW9qbA==}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aecc927</samp>

This pull request improves the integration of Tailwind CSS and `libuild` in the `modern.js` framework. It disables the `transformCache` option for the `tailwind` command to avoid caching issues, and updates the dependencies of the `@modern-js/module-tools` package to use the latest versions of `libuild` and its plugins.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aecc927</samp>

* Disable `transformCache` option in `libuild` config when using `tailwind` command to avoid caching issues with Tailwind CSS ([link](https://github.com/web-infra-dev/modern.js/pull/3482/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dR176-R180))
* Update dependencies of `@modern-js/module-tools` package to version `0.11.11` for compatibility with latest `libuild` features and fixes ([link](https://github.com/web-infra-dev/modern.js/pull/3482/files?diff=unified&w=0#diff-055025f7bf51ab178a16586525252b151c72b7d2b12a919728635d38c7ab6f2aL49-R51))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
