### PR TITLE
docs(builder): fix quick start of builtin builder plugins

### DIFF
--- a/packages/document/builder-doc/docs/en/plugins/plugin-esbuild.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-esbuild.mdx
@@ -13,7 +13,30 @@ Therefore, we recommend that you use SWC instead of esbuild, please refer to [SW
 
 ## Quick Start
 
-### Install
+### Used in Modern.js framework
+
+The Modern.js framework integrates the Builder's esbuild plugin by default, so you don't need to manually install and register the plugin, just use the [tools.esbuild](https://modernjs.dev/en/configure/app/tools/esbuild.html) configuration:
+
+```js
+export default defineConfig({
+  tools: {
+    esbuild: {
+      loader: {
+        target: 'chrome61',
+      },
+      minimize: {
+        target: 'chrome61',
+      },
+    },
+  },
+});
+```
+
+### Use via the Node API
+
+If you use the Builder's Node API, you need to manually install and register the esbuild plugin.
+
+#### Install
 
 You can install the plugin with the following command:
 
@@ -28,19 +51,9 @@ yarn add @modern-js/builder-plugin-esbuild -D
 pnpm add @modern-js/builder-plugin-esbuild -D
 ```
 
-### Register
+#### Register
 
-In upper-level frameworks such as Modern.js, you can register esbuild plugins through the `builderPlugins` config:
-
-```ts
-import { builderPluginEsbuild } from '@modern-js/builder-plugin-esbuild';
-
-export default {
-  builderPlugins: [builderPluginEsbuild()],
-};
-```
-
-If you are using the Builder's Node API, you can register esbuild plugins through the `addPlugins` method:
+Register esbuild plugins through the `addPlugins` method:
 
 ```js
 import { builderPluginEsbuild } from '@modern-js/builder-plugin-esbuild';

--- a/packages/document/builder-doc/docs/en/plugins/plugin-node-polyfill.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-node-polyfill.mdx
@@ -8,7 +8,23 @@ By using the Node Polyfill plugin, Node core libs polyfills are automatically in
 
 ## Quick Start
 
-### Install
+### Used in Modern.js framework
+
+The Modern.js framework integrates the Builder's Node Polyfill plugin by default, so you don't need to manually install and register the plugin, just set the [output.disableNodePolyfill](https://modernjs.dev/configure/app/output/disable-node-polyfill.html) config to `false`:
+
+```js
+export default defineConfig({
+  output: {
+    disableNodePolyfill: false,
+  },
+});
+```
+
+### Use via the Node API
+
+If you use the Builder's Node API, you need to manually install and register the esbuild plugin.
+
+#### Install
 
 You can install the plugin with the following command:
 
@@ -23,19 +39,9 @@ yarn add @modern-js/builder-plugin-node-polyfill -D
 pnpm add @modern-js/builder-plugin-node-polyfill -D
 ```
 
-### Register
+#### Register
 
-In upper-level frameworks such as Modern.js, you can register node polyfill plugins through the `builderPlugins` config:
-
-```ts
-import { builderPluginNodePolyfill } from '@modern-js/builder-plugin-node-polyfill';
-
-export default {
-  builderPlugins: [builderPluginNodePolyfill()],
-};
-```
-
-If you are using the Builder's Node API, you can register node polyfill plugins through the `addPlugins` method:
+Register node polyfill plugins through the `addPlugins` method:
 
 ```js
 import { builderPluginNodePolyfill } from '@modern-js/builder-plugin-node-polyfill';

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-esbuild.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-esbuild.mdx
@@ -13,7 +13,30 @@ Builder 提供了 esbuild 插件，让你能使用 esbuild 代替 babel-loader�
 
 ## 快速开始
 
-### 安装插件
+### 在 Modern.js 框架中使用
+
+Modern.js 框架默认集成了 Builder 的 esbuild 插件，因此，你不需要手动安装和注册插件，只需要使用 [tools.esbuild](https://modernjs.dev/configure/app/tools/esbuild.html) 配置项即可：
+
+```js
+export default defineConfig({
+  tools: {
+    esbuild: {
+      loader: {
+        target: 'chrome61',
+      },
+      minimize: {
+        target: 'chrome61',
+      },
+    },
+  },
+});
+```
+
+### 通过 Node API 使用
+
+如果你直接使用了 Builder 的 Node API，那么需要手动安装和注册 esbuild 插件。
+
+#### 安装插件
 
 你可以通过如下的命令安装插件:
 
@@ -28,19 +51,9 @@ yarn add @modern-js/builder-plugin-esbuild -D
 pnpm add @modern-js/builder-plugin-esbuild -D
 ```
 
-### 注册插件
+#### 注册插件
 
-在 Modern.js 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 esbuild 插件：
-
-```ts
-import { builderPluginEsbuild } from '@modern-js/builder-plugin-esbuild';
-
-export default {
-  builderPlugins: [builderPluginEsbuild()],
-};
-```
-
-当你直接调用 Builder 的 Node API 时，可以通过 `addPlugins` 方法来注册 esbuild 插件：
+通过 `addPlugins` 方法来注册 esbuild 插件：
 
 ```js
 import { builderPluginEsbuild } from '@modern-js/builder-plugin-esbuild';

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-node-polyfill.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-node-polyfill.mdx
@@ -8,7 +8,23 @@
 
 ## 快速开始
 
-### 安装插件
+### 在 Modern.js 框架中使用
+
+Modern.js 框架默认集成了 Builder 的 Node Polyfill 插件，因此，你不需要手动安装和注册插件，只需要将 [output.disableNodePolyfill](https://modernjs.dev/configure/app/output/disable-node-polyfill.html) 设置为 `false` 即可：
+
+```js
+export default defineConfig({
+  output: {
+    disableNodePolyfill: false,
+  },
+});
+```
+
+### 通过 Node API 使用
+
+如果你直接使用了 Builder 的 Node API，那么需要手动安装和注册 Node Polyfill 插件。
+
+#### 安装插件
 
 你可以通过如下的命令安装插件:
 
@@ -23,19 +39,9 @@ yarn add @modern-js/builder-plugin-node-polyfill -D
 pnpm add @modern-js/builder-plugin-node-polyfill -D
 ```
 
-### 注册插件
+#### 注册插件
 
-在 Modern.js 等上层框架中，你可以通过 `builderPlugins` 配置项来注册 node polyfill 插件：
-
-```ts
-import { builderPluginNodePolyfill } from '@modern-js/builder-plugin-node-polyfill';
-
-export default {
-  builderPlugins: [builderPluginNodePolyfill()],
-};
-```
-
-当你直接调用 Builder 的 Node API 时，可以通过 `addPlugins` 方法来注册 node polyfill 插件：
+通过 `addPlugins` 方法来注册 Node Polyfill 插件：
 
 ```js
 import { builderPluginNodePolyfill } from '@modern-js/builder-plugin-node-polyfill';


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d9eee8</samp>

This pull request improves the documentation of the `esbuild` and `node polyfill` plugins for the Modern.js framework and the Node API in both English and Chinese. It adds new sections on how to use the plugins in the framework without installation or registration, and simplifies the existing sections on how to register the plugins via the Node API. It also harmonizes the style and structure of the plugin documentation across languages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d9eee8</samp>

*  Add and update sections in the English and Chinese documentation of the esbuild and node polyfill plugins, explaining how to use them in the Modern.js framework without installing or registering them, and providing examples of the relevant configuration options. ([link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-afbee9606a977b81ef1f709917d638a0707922f8029409912dc21d9a7b71aa40L16-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-5830f8d944386640d345922c56548dd02629f6dad5609609c794a0c785343769L11-R28), [link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-1d78e7dbdce153077696fd50127642532f12482957a04c2a7725b6562fa4587cL16-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-fa1d89237417561d8d44376439f632320206706fdee559ec682c7fcecb405a63L11-R28))
* Simplify the instructions for registering the esbuild and node polyfill plugins via the Node API, and remove the references to the `builderPlugins` config, which is only applicable to the Modern.js framework. ([link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-afbee9606a977b81ef1f709917d638a0707922f8029409912dc21d9a7b71aa40L31-R57), [link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-5830f8d944386640d345922c56548dd02629f6dad5609609c794a0c785343769L26-R45), [link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-1d78e7dbdce153077696fd50127642532f12482957a04c2a7725b6562fa4587cL31-R57), [link](https://github.com/web-infra-dev/modern.js/pull/3628/files?diff=unified&w=0#diff-fa1d89237417561d8d44376439f632320206706fdee559ec682c7fcecb405a63L26-R45))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
