### PR TITLE
docs: enable edit link for all websites

### DIFF
--- a/packages/document/builder-doc/modern.config.ts
+++ b/packages/document/builder-doc/modern.config.ts
@@ -209,6 +209,11 @@ export default defineConfig({
           description: 'A build engine for web development.',
         },
       ],
+      editLink: {
+        docRepoBaseUrl:
+          'https://github.com/web-infra-dev/modern.js/tree/main/packages/document/builder-doc/docs',
+        text: 'Edit this page on GitHub',
+      },
     },
     replaceRules: [
       {

--- a/packages/document/main-doc/modern.config.ts
+++ b/packages/document/main-doc/modern.config.ts
@@ -122,6 +122,11 @@ export default defineConfig({
           label: 'English',
         },
       ],
+      editLink: {
+        docRepoBaseUrl:
+          'https://github.com/web-infra-dev/modern.js/tree/main/packages/document/main-doc/docs',
+        text: 'Edit this page on GitHub',
+      },
       socialLinks: [
         {
           icon: 'github',

--- a/packages/document/module-doc/modern.config.ts
+++ b/packages/document/module-doc/modern.config.ts
@@ -113,6 +113,11 @@ export default defineConfig({
           description: 'Module Engineering Solutions',
         },
       ],
+      editLink: {
+        docRepoBaseUrl:
+          'https://github.com/web-infra-dev/modern.js/tree/main/packages/document/module-doc/docs',
+        text: 'Edit this page on GitHub',
+      },
     },
     builderConfig: {
       dev: {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e96a016</samp>

Add `editLink` option to `builder-doc`, `main-doc`, and `module-doc` packages. This option enables users to edit the documentation source files on GitHub directly from the documentation pages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e96a016</samp>

*  Add `editLink` option to `builder-doc`, `main-doc`, and `module-doc` package configurations ([link](https://github.com/web-infra-dev/modern.js/pull/3602/files?diff=unified&w=0#diff-fc9e3b9be79489436a867bcdd7e7d56a5d8a90bd8c0390fdb2166410e494495fR212-R216), [link](https://github.com/web-infra-dev/modern.js/pull/3602/files?diff=unified&w=0#diff-2b922c5ce43b774ae4f1e3b58a99701031c70908fa0eab909028eb24631381fdR125-R129), [link](https://github.com/web-infra-dev/modern.js/pull/3602/files?diff=unified&w=0#diff-f7f1c8a2a18cfdb353615920a8ff51c5040493c875103d1cdf43acda3ac22d0fR116-R120))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
