### PR TITLE
fix(builder): failed to print file size in some cases

### DIFF
--- a/.changeset/curvy-mails-provide.md
+++ b/.changeset/curvy-mails-provide.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder': patch
+---
+
+fix(builder): failed to print file size in some cases
+
+fix(builder): 修复部分情况下输出产物体积失败的问题

--- a/packages/builder/builder-shared/src/types/stats.ts
+++ b/packages/builder/builder-shared/src/types/stats.ts
@@ -12,6 +12,7 @@ interface StatsOptionsObj {
   colors?: boolean;
 
   /** Rspack not support below opts */
+  cachedAssets?: boolean;
   groupAssetsByInfo?: boolean;
   groupAssetsByPath?: boolean;
   groupAssetsByChunk?: boolean;

--- a/packages/builder/builder/src/plugins/fileSize.ts
+++ b/packages/builder/builder/src/plugins/fileSize.ts
@@ -69,6 +69,7 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
       const origin = stats.toJson({
         all: false,
         assets: true,
+        cachedAssets: true,
         groupAssetsByInfo: false,
         groupAssetsByPath: false,
         groupAssetsByChunk: false,
@@ -146,7 +147,12 @@ export const builderPluginFileSize = (): DefaultBuilderPlugin => ({
       const config = api.getNormalizedConfig();
 
       if (config.performance.printFileSize && stats) {
-        await printFileSizes(stats, api.context.distPath);
+        try {
+          await printFileSizes(stats, api.context.distPath);
+        } catch (err) {
+          logger.error('Failed to print file size.');
+          logger.error(err as Error);
+        }
       }
     });
   },


### PR DESCRIPTION
## Summary

Fix failed to print file size in some cases because webpack will group the assets when `cachedAssets` is `false`.

Ref: https://github.com/webpack/webpack/blob/c1a5e4fdeef6c64b4f5624830de7abdecba6301a/lib/stats/DefaultStatsFactoryPlugin.js#L1935

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97f2dca</samp>

This pull request fixes a bug in the `builderPluginFileSize` plugin that caused it to miss some assets and crash in some cases. It also adds a new option to the `StatsOptionsObj` interface to control whether to include cached assets in the file size information. It updates the packages and the changeset accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97f2dca</samp>

*  Add a changeset file to document the patch updates and the file size printing fix ([link](https://github.com/web-infra-dev/modern.js/pull/3676/files?diff=unified&w=0#diff-4336e8b946847c1f500253caa253ef7a743e86073b7d58cba5d9de2cce062154R1-R8))
*  Add a `cachedAssets` option to the `StatsOptionsObj` interface to control whether to include cached assets in the webpack stats ([link](https://github.com/web-infra-dev/modern.js/pull/3676/files?diff=unified&w=0#diff-fdd219918f4a3c190114fd8ca34ee17f1d98c0a1b18de17b10602bf9e7164711R15))
*  Pass `true` for the `cachedAssets` option when calling `printFileSizes` in the `builderPluginFileSize` plugin to show the cached assets size information ([link](https://github.com/web-infra-dev/modern.js/pull/3676/files?diff=unified&w=0#diff-6ea934f4ff87cceb10e4b242f1d4bd387385ba4bb5eba12d71ed78e34a1ae944R72))
*  Wrap the `printFileSizes` call in a try-catch block to handle any errors gracefully and log them to the console ([link](https://github.com/web-infra-dev/modern.js/pull/3676/files?diff=unified&w=0#diff-6ea934f4ff87cceb10e4b242f1d4bd387385ba4bb5eba12d71ed78e34a1ae944L149-R155))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
