### PR TITLE
docs: removed outdated FAQ

### DIFF
--- a/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
@@ -415,17 +415,3 @@ export default defineConfig({
   },
 });
 ```
-
-## FAQs
-
-1. The code in the product is es2015+ but expect to be in es5.
-
-The default product of react-router^6 is in es2020. If you need the code in the product to be in es5, you can configure `source.include` to get the relevant packages of react-router compiled by the bundler.
-
-```js
-export default defineConfig({
-  source: {
-    include: [/@remix-run\/router/, /react-router-dom/, /react-router/],
-  }
-});
-```

--- a/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
@@ -514,19 +514,5 @@ export default defineConfig({
 });
 ```
 
-## 常见问题
-
-1. 产物中的代码是 es2015+ 的，期望产物中是 es5 的代码
-
-react-router^6 的目前默认产物是 es2020 的，如果需要产物中是 es5 的代码，可以配置 `source.include`，让 react-router 相关包经过 bundler 编译 ：
-
-```js
-export default defineConfig({
-  source: {
-    include: [/@remix-run\/router/, /react-router-dom/, /react-router/],
-  }
-});
-```
-
 
 


### PR DESCRIPTION
## Summary

This FAQ is outdated and should be removed.

Ref: 

- https://github.com/web-infra-dev/modern.js/pull/3618
- https://github.com/web-infra-dev/modern.js/pull/3421

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f85cf15</samp>

Remove outdated FAQs sections from the routes guides in both English and Chinese. Fix a minor formatting issue in the Chinese version.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f85cf15</samp>

* Remove FAQs section from routes guide in both languages ([link](https://github.com/web-infra-dev/modern.js/pull/3622/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L418-L431), [link](https://github.com/web-infra-dev/modern.js/pull/3622/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L517-R518))
* Fix extra code block delimiter in Chinese version of `routes.mdx` ([link](https://github.com/web-infra-dev/modern.js/pull/3622/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L517-R518))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
