### PR TITLE
fix: packages generator overrides field when use npm

### DIFF
--- a/.changeset/warm-moons-sneeze.md
+++ b/.changeset/warm-moons-sneeze.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/packages-generator': patch
+---
+
+fix: packages generator overrides field when use npm
+
+fix: 修复当使用 npm 安装依赖时 packages-generator overrides 字段

--- a/packages/generator/generators/packages-generator/src/index.ts
+++ b/packages/generator/generators/packages-generator/src/index.ts
@@ -22,7 +22,7 @@ const handleTemplateFile = async (
         $set: update,
       },
     });
-  } else {
+  } else if (packageManager === PackageManager.Yarn) {
     const pkgInfo = fs.readJSONSync(
       path.join(context.materials.default.basePath, 'package.json'),
       'utf-8',
@@ -38,6 +38,17 @@ const handleTemplateFile = async (
       if (devDependencies[name]) {
         update[`devDependencies.${name}`] = version as string;
       }
+    });
+    await jsonAPI.update(context.materials.default.get('package.json'), {
+      query: {},
+      update: {
+        $set: update,
+      },
+    });
+  } else {
+    const update: Record<string, string> = {};
+    Object.entries(packagesInfo || {}).forEach(([name, version]) => {
+      update[`overrides.${name}`] = version as string;
     });
     await jsonAPI.update(context.materials.default.get('package.json'), {
       query: {},


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
