### PR TITLE
fix(app-tools): failed to scan public dir when using Rspack

### DIFF
--- a/.changeset/calm-kangaroos-itch.md
+++ b/.changeset/calm-kangaroos-itch.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): failed to scan public dir when using Rspack
+
+fix(app-tools): 修复 Rspack 模式读取 public 目录失败的问题

--- a/packages/solutions/app-tools/src/builder/builder-rspack/adapterCopy.ts
+++ b/packages/solutions/app-tools/src/builder/builder-rspack/adapterCopy.ts
@@ -38,6 +38,11 @@ export const builderPluginAdpaterCopy = (
         normalizedConfig.output.distPath?.root || './dist',
         './public',
       );
+
+      if (!fs.existsSync(publicDir) || !fs.statSync(publicDir).isDirectory()) {
+        return;
+      }
+
       const HTML_REGEXP = /\.html?$/;
 
       const filepaths = (await fs.readdir(publicDir)).map(file =>


### PR DESCRIPTION
## Summary

Fix failed to scan public dir when using Rspack.

<img width="1026" alt="Screen Shot 2023-04-19 at 16 32 34" src="https://user-images.githubusercontent.com/7237365/233018132-83f509d4-5c9b-4a07-b82d-95b8367867ef.png">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a1e8fd</samp>

This pull request fixes a bug in the `@modern-js/app-tools` package that caused an error when using the Rspack mode of the builder. It also updates the changeset file for the package with a patch version bump and a bilingual summary.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a1e8fd</samp>

* Fix a bug that caused an error when using Rspack mode with app-tools builder ([link](https://github.com/web-infra-dev/modern.js/pull/3497/files?diff=unified&w=0#diff-8e7af45593ac63d80358d027a9ac5f37cfed313aeb6ba1f9d536f225fab228a9R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3497/files?diff=unified&w=0#diff-08d94a182e651b75ca11928680c98aff384930cb7a19b6585505651851be382cR41-R45))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
