### PR TITLE
chore(utils): move generateMetaTags method to builder-shared

### DIFF
--- a/.changeset/beige-pandas-switch.md
+++ b/.changeset/beige-pandas-switch.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/main-doc': patch
+'@modern-js/utils': patch
+---
+
+chore(utils): move generateMetaTags method to builder-shared
+
+chore(utils): 移动 generateMetaTags 方法到 builder-shared

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ Some implementations of Modern.js are modified from existing projects, such as [
 
 - `@modern-js/bundle-require`: is modified from [bundle-require](https://github.com/egoist/bundle-require).
 - `@modern-js/plugin`: the hooks API is referenced from [farrow-pipeline](https://github.com/farrow-js/farrow/tree/master/packages/farrow-pipeline).
-- `@modern-js/builder`: the moduleScope and fileSize plugins are referenced from [create-react-app](https://github.com/facebook/create-react-app), the TsConfigPathsPlugin is referenced from [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)。
+- `@modern-js/builder`: the moduleScope and fileSize plugins are referenced from [create-react-app](https://github.com/facebook/create-react-app), the TsConfigPathsPlugin is referenced from [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin), the generateMetaTags function is referenced from [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).
 - `@modern-js/plugin-testing`: the jest runner is referenced from [jest-cli](https://github.com/facebook/jest/blob/fdc74af37235354e077edeeee8aa2d1a4a863032/packages/jest-cli/src/cli/index.ts#L21).
 - `@modern-js/plugin-data-loader`: some code is referenced from [remix](https://github.com/remix-run/remix)。
 - `@modern-js/doc-tools`: some styles are referenced from [vitepress](https://github.com/vuejs/vitepress).
-- `@modern-js/utils`: the generateMetaTags function is referenced from [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,11 +64,10 @@ Modern.js 中的部分代码是参考社区中的其他项目实现的，比如 
 
 - `@modern-js/bundle-require`: 修改自 [bundle-require](https://github.com/egoist/bundle-require)。
 - `@modern-js/plugin`: hook API 的实现参考了 [farrow-pipeline](https://github.com/farrow-js/farrow/tree/master/packages/farrow-pipeline)。
-- `@modern-js/builder`: moduleScope 和 fileSize 插件参考了 [create-react-app](https://github.com/facebook/create-react-app)，TsConfigPathsPlugin 参考了 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)。
+- `@modern-js/builder`: moduleScope 和 fileSize 插件参考了 [create-react-app](https://github.com/facebook/create-react-app)，TsConfigPathsPlugin 参考了 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)，generateMetaTags 函数参考了 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)
 - `@modern-js/plugin-testing`: jest runner 参考了 [jest-cli](https://github.com/facebook/jest/blob/fdc74af37235354e077edeeee8aa2d1a4a863032/packages/jest-cli/src/cli/index.ts#L21)。
 - `@modern-js/doc-tools`: 部分样式参考了 [vitepress](https://github.com/vuejs/vitepress)。
 - `@modern-js/plugin-data-loader`: 部分实现参考了 [remix](https://github.com/remix-run/remix)。
-- `@modern-js/utils`: generateMetaTags 函数参考了 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)。
 
 ## License
 

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_MOUNT_ID,
   DEFAULT_DATA_URL_SIZE,
 } from './constants';
+import { generateMetaTags } from './generateMetaTags';
 import type {
   BuilderTarget,
   SharedHtmlConfig,
@@ -270,7 +271,6 @@ export async function getMetaTags(
   entryName: string,
   config: { html: SharedHtmlConfig; output: NormalizedSharedOutputConfig },
 ) {
-  const { generateMetaTags } = await import('@modern-js/utils');
   const { meta, metaByEntries } = config.html;
 
   const metaOptions = {

--- a/packages/builder/builder-shared/src/generateMetaTags.ts
+++ b/packages/builder/builder-shared/src/generateMetaTags.ts
@@ -1,4 +1,3 @@
-// Todo: only @modern-js/builder-shared used
 /**
  * Copyright JS Foundation and other contributors.
  *

--- a/packages/builder/builder-shared/src/index.ts
+++ b/packages/builder/builder-shared/src/index.ts
@@ -5,6 +5,7 @@ export * from './createPluginStore';
 export * from './createContext';
 export * from './utils';
 export * from './fs';
+export * from './generateMetaTags';
 export * from './getBrowserslist';
 export * from './getCssSupport';
 export * from './logger';

--- a/packages/builder/builder-shared/src/schema/html.ts
+++ b/packages/builder/builder-shared/src/schema/html.ts
@@ -1,4 +1,4 @@
-import { MetaAttributes, MetaOptions } from '@modern-js/utils';
+import { MetaAttributes, MetaOptions } from '../generateMetaTags';
 import {
   CrossOrigin,
   HtmlInjectTag,

--- a/packages/builder/builder-shared/src/types/config/html.ts
+++ b/packages/builder/builder-shared/src/types/config/html.ts
@@ -1,4 +1,4 @@
-import type { MetaOptions } from '@modern-js/utils';
+import type { MetaOptions } from '../../generateMetaTags';
 import type { ArrayOrNot, ChainedConfig } from '../utils';
 
 export type CrossOrigin = 'anonymous' | 'use-credentials';

--- a/packages/builder/builder-shared/tests/generateMetaTags.test.ts
+++ b/packages/builder/builder-shared/tests/generateMetaTags.test.ts
@@ -1,4 +1,5 @@
-import { generateMetaTags } from '../src';
+import { expect, describe, it } from 'vitest';
+import { generateMetaTags } from '../src/generateMetaTags';
 
 describe('generateMetaTags', () => {
   it('should return empty string when params is empty', () => {

--- a/packages/document/main-doc/docs/zh/community/blog/v2-release-note.mdx
+++ b/packages/document/main-doc/docs/zh/community/blog/v2-release-note.mdx
@@ -234,11 +234,10 @@ Modern.js 中的部分代码实现参考了社区中的开源项目，我们对�
 
 - `@modern-js/bundle-require`: 修改自 [bundle-require](https://github.com/egoist/bundle-require)。
 - `@modern-js/plugin`: hook API 的实现参考了 [farrow-pipeline](https://github.com/farrow-js/farrow/tree/master/packages/farrow-pipeline)。
-- `@modern-js/builder`: moduleScope 和 fileSize 插件参考了 [create-react-app](https://github.com/facebook/create-react-app)，TsConfigPathsPlugin 参考了 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)。
+- `@modern-js/builder`: moduleScope 和 fileSize 插件参考了 [create-react-app](https://github.com/facebook/create-react-app)，TsConfigPathsPlugin 参考了 [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)，generateMetaTags 函数参考了 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)。
 - `@modern-js/plugin-testing`: jest runner 参考了 [jest-cli](https://github.com/facebook/jest/blob/fdc74af37235354e077edeeee8aa2d1a4a863032/packages/jest-cli/src/cli/index.ts#L21)。
 - `@modern-js/doc-tools`: 部分样式参考了 [vitepress](https://github.com/vuejs/vitepress)。
 - `@modern-js/plugin-data-loader`: 部分实现参考了 [remix](https://github.com/remix-run/remix)。
-- `@modern-js/utils`: generateMetaTags 函数参考了 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)。
 
 ## 最后
 

--- a/packages/solutions/app-tools/src/types/legacyConfig/output.ts
+++ b/packages/solutions/app-tools/src/types/legacyConfig/output.ts
@@ -1,5 +1,5 @@
-import { MetaOptions } from '@modern-js/utils';
-import { SSGConfig } from '../config';
+import type { MetaOptions } from '@modern-js/builder-shared';
+import type { SSGConfig } from '../config';
 
 type CrossOrigin = 'anonymous' | 'use-credentials';
 

--- a/packages/toolkit/utils/src/cli/index.ts
+++ b/packages/toolkit/utils/src/cli/index.ts
@@ -8,7 +8,6 @@ export * from './commands';
 export * from './common';
 export * from './ensure';
 export * from './fs';
-export * from './generateMetaTags';
 export * from './logger';
 export * from './monorepo';
 export * from './package';


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9cbfff</samp>

Refactor the `generateMetaTags` function to be part of the `@modern-js/builder-shared` package instead of the `@modern-js/utils` package. Update the references, tests, and documentation of the function accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9cbfff</samp>

*  Move `generateMetaTags` function from `@modern-js/utils` to `@modern-js/builder-shared` as it is only used by the latter ([link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-16f4258765db05cbcd707dc19572926704cb41ab8cef0a08b50f6b2fd08a9667R1-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eR17), [link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eL273), [link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-8376634baad964ee1197f1f2f49a7f7920849f524f22d517e88064df95918f74L1), [link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-8aac5478574eea52dc8b594f0c725ec404014b84577cc13a778193db47d455d9L11))
* Update test file for `generateMetaTags` function to use `vitest` instead of `jest` and import from the correct file ([link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-f2317c0d770d2a225fbc155774946a10f2f52855a44ecfd4764e5cba388c8d3dL1-R2))
* Update `Credits` section in `README.md` and `README.zh-CN.md` to reference `generateMetaTags` function from `html-webpack-plugin` instead of `@modern-js/utils` ([link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R70), [link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L67-R70))
* Update `Credits` section in `v2-release-note.mdx` to reference `generateMetaTags` function from `html-webpack-plugin` instead of `@modern-js/utils` ([link](https://github.com/web-infra-dev/modern.js/pull/3678/files?diff=unified&w=0#diff-d967d71a8e790174c6f4cb4fa5b95b2100a5228e9cc5b8e667067e468cbed7deL237-R240))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
