### PR TITLE
fix: app-doc & ssr test case

### DIFF
--- a/.changeset/mean-kangaroos-play.md
+++ b/.changeset/mean-kangaroos-play.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: ssr and document integration test error
+fix: 修复 ssr 和 document 的集测错误
+

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
@@ -200,7 +200,7 @@ export default class Entry {
     templateData: ReturnType<typeof buildTemplateData>,
     routerData?: Record<string, any>,
   ) {
-    const useInlineScript = this.pluginConfig.inlineScript;
+    const useInlineScript = this.pluginConfig.inlineScript !== false;
     const ssrData = serializeJson(templateData);
 
     let ssrDataScripts = useInlineScript

--- a/tests/integration/app-document/src/sub/Document.tsx
+++ b/tests/integration/app-document/src/sub/Document.tsx
@@ -20,11 +20,11 @@ export default function Document(): React.ReactElement {
     <Html {...{ fromUserDoc: true }}>
       <Head>
         {/* comment should be render to html by Comment.children */}
-        <Comment comment="<!== COMMENT BY APP but inline ==>">
+        <Comment comment="!== COMMENT BY APP but inline ==">
           {'<!-- COMMENT BY APP -->'}
         </Comment>
         {/* comment should be render to html by Comment.comment */}
-        <Comment comment="<!== COMMENT BY APP in inline ==>" />
+        <Comment comment="!== COMMENT BY APP in inline ==" />
         <link href="/ababad"></link>
         <script
           dangerouslySetInnerHTML={{

--- a/tests/integration/app-document/tests/index.test.js
+++ b/tests/integration/app-document/tests/index.test.js
@@ -112,11 +112,7 @@ describe('test build', () => {
     );
 
     expect(htmlWithDoc.includes('<!-- COMMENT BY APP -->')).toBe(true);
-    expect(htmlWithDoc.includes('<!== COMMENT BY APP in inline ==>')).toBe(
-      true,
-    );
-    expect(htmlWithDoc.includes('<!== COMMENT BY APP but inline ==>')).toBe(
-      false,
-    );
+    expect(htmlWithDoc.includes('== COMMENT BY APP in inline ==')).toBe(true);
+    expect(htmlWithDoc.includes('== COMMENT BY APP but inline ==')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ffc7b1</samp>

This pull request fixes the ssr and document integration test errors for the `@modern-js/runtime` package by adjusting the `useInlineScript` variable and the comment syntax. It also adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ffc7b1</samp>

*  Add changeset file for patch update of `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/3503/files?diff=unified&w=0#diff-6240ce46bdaa7fc43049b01d2424ea81a960d37681487ed89851e257143d4ca7R1-R7))
  - Setting `useInlineScript` to `true` by default in `plugin-runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/3503/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL203-R203))
  - Removing invalid HTML comments from `Document.tsx` in `app-document` test project ([link](https://github.com/web-infra-dev/modern.js/pull/3503/files?diff=unified&w=0#diff-5522b77a13d29ece18079fd33a607da6020c95913eefbb88642841ab8a116266L23-R27))
  - Updating assertions in `index.test.js` to match updated comments and verify ssr rendering ([link](https://github.com/web-infra-dev/modern.js/pull/3503/files?diff=unified&w=0#diff-d7c068470c15d603734c5f0e099d42da3e09bfa5e0ab3f5ec9dfebc0c6ec713eL115-R116))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
