### PR TITLE
fix: code line highlight in js compiler

### DIFF
--- a/.changeset/unlucky-snails-perform.md
+++ b/.changeset/unlucky-snails-perform.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: code line highlight in js compiler
+
+fix: js 版本编译器中代码行高亮问题

--- a/packages/cli/doc-core/src/node/mdx/rehypePlugins/preWrapper.ts
+++ b/packages/cli/doc-core/src/node/mdx/rehypePlugins/preWrapper.ts
@@ -22,7 +22,7 @@ export const rehypePluginPreWrapper: Plugin<[], Root> = () => {
         const highlightReg = /{[\d,-]*}/i;
         const highlightMeta = highlightReg.exec(meta)?.[0];
         if (highlightMeta && codeNode.properties) {
-          codeNode.properties.className = `${codeNode.properties.className} ${highlightMeta}`;
+          codeNode.properties.meta = highlightMeta;
           meta = meta.replace(highlightReg, '').trim();
         }
         const parsedMeta = qs.parse(meta);
@@ -58,7 +58,7 @@ export const rehypePluginPreWrapper: Plugin<[], Root> = () => {
             children: [
               {
                 type: 'text',
-                value: title as string,
+                value: title,
               },
             ],
           },

--- a/packages/cli/doc-core/src/runtime/hooks.ts
+++ b/packages/cli/doc-core/src/runtime/hooks.ts
@@ -29,7 +29,7 @@ export function usePageData() {
 
 export function useLang(): string {
   const ctx = useContext(DataContext);
-  return ctx.data.page.lang || 'zh';
+  return ctx.data.page.lang || '';
 }
 
 export function useDark() {

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/docComponents/link.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/docComponents/link.tsx
@@ -8,7 +8,7 @@ export const A = (props: ComponentProps<'a'>) => {
   const lang = useLang();
   const pageData = usePageData();
   const defaultLang = pageData.siteData.lang;
-  if (!isExternalUrl(href) && !href.startsWith('#')) {
+  if (defaultLang && !isExternalUrl(href) && !href.startsWith('#')) {
     href = normalizeSlash(href);
     // Add lang prefix if not default lang
     if (lang !== defaultLang && !href.startsWith(`/${lang}`)) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1394f99</samp>

This pull request refactors the MDX processing and the language handling logic in the `doc-core` package. It fixes some issues with the `preWrapper` plugin, the `useLang` hook, and the `Link` component that could cause incorrect or inconsistent URL generation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1394f99</samp>

*  Store highlight meta information in `meta` property of code node to avoid conflicts with other plugins ([link](https://github.com/web-infra-dev/modern.js/pull/3587/files?diff=unified&w=0#diff-0d152863ca5948cf71d24b86201e523dbd974e7e93a29696be8ea4016c828db6L25-R25))
*  Remove unnecessary type assertion of `title` in `preWrapper` plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3587/files?diff=unified&w=0#diff-0d152863ca5948cf71d24b86201e523dbd974e7e93a29696be8ea4016c828db6L61-R61))
*  Return empty string as default language value in `useLang` hook to avoid unwanted URL prefix ([link](https://github.com/web-infra-dev/modern.js/pull/3587/files?diff=unified&w=0#diff-d61a16ba23fa642cb411f9570bdafe549af7dfd0cb826e87d3d55cb3c1e0e3f3L32-R32))
*  Check `defaultLang` before normalizing `href` in `Link` component to avoid unnecessary slash ([link](https://github.com/web-infra-dev/modern.js/pull/3587/files?diff=unified&w=0#diff-01b173c7216a9f5145a4b71c9d614c9ec5ec746a8aab435b720b8fb548fe6ef0L11-R11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
