### PR TITLE
fix(plugin-module-doc): get lang from useLang not pageData

### DIFF
--- a/.changeset/thick-apricots-lick.md
+++ b/.changeset/thick-apricots-lick.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+fix: get lang from useLang not pageData
+fix: 使用useLang获取lang

--- a/.changeset/tricky-geckos-compete.md
+++ b/.changeset/tricky-geckos-compete.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: set defaultHasAside false if in iframe
+fix: 被iframe引入时默认不展示aside

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
@@ -52,9 +52,11 @@ export function DocLayout(props: DocLayoutProps) {
     frontmatter?.sidebar !== false && Object.keys(sidebar).length > 0;
   const outlineTitle =
     localesData?.outlineTitle || themeConfig?.outlineTitle || 'ON THIS PAGE';
+  const notInIframe = window.top === window.self;
+  const defaultHasAside = notInIframe;
   const hasAside =
     headers.length > 0 &&
-    (frontmatter?.outline ?? themeConfig?.outline ?? true);
+    (frontmatter?.outline ?? themeConfig?.outline ?? defaultHasAside);
   const isOverviewPage = frontmatter?.overview ?? false;
 
   return (

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
@@ -52,13 +52,21 @@ export function DocLayout(props: DocLayoutProps) {
     frontmatter?.sidebar !== false && Object.keys(sidebar).length > 0;
   const outlineTitle =
     localesData?.outlineTitle || themeConfig?.outlineTitle || 'ON THIS PAGE';
-  const notInIframe = window.top === window.self;
-  const defaultHasAside = notInIframe;
-  const hasAside =
-    headers.length > 0 &&
-    (frontmatter?.outline ?? themeConfig?.outline ?? defaultHasAside);
   const isOverviewPage = frontmatter?.overview ?? false;
 
+  const getHasAside = () => {
+    // if in iframe, default value is false
+    const defaultHasAside =
+      typeof window === 'undefined' ? true : window.top === window.self;
+    return (
+      (frontmatter?.outline ?? themeConfig?.outline ?? defaultHasAside) &&
+      headers.length > 0
+    );
+  };
+  const [hasAside, setHasAside] = useState(getHasAside());
+  useEffect(() => {
+    setHasAside(getHasAside());
+  }, []);
   return (
     <div className={`${styles.docLayout} pt-0 md:mt-14`}>
       {beforeDoc}

--- a/packages/module/plugin-module-doc/src/components/overview/index.tsx
+++ b/packages/module/plugin-module-doc/src/components/overview/index.tsx
@@ -1,4 +1,4 @@
-import { usePageData } from '@modern-js/doc-core/runtime';
+import { useLang, usePageData } from '@modern-js/doc-core/runtime';
 import { Link } from '@modern-js/doc-core/theme';
 import { PageData } from '@modern-js/doc-core';
 import { IconRight } from '@arco-design/web-react/icon';
@@ -27,8 +27,8 @@ const getGridClass = (count?: number): string => {
 };
 
 export default ({ list, ...props }: { list?: List[] }) => {
-  const pageData = usePageData() as PageData;
-  const { siteData, lang } = pageData;
+  const { siteData } = usePageData() as PageData;
+  const lang = useLang();
   const moduleList = list ?? [];
 
   if (moduleList.length === 0) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d94d435</samp>

This pull request fixes some bugs related to document language and outline display in the `@modern-js/plugin-module-doc` and `@modern-js/doc-core` packages. It uses the `useLang` hook to get the correct language and checks if the document is in an iframe to hide the outline if needed.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d94d435</samp>

*  Fix bugs in `@modern-js/plugin-module-doc` and `@modern-js/doc-core` packages ([link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-aa31402b7fd38177adde37feb2a3a6b749cd94fbcfd54aed5a7688a927dfa66bR1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-e66287f8237f04a085212b056b17cb75697601b43fe9811528907f3500dacd86R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-04c56a17410f0a719914810a646051c5b8b6778f03884bcf9b0813dc2728a79cL55-R59), [link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fL1-R1), [link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fL30-R31))
  * Use `useLang` hook to get language in `overview` component of `@modern-js/plugin-module-doc` ([link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fL1-R1), [link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-5640cafb3329d42ea19cb1e962a4aa44cf81aa204cba08176b187c55f2f1e54fL30-R31))
  * Set default value of `hasAside` to false if document is in iframe in `DocLayout` component of `@modern-js/doc-core` ([link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-04c56a17410f0a719914810a646051c5b8b6778f03884bcf9b0813dc2728a79cL55-R59))
  * Update changelogs for both packages ([link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-aa31402b7fd38177adde37feb2a3a6b749cd94fbcfd54aed5a7688a927dfa66bR1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3531/files?diff=unified&w=0#diff-e66287f8237f04a085212b056b17cb75697601b43fe9811528907f3500dacd86R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
