### PR TITLE
docs: fix wrong demo code

### DIFF
--- a/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
@@ -419,7 +419,7 @@ export default defineConfig({
 
 The default product of react-router^6 is in es2020. If you need the code in the product to be in es5, you can configure `source.include` to get the relevant packages of react-router compiled by the bundler.
 
-```
+```js
 export default defineConfig({
   source: {
     include: [/@remix-run\/router/, /react-router-dom/, /react-router/],

--- a/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
@@ -412,3 +412,17 @@ export default defineConfig({
   },
 });
 ```
+
+## FAQs
+
+1. The code in the product is es2015+ but expect to be in es5.
+
+The default product of react-router^6 is in es2020. If you need the code in the product to be in es5, you can configure `source.include` to get the relevant packages of react-router compiled by the bundler.
+
+```
+export default defineConfig({
+  source: {
+    include: [/@remix-run\/router/, /react-router-dom/, /react-router/],
+  }
+});
+```

--- a/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
@@ -513,18 +513,18 @@ export default defineConfig({
 });
 ```
 
-### 常见问题
+## 常见问题
 
 1. 产物中的代码是 es2015+ 的，期望产物中是 es5 的代码
 
 react-router^6 的目前默认产物是 es2020 的，如果需要产物中是 es5 的代码，可以配置 `source.include`，让 react-router 相关包经过 bundler 编译 ：
 
 ```
-source: {
+export default defineConfig({
   source: {
     include: [/@remix-run\/router/, /react-router-dom/, /react-router/],
   }
-}
+});
 ```
 
 

--- a/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
@@ -519,7 +519,7 @@ export default defineConfig({
 
 react-router^6 的目前默认产物是 es2020 的，如果需要产物中是 es5 的代码，可以配置 `source.include`，让 react-router 相关包经过 bundler 编译 ：
 
-```
+```js
 export default defineConfig({
   source: {
     include: [/@remix-run\/router/, /react-router-dom/, /react-router/],


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

修改文档中的错误示例代码

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f50ece</samp>

* Add a new section of FAQs to the routes guide in English and Chinese, explaining how to compile react-router packages to es5 for compatibility ([link](https://github.com/web-infra-dev/modern.js/pull/3618/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134R415-R428), [link](https://github.com/web-infra-dev/modern.js/pull/3618/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L516-R516))
* Fix a typo in the heading level of the FAQs section in the Chinese version of `routes.mdx` ([link](https://github.com/web-infra-dev/modern.js/pull/3618/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L516-R516))
* Update the code snippet in the Chinese version of `routes.mdx` to include the `defineConfig` export statement ([link](https://github.com/web-infra-dev/modern.js/pull/3618/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L523-R527))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
