### PR TITLE
fix: optimize alias for plugin-express & export useBlocker

### DIFF
--- a/.changeset/long-laws-sing.md
+++ b/.changeset/long-laws-sing.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/plugin-express': patch
+---
+
+fix: optimize alias for plugin-express & export useBlocker
+fix: 优化 plugin-express 的 alias 的实现 & 导出 useBlocker

--- a/packages/runtime/plugin-runtime/src/router/runtime/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/index.ts
@@ -142,6 +142,8 @@ export {
   renderMatches,
   resolvePath,
   createPath,
+  unstable_useBlocker,
+  unstable_usePrompt,
 } from 'react-router-dom';
 
 // `react-router-dom` has its own dependency: `@remix-run/router`.

--- a/packages/server/plugin-express/package.json
+++ b/packages/server/plugin-express/package.json
@@ -33,6 +33,9 @@
         "require": "./dist/cjs/index.js"
       },
       "default": "./dist/esm/index.js"
+    },
+    "./runtime": {
+      "default": "./dist/cjs/runtime/index.js"
     }
   },
   "scripts": {

--- a/packages/server/plugin-express/src/cli/index.ts
+++ b/packages/server/plugin-express/src/cli/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import type { CliPlugin } from '@modern-js/core';
 import { createRuntimeExportsUtils } from '@modern-js/utils';
-import { getRelativeRuntimePath } from '@modern-js/bff-core';
 import type { AppTools } from '@modern-js/app-tools';
 
 export default (): CliPlugin<AppTools> => ({
@@ -13,38 +12,22 @@ export default (): CliPlugin<AppTools> => ({
     return {
       config() {
         const appContext = useAppContext();
-        const { appDirectory } = appContext;
         bffExportsUtils = createRuntimeExportsUtils(
           appContext.internalDirectory,
           'server',
         );
-
-        const serverRuntimePath = bffExportsUtils.getPath();
-
-        const relativeRuntimePath = getRelativeRuntimePath(
-          appDirectory,
-          serverRuntimePath,
-        );
-
-        if (process.env.NODE_ENV === 'production') {
-          return {
-            source: {
-              alias: {
-                '@modern-js/runtime/server': relativeRuntimePath,
-                '@modern-js/runtime/express': relativeRuntimePath,
-              },
+        const runtimePath =
+          process.env.NODE_ENV === 'development'
+            ? require.resolve('@modern-js/plugin-express/runtime')
+            : '@modern-js/plugin-express/runtime';
+        return {
+          source: {
+            alias: {
+              '@modern-js/runtime/server': runtimePath,
+              '@modern-js/runtime/express': runtimePath,
             },
-          };
-        } else {
-          return {
-            source: {
-              alias: {
-                '@modern-js/runtime/server': serverRuntimePath,
-                '@modern-js/runtime/express': serverRuntimePath,
-              },
-            },
-          };
-        }
+          },
+        };
       },
 
       collectServerPlugins({ plugins }) {

--- a/packages/server/plugin-express/src/runtime/operators.ts
+++ b/packages/server/plugin-express/src/runtime/operators.ts
@@ -52,7 +52,7 @@ export type Pipe = typeof Pipe;
 
 export const Middleware = (
   middleware: (req: Request, res: Response, next: NextFunction) => void,
-): Operator => {
+): Operator<void> => {
   return {
     name: 'middleware',
     metadata(helper) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1381f2</samp>

This pull request improves the server-side rendering and routing features of the `@modern-js/plugin-express` and `@modern-js/runtime` packages. It simplifies the webpack config, exposes new hooks from `react-router`, adds a new entry point for the runtime logic, and enhances the type safety of the middleware factory.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1381f2</samp>

*  Expose `unstable_useBlocker` and `unstable_usePrompt` hooks from `react-router` to `@modern-js/runtime` users ([link](https://github.com/web-infra-dev/modern.js/pull/3588/files?diff=unified&w=0#diff-a2ba2aef031ad97c2b7c5dfd1a62d150661a28f360bedf74aeb67d2f800f601eR145-R146))
*  Add `./runtime` entry point to `@modern-js/plugin-express` package for exporting runtime logic ([link](https://github.com/web-infra-dev/modern.js/pull/3588/files?diff=unified&w=0#diff-d0cf38ac401cc05ef3c3a50c7c63d63596855ce7e84dda0e4643f606566dbd0cR36-R38))
*  Simplify webpack aliasing for `@modern-js/runtime/server` and `@modern-js/runtime/express` modules in `@modern-js/plugin-express/src/cli/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3588/files?diff=unified&w=0#diff-ffacac3b3e74ba9cef26e13c1a001acff9b17a1bf7a4e38a14061ca17635adf4L16-R30))
*  Remove unused import of `getRelativeRuntimePath` from `@modern-js/plugin-express/src/cli/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3588/files?diff=unified&w=0#diff-ffacac3b3e74ba9cef26e13c1a001acff9b17a1bf7a4e38a14061ca17635adf4L4))
*  Add generic type parameter to `Middleware` function in `@modern-js/plugin-express/src/runtime/operators.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3588/files?diff=unified&w=0#diff-81554b2c2d47d1a2286a29083dc025f158af016cf6782130adda8d502cff99fcL55-R55))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
