### PR TITLE
fix: rspack ssr occur error, because in config hook we can't get resolvedConfig.

### DIFF
--- a/.changeset/lovely-cooks-complain.md
+++ b/.changeset/lovely-cooks-complain.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: config hook can't get nomarlized config
+fix: config hook 不能拿到固定后的 config

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -54,7 +54,7 @@ export default (): CliPlugin<AppTools> => ({
           'plugins',
         );
 
-        const userConfig = api.useResolvedConfigContext();
+        const userConfig = api.useConfigContext();
         const { bundlerType = 'webpack' } = api.useAppContext();
         // eslint-disable-next-line consistent-return
         const babelConfig = (() => {
@@ -67,7 +67,10 @@ export default (): CliPlugin<AppTools> => ({
                 path.join(__dirname, './babel-plugin-ssr-loader-id'),
               );
 
-              if (isUseSSRBundle(userConfig) && hasStringSSREntry(userConfig)) {
+              if (
+                isUseSSRBundle(userConfig) &&
+                hasStringSSREntry(userConfig as any)
+              ) {
                 config.plugins?.push(require.resolve('@loadable/babel-plugin'));
               }
             };
@@ -80,7 +83,7 @@ export default (): CliPlugin<AppTools> => ({
                 config.plugins?.push(
                   path.join(__dirname, './babel-plugin-ssr-loader-id'),
                 );
-                if (hasStringSSREntry(userConfig)) {
+                if (hasStringSSREntry(userConfig as any)) {
                   config.plugins?.push(
                     require.resolve('@loadable/babel-plugin'),
                   );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f1848b</samp>

This pull request fixes TypeScript errors and improves config access in the `@modern-js/runtime` package. It also updates the changeset file to document the patch update for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f1848b</samp>

*  Update changeset file to indicate patch update for `@modern-js/runtime` package and describe fixes for config hook ([link](https://github.com/web-infra-dev/modern.js/pull/3670/files?diff=unified&w=0#diff-5e6db6bf5222dc65948383f4d545f90903691ebf95fa08e9a329458d71b3b1a3R1-R6))
*  Replace deprecated `useResolvedConfigContext` hook with `useConfigContext` hook in `ssr` command of runtime plugin (`packages/runtime/plugin-runtime/src/ssr/cli/index.ts`) ([link](https://github.com/web-infra-dev/modern.js/pull/3670/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L57-R57))
*  Add type assertions to `userConfig` parameter of `hasStringSSREntry` function calls in `ssr` command of runtime plugin (`packages/runtime/plugin-runtime/src/ssr/cli/index.ts`) to avoid TypeScript errors and access `ssr` property of user configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3670/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L70-R73), [link](https://github.com/web-infra-dev/modern.js/pull/3670/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L83-R86))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
