### PR TITLE
feat(mwa-generator): add a default browserslist config for new projects

### DIFF
--- a/.changeset/old-swans-switch.md
+++ b/.changeset/old-swans-switch.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/mwa-generator': patch
+---
+
+feat(mwa-generator): add a default browserslist config for new projects
+
+feat(mwa-generator): 为新项目增加默认的 browserslist 配置

--- a/packages/document/builder-doc/docs/en/guide/advanced/browserslist.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/browserslist.md
@@ -38,7 +38,7 @@ Set via `browserslist` in `package.json`:
 
 Set via a separate `.browserslistrc` file:
 
-```
+```yaml
 iOS >= 9
 Android >= 4.4
 last 2 versions
@@ -101,11 +101,45 @@ In most cases, it is recommended to use the `.browserslistrc` file rather than t
 
 The following are some commonly used Browserslist, you can choose according to your project type.
 
-### Mobile H5 scene
+### Desktop PC scenario
 
-The mobile H5 scene is mainly compatible with `iOS` and `Android` systems, usually we set Browserslist as:
+In the desktop PC scenario, if you need to be compatible with IE 11 browsers, you can set Browserslist to:
 
+```yaml
+> 0.5%
+not dead
+Internet Explorer 11
 ```
+
+The above Browserslist will compile the code to the ES5 specification. For the specific browser list, please check [browserslist.dev](https://browserslist.dev/?q=PiAwLjUlLCBub3QgZGVhZCwgSUUgMTE%3D).
+
+If you don't need to be compatible with IE 11 browsers, you can adjust Browserslist to get a more performant output, such as:
+
+- Set to browsers that supports native ES Modules (recommended):
+
+```yaml
+chrome >= 61
+edge >= 16
+firefox >= 60
+safari >= 11
+ios_saf >= 11
+```
+
+- Set to browsers that support ES6:
+
+```yaml
+chrome >= 51
+edge >= 15
+firefox >= 54
+safari >= 10
+ios_saf >= 10
+```
+
+### Mobile H5 scenario
+
+The mobile H5 scenario is mainly compatible with `iOS` and `Android` systems, usually we set Browserslist as:
+
+```yaml
 iOS >= 9
 Android >= 4.4
 last 2 versions
@@ -119,34 +153,12 @@ The above Browserslist will compile the code to the ES5 specification, which is 
 
 You can also choose to use the ES6 specification in the H5 scene, which will make the performance of the page better. The corresponding Browserslist is as follows:
 
-```
+```yaml
 iOS >= 10
 Chrome >= 51
 > 0.5%
 not dead
 not op_mini all
-```
-
-### Desktop PC scene
-
-In the desktop PC scenario, if you need to be compatible with IE 11 browsers, you can set Browserslist to:
-
-```
-> 0.5%
-not dead
-Internet Explorer 11
-```
-
-The above Browserslist will compile the code to the ES5 specification. For the specific browser list, please check [browserslist.dev](https://browserslist.dev/?q=PiAwLjUlLCBub3QgZGVhZCwgSUUgMTE%3D).
-
-If you don't need to be compatible with IE 11 browsers, you can adjust Browserslist to get a more performant output, such as setting it to browsers that supports native ES Modules:
-
-```
-chrome >= 61
-edge >= 16
-firefox >= 60
-safari >= 11
-ios_saf >= 11
 ```
 
 ## Default Browserslist
@@ -157,7 +169,7 @@ Builder will set different default values of Browserslist according to [build ta
 
 The default values of web target are as follows:
 
-```bash
+```yaml
 > 0.01%
 not dead
 not op_mini all
@@ -169,7 +181,7 @@ Under this browser range, JavaScript code will be compiled to ES5 syntax.
 
 Node target will be compatible with Node.js 14.0 by default.
 
-```bash
+```yaml
 node >= 14
 ```
 
@@ -177,7 +189,7 @@ node >= 14
 
 The default Browserslist of the Web Worker target is consistent with the Web target.
 
-```bash
+```yaml
 > 0.01%
 not dead
 not op_mini all
@@ -187,7 +199,7 @@ not op_mini all
 
 Modern Web target will be compatible with browsers that support [native ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) by default.
 
-```bash
+```yaml
 chrome >= 61
 edge >= 16
 firefox >= 60

--- a/packages/document/builder-doc/docs/zh/guide/advanced/browserslist.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/browserslist.md
@@ -38,7 +38,7 @@ polyfill 是一种用于解决浏览器兼容问题的技术。它用于模拟�
 
 通过独立的 `.browserslistrc` 文件设置：
 
-```
+```yaml
 iOS >= 9
 Android >= 4.4
 last 2 versions
@@ -101,11 +101,45 @@ export default {
 
 以下是一些常用的浏览器范围，你可以根据自己的项目类型进行选择。
 
+### 桌面端 PC 场景
+
+在桌面端 PC 场景下，如果你需要兼容 IE 11 浏览器，则可以将 Browserslist 设置为：
+
+```yaml
+> 0.5%
+not dead
+IE 11
+```
+
+以上浏览器范围会将代码编译至 ES5 规范，具体对应的浏览器列表可以查看 [browserslist.dev](https://browserslist.dev/?q=PiAwLjUlLCBub3QgZGVhZCwgSUUgMTE%3D)。
+
+如果你不需要兼容 IE 11 浏览器，那么可以调整 Browserslist 来获得更高性能的产物，比如：
+
+- 设置为支持原生 ES Modules 的浏览器（推荐）：
+
+```yaml
+chrome >= 61
+edge >= 16
+firefox >= 60
+safari >= 11
+ios_saf >= 11
+```
+
+- 设置为支持 ES6 的浏览器：
+
+```yaml
+chrome >= 51
+edge >= 15
+firefox >= 54
+safari >= 10
+ios_saf >= 10
+```
+
 ### 移动端 H5 场景
 
 移动端 H5 场景主要兼容 `iOS` 和 `Android` 系统，通常我们将 Browserslist 设置为：
 
-```
+```yaml
 iOS >= 9
 Android >= 4.4
 last 2 versions
@@ -119,34 +153,12 @@ not dead
 
 你也可以选择在 H5 场景使用 ES6 规范，这样会让页面的性能表现更好，对应的 Browserslist 如下：
 
-```
+```yaml
 iOS >= 10
 Chrome >= 51
 > 0.5%
 not dead
 not op_mini all
-```
-
-### 桌面端 PC 场景
-
-在桌面端 PC 场景下，如果你需要兼容 IE 11 浏览器，则可以将 Browserslist 设置为：
-
-```
-> 0.5%
-not dead
-IE 11
-```
-
-以上浏览器范围会将代码编译至 ES5 规范，具体对应的浏览器列表可以查看 [browserslist.dev](https://browserslist.dev/?q=PiAwLjUlLCBub3QgZGVhZCwgSUUgMTE%3D)。
-
-如果你不需要兼容 IE 11 浏览器，那么可以调整 Browserslist 来获得更高性能的产物，比如设置为支持原生 ES Modules 的浏览器：
-
-```
-chrome >= 61
-edge >= 16
-firefox >= 60
-safari >= 11
-ios_saf >= 11
 ```
 
 ## Browserslist 默认值
@@ -157,7 +169,7 @@ Builder 会根据[构建产物类型](/guide/basic/build-target.html)来设置�
 
 Web 产物的默认值如下所示：
 
-```
+```yaml
 > 0.01%
 not dead
 not op_mini all
@@ -169,7 +181,7 @@ not op_mini all
 
 Node 产物默认最低兼容到 Node.js 14.0 版本。
 
-```
+```yaml
 node >= 14
 ```
 
@@ -177,7 +189,7 @@ node >= 14
 
 Web Worker 产物默认的浏览器范围与 Web 一致。
 
-```
+```yaml
 > 0.01%
 not dead
 not op_mini all
@@ -187,7 +199,7 @@ not op_mini all
 
 Modern Web 产物默认最低兼容到支持[原生 ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) 的浏览器。
 
-```
+```yaml
 chrome >= 61
 edge >= 16
 firefox >= 60

--- a/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
@@ -1,8 +1,26 @@
 ---
-title: Compatibility
 sidebar_position: 5
 ---
-# Compatibility
+
+# Browser Compatibility
+
+## Browserslist Configuration
+
+Modern.js supports setting the browserslist for your web applications. You can set the [Browserslist](https://browsersl.ist/) in the `.browserslistrc` file.
+
+When you create a new Modern.js project, it includes a `.browserslistrc` configuration by default, which means that JavaScript code will be compiled to ES6.
+
+```yaml title=".browserslistrc"
+chrome >= 51
+edge >= 15
+firefox >= 54
+safari >= 10
+ios_saf >= 10
+```
+
+:::tip
+Please refer to [Modern.js Builder - Browserslist](https://modernjs.dev/builder/en/guide/advanced/browserslist) for more information.
+:::
 
 ## Browserslist
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/compatibility.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/compatibility.mdx
@@ -1,26 +1,25 @@
 ---
-title: 客户端兼容性
 sidebar_position: 5
 ---
-# 客户端兼容性
+
+# 浏览器兼容性
 
 ## Browserslist 配置
 
-Modern.js 支持在项目根目录 `package.json` 文件中的 `browserslist` 字段（或单独的 `.browserslistrc` 文件）指定项目覆盖的目标浏览器范围。该值会被 [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env) 和 [`autoprefixer`](https://github.com/postcss/autoprefixer) 用来确定需要转换的 JavaScript 语法特性和需要添加的 CSS 浏览器前缀。
+Modern.js 支持设置 Web 应用需要兼容的浏览器范围，你可以在 `.browserslistrc` 文件里设置 [Browserslist](https://browsersl.ist/) 的值。
 
-Modern.js 中默认值如下:
+当你创建一个新的 Modern.js 项目时，默认会包含一份 `.browserslistrc` 配置，这表示 JavaScript 代码会被编译至 ES6 格式。
 
-```js
-['> 0.01%', 'not dead', 'not op_mini all'];
+```yaml title=".browserslistrc"
+chrome >= 51
+edge >= 15
+firefox >= 54
+safari >= 10
+ios_saf >= 10
 ```
 
-可以在[这里](https://github.com/browserslist/browserslist)了解如何自定义浏览器范围。
-
-查看 Modern.js Builder 文档了解更多 [Browserslist](https://modernjs.dev/builder/guide/advanced/browserslist.html) 相关内容。
-
-:::note
-Modern.js 支持配置 [output.overrideBrowserslist](/configure/app/output/override-browserslist) 覆盖默认 browserslist 值。
-
+:::tip
+请查看 [Modern.js Builder - 设置浏览器范围](https://modernjs.dev/builder/guide/advanced/browserslist) 来了解更多内容。
 :::
 
 ## Polyfill

--- a/packages/generator/generators/mwa-generator/templates/base-template/.browserslistrc.handlebars
+++ b/packages/generator/generators/mwa-generator/templates/base-template/.browserslistrc.handlebars
@@ -1,0 +1,5 @@
+chrome >= 51
+edge >= 15
+firefox >= 54
+safari >= 10
+ios_saf >= 10


### PR DESCRIPTION
## Summary

Add a default .browserslistrc config to new projects, this change will not affect the existing projects. 

For new projects, the JavaScript code will be compiled to ES6, and the bundle size will be smaller because some legacy polyfills will not be injected.

Most web frameworks in the community have changed their browserslist config and target to ES6 (or higher) by default, see: https://github.com/vercel/next.js/discussions/33227

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e99afcb</samp>

*  Add a default browserslist config for new projects in the `@modern-js/mwa-generator` package and update the patch version ([link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-d89ab7d8e5cecd8e273a85da087565fbd222359da14b4d6251657cf7f3763d5fR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-2d1f34757010f79b8750addfd292f2c4fe7b31d971b486d669e15277f8610ff2R1-R5))
*  Refactor the compatibility guide in the main document for both English and Chinese, to make it more clear and concise and refer to the browserslist guide in the builder document ([link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-7f31c05c259853063fea86db5178890ae9ccb82ccc9f512c297b0e63a26c5193L2-R24), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-1c8fb78deb19868569c70860941182a838b37b1da2c5f88bdf4d1cc206046673L2-R22))
*  Update the code block syntax from plain text to YAML in the browserslist guide in the builder document for both English and Chinese, to make it consistent with the `.browserslistrc` file format ([link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL104-R142), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL122-R156), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL160-R172), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL172-R184), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL180-R192), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL190-R202), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L104-R142), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L122-R156), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L160-R172), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L172-R184), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L180-R192), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L190-R202))
*  Reorder the sections for the commonly used browserslist in the browserslist guide in the builder document for both English and Chinese, to match the order in the main document and add some links and explanations for the browsers that support native ES Modules or ES6 ([link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL104-R142), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L104-R142))
*  Remove the redundant section `Desktop PC scenario` from the section `Mobile H5 scenario` in the browserslist guide in the builder document for both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-dc9a34f45a6a81f5308a73c5cd1ddd63aa7dd66df7d404f1db40152e9e6f875aL130-L151), [link](https://github.com/web-infra-dev/modern.js/pull/3695/files?diff=unified&w=0#diff-5f284548c7409273753db9db907fc84d7c01ef0667d106b04fa47b70f8854706L130-L151))

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
