### PR TITLE
docs: add releases page to website

### DIFF
--- a/packages/document/main-doc/docs/en/about/releases.mdx
+++ b/packages/document/main-doc/docs/en/about/releases.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_position: 2
+---
+
+# Releases
+
+## Changelog
+
+Please visit [GitHub - Releases](https://github.com/web-infra-dev/modern.js/releases) to see what has changed with each release of Modern.js.
+
+## Version Specification
+
+Modern.js follows the [Semantic Versioning](https://semver.org) specification.
+
+- Major version: Contains incompatible API changes.
+- Minor version: Contains backward compatible functional changes.
+- Patch version: Contains backwards compatible bug fixes
+
+## Release Cycle
+
+- Modern.js generally releases an official release every Thursday.
+- If critical bugs appear, we will release a revised version on the same day.
+- We expect to keep Modern.js v2 stable and compatible, there are currently no plans to release the next major version.
+
+## Version Upgrade
+
+When you need to upgrade the Modern.js version in your project, you can use the `modern upgrade` command, refer to [Upgrade](/guides/get-started/upgrade).
+
+```bash
+npx modern upgrade
+```

--- a/packages/document/main-doc/docs/zh/about/releases.mdx
+++ b/packages/document/main-doc/docs/zh/about/releases.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_position: 2
+---
+
+# 版本发布
+
+## 更新日志
+
+请访问 [GitHub - Release](https://github.com/web-infra-dev/modern.js/releases) 来了解 Modern.js 每个版本的变更内容。
+
+## 版本规范
+
+Modern.js 遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/) 语义化版本规范。
+
+- 主版本号：包含不兼容的 API 变更。
+- 次版本号：包含向下兼容的功能性变更。
+- 修订号：包含向下兼容的问题修正。
+
+## 发版周期
+
+- Modern.js 通常在每周四发布一个正式版本。
+- 当出现较为严重的问题时，我们会在当天发布修订版本。
+- 我们期望保持 Modern.js v2 的稳定和兼容，目前没有发布下一个 Major 版本的计划。
+
+## 版本升级
+
+当你需要升级项目中的 Modern.js 版本时，可以使用 `modern upgrade` 命令，参考 [升级](/guides/get-started/upgrade)。
+
+```bash
+npx modern upgrade
+```


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcb1381</samp>

This pull request adds a new document page for both English and Chinese versions of the website, which provides release information of Modern.js. The new page is `releases.mdx` under the `about` section of the sidebar.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcb1381</samp>

* Add new document pages for the release information of Modern.js in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3550/files?diff=unified&w=0#diff-93018fee1b8f3f9ad062c514914977c1ecf27e9e8727035afb1c3c3ee7f9882aR1-R31), [link](https://github.com/web-infra-dev/modern.js/pull/3550/files?diff=unified&w=0#diff-afe8b84975e27f5b9fbf3a8804423495de13dc3ee5069186ef95fd20b038aa7dR1-R31))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
