### PR TITLE
perf(builder): optimize stats.toJson performance

### DIFF
--- a/.changeset/soft-terms-lie.md
+++ b/.changeset/soft-terms-lie.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder': patch
+---
+
+perf(builder): optimize stats.toJson performance
+
+perf(builder): 优化 stats.toJson 性能

--- a/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
@@ -22,6 +22,7 @@ export async function createCompiler({
 
   compiler.hooks.done.tap('done', async stats => {
     const obj = stats.toJson({
+      all: false,
       timings: true,
     });
 

--- a/packages/builder/builder/src/plugins/fileSize.ts
+++ b/packages/builder/builder/src/plugins/fileSize.ts
@@ -67,7 +67,7 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
   const assets = multiStats
     .map(stats => {
       const origin = stats.toJson({
-        all: true,
+        all: false,
         assets: true,
         groupAssetsByInfo: false,
         groupAssetsByPath: false,
@@ -75,6 +75,7 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
         groupAssetsByExtension: false,
         groupAssetsByEmitStatus: false,
       });
+
       const filteredAssets = origin.assets!.filter(asset =>
         filterAsset(asset.name),
       );


### PR DESCRIPTION
## Summary

The `stats.toJson` method can be very slow in large applications, so we should only get the used data from stats.

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/b0fdadd0-3633-4e26-ab1e-f3d259e0cc7c)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4af9e2</samp>

This pull request enhances the performance and code quality of the `@modern-js/builder` and `@modern-js/builder-rspack-provider` packages. It simplifies the `printFileSizes` function, reduces the verbosity of the `stats.toJson` method, and adds a changeset file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4af9e2</samp>

*  Improve performance of `stats.toJson` method by setting `all` option to `false` in `@modern-js/builder-rspack-provider` and `@modern-js/builder` packages ([link](https://github.com/web-infra-dev/modern.js/pull/3646/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3R25), [link](https://github.com/web-infra-dev/modern.js/pull/3646/files?diff=unified&w=0#diff-6ea934f4ff87cceb10e4b242f1d4bd387385ba4bb5eba12d71ed78e34a1ae944L70-R70))
*  Add changeset file to describe patch-level updates and provide bilingual summary of changes in `.changeset/soft-terms-lie.md` ([link](https://github.com/web-infra-dev/modern.js/pull/3646/files?diff=unified&w=0#diff-e5e742af9bed561d5babd50dc9f2bec2d8d0cdf64e5c956f3e3f7ffda30d9865R1-R8))
*  Add blank line to end of `fileSize.ts` file to comply with code style ([link](https://github.com/web-infra-dev/modern.js/pull/3646/files?diff=unified&w=0#diff-6ea934f4ff87cceb10e4b242f1d4bd387385ba4bb5eba12d71ed78e34a1ae944R78))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
