### PR TITLE
fix(app-tools): SVG default export type

### DIFF
--- a/.changeset/small-scissors-help.md
+++ b/.changeset/small-scissors-help.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): SVG default export type
+
+fix(app-tools): 修复 SVG 默认导出的类型错误

--- a/packages/solutions/app-tools/lib/types.d.ts
+++ b/packages/solutions/app-tools/lib/types.d.ts
@@ -53,8 +53,12 @@ declare module '*.svg' {
     React.SVGProps<SVGSVGElement>
   >;
 
-  const src: string;
-  export default src;
+  /**
+   * The default export type depends on the svgDefaultExport config,
+   * it can be a string or a ReactComponent
+   * */
+  const content: any;
+  export default content;
 }
 
 declare module '*.bmp?inline' {
@@ -99,12 +103,8 @@ declare module '*.svg?inline' {
     React.SVGProps<SVGSVGElement>
   >;
 
-  /**
-   * The default export type depends on the svgDefaultExport config,
-   * it can be a string or a ReactComponent
-   * */
-  const content: any;
-  export default content;
+  const src: string;
+  export default src;
 }
 
 declare module '*.bmp?url' {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ab8134</samp>

Fix default export type of SVG files in `@modern-js/app-tools`. Update changeset file with patch-level change and Chinese translation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ab8134</samp>

* Fix default export type of SVG files in `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/3688/files?diff=unified&w=0#diff-f83ad99f98987ac66a778ae1d4c2e57b7196922fbb6998751d45ad28e4ec4c05R1-R7),                            

## Related Issue

- https://github.com/web-infra-dev/modern.js/pull/2656

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
