### PR TITLE
docs: add guide for AppUserConfig, improve tailwindcss config

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/tools/tailwindcss.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/tailwindcss.mdx
@@ -24,9 +24,37 @@ const tailwind = {
 };
 ```
 
-When the value is of type `Object`, rhe configuration corresponding to [TailwindCSS](https://tailwindcss.com/docs/configuration) is merged with the default configuration through `Object.assign`.
+### Function Type
 
-When the value is of type `Function`, the object returned by the function is merged with the default configuration by `Object.assign`.
+When `tools.tailwindcss`'s type is Function, the default tailwindcss config will be passed in as the first parameter, the config object can be modified directly, or a value can be returned as the final result.
+
+```ts title="modern.config.ts"
+export default {
+  tools: {
+    tailwindcss(config) {
+      config.content.push('./some-folder/**/*.{js,ts}');
+    },
+  },
+};
+```
+
+### Object Type
+
+When `tools.tailwindcss`'s type is `Object`, the config will be shallow merged with default config by `Object.assign`.
+
+```ts title="modern.config.ts"
+export default {
+  tools: {
+    tailwindcss: {
+      plugins: [
+        require('@tailwindcss/forms'),
+        require('@tailwindcss/aspect-ratio'),
+        require('@tailwindcss/typography'),
+      ],
+    },
+  },
+};
+```
 
 ### Limitations
 

--- a/packages/document/main-doc/docs/en/configure/app/usage.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/usage.mdx
@@ -43,6 +43,15 @@ export default defineConfig({
 });
 ```
 
+When using Rspack as the bundler, due to some differences in configuration types between webpack and Rspack, you need to specify `<'rspack'>` generic type for `defineConfig`:
+
+```diff title=modern.config.ts
+- export default defineConfig({
++ export default defineConfig<'rspack'>({
+   //...
+});
+```
+
 ### modern.config.js
 
 If you are developing a non-TypeScript project, you can use the configuration file in .js format:
@@ -239,6 +248,32 @@ const mergedConfig = {
   },
   tools: {
     postcss: [() => console.log('config1'), () => console.log('config2')],
+  },
+};
+```
+
+## Configuration Type
+
+Modern.js exports `AppUserConfig` type, which corresponds to the type of Modern.js configuration object:
+
+```ts title="modern.config.ts"
+import type { AppUserConfig } from '@modern-js/app-tools';
+
+const config: AppUserConfig = {
+  tools: {
+    webpack: {},
+  },
+};
+```
+
+When using Rspack as the bundler, due to some differences in configuration types between webpack and Rspack, you need to specify `<'rspack'>` generic type for `defineConfig`:
+
+```ts title="modern.config.ts"
+import type { AppUserConfig } from '@modern-js/app-tools';
+
+const config: AppUserConfig<'rspack'> = {
+  tools: {
+    rspack: {},
   },
 };
 ```

--- a/packages/document/main-doc/docs/en/guides/advanced-features/testing.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/testing.mdx
@@ -4,7 +4,7 @@ title: Testing
 ---
 # Testing
 
-Modern.js inherits the testing capabilities of [Jest](https://jestjs.io/) by default.
+Modern.js integrates the testing capabilities of [Jest](https://jestjs.io/) by default.
 
 First need to execute `pnpm run new` enable [unit test/integration test] features:
 

--- a/packages/document/main-doc/docs/zh/configure/app/tools/tailwindcss.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/tailwindcss.mdx
@@ -26,12 +26,40 @@ const tailwind = {
 
 对应 [TailwindCSS](https://tailwindcss.com/docs/configuration) 的配置。
 
-当值为 `Object` 类型时，与默认配置通过 `Object.assign` 合并。
+### Function 类型
 
-当值为 `Function` 类型时，函数返回的对象与默认配置通过 `Object.assign` 合并。
+当 `tools.tailwindcss` 为 Function 类型时，默认配置会作为第一个参数传入，你可以直接修改配置对象，也可以返回一个值作为最终结果：
+
+```ts title="modern.config.ts"
+export default {
+  tools: {
+    tailwindcss(config) {
+      config.content.push('./some-folder/**/*.{js,ts}');
+    },
+  },
+};
+```
+
+### Object 类型
+
+当 `tools.tailwindcss` 的值为 `Object` 类型时，会与默认配置通过 `Object.assign` 浅合并。
+
+```ts title="modern.config.ts"
+export default {
+  tools: {
+    tailwindcss: {
+      plugins: [
+        require('@tailwindcss/forms'),
+        require('@tailwindcss/aspect-ratio'),
+        require('@tailwindcss/typography'),
+      ],
+    },
+  },
+};
+```
 
 ### 限制
 
 注意，该配置中不允许使用 `theme` 配置项，否则会构建失败。在 Modern.js 中，请使用 [source.designSystem](/configure/app/source/design-system) 作为 `Tailwind CSS Theme` 配置。
 
-其他的使用方式和 Tailwind CSS 一致: [快速传送门](https://tailwindcss.com/docs/configuration)。
+其他配置的使用方式和 Tailwind CSS 一致，请参考 [tailwindcss - Configuration](https://tailwindcss.com/docs/configuration)。

--- a/packages/document/main-doc/docs/zh/configure/app/usage.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/usage.mdx
@@ -43,6 +43,15 @@ export default defineConfig({
 });
 ```
 
+当你使用 Rspack 作为打包工具时，由于 webpack 和 Rspack 的配置类型存在一些差异，需要为 `defineConfig` 指定 `<'rspack'>` 泛型：
+
+```diff title=modern.config.ts
+- export default defineConfig({
++ export default defineConfig<'rspack'>({
+  // ...
+});
+```
+
 ### modern.config.js
 
 如果你在开发一个非 TypeScript 项目，可以使用 .js 格式的配置文件：
@@ -239,6 +248,32 @@ const mergedConfig = {
   },
   tools: {
     postcss: [() => console.log('config1'), () => console.log('config2')],
+  },
+};
+```
+
+## 配置类型定义
+
+Modern.js 导出了 `AppUserConfig` 类型，对应 Modern.js 配置对象的类型：
+
+```ts title="modern.config.ts"
+import type { AppUserConfig } from '@modern-js/app-tools';
+
+const config: AppUserConfig = {
+  tools: {
+    webpack: {},
+  },
+};
+```
+
+当你使用 Rspack 作为打包工具时，由于 webpack 和 Rspack 的配置类型存在一些差异，需要为 `AppUserConfig` 指定 `<'rspack'>` 泛型：
+
+```ts title="modern.config.ts"
+import type { AppUserConfig } from '@modern-js/app-tools';
+
+const config: AppUserConfig<'rspack'> = {
+  tools: {
+    rspack: {},
   },
 };
 ```

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/testing.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/testing.mdx
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 # 测试
 
-Modern.js 默认继承了 [Jest](https://jestjs.io/) 的测试能力。
+Modern.js 默认集成了 [Jest](https://jestjs.io/) 的测试能力。
 
 我们首先需要执行 `pnpm run new` 启用「单元测试 / 集成测试」功能：
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7255455</samp>

This pull request updates the documentation of Modern.js in both English and Chinese versions. It improves the explanations and examples of the configuration options, especially for the `defineConfig` function and the `tools.tailwindcss` option. It also fixes a minor wording issue in the testing guide.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7255455</samp>

*  Update the documentation of the `tools.tailwindcss` configuration option for both English and Chinese versions, adding more details and examples of how to use the function and object types, and reordering the sections for clarity. ([link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-a2bcb69ffc32be0c70474b45273e7348605a973eadbc9ce49ab846bb6987c4b7L27-R58), [link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-a199dd051e5150078b303745af954bbad98c64d0c92cf364ecfc010062c52ff8L29-R65))
*  Add a note to the documentation of the `defineConfig` function for both English and Chinese versions, explaining that when using Rspack as the bundler, the generic type `<'rspack'>` needs to be specified to avoid type errors. ([link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-46a44484d97cd2d649878638e67e633c681aee562bc86de10e7a29f5f8c572c6R46-R54), [link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-9490cea7c40ba5159128b3f2630ffcf04f500b254b50b807773181cda89435fcR46-R54))
*  Add a section to the documentation of the Modern.js configuration for both English and Chinese versions, introducing the `AppUserConfig` type and showing how to use it with webpack and Rspack as the bundlers. ([link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-46a44484d97cd2d649878638e67e633c681aee562bc86de10e7a29f5f8c572c6R254-R279), [link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-9490cea7c40ba5159128b3f2630ffcf04f500b254b50b807773181cda89435fcR254-R279))
*  Modify the wording of the introduction to the testing guide for both English and Chinese versions, changing "inherits" to "integrates" to better reflect the relationship between Modern.js and Jest. ([link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-a835c7040690973a7f867741fc166dd6da708121bb820f1bd6e7d1ae0fa88e5cL7-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3616/files?diff=unified&w=0#diff-99ecfa6ff583c8215433562d77ffba702527f7ba40789a6f09591ec76e3d3fdaL7-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
