### PR TITLE
fix: generator test new command params not work

### DIFF
--- a/tests/generator/module.ts
+++ b/tests/generator/module.ts
@@ -106,6 +106,7 @@ async function runModuleNewCommand(
       [
         'run',
         'new',
+        '--',
         '--dist-tag',
         'next',
         '--config',

--- a/tests/generator/monorepo.ts
+++ b/tests/generator/monorepo.ts
@@ -51,7 +51,7 @@ async function runNewInMonorepoProject(
     return;
   }
   console.info('process', project);
-  const packageManager = project.includes('pnpm') ? 'pnpm' : 'yarn';
+  const packageManager = project.includes('pnpm') ? 'pnpm' : 'npm';
   const cases = getMonorepoNewCases(isSimple ? 5 : undefined);
   for (const config of cases) {
     const subProjectPath = path.join(
@@ -98,7 +98,7 @@ async function runNewInMonorepoProject(
 
 async function runMonorepoNewCommand(
   isLocal: boolean,
-  packageManager: 'pnpm' | 'yarn',
+  packageManager: 'pnpm' | 'npm',
   options: {
     config: string;
     cwd: string;
@@ -118,8 +118,16 @@ async function runMonorepoNewCommand(
     });
   } else {
     await execaWithStreamLog(
-      'yarn',
-      ['new', '--dist-tag', 'next', '--config', config, debug ? '--debug' : ''],
+      'npm',
+      [
+        'new',
+        '--',
+        '--dist-tag',
+        'next',
+        '--config',
+        config,
+        debug ? '--debug' : '',
+      ],
       {
         cwd,
         env: {

--- a/tests/generator/mwa.ts
+++ b/tests/generator/mwa.ts
@@ -151,6 +151,7 @@ async function runMWANewCommand(
       [
         'run',
         'new',
+        '--',
         '--dist-tag',
         'next',
         '--config',


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae8ad73</samp>

This pull request refactors the `new` command to use `npm` as the default package manager, and updates the tests accordingly. It also fixes a bug with passing options to the `new` command when using `npm`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae8ad73</samp>

*  Refactor `new` command to use `npm` as the default package manager ([link](https://github.com/web-infra-dev/modern.js/pull/3632/files?diff=unified&w=0#diff-e8a0243fcd47e39ac2d708353d6f308e3d3698d2ca8ee9e8495c090b7832a7a4R109), [link](https://github.com/web-infra-dev/modern.js/pull/3632/files?diff=unified&w=0#diff-bfa82c2363f8fb9cb77d22ba9638af0e5fa4bf745b81cf1256e0b59b30869a8fL54-R54), [link](https://github.com/web-infra-dev/modern.js/pull/3632/files?diff=unified&w=0#diff-bfa82c2363f8fb9cb77d22ba9638af0e5fa4bf745b81cf1256e0b59b30869a8fL101-R101), [link](https://github.com/web-infra-dev/modern.js/pull/3632/files?diff=unified&w=0#diff-bfa82c2363f8fb9cb77d22ba9638af0e5fa4bf745b81cf1256e0b59b30869a8fL121-R130), [link](https://github.com/web-infra-dev/modern.js/pull/3632/files?diff=unified&w=0#diff-3d21024e12c6b1ce5711f2b8320a9b456916663a71da5a06f2917e8f7d240057R154))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
