### PR TITLE
fix(module-tools): fix error config name and config merge logic

### DIFF
--- a/.changeset/green-icons-carry.md
+++ b/.changeset/green-icons-carry.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+'@modern-js/plugin-tailwindcss': patch
+---
+
+fix(module-tools, plugin-tailwindcss): fix `style.tailwindcss` config name and merge logic
+fix(module-tools, plugin-tailwindcss): 修复 `style.tailwindcss` 错误的配置名和合并逻辑

--- a/packages/cli/doc-core/modern.config.ts
+++ b/packages/cli/doc-core/modern.config.ts
@@ -112,7 +112,8 @@ export default {
       },
       style: {
         tailwindcss: {
-          ...tailwindConfig,
+          // ...tailwindConfig,
+          darkMode: 'class',
         },
         modules: {
           localsConvention: 'camelCase',

--- a/packages/cli/plugin-tailwind/src/cli.ts
+++ b/packages/cli/plugin-tailwind/src/cli.ts
@@ -155,7 +155,7 @@ export default (
         const { designSystem } = modernConfig;
         const tailwindConfig = getTailwindConfig(
           tailwindVersion,
-          config.style.tailwindCss,
+          config.style.tailwindcss,
           designSystem,
           {
             pureConfig: {

--- a/packages/solutions/module-tools/src/constants/build.ts
+++ b/packages/solutions/module-tools/src/constants/build.ts
@@ -36,7 +36,7 @@ export const defaultBuildConfig = Object.freeze<BaseBuildConfig>({
     less: {},
     sass: {},
     postcss: {},
-    tailwindCss: {},
+    tailwindcss: {},
     inject: false,
     autoModules: true,
     modules: {},

--- a/packages/solutions/module-tools/src/types/config/index.ts
+++ b/packages/solutions/module-tools/src/types/config/index.ts
@@ -72,7 +72,7 @@ export type BaseBuildConfig = Omit<
   sideEffects: LibuildUserConfig['sideEffects'];
   dts: false | DTSOptions;
   style: Omit<Required<LibuildStyle>, 'cleanCss'> & {
-    tailwindCss: TailwindCSSConfig;
+    tailwindcss: TailwindCSSConfig;
   };
   alias: Record<string, string>;
 };

--- a/packages/solutions/module-tools/src/utils/config.ts
+++ b/packages/solutions/module-tools/src/utils/config.ts
@@ -117,7 +117,8 @@ export const mergeDefaultBaseConfig = async (
       modules: pConfig.style?.modules ?? defaultConfig.style.modules,
       autoModules:
         pConfig.style?.autoModules ?? defaultConfig.style.autoModules,
-      tailwindCss: defaultConfig.style.tailwindCss,
+      tailwindcss:
+        pConfig.style?.tailwindcss ?? defaultConfig.style.tailwindcss,
     },
     redirect: {
       ...defaultConfig.redirect,


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1bf348f</samp>

This pull request fixes a typo in the `tailwindcss` property name across the `@modern-js/module-tools` and `@modern-js/plugin-tailwindcss` packages. This improves the consistency and compatibility of the TailwindCSS integration in the Modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1bf348f</samp>

*  Fix typo in `tailwindcss` property name for build configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3638/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dL158-R158), [link](https://github.com/web-infra-dev/modern.js/pull/3638/files?diff=unified&w=0#diff-ba4c98ff890890d89ce89a86119cf794ab7e04b21796ec80d3b3fa373b23ef09L39-R39), [link](https://github.com/web-infra-dev/modern.js/pull/3638/files?diff=unified&w=0#diff-c396ea1ac3680532b4b931369f621014fab56d1b80aee366816b7398311e8027L75-R75), [link](https://github.com/web-infra-dev/modern.js/pull/3638/files?diff=unified&w=0#diff-3afd2b55e4c2b246951bbbc69619d3d9e54534d125b6dfead2de7f815d196e3fL120-R121))
*  Add changeset file for patch updates of `@modern-js/module-tools` and `@modern-js/plugin-tailwindcss` packages ([link](https://github.com/web-infra-dev/modern.js/pull/3638/files?diff=unified&w=0#diff-7e2aa04f90835692557d9cc837e8228812598dc599938e1d13f661271aa644cfR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
