### PR TITLE
feat(doc-core): change content padding-bottom from 48px to 72px

### DIFF
--- a/.changeset/light-guests-wink.md
+++ b/.changeset/light-guests-wink.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: change content padding-bottom from 48px to 72px, equal to header height
+fix: 将内容区域的底部内边距从48px修改为72px，和头部高度保持一致

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.module.scss
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.module.scss
@@ -38,7 +38,7 @@
   .content {
     margin-left: var(--modern-sidebar-width);
     width: calc(100vw - var(--modern-sidebar-width));
-    padding: 48px;
+    padding: 48px 48px 72px 48px;
 
     :global(.modern-doc) {
       padding-right: 48px;
@@ -62,7 +62,7 @@
   .content {
     margin-left: var(--modern-sidebar-width);
     width: calc(1440px - var(--modern-sidebar-width));
-    padding: 48px 64px;
+    padding: 48px 64px 72px 64px;
     :global(.modern-doc) {
       padding-right: 64px;
       width: calc(


### PR DESCRIPTION


## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41aebd9</samp>

Fixed the content padding and added a changeset for the `doc-core` package. This improves the layout of the documentation pages and records the changes for future releases.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41aebd9</samp>

* Add a changeset file to describe the fixes to the doc-core package ([link](https://github.com/web-infra-dev/modern.js/pull/3512/files?diff=unified&w=0#diff-1d2ed59f523b3f9dddff491be9c6f8c8e02326067e58de340ac3f12b59b6f5f0R1-R6))
* Increase the bottom padding of the content area in the default doc layout for the doc-core package to match the header height ([link](https://github.com/web-infra-dev/modern.js/pull/3512/files?diff=unified&w=0#diff-bba1d4ce4b34efc0704505701ad0803d218232fb20f86383cd9e268f7aed7718L41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/3512/files?diff=unified&w=0#diff-bba1d4ce4b34efc0704505701ad0803d218232fb20f86383cd9e268f7aed7718L65-R65))
* Modify the CSS style of the content area in `index.module.scss` for different screen widths ([link](https://github.com/web-infra-dev/modern.js/pull/3512/files?diff=unified&w=0#diff-bba1d4ce4b34efc0704505701ad0803d218232fb20f86383cd9e268f7aed7718L41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/3512/files?diff=unified&w=0#diff-bba1d4ce4b34efc0704505701ad0803d218232fb20f86383cd9e268f7aed7718L65-R65))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
