### PR TITLE
chore: integartion test use linux os and remove cancel

### DIFF
--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -2,7 +2,6 @@ name: Cypress Test
 
 concurrency:
   group: macos-cypress-test-${{ github.head_ref }}
-  cancel-in-progress: true
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -1,8 +1,5 @@
 name: Cypress Test
 
-concurrency:
-  group: macos-cypress-test-${{ github.head_ref }}
-
 # Controls when the action will run.
 on:
   # Triggers unit test on push events for the main branch to collect unit test coverage

--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -1,8 +1,7 @@
-name: Integration Test(macOS)
+name: Integration Test(Linux)
 
 concurrency:
-  group: macos-integration-test-${{ github.ref }}
-  cancel-in-progress: true
+  group: linux-integration-test-${{ github.ref }}
 
 # Controls when the action will run.
 on:
@@ -15,13 +14,13 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  integration-test-mac:
+  integration-test-linux:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [16.x]
-        os: [macos-latest] # macos-latest
+        os: [ubuntu-latest] # ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -1,8 +1,5 @@
 name: Integration Test(Linux)
 
-concurrency:
-  group: linux-integration-test-${{ github.ref }}
-
 # Controls when the action will run.
 on:
   # Triggers the workflow on pull request events but only for the main branch

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -1,8 +1,5 @@
 name: Integration Test(Windows)
 
-concurrency:
-  group: windows-integration-test-${{ github.ref }}
-
 # Controls when the action will run.
 on:
   # Triggers the workflow on pull request events but only for the main branch

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -2,7 +2,6 @@ name: Integration Test(Windows)
 
 concurrency:
   group: windows-integration-test-${{ github.ref }}
-  cancel-in-progress: true
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -2,7 +2,6 @@ name: E2E Test (Builder)
 
 concurrency:
   group: builder-test-${{ github.head_ref }}
-  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -1,8 +1,5 @@
 name: E2E Test (Builder)
 
-concurrency:
-  group: builder-test-${{ github.head_ref }}
-
 on:
   push:
     branches: [main, update-rspack-**]


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa441af</samp>

This pull request changes the integration test workflows to run on Linux runners instead of macOS runners, and to avoid canceling parallel workflows. This improves the performance and reliability of the GitHub Actions testing.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa441af</samp>

* Migrate integration tests from macOS to Linux runners to improve availability and reduce costs ([link](https://github.com/web-infra-dev/modern.js/pull/3613/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL1-R4), [link](https://github.com/web-infra-dev/modern.js/pull/3613/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL18-R17), [link](https://github.com/web-infra-dev/modern.js/pull/3613/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL24-R23))
  * Rename workflow and concurrency group in `.github/workflows/integration-test-Linux.yml` to reflect operating system ([link](https://github.com/web-infra-dev/modern.js/pull/3613/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL1-R4), [link](https://github.com/web-infra-dev/modern.js/pull/3613/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL18-R17))
  * Use ubuntu-latest instead of macos-latest as the matrix configuration for the runners in `.github/workflows/integration-test-Linux.yml` ([link](https://github.com/web-infra-dev/modern.js/pull/3613/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL24-R23))
* Remove cancel-in-progress option from concurrency group in `.github/workflows/integration-test-Windows.yml` to avoid unintended cancellation of parallel workflows ([link](https://github.com/web-infra-dev/modern.js/pull/3613/files?diff=unified&w=0#diff-0140bd37d64c64518fe24fe1d94ea665cfae9e6da21a3ff99117c6b4f2076b91L5))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
