### PR TITLE
fix(app-tools): can not disable output.cleanDistPath

### DIFF
--- a/.changeset/dirty-pigs-watch.md
+++ b/.changeset/dirty-pigs-watch.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): can not disable output.cleanDistPath
+
+fix(app-tools): 修复无法禁用 output.cleanDistPath 的问题

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -235,14 +235,19 @@ export default (
 
       async prepare() {
         const command = getCommand();
+
+        // clean dist path before building
         if (
           command === 'dev' ||
           command === 'start' ||
           command === 'build' ||
           command === 'deploy'
         ) {
-          const appContext = api.useAppContext();
-          await emptyDir(appContext.distDirectory);
+          const resolvedConfig = api.useResolvedConfigContext();
+          if (resolvedConfig.output.cleanDistPath) {
+            const appContext = api.useAppContext();
+            await emptyDir(appContext.distDirectory);
+          }
         }
       },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4534,6 +4534,29 @@ importers:
       '@types/react-dom': 18.0.6
       typescript: 4.9.5
 
+  tests/integration/clean-dist-path:
+    specifiers:
+      '@modern-js/app-tools': workspace:*
+      '@modern-js/runtime': workspace:*
+      '@types/jest': ^29
+      '@types/node': ^14
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      react: ^18
+      react-dom: ^18
+      typescript: ^4
+    dependencies:
+      '@modern-js/runtime': link:../../../packages/runtime/plugin-runtime
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@modern-js/app-tools': link:../../../packages/solutions/app-tools
+      '@types/jest': 29.2.6
+      '@types/node': 14.18.35
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      typescript: 4.9.5
+
   tests/integration/copy-assets:
     specifiers:
       '@types/jest': ^29

--- a/tests/integration/clean-dist-path/modern.config.ts
+++ b/tests/integration/clean-dist-path/modern.config.ts
@@ -1,0 +1,8 @@
+import appTools, { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig<'rspack'>({
+  output: {
+    cleanDistPath: false,
+  },
+  plugins: [appTools({ bundler: 'experimental-rspack' })],
+});

--- a/tests/integration/clean-dist-path/package.json
+++ b/tests/integration/clean-dist-path/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "name": "integration-clean-dist-path",
+  "version": "2.9.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "serve": "modern serve"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "typescript": "^4",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@types/jest": "^29",
+    "@types/node": "^14"
+  }
+}

--- a/tests/integration/clean-dist-path/src/App.tsx
+++ b/tests/integration/clean-dist-path/src/App.tsx
@@ -1,0 +1,3 @@
+const App = () => <div>hello</div>;
+
+export default App;

--- a/tests/integration/clean-dist-path/tests/index.test.ts
+++ b/tests/integration/clean-dist-path/tests/index.test.ts
@@ -1,13 +1,15 @@
 import path from 'path';
-import { writeFileSync, existsSync } from 'fs';
+import { fs } from '@modern-js/utils';
 import { modernBuild } from '../../../utils/modernTestUtils';
 
 describe('clean dist path', () => {
   it(`should not clean dist path when output.cleanDistPath is false`, async () => {
     const appDir = path.resolve(__dirname, '..');
-    const tempFile = path.join(appDir, 'dist', 'foo.txt');
-    writeFileSync(tempFile, 'foo');
+    const tempFile = path.join(appDir, 'dist/foo.txt');
+    const htmlFile = path.join(appDir, 'dist/html/main/index.html');
+    fs.outputFileSync(tempFile, 'foo');
     await modernBuild(appDir);
-    expect(existsSync(tempFile)).toBeTruthy();
+    expect(fs.existsSync(tempFile)).toBeTruthy();
+    expect(fs.existsSync(htmlFile)).toBeTruthy();
   });
 });

--- a/tests/integration/clean-dist-path/tests/index.test.ts
+++ b/tests/integration/clean-dist-path/tests/index.test.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+import { writeFileSync, existsSync } from 'fs';
+import { modernBuild } from '../../../utils/modernTestUtils';
+
+describe('clean dist path', () => {
+  it(`should not clean dist path when output.cleanDistPath is false`, async () => {
+    const appDir = path.resolve(__dirname, '..');
+    const tempFile = path.join(appDir, 'dist', 'foo.txt');
+    writeFileSync(tempFile, 'foo');
+    await modernBuild(appDir);
+    expect(existsSync(tempFile)).toBeTruthy();
+  });
+});

--- a/tests/integration/clean-dist-path/tsconfig.json
+++ b/tests/integration/clean-dist-path/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "outDir": "dist"
+  },
+  "include": ["src", "tests", "modern.config.ts"]
+}


### PR DESCRIPTION
## Summary

Fix can not disable `output.cleanDistPath`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 717909a</samp>

*  Add output.cleanDistPath option to app-tools config to control whether to clean the dist path before building ([link](https://github.com/web-infra-dev/modern.js/pull/3488/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR238-R239), [link](https://github.com/web-infra-dev/modern.js/pull/3488/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL244-R250))
*  Implement integration test for output.cleanDistPath option using experimental-rspack bundler ([link](https://github.com/web-infra-dev/modern.js/pull/3488/files?diff=unified&w=0#diff-35bacb80c0a6cf240208d4135d00bfc5c10858c6ba071da514474c0fef5322a0R1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/3488/files?diff=unified&w=0#diff-3dc10ff91f5eafa31a51f9a082a40c388865f2cd55f0719f8212897a85f7e8aeR1-R23), [link](https://github.com/web-infra-dev/modern.js/pull/3488/files?diff=unified&w=0#diff-56cf97a8f5e97dc57c72998adae8ba6b17a19c788c638c70e5ce86af0eec4b2aR1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/3488/files?diff=unified&w=0#diff-6b9a2bbb18994086e95db1520e356b67cc53db9fdf978f13641718761c4da4e5R1-R13), [link](https://github.com/web-infra-dev/modern.js/pull/3488/files?diff=unified&w=0#diff-22cdf33297bd53386be0fddff41d641d93f2b1db6830aa951f82e13e556f511eR1-R10))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
