### PR TITLE
feat(doc-core): support react 17

### DIFF
--- a/.changeset/eleven-pandas-fly.md
+++ b/.changeset/eleven-pandas-fly.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+feat(doc-core): support react 17
+
+feat(doc-core): 支持 react 17

--- a/packages/cli/doc-core/src/node/utils/detectReactVersion.ts
+++ b/packages/cli/doc-core/src/node/utils/detectReactVersion.ts
@@ -1,0 +1,48 @@
+import path from 'path';
+import fs from '@modern-js/utils/fs-extra';
+import { PACKAGE_ROOT } from '../constants';
+import { resolveDepPath } from './flattenMdxContent';
+
+const DEFAULT_REACT_VERSION = 18;
+
+export async function detectReactVersion(): Promise<number> {
+  // Detect react version from current cwd
+  // return the major version of react
+  // if not found, return 18
+  const cwd = process.cwd();
+  const reactPath = path.join(cwd, 'node_modules', 'react');
+  if (await fs.pathExists(reactPath)) {
+    const reactPkg = await fs.readJson(path.join(reactPath, 'package.json'));
+    const version = Number(reactPkg.version.split('.')[0]);
+    return version;
+  } else {
+    return DEFAULT_REACT_VERSION;
+  }
+}
+
+export async function resolveReactAlias(reactVersion: number) {
+  const basedir =
+    reactVersion === DEFAULT_REACT_VERSION ? PACKAGE_ROOT : process.cwd();
+  const libPaths = [
+    'react',
+    'react/jsx-runtime',
+    'react/jsx-dev-runtime',
+    'react-dom',
+    'react-dom/server',
+  ];
+  if (reactVersion === DEFAULT_REACT_VERSION) {
+    libPaths.push('react-dom/client');
+  }
+  const alias: Record<string, string> = {};
+  await Promise.all(
+    libPaths.map(async lib => {
+      try {
+        alias[lib] = await resolveDepPath(lib, basedir, {});
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(`warning: ${lib} not found`);
+      }
+    }),
+  );
+  return alias;
+}

--- a/packages/cli/doc-core/src/node/utils/flattenMdxContent.ts
+++ b/packages/cli/doc-core/src/node/utils/flattenMdxContent.ts
@@ -18,7 +18,7 @@ export async function resolveDepPath(
   if (!resolver) {
     resolver = ResolverFactory.createResolver({
       fileSystem: new CachedInputFileSystem(fs),
-      extensions: ['.mdx', '.md'],
+      extensions: ['.mdx', '.md', '.js'],
       alias,
     });
   }

--- a/packages/cli/doc-core/src/node/utils/index.ts
+++ b/packages/cli/doc-core/src/node/utils/index.ts
@@ -2,3 +2,4 @@ export * from './normalizePath';
 export * from './getPageKey';
 export * from './createHash';
 export * from './logger';
+export * from './detectReactVersion';

--- a/packages/cli/doc-core/src/runtime/Content.tsx
+++ b/packages/cli/doc-core/src/runtime/Content.tsx
@@ -1,5 +1,4 @@
 import { matchRoutes, useLocation } from 'react-router-dom';
-import { Suspense } from 'react';
 import { normalizeRoutePath } from './utils';
 
 const { routes } = process.env.__SSR__
@@ -13,5 +12,6 @@ export const Content = () => {
     return <div></div>;
   }
   const routesElement = matched[0].route.element;
-  return <Suspense>{routesElement}</Suspense>;
+
+  return routesElement;
 };

--- a/packages/cli/doc-core/src/runtime/clientEntry.tsx
+++ b/packages/cli/doc-core/src/runtime/clientEntry.tsx
@@ -1,6 +1,5 @@
 import Theme from '@theme';
 import { useState } from 'react';
-import { createRoot, hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App, initPageData } from './App';
 import { DataContext, ThemeContext } from './hooks';
@@ -28,10 +27,20 @@ export async function renderInBrowser() {
     };
   };
   const RootApp = await enhancedApp();
-  if (isProduction()) {
-    hydrateRoot(container, <RootApp />);
+  if (process.env.__IS_REACT_18__) {
+    const { createRoot, hydrateRoot } = require('react-dom/client');
+    if (isProduction()) {
+      hydrateRoot(container, <RootApp />);
+    } else {
+      createRoot(container).render(<RootApp />);
+    }
   } else {
-    createRoot(container).render(<RootApp />);
+    const ReactDOM = require('react-dom');
+    if (isProduction()) {
+      ReactDOM.hydrate(<RootApp />, container);
+    } else {
+      ReactDOM.render(<RootApp />, container);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 144f484</samp>

This pull request adds support for React 17 and concurrent mode to the `@modern-js/doc-core` package. It updates the doc site build and runtime logic to dynamically detect and resolve the React version and aliases. It also removes some unnecessary components and improves the dependency resolution.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 144f484</samp>

*  Add support for React 17 in the `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-539c21d918dd70913441dbbb5ed0be561152e760a826f39a9405fedc1e6f77d1R1-R7))
*  Import and export utility functions to detect and resolve React version and aliases from the user's project ([link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R25), [link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-4cdd5c571a46280a8b3d64d74d31ea452441778934a59ad8517dd53cdf951477R1-R48), [link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-5bfa8990a30a972f8389dffe805cb8882241f283c272e125a9affa58ee4e5cedR5))
*  Use the utility functions to configure the React-related options for the doc site build in the `createInternalBuildConfig` function in `createBuilder.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R68), [link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554L107-L112), [link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R118), [link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R124))
*  Fix a typo in a comment in the `createInternalBuildConfig` function in `createBuilder.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554L99-R101))
*  Remove unused or hard-coded React imports and aliases from the runtime code in `clientEntry.tsx` and `Content.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-4dc558feca5137c2aacd92ae0c22dc682581c9a67da5718349b95e2c8b082228L2), [link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-4dc558feca5137c2aacd92ae0c22dc682581c9a67da5718349b95e2c8b082228L16-R16), [link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-b8322e866782d25d3cb6ae4cb32ab5745149abee212e3b911a94c052ecf6b2bdL3))
*  Use different React rendering methods based on the React version in the `renderInBrowser` function in `clientEntry.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-b8322e866782d25d3cb6ae4cb32ab5745149abee212e3b911a94c052ecf6b2bdL31-R43))
*  Add the `.js` extension to the `resolveDepPath` function in `flattenMdxContent.ts` to resolve the React modules that are dynamically aliased ([link](https://github.com/web-infra-dev/modern.js/pull/3652/files?diff=unified&w=0#diff-2ce8de590c529b28f3a2bf80a62718455661c3ad2ba9e4efb2de10b59093d5ebL21-R21))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
