### PR TITLE
fix(builder-shared): add protocol for generated URL when assetPrefix is true

### DIFF
--- a/.changeset/ten-vans-explain.md
+++ b/.changeset/ten-vans-explain.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder-shared):  assetPrefix  starts with http://

--- a/.changeset/ten-vans-explain.md
+++ b/.changeset/ten-vans-explain.md
@@ -2,5 +2,6 @@
 '@modern-js/builder-shared': patch
 ---
 
-fix(builder-shared):  assetPrefix  starts with http://
-fix(builder-shared): update assetPrefix protocol for dev.https
+fix(builder-shared): add protocol for gererated URL when assetPrefix is true
+
+fix(builder-shared): assetPrefix 为 true 时生成的 URL 添加 protocol

--- a/.changeset/ten-vans-explain.md
+++ b/.changeset/ten-vans-explain.md
@@ -3,3 +3,4 @@
 ---
 
 fix(builder-shared):  assetPrefix  starts with http://
+fix(builder-shared): update assetPrefix protocol for dev.https

--- a/.changeset/ten-vans-explain.md
+++ b/.changeset/ten-vans-explain.md
@@ -2,6 +2,6 @@
 '@modern-js/builder-shared': patch
 ---
 
-fix(builder-shared): add protocol for gererated URL when assetPrefix is true
+fix(builder-shared): add protocol for generated URL when assetPrefix is true
 
 fix(builder-shared): assetPrefix 为 true 时生成的 URL 添加 protocol

--- a/packages/builder/builder-shared/src/apply/output.ts
+++ b/packages/builder/builder-shared/src/apply/output.ts
@@ -88,9 +88,9 @@ function getPublicPath({
       // The http://0.0.0.0:port can't visit in windows, so we shouldn't set publicPath as `//0.0.0.0:${port}/`;
       // Relative to docs:
       // - https://github.com/quarkusio/quarkus/issues/12246
-      publicPath = `//${localHostname}:${port}/`;
+      publicPath = `http://${localHostname}:${port}/`;
     } else {
-      publicPath = `//${hostname}:${port}/`;
+      publicPath = `http://${hostname}:${port}/`;
     }
   }
 

--- a/packages/builder/builder-shared/src/apply/output.ts
+++ b/packages/builder/builder-shared/src/apply/output.ts
@@ -80,6 +80,7 @@ function getPublicPath({
   } else if (typeof dev.assetPrefix === 'string') {
     publicPath = dev.assetPrefix;
   } else if (dev.assetPrefix === true) {
+    const protocol = dev.https ? 'https' : 'http';
     const hostname = context.devServer?.hostname || DEFAULT_DEV_HOST;
     const port = context.devServer?.port || DEFAULT_PORT;
     if (hostname === DEFAULT_DEV_HOST) {
@@ -88,9 +89,9 @@ function getPublicPath({
       // The http://0.0.0.0:port can't visit in windows, so we shouldn't set publicPath as `//0.0.0.0:${port}/`;
       // Relative to docs:
       // - https://github.com/quarkusio/quarkus/issues/12246
-      publicPath = `http://${localHostname}:${port}/`;
+      publicPath = `${protocol}://${localHostname}:${port}/`;
     } else {
-      publicPath = `http://${hostname}:${port}/`;
+      publicPath = `${protocol}://${hostname}:${port}/`;
     }
   }
 

--- a/packages/document/builder-doc/docs/en/config/dev/assetPrefix.md
+++ b/packages/document/builder-doc/docs/en/config/dev/assetPrefix.md
@@ -9,7 +9,7 @@ This config is only used in the development environment. In the production envir
 
 #### Boolean Type
 
-If `assetPrefix` is set to `true`, the URL prefix will be `//localhost:port/`:
+If `assetPrefix` is set to `true`, the URL prefix will be `http://localhost:port/`:
 
 ```js
 export default {
@@ -22,7 +22,7 @@ export default {
 The script URL will be:
 
 ```js
-<script defer src="//localhost:8080/static/js/main.js"></script>
+<script defer src="http://localhost:8080/static/js/main.js"></script>
 ```
 
 If `assetPrefix` is set to `false` or not set, `/` is used as the default value.

--- a/packages/document/builder-doc/docs/zh/config/dev/assetPrefix.md
+++ b/packages/document/builder-doc/docs/zh/config/dev/assetPrefix.md
@@ -9,7 +9,7 @@
 
 #### Boolean 类型
 
-如果设置 `assetPrefix` 为 `true`，Builder 会使用 `//localhost:port/` 作为 URL 前缀：
+如果设置 `assetPrefix` 为 `true`，Builder 会使用 `http://localhost:port/` 作为 URL 前缀：
 
 ```js
 export default {
@@ -22,7 +22,7 @@ export default {
 对应 JS 文件在浏览器中加载的地址如下：
 
 ```js
-<script defer src="//localhost:8080/static/js/main.js"></script>
+<script defer src="http://localhost:8080/static/js/main.js"></script>
 ```
 
 如果设置 `assetPrefix` 为 `false` 或不设置，则默认使用 `/` 作为访问前缀。

--- a/tests/integration/asset-prefix/test/index.test.ts
+++ b/tests/integration/asset-prefix/test/index.test.ts
@@ -18,7 +18,7 @@ describe('asset prefix', () => {
       path.join(appDir, 'dist/html/main/index.html'),
       'utf-8',
     );
-    expect(HTML.includes(`//${DEFAULT_DEV_HOST}:3333/static/js/`)).toBeTruthy();
+    expect(HTML.includes(`http://${DEFAULT_DEV_HOST}:3333/static/js/`)).toBeTruthy();
 
     await killApp(app);
   });
@@ -27,7 +27,7 @@ describe('asset prefix', () => {
     const appDir = path.resolve(fixtures, 'dev-asset-prefix');
 
     const app = await launchApp(appDir);
-    const expected = `//${DEFAULT_DEV_HOST}:3333`;
+    const expected = `http://${DEFAULT_DEV_HOST}:3333`;
 
     const mainJs = readFileSync(
       path.join(appDir, 'dist/static/js/main.js'),


### PR DESCRIPTION
## Summary


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b976672</samp>

This pull request fixes a bug and updates the documentation for the `assetPrefix` option in `modern.js`. It ensures that the URL prefix for assets is consistent and correct when using `assetPrefix` in development mode.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b976672</samp>

*  Fix bug in `getPublicPath` function that caused incorrect URL prefix for assets ([link](https://github.com/web-infra-dev/modern.js/pull/3576/files?diff=unified&w=0#diff-5071b6a55bc61e45b3db5266c355c86bb495f414f628f6aebaf5584a1db86911L91-R93))
*  Update documentation and code examples for `assetPrefix` configuration option in English and Chinese versions ([link](https://github.com/web-infra-dev/modern.js/pull/3576/files?diff=unified&w=0#diff-c2863b0e5c45f178afbf38b5e834647ee8b0de44e7e02460efe0f5fe45f5e015L12-R12), [link](https://github.com/web-infra-dev/modern.js/pull/3576/files?diff=unified&w=0#diff-c2863b0e5c45f178afbf38b5e834647ee8b0de44e7e02460efe0f5fe45f5e015L25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/3576/files?diff=unified&w=0#diff-33e119e097c7c61d3916558dc8dff5f0ff117e788094ff71bb368cf61751e3d5L12-R12), [link](https://github.com/web-infra-dev/modern.js/pull/3576/files?diff=unified&w=0#diff-33e119e097c7c61d3916558dc8dff5f0ff117e788094ff71bb368cf61751e3d5L25-R25))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
