### PR TITLE
fix(doc-tools): edit link should open a new tab

### DIFF
--- a/.changeset/nasty-cameras-protect.md
+++ b/.changeset/nasty-cameras-protect.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-tools): edit link should open a new tab
+
+fix(doc-tools): edit link 应该打开一个新窗口

--- a/packages/cli/doc-core/src/theme-default/components/EditLink/index.module.scss
+++ b/packages/cli/doc-core/src/theme-default/components/EditLink/index.module.scss
@@ -3,12 +3,9 @@
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
+  margin: 20px 0;
+
   &:hover {
     text-decoration: underline;
   }
-  margin: 20px 0;
-}
-
-.editLink span {
-  margin-right: 4px;
 }

--- a/packages/cli/doc-core/src/theme-default/components/EditLink/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/EditLink/index.tsx
@@ -12,16 +12,11 @@ export default function EditLink() {
   const { text, link } = editLinkObj;
 
   return (
-    <a href={link} className={styles.editLink}>
-      <span>
-        <Edit
-          style={{
-            with: '18px',
-            height: '18px',
-            display: 'inline-block',
-          }}
-        />
-      </span>
+    <a href={link} target="_blank" className={styles.editLink}>
+      <Edit
+        className="h-5.5 mr-2 inline-block"
+        style={{ verticalAlign: '-5px' }}
+      />
       {text}
     </a>
   );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
