### PR TITLE
fix: generator test yarn install error

### DIFF
--- a/tests/generator/module.ts
+++ b/tests/generator/module.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import path from 'path';
 import { getModuleCases, getModuleNewCases } from '@modern-js/generator-cases';
 import { fs, nanoid, semver } from '@modern-js/utils';
@@ -130,6 +131,10 @@ async function runModuleNewCommand(
   const params = ['install', '--ignore-scripts', '--force'];
   const packageManager = getPackageManager(project);
   if (isNode16 || project.includes('pnpm')) {
+    if (packageManager === 'yarn') {
+      params.push('--cache-folder');
+      params.push(path.join(os.tmpdir(), project, 'yarn-cache'));
+    }
     await execaWithStreamLog(packageManager, params, {
       cwd,
     });

--- a/tests/generator/monorepo.ts
+++ b/tests/generator/monorepo.ts
@@ -135,11 +135,6 @@ async function runMonorepoNewCommand(
         },
       },
     );
-    if (packageManager === 'pnpm') {
-      await execaWithStreamLog('pnpm', ['install'], {
-        cwd,
-      });
-    }
   }
 }
 

--- a/tests/generator/mwa.ts
+++ b/tests/generator/mwa.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import path from 'path';
 import { getMWACases, getMWANewCases } from '@modern-js/generator-cases';
 import { fs, nanoid, semver } from '@modern-js/utils';
@@ -175,6 +176,10 @@ async function runMWANewCommand(
   const params = ['install', '--ignore-scripts', '--force'];
   const packageManager = getPackageManager(project);
   if (isNode16 || project.includes('pnpm')) {
+    if (packageManager === 'yarn') {
+      params.push('--cache-folder');
+      params.push(path.join(os.tmpdir(), project, 'yarn-cache'));
+    }
     await execaWithStreamLog(packageManager, params, {
       cwd,
     });

--- a/tests/generator/utils/command.ts
+++ b/tests/generator/utils/command.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import path from 'path';
 import { fs, semver } from '@modern-js/utils';
 import { execaWithStreamLog, getPackageManager } from './tools';
@@ -88,6 +89,10 @@ export async function runInstallAndBuildProject(type: string, tmpDir: string) {
         const isNode16 = semver.gte(process.versions.node, '16.0.0');
         const params = ['install', '--ignore-scripts', '--force'];
         if (isNode16 || project.includes('pnpm')) {
+          if (packageManager === 'yarn') {
+            params.push('--cache-folder');
+            params.push(path.join(os.tmpdir(), project, 'yarn-cache'));
+          }
           await execaWithStreamLog(packageManager, params, {
             cwd: path.join(tmpDir, project),
           });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at defc7ec</samp>

This pull request fixes the CI tests for the `generator` module by using the system temporary directory for the `yarn` cache. It also removes a redundant `pnpm install` command from the `monorepo` test and imports the `os` module in several files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at defc7ec</samp>

* Import `os` module to get system temporary directory in `module.ts`, `monorepo.ts`, and `utils/command.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3665/files?diff=unified&w=0#diff-e8a0243fcd47e39ac2d708353d6f308e3d3698d2ca8ee9e8495c090b7832a7a4R1), [link](https://github.com/web-infra-dev/modern.js/pull/3665/files?diff=unified&w=0#diff-3d21024e12c6b1ce5711f2b8320a9b456916663a71da5a06f2917e8f7d240057R1), [link](https://github.com/web-infra-dev/modern.js/pull/3665/files?diff=unified&w=0#diff-3638fb9c95d03d4a2fdc2286bc9856dd11eac61bd4fc20edcb96ee330547e209R1))
* Add `--cache-folder` and temporary directory path to `params` array for `yarn` package manager in `module.ts` and `mwa.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3665/files?diff=unified&w=0#diff-e8a0243fcd47e39ac2d708353d6f308e3d3698d2ca8ee9e8495c090b7832a7a4R134-R137), [link](https://github.com/web-infra-dev/modern.js/pull/3665/files?diff=unified&w=0#diff-3d21024e12c6b1ce5711f2b8320a9b456916663a71da5a06f2917e8f7d240057R179-R182), [link](https://github.com/web-infra-dev/modern.js/pull/3665/files?diff=unified&w=0#diff-3638fb9c95d03d4a2fdc2286bc9856dd11eac61bd4fc20edcb96ee330547e209R92-R95))
* Remove redundant `pnpm install` command from `runMonorepoNewCommand` function in `monorepo.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3665/files?diff=unified&w=0#diff-bfa82c2363f8fb9cb77d22ba9638af0e5fa4bf745b81cf1256e0b59b30869a8fL138-L142))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
