### PR TITLE
fix(doc-tools-doc): toggle lang zh, nav switch back to en

### DIFF
--- a/packages/document/doc-tools-doc/modern.config.ts
+++ b/packages/document/doc-tools-doc/modern.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
       exclude: ['**/fragments/**'],
     },
     themeConfig: {
-      nav: getNavbar(),
       sidebar: getSidebar(),
       footer: {
         message: '© 2023 Bytedance Inc. All Rights Reserved.',
@@ -44,10 +43,12 @@ export default defineConfig({
         {
           lang: 'zh',
           label: '简体中文',
+          nav: getNavbar('zh'),
         },
         {
           lang: 'en',
           label: 'English',
+          nav: getNavbar('en'),
         },
       ],
       editLink: {
@@ -121,16 +122,19 @@ function getSidebar(): Sidebar {
   };
 }
 
-function getNavbar(): NavItem[] {
+function getNavbar(lang: string): NavItem[] {
+  const cn = lang === 'zh';
+  const prefix = cn ? '/zh' : '';
+  const getLink = (str: string) => `${prefix}${str}`;
   return [
     {
       text: getI18nKey('guide'),
-      link: '/guide/getting-started',
+      link: getLink('/guide/getting-started'),
       activeMatch: '/guide/',
     },
     {
       text: getI18nKey('api'),
-      link: '/api/',
+      link: getLink('/api/'),
       activeMatch: '/api/',
     },
   ];


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at caa5987</samp>

This pull request enables multilingual navigation for the documentation site. It changes the `modern.config.ts` file to use locale-specific `nav` properties and a language-aware `getNavbar` function.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at caa5987</samp>

*  Remove global navigation bar and add language-specific navigation bars for documentation site ([link](https://github.com/web-infra-dev/modern.js/pull/3597/files?diff=unified&w=0#diff-ace098861d0d64fc731554fdf597402cd4d20922a4aca5bff9697a0addb06c0dL31), [link](https://github.com/web-infra-dev/modern.js/pull/3597/files?diff=unified&w=0#diff-ace098861d0d64fc731554fdf597402cd4d20922a4aca5bff9697a0addb06c0dL47-R51), [link](https://github.com/web-infra-dev/modern.js/pull/3597/files?diff=unified&w=0#diff-ace098861d0d64fc731554fdf597402cd4d20922a4aca5bff9697a0addb06c0dL124-R137))

## Related Issue

<!--- Provide link of related issues -->
#3596 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
