### PR TITLE
chore(server): no longer replace globalVars when compiler is babel

### DIFF
--- a/.changeset/funny-berries-compete.md
+++ b/.changeset/funny-berries-compete.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/plugin-server': patch
+'@modern-js/plugin-bff': patch
+'@modern-js/server-utils': patch
+'@modern-js/server-core': patch
+---
+
+chore(server): no longer replace globalVars when compiler is babel
+
+chore(server): 进行 babel compile 时不再替换 globalVars

--- a/packages/builder/builder-shared/src/devServer.ts
+++ b/packages/builder/builder-shared/src/devServer.ts
@@ -63,8 +63,6 @@ export const getDevServerOptions = async ({
     },
     source: {
       alias: {},
-      define: {},
-      globalVars: {},
     },
     html: {},
     tools: {

--- a/packages/builder/builder-shared/tests/devServer.test.ts
+++ b/packages/builder/builder-shared/tests/devServer.test.ts
@@ -103,8 +103,6 @@ describe('test dev server', () => {
           "server": {},
           "source": {
             "alias": {},
-            "define": {},
-            "globalVars": {},
           },
           "tools": {
             "babel": {},
@@ -171,8 +169,6 @@ describe('test dev server', () => {
           "server": {},
           "source": {
             "alias": {},
-            "define": {},
-            "globalVars": {},
           },
           "tools": {
             "babel": {},

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -151,7 +151,7 @@ export default (): CliPlugin<AppTools> => ({
         }
 
         const { server } = modernConfig;
-        const { alias, define, globalVars } = modernConfig.source;
+        const { alias } = modernConfig.source;
         const { babel } = modernConfig.tools;
 
         if (sourceDirs.length > 0) {
@@ -160,8 +160,6 @@ export default (): CliPlugin<AppTools> => ({
             {
               server,
               alias,
-              define,
-              globalVars,
               babelConfig: babel,
             },
             {

--- a/packages/server/core/src/types/config/source.ts
+++ b/packages/server/core/src/types/config/source.ts
@@ -1,18 +1,8 @@
 import type { Alias } from '@modern-js/utils';
 import type { ChainedConfig } from './share';
 
-type JSONPrimitive = string | number | boolean | null | undefined;
-
-type JSONArray = Array<JSONValue>;
-
-type JSONObject = { [key: string]: JSONValue };
-
-type JSONValue = JSONPrimitive | JSONObject | JSONArray;
-
 export interface SourceUserConfig {
   alias?: ChainedConfig<Alias>;
-  define?: Record<string, any>;
-  globalVars?: Record<string, JSONValue>;
 }
 
 export type SourceNormalizedConfig = SourceUserConfig;

--- a/packages/server/plugin-server/src/cli.ts
+++ b/packages/server/plugin-server/src/cli.ts
@@ -33,7 +33,7 @@ export default (): CliPlugin<AppTools> => ({
       }
 
       const { server } = modernConfig;
-      const { alias, globalVars } = modernConfig.source;
+      const { alias } = modernConfig.source;
       const { babel } = modernConfig.tools;
 
       if (sourceDirs.length > 0) {
@@ -42,7 +42,6 @@ export default (): CliPlugin<AppTools> => ({
           {
             server,
             alias,
-            globalVars,
             babelConfig: babel,
           },
           {

--- a/packages/server/utils/src/common/index.ts
+++ b/packages/server/utils/src/common/index.ts
@@ -15,8 +15,6 @@ export interface Pattern {
 
 export interface IConfig {
   alias?: SourceNormalizedConfig['alias'];
-  define?: SourceNormalizedConfig['define'];
-  globalVars?: SourceNormalizedConfig['globalVars'];
   babelConfig?: ToolsNormalizedConfig['babel'];
   server: {
     compiler?: 'babel' | 'typescript';

--- a/packages/server/utils/src/compilers/babel/index.ts
+++ b/packages/server/utils/src/compilers/babel/index.ts
@@ -69,13 +69,7 @@ export const resolveBabelConfig = (
   config: Parameters<CompileFunc>[1],
   option: IPackageModeValue,
 ): any => {
-  const { globalVars, alias, babelConfig, define } = config;
-  const globalDefineVars =
-    define &&
-    Object.entries(define).reduce((object, [key, value]) => {
-      object[key] = JSON.stringify(value);
-      return object;
-    }, {} as Record<string, string>);
+  const { alias, babelConfig } = config;
   // alias config
   const aliasConfig = getAliasConfig(alias, {
     appDirectory,
@@ -90,10 +84,6 @@ export const resolveBabelConfig = (
       enableTypescriptPreset: true,
       alias: aliasConfig,
       envVars: [],
-      globalVars: {
-        ...globalVars,
-        ...globalDefineVars,
-      } as Record<string, any>,
     },
     {
       type: option.type,

--- a/packages/server/utils/tests/__snapshots__/babel.test.ts.snap
+++ b/packages/server/utils/tests/__snapshots__/babel.test.ts.snap
@@ -55,10 +55,6 @@ exports[`babel resolveBabelConfig 1`] = `
       "styled-components",
     ],
     [
-      "/babel-plugin-transform-define/lib/index.js",
-      {},
-    ],
-    [
       "/babel-plugin-transform-inline-environment-variables/lib/index.js",
       {
         "include": [],

--- a/packages/server/utils/tests/helpers.ts
+++ b/packages/server/utils/tests/helpers.ts
@@ -8,7 +8,6 @@ const sourceDefaults = {
   configDir: './config',
   apiDir: './api',
   envVars: [],
-  globalVars: undefined,
   alias: undefined,
   moduleScopes: undefined,
   include: [],


### PR DESCRIPTION
## Summary

No longer replace globalVars when compiler is babel.

Motivations:

- Keep same behavior between `compiler: 'ts'` and `compiler: 'babel'`.
- Usually this replacement is not necessary, because Node.js can access `process.env.xxx` in runtime.
- It is undocumented.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 800267f</samp>

This pull request removes the unused `define` and `globalVars` features from the server-side packages of the modern.js framework. This simplifies the configuration and compilation of the server plugins and utils, and makes the code more consistent and maintainable. The changes affect the cli, core, utils, and builder-shared packages, as well as the devServer options and the SourceUserConfig interface.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 800267f</samp>

*  Remove globalVars and define features from server plugins and utils ([link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-a5990cc6fe318946ff4266926b298fb0baa929f669adce5b73914ddf30e3959dR1-R11))
  * Delete define and globalVars properties from devServer options in `builder-shared` ([link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-1876b89358da5214f40c6a33a70fd6ca415b4222d9ae36cbe1f701dfa4fe083aL66-L67))
  * Delete define and globalVars properties from modernConfig and serverOptions objects in `plugin-bff` and `plugin-server` cli files ([link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-ddb13338fa5e4286f0affca3a481539c4265f010c94db3bb4beb2c5ba9202033L154-R154), [link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-ddb13338fa5e4286f0affca3a481539c4265f010c94db3bb4beb2c5ba9202033L163-L164), [link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-8c5b22ca30ef6f3973f23950a816f73258deba81162d44c6686139a08308b50fL36-R36), [link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-8c5b22ca30ef6f3973f23950a816f73258deba81162d44c6686139a08308b50fL45))
  * Delete define and globalVars properties from SourceUserConfig interface in `server-core` ([link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-751b74ade4547bc7df057d99f3fe708d7eb95a8f1d4d7f554738558ea042ad16L4-R5))
  * Delete define and globalVars properties from IConfig interface and babelOptions object in `server-utils` ([link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-da31f592085b6c0bdd3e10fc9a934bda10d07fb3fddd1aca6e65dd5de1063adcL18-L19), [link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-a677389227451c796a51dda15e4ab6cc80cab6acb587f16c2673ac0a02d7b7ceL72-R72), [link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-a677389227451c796a51dda15e4ab6cc80cab6acb587f16c2673ac0a02d7b7ceL93-L96))
  * Delete globalVars property from sourceDefaults object in `server-utils` tests ([link](https://github.com/web-infra-dev/modern.js/pull/3498/files?diff=unified&w=0#diff-563f03e97a40522864c93369bf3ac2b952f527126e77ce2c579a4c742fa08c24L11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
