### PR TITLE
fix(e2e): hmr occasional failure of builder e2e test

### DIFF
--- a/tests/e2e/builder/cases/dev/.gitignore
+++ b/tests/e2e/builder/cases/dev/.gitignore
@@ -1,2 +1,2 @@
-test-src
+test-*
 dist-1

--- a/tests/e2e/builder/cases/dev/dev.test.ts
+++ b/tests/e2e/builder/cases/dev/dev.test.ts
@@ -125,11 +125,12 @@ rspackOnlyTest('dev.port & output.distPath', async ({ page }) => {
 rspackOnlyTest(
   'hmr should work when setting dev.port & serverOptions.dev.client',
   async ({ page }) => {
+    await fs.copy(join(fixtures, 'hmr/src'), join(fixtures, 'hmr/test-src-1'));
     const cwd = join(fixtures, 'hmr');
     const buildOpts = {
       cwd,
       entry: {
-        main: join(cwd, 'test-src/index.ts'),
+        main: join(cwd, 'test-src-1/index.ts'),
       },
     };
 
@@ -152,7 +153,7 @@ rspackOnlyTest(
     await page.goto(getHrefByEntryName('main', builder.port));
     expect(builder.port).toBe(3001);
 
-    const appPath = join(fixtures, 'hmr', 'test-src/App.tsx');
+    const appPath = join(fixtures, 'hmr', 'test-src-1/App.tsx');
 
     await expect(
       page.evaluate(`document.getElementById('test').innerHTML`),


### PR DESCRIPTION
## Summary

fix occasional failure of builder e2e test： https://github.com/web-infra-dev/modern.js/actions/runs/4943468024/jobs/8837990730#step:8:154

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e5a3ff</samp>

Improved the hmr test case in `dev.test.ts` by using a separate test source directory. Updated the `.gitignore` file to ignore any test source directories with a prefix of `test-`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e5a3ff</samp>

* Ignore test source directories with `test-` prefix in `.gitignore` ([link](https://github.com/web-infra-dev/modern.js/pull/3658/files?diff=unified&w=0#diff-b40527312ab6864c5fa7074babe5ed0a31a94ae2d32a706d3e72c4cb1059e7cdL1-R1))
* Copy `hmr/src` to `hmr/test-src-1` before testing hot module replacement in `dev.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3658/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L128-R133))
* Use `hmr/test-src-1` as entry point and appPath for hmr test case in `dev.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3658/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L155-R156))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
