### PR TITLE
fix(builder): incorrect dynamicImportMode when target is web-worker

### DIFF
--- a/.changeset/two-cameras-sparkle.md
+++ b/.changeset/two-cameras-sparkle.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder': patch
+---
+
+fix(builder): incorrect dynamicImportMode when target is web-worker
+
+fix(builder): 修复 target 为 web-worker 时 dynamicImportMode 错误的问题

--- a/packages/builder/builder-webpack-provider/src/plugins/basic.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/basic.ts
@@ -10,26 +10,23 @@ export const builderPluginBasic = (): BuilderPlugin => ({
   setup(api) {
     applyBuilderBasicPlugin(api);
 
-    api.modifyWebpackChain(
-      async (chain, { isServer, isWebWorker, isServiceWorker }) => {
-        /**
-         * If the chunk size exceeds 3MB, we will throw a warning.
-         * If the target is server or web-worker, we will increase
-         * the limit to 30MB because they are only single file.
-         */
-        const maxAssetSize =
-          isServer || isWebWorker ? 30 * 1000 * 1000 : 3 * 1000 * 1000;
-        chain.performance.maxAssetSize(maxAssetSize);
-        chain.performance.maxEntrypointSize(maxAssetSize);
+    api.modifyWebpackChain(async (chain, { isServer, isWebWorker }) => {
+      /**
+       * If the chunk size exceeds 3MB, we will throw a warning.
+       * If the target is server or web-worker, we will increase
+       * the limit to 30MB because they are only single file.
+       */
+      const maxAssetSize =
+        isServer || isWebWorker ? 30 * 1000 * 1000 : 3 * 1000 * 1000;
+      chain.performance.maxAssetSize(maxAssetSize);
+      chain.performance.maxEntrypointSize(maxAssetSize);
 
-        // This will be futureDefaults in webpack 6
-        chain.module.parser.merge({
-          javascript: {
-            exportsPresence: 'error',
-            dynamicImportMode: isServiceWorker ? 'eager' : undefined,
-          },
-        });
-      },
-    );
+      // This will be futureDefaults in webpack 6
+      chain.module.parser.merge({
+        javascript: {
+          exportsPresence: 'error',
+        },
+      });
+    });
   },
 });

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -26,7 +26,6 @@ exports[`webpackConfig > should allow to use tools.webpackChain to modify config
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -50,7 +49,6 @@ exports[`webpackConfig > should allow tools.webpack to be an array 1`] = `
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -74,7 +72,6 @@ exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -98,7 +95,6 @@ exports[`webpackConfig > should allow tools.webpack to modify config object 1`] 
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -122,7 +118,6 @@ exports[`webpackConfig > should allow tools.webpack to return config 1`] = `
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -146,7 +141,6 @@ exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -644,7 +638,6 @@ exports[`webpackConfig > should provide mergeConfig util in tools.webpack functi
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -27,7 +27,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -894,7 +893,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -1809,7 +1807,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
         "exportsPresence": "error",
       },
     },
@@ -2545,7 +2542,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "module": {
     "parser": {
       "javascript": {
-        "dynamicImportMode": undefined,
+        "dynamicImportMode": "eager",
         "exportsPresence": "error",
       },
     },

--- a/packages/builder/builder/src/plugins/splitChunks.ts
+++ b/packages/builder/builder/src/plugins/splitChunks.ts
@@ -249,7 +249,7 @@ export function builderPluginSplitChunks(): DefaultBuilderPlugin {
             chain.optimization.splitChunks(false);
 
             // web worker does not support dynamic imports, dynamicImportMode need set to eager
-            if (isWebWorker) {
+            if (isWebWorker || isServiceWorker) {
               // todo: not support in rspack
               // @ts-expect-error
               chain.module.parser.merge({


### PR DESCRIPTION
## Summary

The `dynamicImportMode` should be `eager` when `target` is `web-worker`, but it is overridden by `packages/builder/builder-webpack-provider/src/plugins/basic.ts`.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f62209</samp>

This pull request fixes the incorrect `dynamicImportMode` option for web-worker and service worker targets in the `@modern-js/builder-webpack-provider` and `@modern-js/builder` packages. It also updates the changeset file and removes some unnecessary code.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f62209</samp>

*  Add a changeset file to document the patch updates for two packages and the fix for the incorrect dynamicImportMode option ([link](https://github.com/web-infra-dev/modern.js/pull/3654/files?diff=unified&w=0#diff-c84d18f8cae30d494a2904ecf11f19f5a34cddeedf98e122f3cdc549d489af85R1-R8))
*  Remove the dynamicImportMode option from the builderPluginBasic function in `basic.ts`, since it is no longer needed ([link](https://github.com/web-infra-dev/modern.js/pull/3654/files?diff=unified&w=0#diff-a70e59e88431ce18033a96c20e9cf52570c221b79b102900895c1bace3de06b2L13-R30))
*  Remove the unused isServiceWorker parameter from the api.modifyWebpackChain callback in `basic.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3654/files?diff=unified&w=0#diff-a70e59e88431ce18033a96c20e9cf52570c221b79b102900895c1bace3de06b2L13-R30))
*  Add the isServiceWorker condition to the builderPluginSplitChunks function in `splitChunks.ts`, to set the dynamicImportMode option to eager for service workers as well as web workers ([link](https://github.com/web-infra-dev/modern.js/pull/3654/files?diff=unified&w=0#diff-acd8a3657576d12badbc5b7b055318732b09ef565ffcee6e27629005bf5f1951L252-R252))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
