### PR TITLE
chore: add root and ensure vm

### DIFF
--- a/.changeset/neat-ties-exist.md
+++ b/.changeset/neat-ties-exist.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+chore: add root and ensure vm path
+chore: 添加root和确认虚拟模块路径

--- a/packages/module/plugin-module-doc/src/features/lanchDoc.ts
+++ b/packages/module/plugin-module-doc/src/features/lanchDoc.ts
@@ -47,6 +47,7 @@ export async function launchDoc({
   const modernDocConfig = mergeDocConfig(
     {
       doc: {
+        root,
         title: json.name,
         lang: DEFAULT_LANG,
         builderConfig: {

--- a/packages/module/plugin-module-doc/src/runtimeModule.ts
+++ b/packages/module/plugin-module-doc/src/runtimeModule.ts
@@ -20,6 +20,7 @@ export default class RuntimeModulesPlugin {
   writeModule(path: string, content: string) {
     const normalizedPath = this.#normalizePath(path);
     this.staticModules[normalizedPath] = content;
+    fs.ensureFileSync(normalizedPath);
     fs.writeFileSync(normalizedPath, content);
   }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7955748</samp>

This pull request fixes a bug and adds a feature to the `@modern-js/plugin-module-doc` package, which provides documentation support for modules. It allows specifying the root directory of the module when launching the documentation server, and ensures the virtual module file exists before writing to it.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7955748</samp>

*  Add `root` option to `launchDoc` function to specify module root directory ([link](https://github.com/web-infra-dev/modern.js/pull/3692/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9R50))
*  Check virtual module file existence before writing to it in `runtimeModule` function ([link](https://github.com/web-infra-dev/modern.js/pull/3692/files?diff=unified&w=0#diff-5f22ae0416e43a3d793fed3b001b09da477d500957a1b9222300edf2ab7dd971R23))
*  Add changeset file for patch update of `@modern-js/plugin-module-doc` package ([link](https://github.com/web-infra-dev/modern.js/pull/3692/files?diff=unified&w=0#diff-0665f2894f4a3c8b36e190c17a513ecdb83e5d489ed56956e47be09d7e913192R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
