### PR TITLE
chore: comment the doc for runtime and server plugin hooks

### DIFF
--- a/.changeset/hip-melons-smoke.md
+++ b/.changeset/hip-melons-smoke.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/main-doc': patch
+---
+
+chore: comment the doc for runtime and server plugin hooks
+chore: 注释 runtime 和 server 插件钩子文档

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -611,7 +611,7 @@ export default (): CliPlugin => ({
 
 This adds a new Script tag to the HTML template.
 
-## Server
+<!-- ## Server
 
 :::note
 The Server plugin is currently not fully opened, and the API is not guaranteed to be stable. Use with caution.
@@ -691,7 +691,7 @@ export default (): ServerPlugin => ({
     };
   },
 });
-```
+``` -->
 
 ## Runtime
 
@@ -699,7 +699,7 @@ export default (): ServerPlugin => ({
 The Runtime plugin is currently not fully opened, and the API is not guaranteed to be stable. Use with caution.
 :::
 
-The Runtime plugin is mainly used for developers to modify the components and elements that need to be rendered, and customize the rendering process on the server and client side.
+The Runtime plugin is mainly used for developers to modify the component that need to be rendered.
 
 ### `init`
 
@@ -732,23 +732,29 @@ export default (): Plugin => ({
 - Type: `Pipeline<{ App: React.ComponentType<any>; }, React.ComponentType<any>>`
 - Usage Example:
 
+:::note
+When using the hoc hook, you need to copy the static properties of the original App component to the new component and pass through the props.
+:::
+
 ```ts
 import { createContext } from 'react';
 import type { Plugin } from '@modern-js/runtime';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 export default (): Plugin => ({
   setup(api) {
     const FooContext = createContext('');
     return {
       hoc({ App }, next) {
+        const AppWrapper = (props: any) => {
+          return (
+            <FooContext.Provider store={'test'}>
+              <App {...props} />
+            </FooContext.Provider>
+          );
+        };
         return next({
-          App: (props: any) => {
-            return (
-              <FooContext.Provider store={'test'}>
-                <App {...props} />
-              </FooContext.Provider>
-            );
-          },
+          App: hoistNonReactStatics(AppWrapper, App)
         });
       },
     };
@@ -756,7 +762,7 @@ export default (): Plugin => ({
 });
 ```
 
-### `provide`
+<!-- ### `provide`
 
 - Function: Modifies the Elements that need to be rendered.
 - Execution Stage: Rendering (SSR/CSR).
@@ -828,4 +834,4 @@ export default (): Plugin => ({
     };
   },
 });
-```
+``` -->

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -611,7 +611,7 @@ export default (): CliPlugin => ({
 
 这样就为 HTML 模版中新增了一个 Script 标签。
 
-## Server
+<!-- ## Server
 
 :::note
 目前 Server 插件还未完全开放，API 不保证稳定，使用需谨慎。
@@ -692,7 +692,7 @@ export default (): ServerPlugin => ({
     };
   },
 });
-```
+``` -->
 
 ## Runtime
 
@@ -701,7 +701,7 @@ export default (): ServerPlugin => ({
 
 :::
 
-Runtime 插件主要用于开发者修改需要渲染的组件与 Element 和定制服务器端、客户端的渲染过程。
+Runtime 插件主要用于开发者修改需要渲染的组件。
 
 ### `init`
 
@@ -734,23 +734,29 @@ export default (): Plugin => ({
 - 类型：`Pipeline<{ App: React.ComponentType<any>; }, React.ComponentType<any>>`
 - 使用示例：
 
+:::note
+使用 hoc 钩子时，需要把原来的 App 组件的静态属性拷贝到新的组件上，并透传 props.
+:::
+
 ```ts
 import { createContext } from 'react';
 import type { Plugin } from '@modern-js/runtime';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 export default (): Plugin => ({
   setup(api) {
     const FooContext = createContext('');
     return {
       hoc({ App }, next) {
+        const AppWrapper = (props: any) => {
+          return (
+            <FooContext.Provider store={'test'}>
+              <App {...props} />
+            </FooContext.Provider>
+          );
+        };
         return next({
-          App: (props: any) => {
-            return (
-              <FooContext.Provider store={'test'}>
-                <App {...props} />
-              </FooContext.Provider>
-            );
-          },
+          App: hoistNonReactStatics(AppWrapper, App)
         });
       },
     };
@@ -758,7 +764,7 @@ export default (): Plugin => ({
 });
 ```
 
-### `provide`
+<!-- ### `provide`
 
 - 功能：修改需要渲染的 Element
 - 执行阶段：渲染（SSR/CSR）
@@ -830,4 +836,4 @@ export default (): Plugin => ({
     };
   },
 });
-```
+``` -->


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90d5948</samp>

This pull request updates the documentation for the framework plugin hooks in `packages/document/main-doc/docs` to match the current implementation. It also adds a changeset file in `.changeset` to document the patch version update and the chore of commenting the documentation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90d5948</samp>

*  Add a changeset file to document the patch version update and the chore of commenting the documentation for the runtime and server plugin hooks ([link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-cf2364acfc31ace56d56b8b4da376f3502494b01b562e7754bfabcefb00c54c5R1-R6))
*  Comment out the server and provide sections of the documentation for the runtime and server plugin hooks in both English and Chinese versions, as these features are not yet implemented or documented ([link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L614-R614), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L694-R694), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L759-R765), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L831-R837), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L614-R614), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L695-R695), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L761-R767), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L833-R839))
*  Simplify the description of the runtime plugin in both English and Chinese versions, as the customization of the rendering process is not yet supported or documented ([link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L702-R702), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L704-R704))
*  Add and implement a note in both English and Chinese versions to explain that when using the hoc hook, the static properties of the original App component need to be copied to the new component and the props need to be passed through, using the `hoist-non-react-statics` package ([link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L735-R742), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L744-R757), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L737-R744), [link](https://github.com/web-infra-dev/modern.js/pull/3607/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L746-R759))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
