### PR TITLE
fix(runtime): MODERN_TARGET is not injected when using Rspack

### DIFF
--- a/.changeset/six-tigers-own.md
+++ b/.changeset/six-tigers-own.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(runtime): MODERN_TARGET is not injected when using Rspack
+
+fix(runtime): 修复 Rspack 模式未注入 MODERN_TARGET 的问题

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -83,6 +83,12 @@ export default (): CliPlugin<AppTools> => ({
               '@modern-js/utils/ssr': require.resolve('@modern-js/utils/ssr'),
               '@modern-js/runtime/plugins': pluginsExportsUtils.getPath(),
             },
+            globalVars: (values, { target }) => {
+              values['process.env.MODERN_TARGET'] =
+                target === 'node' || target === 'service-worker'
+                  ? 'node'
+                  : 'browser';
+            },
           },
           tools: {
             webpackChain: (chain, { isServer, isServiceWorker, CHAIN_ID }) => {
@@ -102,23 +108,6 @@ export default (): CliPlugin<AppTools> => ({
                     { filename: LOADABLE_STATS_FILE },
                   ]);
               }
-
-              // add environment variables to determine the node/browser
-              const modernVars = {
-                [`process.env.MODERN_TARGET`]: JSON.stringify(
-                  isServer || isServiceWorker ? 'node' : 'browser',
-                ),
-              };
-              chain.plugin(CHAIN_ID.PLUGIN.DEFINE).tap(args => {
-                const [vars, ...rest] = args;
-                return [
-                  {
-                    ...vars,
-                    ...modernVars,
-                  },
-                  ...rest,
-                ];
-              });
             },
             babel: babelConfig,
           },


### PR DESCRIPTION
## Summary

This PR relies on https://github.com/web-infra-dev/modern.js/pull/3501

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8c52e6</samp>

This pull request fixes the global variable issue for modern mode in server-side rendering by adding a `globalVars` option to the `rspack` command and removing the `DefinePlugin` code from the `@modern-js/runtime` package. It also updates the changeset file for the patch release of the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8c52e6</samp>

* Add `globalVars` option to `rspack` command to inject `process.env.MODERN_TARGET` variable based on target environment ([link](https://github.com/web-infra-dev/modern.js/pull/3502/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5R86-R91))
* Remove redundant code that was setting `process.env.MODERN_TARGET` using `DefinePlugin` in `plugin-runtime/src/ssr/cli/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3502/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L105-L121))
* Add changeset file to document patch update for `@modern-js/runtime` package with fix description in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3502/files?diff=unified&w=0#diff-8ec6e334884bba5d10f8e7622ebbf0f32927fed7498bf5214e0079d56ccccfc2R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
