### PR TITLE
fix(tailwindcss): avoid unnecessary rebuild when running dev

### DIFF
--- a/.changeset/happy-bulldogs-raise.md
+++ b/.changeset/happy-bulldogs-raise.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-tailwindcss': patch
+---
+
+fix(tailwindcss): avoid unnecessary rebuild when running dev
+
+fix(tailwindcss): 修复 dev 模式下不必要的重新构建

--- a/packages/cli/plugin-tailwind/src/cli.ts
+++ b/packages/cli/plugin-tailwind/src/cli.ts
@@ -30,6 +30,30 @@ export const getRandomTwConfigFileName = (internalDirectory: string) => {
   );
 };
 
+function getDefaultContent(appDirectory: string) {
+  const defaultContent = [
+    './src/**/*.js',
+    './src/**/*.jsx',
+    './src/**/*.ts',
+    './src/**/*.tsx',
+  ];
+
+  // Only add storybook and html config when they exist
+  // Otherwise, it will cause an unnecessary rebuild
+  if (fs.existsSync(path.join(appDirectory, 'storybook'))) {
+    defaultContent.push('./storybook/**/*');
+  }
+  if (fs.existsSync(path.join(appDirectory, 'config/html'))) {
+    defaultContent.push(
+      './config/html/**/*.html',
+      './config/html/**/*.ejs',
+      './config/html/**/*.hbs',
+    );
+  }
+
+  return defaultContent;
+}
+
 export default (
   { pluginName } = {
     pluginName: '@modern-js/plugin-tailwindcss',
@@ -50,18 +74,7 @@ export default (
     const haveTwinMacro = await checkTwinMacroExist(appDirectory);
     const tailwindPath = getTailwindPath(appDirectory);
     const tailwindVersion = getTailwindVersion(appDirectory);
-
-    const defaultContent = [
-      './config/html/**/*.html',
-      './config/html/**/*.ejs',
-      './config/html/**/*.hbs',
-      './src/**/*.js',
-      './src/**/*.jsx',
-      './src/**/*.ts',
-      './src/**/*.tsx',
-      // about storybook
-      './storybook/**/*',
-    ];
+    const defaultContent = getDefaultContent(appDirectory);
 
     return {
       prepare() {


### PR DESCRIPTION
## Summary

Only add 'storybook' and 'html/config' folder when they exist, otherwise it will cause an unnecessary rebuild

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5370965</samp>

This pull request fixes a performance issue in the `@modern-js/plugin-tailwindcss` package by using a dynamic file pattern generator for TailwindCSS scanning. It also updates the changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5370965</samp>

*  Add a changeset file for patching `@modern-js/plugin-tailwindcss` package ([link](https://github.com/web-infra-dev/modern.js/pull/3702/files?diff=unified&w=0#diff-30799961cdb2454ee5fb58d44800ca5973acfcf8017fe22f0d597ed095243420R1-R7))
  - Creating a `getDefaultContent` function that checks for existing directories ([link](https://github.com/web-infra-dev/modern.js/pull/3702/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dR33-R56))
  - Using the function instead of a hardcoded array in the `tailwindcss` command ([link](https://github.com/web-infra-dev/modern.js/pull/3702/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dL53-R78))
*  Update the `packages/cli/plugin-tailwind/src/cli.ts` file with the above changes ([link](https://github.com/web-infra-dev/modern.js/pull/3702/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dR33-R56),[link](https://github.com/web-infra-dev/modern.js/pull/3702/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dL53-R78))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
