### PR TITLE
fix: doc e2e case does not kill normally

### DIFF
--- a/tests/integration/doc/test/base.test.ts
+++ b/tests/integration/doc/test/base.test.ts
@@ -106,6 +106,6 @@ describe('Basic render', () => {
     // check the class in html
     htmlClass = await page.evaluate(html => html?.getAttribute('class'), html);
     expect(htmlClass).toContain(defaultMode === 'dark' ? 'light' : 'dark');
-    killApp(serveApp);
+    await killApp(serveApp);
   });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d0138f</samp>

Await `killApp` in integration tests to avoid port conflicts and memory leaks. This improves the reliability of the tests for the `modern.js` framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d0138f</samp>

*  Await `killApp` function to prevent port conflicts or memory leaks in integration tests ([link](https://github.com/web-infra-dev/modern.js/pull/3546/files?diff=unified&w=0#diff-ef44d5c3651ab23f96e0c344f163625fe591107d4081c17f2e7a7478680ecb06L109-R109))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
