### PR TITLE
fix(transformImport-e2e): fix e2e tests

### DIFF
--- a/tests/e2e/builder/cases/source/plugin-import/index.test.ts
+++ b/tests/e2e/builder/cases/source/plugin-import/index.test.ts
@@ -164,6 +164,12 @@ function shareTest(
   entry: string,
   transformImport: SharedTransformImport,
 ) {
+  const setupConfig = {
+    cwd: __dirname,
+    entry: {
+      index: entry,
+    },
+  };
   const config: BuilderConfig = {
     source: {
       transformImport: [transformImport],
@@ -177,14 +183,7 @@ function shareTest(
 
   // webpack
   webpackOnlyTest(`${msg}-webpack`, async () => {
-    const builder = await build(
-      {
-        entry: {
-          index: entry,
-        },
-      },
-      { ...config },
-    );
+    const builder = await build(setupConfig, { ...config });
     const files = await builder.unwrapOutputJSON(false);
     expect(files[findEntry(files)]).toContain('transformImport test succeed');
   });
@@ -193,9 +192,7 @@ function shareTest(
   webpackOnlyTest(`${msg}-webpack-swc`, async () => {
     const builder = await build(
       {
-        entry: {
-          index: entry,
-        },
+        ...setupConfig,
         plugins: [builderPluginSwc()],
       },
       { ...config },
@@ -206,14 +203,7 @@ function shareTest(
 
   // rspack
   rspackOnlyTest(`${msg}-rspack`, async () => {
-    const builder = await build(
-      {
-        entry: {
-          index: entry,
-        },
-      },
-      { ...config },
-    );
+    const builder = await build(setupConfig, { ...config });
     const files = await builder.unwrapOutputJSON(false);
     expect(files[findEntry(files)]).toContain('transformImport test succeed');
   });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28e0fa7</samp>

Refactor entry configuration and add swc plugin for e2e test cases in `plugin-import` directory. This improves code quality and supports the swc builder.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28e0fa7</samp>

*  Simplify entry configuration for different builders by defining a common setupConfig object ([link](https://github.com/web-infra-dev/modern.js/pull/3517/files?diff=unified&w=0#diff-8d377dd5181442e2e489e09dbe697ea95bd979e8cc5ec769990ecedcd729cf85R167-R172))
*  Use setupConfig object instead of inline entry configuration in webpack test case ([link](https://github.com/web-infra-dev/modern.js/pull/3517/files?diff=unified&w=0#diff-8d377dd5181442e2e489e09dbe697ea95bd979e8cc5ec769990ecedcd729cf85L180-R186))
*  Use setupConfig object instead of inline entry configuration in swc test case and add builderPluginSwc plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3517/files?diff=unified&w=0#diff-8d377dd5181442e2e489e09dbe697ea95bd979e8cc5ec769990ecedcd729cf85L196-R195))
*  Use setupConfig object instead of inline entry configuration in rspack test case ([link](https://github.com/web-infra-dev/modern.js/pull/3517/files?diff=unified&w=0#diff-8d377dd5181442e2e489e09dbe697ea95bd979e8cc5ec769990ecedcd729cf85L209-R206))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
