### PR TITLE
fix: github action integration test error

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -8,7 +8,7 @@
     "test:rspack": "jest -w 1 builder-rspack && pnpm test:builder:rspack",
     "test:builder:rspack": "cd e2e/builder && pnpm test:rspack",
     "test:doc": "cd integration && jest -w 1 --testMatch **/doc/**/*.test.ts",
-    "test": "pnpm test --filter api-service-koa & jest -w 8",
+    "test": "pnpm test --filter api-service-koa & jest",
     "test:ut": "node --conditions=jsnext:source -r btsm ./node_modules/jest/bin/jest.js -c jest-ut.config.js --maxWorkers=2",
     "cypress:test": "pnpm --parallel --filter '@cypress-test/*' run dev & cypress open",
     "prepare": "node node_modules/puppeteer/install.js",


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fd879c</samp>

Simplified the `test` script in `tests/package.json` by removing the `-w 8` option from jest. This can improve the testing workflow and avoid potential issues with parallel testing.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7fd879c</samp>

*  Simplify `test` script by removing unnecessary option ([link](https://github.com/web-infra-dev/modern.js/pull/3671/files?diff=unified&w=0#diff-c7273ca77f452520adba2dfb738cd146b83110e7faa7b861318e89b2b56b5d56L11-R11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
