### PR TITLE
chore: generator test use npm package manager

### DIFF
--- a/tests/generator/module.ts
+++ b/tests/generator/module.ts
@@ -62,7 +62,7 @@ async function runNewInModuleProject(
       cwd: path.join(tmpDir, project),
     },
   );
-  const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
+  const packageManager = project.includes('pnpm') ? 'pnpm' : 'npm';
   const cases = getModuleNewCases();
   for (const config of cases) {
     await runModuleNewCommand(isLocal, packageManager, {
@@ -71,10 +71,10 @@ async function runNewInModuleProject(
         ...config,
       }),
     });
-    await execaWithStreamLog(packageManager, ['build'], {
+    await execaWithStreamLog(packageManager, ['run', 'build'], {
       cwd: path.join(tmpDir, project),
     });
-    await execaWithStreamLog(packageManager, ['lint'], {
+    await execaWithStreamLog(packageManager, ['run', 'lint'], {
       cwd: path.join(tmpDir, project),
     });
   }
@@ -82,7 +82,7 @@ async function runNewInModuleProject(
 
 async function runModuleNewCommand(
   isLocal: boolean,
-  packageManager: 'pnpm' | 'yarn',
+  packageManager: 'pnpm' | 'npm',
   options: {
     config: string;
     cwd: string;
@@ -102,8 +102,16 @@ async function runModuleNewCommand(
     });
   } else {
     await execaWithStreamLog(
-      'yarn',
-      ['new', '--dist-tag', 'next', '--config', config, debug ? '--debug' : ''],
+      'npm',
+      [
+        'run',
+        'new',
+        '--dist-tag',
+        'next',
+        '--config',
+        config,
+        debug ? '--debug' : '',
+      ],
       {
         cwd,
         env: {

--- a/tests/generator/mwa.ts
+++ b/tests/generator/mwa.ts
@@ -63,7 +63,7 @@ async function runNewMWAProject(
       cwd: path.join(tmpDir, project),
     },
   );
-  const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
+  const packageManager = project.includes('pnpm') ? 'pnpm' : 'npm';
   const cases = getMWANewCases(isSimple ? 5 : undefined);
   let hasMicroFrontend = false;
   let hasSSG = false;
@@ -116,10 +116,10 @@ async function runNewMWAProject(
         ...config,
       }),
     });
-    await execaWithStreamLog(packageManager, ['build'], {
+    await execaWithStreamLog(packageManager, ['run', 'build'], {
       cwd: path.join(tmpDir, project),
     });
-    await execaWithStreamLog(packageManager, ['lint'], {
+    await execaWithStreamLog(packageManager, ['run', 'lint'], {
       cwd: path.join(tmpDir, project),
     });
   }
@@ -127,7 +127,7 @@ async function runNewMWAProject(
 
 async function runMWANewCommand(
   isLocal: boolean,
-  packageManager: 'pnpm' | 'yarn',
+  packageManager: 'pnpm' | 'npm',
   options: {
     config: string;
     cwd: string;
@@ -147,8 +147,16 @@ async function runMWANewCommand(
     });
   } else {
     await execaWithStreamLog(
-      'yarn',
-      ['new', '--dist-tag', 'next', '--config', config, debug ? '--debug' : ''],
+      'npm',
+      [
+        'run',
+        'new',
+        '--dist-tag',
+        'next',
+        '--config',
+        config,
+        debug ? '--debug' : '',
+      ],
       {
         cwd,
         env: {

--- a/tests/generator/utils/command.ts
+++ b/tests/generator/utils/command.ts
@@ -81,7 +81,7 @@ export async function runInstallAndBuildProject(type: string, tmpDir: string) {
       .filter(project => project.includes(type))
       .map(async project => {
         console.info('install and build process', project);
-        const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
+        const packageManager = project.includes('pnpm') ? 'pnpm' : 'npm';
         await execaWithStreamLog(
           packageManager,
           ['install', '--ignore-scripts'],
@@ -92,7 +92,7 @@ export async function runInstallAndBuildProject(type: string, tmpDir: string) {
         if (project.includes('monorepo')) {
           return Promise.resolve();
         }
-        await execaWithStreamLog(packageManager, ['build'], {
+        await execaWithStreamLog(packageManager, ['run', 'build'], {
           cwd: path.join(tmpDir, project),
         });
         return Promise.resolve();
@@ -109,8 +109,8 @@ export async function runLintProject(type: string, tmpDir: string) {
       )
       .map(async project => {
         console.info('lint process', project);
-        const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
-        await execaWithStreamLog(packageManager, ['lint'], {
+        const packageManager = project.includes('pnpm') ? 'pnpm' : 'npm';
+        await execaWithStreamLog(packageManager, ['run', 'lint'], {
           cwd: path.join(tmpDir, project),
         });
         return Promise.resolve();


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f97879f</samp>

This pull request adds `npm` as an optional package manager for the `modern.js` generator and updates the tests and utility functions accordingly. It modifies the `packageManager` variable and parameter, the `build` and `lint` scripts, and the `new` command in various files under `./tests/generator/`. It also adds the `run` prefix to the scripts when using `npm`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f97879f</samp>

*  Support `npm` as a package manager option for the `modern.js` generator ([link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-e8a0243fcd47e39ac2d708353d6f308e3d3698d2ca8ee9e8495c090b7832a7a4L65-R65), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-3d21024e12c6b1ce5711f2b8320a9b456916663a71da5a06f2917e8f7d240057L66-R66), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-3638fb9c95d03d4a2fdc2286bc9856dd11eac61bd4fc20edcb96ee330547e209L84-R84))
* Update the tests to reflect the changes in the `modern.js` generator ([link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-e8a0243fcd47e39ac2d708353d6f308e3d3698d2ca8ee9e8495c090b7832a7a4L74-R77), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-e8a0243fcd47e39ac2d708353d6f308e3d3698d2ca8ee9e8495c090b7832a7a4L85-R85), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-e8a0243fcd47e39ac2d708353d6f308e3d3698d2ca8ee9e8495c090b7832a7a4L105-R114), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-3d21024e12c6b1ce5711f2b8320a9b456916663a71da5a06f2917e8f7d240057L119-R122), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-3d21024e12c6b1ce5711f2b8320a9b456916663a71da5a06f2917e8f7d240057L130-R130), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-3d21024e12c6b1ce5711f2b8320a9b456916663a71da5a06f2917e8f7d240057L150-R159), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-3638fb9c95d03d4a2fdc2286bc9856dd11eac61bd4fc20edcb96ee330547e209L95-R95), [link](https://github.com/web-infra-dev/modern.js/pull/3629/files?diff=unified&w=0#diff-3638fb9c95d03d4a2fdc2286bc9856dd11eac61bd4fc20edcb96ee330547e209L112-R113))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
