### PR TITLE
chore: generator test support parallel

### DIFF
--- a/tests/generator/utils/command.ts
+++ b/tests/generator/utils/command.ts
@@ -76,51 +76,44 @@ export async function runCreteCommand(
 
 export async function runInstallAndBuildProject(type: string, tmpDir: string) {
   const projects = fs.readdirSync(tmpDir);
-  for (const project of projects) {
-    if (!project.includes(type)) {
-      continue;
-    }
-    console.info('install and build process', project);
-    const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
-    await execaWithStreamLog(packageManager, ['install', '--ignore-scripts'], {
-      cwd: path.join(tmpDir, project),
-    });
-    if (project.includes('monorepo')) {
-      continue;
-    }
-    await execaWithStreamLog(packageManager, ['build'], {
-      cwd: path.join(tmpDir, project),
-    });
-  }
+  await Promise.all(
+    projects
+      .filter(project => project.includes(type))
+      .map(async project => {
+        console.info('install and build process', project);
+        const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
+        await execaWithStreamLog(
+          packageManager,
+          ['install', '--ignore-scripts'],
+          {
+            cwd: path.join(tmpDir, project),
+          },
+        );
+        if (project.includes('monorepo')) {
+          return Promise.resolve();
+        }
+        await execaWithStreamLog(packageManager, ['build'], {
+          cwd: path.join(tmpDir, project),
+        });
+        return Promise.resolve();
+      }),
+  );
 }
 
 export async function runLintProject(type: string, tmpDir: string) {
   const projects = fs.readdirSync(tmpDir);
-  for (const project of projects) {
-    if (!project.includes(type)) {
-      continue;
-    }
-    console.info('lint process', project);
-    const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
-    if (project.includes('monorepo')) {
-      continue;
-    }
-    await execaWithStreamLog(packageManager, ['lint'], {
-      cwd: path.join(tmpDir, project),
-    });
-  }
-}
-
-export async function runTestProject(tmpDir: string) {
-  const projects = fs.readdirSync(tmpDir);
-  for (const project of projects) {
-    console.info('test process', project);
-    const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
-    if (project.includes('monorepo')) {
-      continue;
-    }
-    await execaWithStreamLog(packageManager, ['test'], {
-      cwd: path.join(tmpDir, project),
-    });
-  }
+  await Promise.all(
+    projects
+      .filter(
+        project => project.includes(type) && !project.includes('monorepo'),
+      )
+      .map(async project => {
+        console.info('lint process', project);
+        const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
+        await execaWithStreamLog(packageManager, ['lint'], {
+          cwd: path.join(tmpDir, project),
+        });
+        return Promise.resolve();
+      }),
+  );
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f837721</samp>

Refactor `runInstallAndBuildProject` and `runLintProject` in `tests/generator/utils/command.ts` to use `Promise.all` and array methods. This improves code quality and performance for testing different project types.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f837721</samp>

*  Refactor `runInstallAndBuildProject` and `runLintProject` functions to use `Promise.all` and array methods instead of loops and `continue` statements ([link](https://github.com/web-infra-dev/modern.js/pull/3626/files?diff=unified&w=0#diff-3638fb9c95d03d4a2fdc2286bc9856dd11eac61bd4fc20edcb96ee330547e209L79-R119))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
