### PR TITLE
fix(builder): update alias type when using Rspack

### DIFF
--- a/.changeset/swift-waves-sip.md
+++ b/.changeset/swift-waves-sip.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+'@modern-js/builder-doc': patch
+---
+
+fix(builder): update source.alias type when using Rspack
+
+fix(builder): 更新使用 Rspack 时的 source.alias 类型

--- a/packages/builder/builder-rspack-provider/src/config/validate/source.ts
+++ b/packages/builder/builder-rspack-provider/src/config/validate/source.ts
@@ -4,11 +4,6 @@ import type { SourceConfig } from '../../types';
 export const sourceConfigSchema: z.ZodType<SourceConfig> =
   sharedSourceConfigSchema
     .extend({
-      alias: z.chained(z.record(z.string()), undefined, {
-        errorMap: () => ({
-          message: 'Only support Record<string, string> or Function',
-        }),
-      }),
       define: z.record(z.any()),
     })
     .partial();

--- a/packages/builder/builder-rspack-provider/src/types/config/source.ts
+++ b/packages/builder/builder-rspack-provider/src/types/config/source.ts
@@ -1,25 +1,16 @@
 import type {
   SharedSourceConfig,
   NormalizedSharedSourceConfig,
-  ChainedConfig,
 } from '@modern-js/builder-shared';
 import type { Builtins } from '@rspack/core';
 import type { RspackBuiltinsConfig } from '../rspack';
-/**
- * type: Record<string, string> | Function
- *
- * not support Record<string, string[]>
- */
-type Alias = ChainedConfig<Record<string, string>>;
 
 export type SourceConfig = SharedSourceConfig & {
-  alias?: Alias;
   define?: RspackBuiltinsConfig['define'];
   transformImport?: Builtins['pluginImport'];
 };
 
 export type NormalizedSourceConfig = NormalizedSharedSourceConfig & {
-  alias?: Alias;
   define: Record<string, string>;
   transformImport?: Builtins['pluginImport'];
 };

--- a/packages/builder/builder-shared/src/schema/source.ts
+++ b/packages/builder/builder-shared/src/schema/source.ts
@@ -14,6 +14,7 @@ export const MainFieldsSchema: ZodType<MainFields> = z.array(
 );
 
 export const sharedSourceConfigSchema = z.partialObj({
+  alias: z.chained(z.record(z.arrayOrNot(z.string()))),
   include: z.array(z.union([z.string(), z.instanceof(RegExp)])),
   exclude: z.array(z.union([z.string(), z.instanceof(RegExp)])),
   preEntry: z.arrayOrNot(z.string()),

--- a/packages/builder/builder-shared/src/types/config/source.ts
+++ b/packages/builder/builder-shared/src/types/config/source.ts
@@ -1,11 +1,17 @@
+import type { Alias } from '@modern-js/utils';
 import type { BuilderTarget } from '../builder';
-import type { JSONValue } from '../utils';
+import type { ChainedConfig, JSONValue } from '../utils';
 
 export type ModuleScopes = Array<string | RegExp>;
 
 export type MainFields = (string | string[])[];
 
 export interface SharedSourceConfig {
+  /**
+   * Create aliases to import or require certain modules,
+   * same as the [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config of webpack.
+   */
+  alias?: ChainedConfig<Alias>;
   /**
    * Specify directories or modules that need additional compilation.
    * In order to maintain faster compilation speed, Builder will not compile files under node_modules through

--- a/packages/builder/builder-webpack-provider/src/config/validate/source.ts
+++ b/packages/builder/builder-webpack-provider/src/config/validate/source.ts
@@ -5,7 +5,6 @@ export const sourceConfigSchema: z.ZodType<SourceConfig> =
   sharedSourceConfigSchema
     .extend({
       define: z.record(z.any()),
-      alias: z.chained(z.record(z.arrayOrNot(z.string()))),
       moduleScopes: z.chained(
         z.array(z.union([z.string(), z.instanceof(RegExp)])),
       ),

--- a/packages/builder/builder-webpack-provider/src/types/config/source.ts
+++ b/packages/builder/builder-webpack-provider/src/types/config/source.ts
@@ -4,7 +4,6 @@ import type {
   ChainedConfig,
   ModuleScopes,
 } from '@modern-js/builder-shared';
-import type { Alias } from '@modern-js/utils';
 
 export type TransformImport = {
   libraryName: string;
@@ -18,11 +17,6 @@ export type TransformImport = {
 };
 
 export interface SourceConfig extends SharedSourceConfig {
-  /**
-   * Create aliases to import or require certain modules,
-   * same as the [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config of webpack.
-   */
-  alias?: ChainedConfig<Alias>;
   /**
    * Replaces variables in your code with other values or expressions at compile time.
    */
@@ -39,12 +33,6 @@ export interface SourceConfig extends SharedSourceConfig {
 }
 
 export interface NormalizedSourceConfig extends NormalizedSharedSourceConfig {
-  /**
-   * Create aliases to import or require certain modules,
-   * same as the [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config of webpack.
-   */
-  alias?: ChainedConfig<Alias>;
-
   define: Record<string, any>;
 
   /**

--- a/packages/document/builder-doc/docs/en/config/source/alias.md
+++ b/packages/document/builder-doc/docs/en/config/source/alias.md
@@ -7,10 +7,6 @@ Create aliases to import or require certain modules, same as the [resolve.alias]
 For TypeScript projects, you only need to configure [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) in `tsconfig.json`, Builder will automatically recognize the aliases in `tsconfig.json`, so the `alias` config is unnecessary.
 :::
 
-:::tip
-When using Rspack as the bundler, only the `Record<string, string> | Function` type is supported.
-:::
-
 #### Object Type
 
 The `alias` can be an Object, and the relative path will be automatically converted to absolute path.

--- a/packages/document/builder-doc/docs/zh/config/source/alias.md
+++ b/packages/document/builder-doc/docs/zh/config/source/alias.md
@@ -7,10 +7,6 @@
 对于 TypeScript 项目，只需要在 `tsconfig.json` 中配置 [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) 即可，Builder 会自动识别 `tsconfig.json` 里的别名，因此不需要额外配置 `alias` 字段。
 :::
 
-:::tip
-在使用 Rspack 作为打包工具时，只支持 `Record<string, string> | Function` 类型。
-:::
-
 #### Object 类型
 
 `alias` 的值可以定义为 Object 类型，其中的相对路径会自动被 Builder 转换为绝对路径。


### PR DESCRIPTION
## Summary

Rspack supports setting alias to `Record<string, false | string | (string | false)[]>` now, see https://www.rspack.dev/config/resolve.html#resolve-alias

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
