### PR TITLE
fix(plugin-module-doc): make plugin options optional

### DIFF
--- a/.changeset/lovely-spies-attack.md
+++ b/.changeset/lovely-spies-attack.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+fix: make plugin options optional
+fix: 使插件参数变为可选项

--- a/packages/module/plugin-module-doc/src/index.ts
+++ b/packages/module/plugin-module-doc/src/index.ts
@@ -2,7 +2,7 @@ import type { CliPlugin, ModuleTools } from '@modern-js/module-tools';
 import type { PluginOptions } from './types';
 import { run } from './features';
 
-export default (pluginOptions: PluginOptions): CliPlugin<ModuleTools> => ({
+export default (pluginOptions?: PluginOptions): CliPlugin<ModuleTools> => ({
   name: '@modern-js/plugin-module-doc',
   setup: api => ({
     registerDev() {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 542dd19</samp>

This pull request fixes the plugin-module-doc package to make the pluginOptions parameter optional and adds a changeset file to document the change. This improves the usability and flexibility of the plugin and the versioning and release process.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 542dd19</samp>

* Make pluginOptions parameter optional for plugin-module-doc package ([link](https://github.com/web-infra-dev/modern.js/pull/3564/files?diff=unified&w=0#diff-f9d76df0ab20ff0e46c28528a653a39ee264c362416fa19619938df0ff29cad3L5-R5))
* Add changeset file to document fixes for plugin-module-doc package ([link](https://github.com/web-infra-dev/modern.js/pull/3564/files?diff=unified&w=0#diff-4806c88689e7eb1f5c191df585d85cdcbf34b44414d4c7ae06a2cdef99cfcec3R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
