### PR TITLE
feat: support add custom tempdir for modern.js App

### DIFF
--- a/.changeset/popular-toes-whisper.md
+++ b/.changeset/popular-toes-whisper.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/core': patch
+---
+
+feat: 添加 output.tempDir 配置，支持单项目多配置同时启动
+feat: add output.tempDir configuration, supports launching project with multiple config at the same time

--- a/packages/cli/core/src/createCli.ts
+++ b/packages/cli/core/src/createCli.ts
@@ -109,6 +109,8 @@ export const createCli = () => {
       },
     );
 
+    await hooksRunner.afterInit();
+
     const extraConfigs = await hooksRunner.config();
 
     const extraSchemas = await hooksRunner.validateSchema();

--- a/packages/cli/core/src/createCli.ts
+++ b/packages/cli/core/src/createCli.ts
@@ -109,7 +109,7 @@ export const createCli = () => {
       },
     );
 
-    await hooksRunner.afterInit();
+    await hooksRunner.beforeConfig();
 
     const extraConfigs = await hooksRunner.config();
 

--- a/packages/cli/core/src/manager.ts
+++ b/packages/cli/core/src/manager.ts
@@ -16,6 +16,7 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 const baseHooks: BaseHooks<{}> = {
+  afterInit: createAsyncWorkflow(),
   config: createParallelWorkflow(),
   resolvedConfig: createAsyncWaterfall(),
   validateSchema: createParallelWorkflow(),

--- a/packages/cli/core/src/manager.ts
+++ b/packages/cli/core/src/manager.ts
@@ -16,7 +16,7 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 const baseHooks: BaseHooks<{}> = {
-  afterInit: createAsyncWorkflow(),
+  beforeConfig: createAsyncWorkflow(),
   config: createParallelWorkflow(),
   resolvedConfig: createAsyncWaterfall(),
   validateSchema: createParallelWorkflow(),

--- a/packages/cli/core/src/types/hooks.ts
+++ b/packages/cli/core/src/types/hooks.ts
@@ -22,7 +22,7 @@ export type BaseHooks<
   // eslint-disable-next-line @typescript-eslint/ban-types
   ExtendNormalizedConfig extends Record<string, any> = {},
 > = {
-  afterInit: AsyncWorkflow<void, void>;
+  beforeConfig: AsyncWorkflow<void, void>;
   config: ParallelWorkflow<void, UserConfig<Extends>>;
   resolvedConfig: AsyncWaterfall<{
     resolved: NormalizedConfig<Extends>;

--- a/packages/cli/core/src/types/hooks.ts
+++ b/packages/cli/core/src/types/hooks.ts
@@ -22,6 +22,7 @@ export type BaseHooks<
   // eslint-disable-next-line @typescript-eslint/ban-types
   ExtendNormalizedConfig extends Record<string, any> = {},
 > = {
+  afterInit: AsyncWorkflow<void, void>;
   config: ParallelWorkflow<void, UserConfig<Extends>>;
   resolvedConfig: AsyncWaterfall<{
     resolved: NormalizedConfig<Extends>;

--- a/packages/document/main-doc/docs/en/configure/app/output/temp-dir.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/temp-dir.mdx
@@ -13,7 +13,7 @@ If you want to start a project with multiple configurations at the same time, yo
 
 The configuration can be a relative or absolute path, but paths outside the project should be avoided.
 
-示例
+Example:
 
 ```ts
 export default {

--- a/packages/document/main-doc/docs/en/configure/app/output/temp-dir.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/temp-dir.mdx
@@ -1,0 +1,24 @@
+---
+sidebar_label: tempDir
+---
+
+# output.tempDir
+
+- **Type:** `string`
+- **Default:** `''`
+
+When developing or building a project, Modern.js generates real Webpack entries and HTML templates, placing them in a temporary directory.
+
+If you want to start a project with multiple configurations at the same time, you can use this configuration to generate files in different temporary directories to avoid interference with each other.
+
+The configuration can be a relative or absolute path, but paths outside the project should be avoided.
+
+示例
+
+```ts
+export default {
+  output: {
+    tempDir: path.join('node_modules', '.temp-dir'),
+  }
+}
+```

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -9,6 +9,28 @@ Modern.js exposes three types of plugins: CLI, Runtime, and Server.
 
 ## CLI
 
+### `beforeConfig`
+
+- Functionality: Running tasks before the config process
+- Execution phase: Before the config process
+- Hook model: AsyncWorkflow
+- Type: `AsyncWorkflow<void, void>`
+- Example usage:
+
+```ts
+import type { CliPlugin } from '@modern-js/core';
+
+export default (): CliPlugin => ({
+  setup(api) {
+    return {
+      beforeConfig: () => {
+        // do something
+      },
+    };
+  },
+});
+```
+
 ### `config`
 
 - Functionality: Collect configuration

--- a/packages/document/main-doc/docs/zh/configure/app/output/temp-dir.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/temp-dir.mdx
@@ -1,0 +1,22 @@
+---
+sidebar_label: tempDir
+---
+
+# output.tempDir
+
+- **类型：** `string`
+- **默认值：** `''`
+
+项目开发或构建时，Modern.js 会生成真实的 Webpack 入口和 HTML 模板，并放在临时目录下。
+
+如果希望由多个配置同时启动某项目，可以通过该配置，将文件生成到不同的临时目录下，避免相互干扰。配置可以是相对路径或绝对路径，但应避免项目外的路径。
+
+示例
+
+```ts
+export default {
+  output: {
+    tempDir: path.join('node_modules', '.temp-dir'),
+  }
+}
+```

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -8,6 +8,28 @@ sidebar_position: 8
 
 ## CLI
 
+### `beforeConfig`
+
+- 功能：运行收集配置前的任务
+- 执行阶段：收集配置前
+- Hook 模型：AsyncWorkflow
+- 类型：`AsyncWorkflow<void, void>`
+- 使用示例：
+
+```ts
+import type { CliPlugin } from '@modern-js/core';
+
+export default (): CliPlugin => ({
+  setup(api) {
+    return {
+      beforeConfig: () => {
+        // do something
+      },
+    };
+  },
+});
+```
+
 ### `config`
 
 - 功能：收集配置

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -115,7 +115,6 @@ export const buildCommand = async (
 export type AppToolsOptions = {
   /** Specify the use what kind of bundler to compiler, default: `webpack` */
   bundler?: 'experimental-rspack' | 'webpack';
-  tempDir?: string;
 };
 
 export default (
@@ -156,12 +155,15 @@ export default (
 
     return {
       async afterInit() {
-        const { tempDir } = options;
+        const userConfig = api.useConfigContext();
         const appContext = api.useAppContext();
-        if (tempDir) {
+        if (userConfig.output?.tempDir) {
           api.setAppContext({
             ...appContext,
-            internalDirectory: path.resolve(appContext.appDirectory, tempDir),
+            internalDirectory: path.resolve(
+              appContext.appDirectory,
+              userConfig.output.tempDir,
+            ),
           });
         }
       },

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -154,7 +154,7 @@ export default (
     i18n.changeLanguage({ locale });
 
     return {
-      async afterInit() {
+      async beforeConfig() {
         const userConfig = api.useConfigContext();
         const appContext = api.useAppContext();
         if (userConfig.output?.tempDir) {

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -115,6 +115,7 @@ export const buildCommand = async (
 export type AppToolsOptions = {
   /** Specify the use what kind of bundler to compiler, default: `webpack` */
   bundler?: 'experimental-rspack' | 'webpack';
+  tempDir?: string;
 };
 
 export default (
@@ -154,6 +155,16 @@ export default (
     i18n.changeLanguage({ locale });
 
     return {
+      async afterInit() {
+        const { tempDir } = options;
+        const appContext = api.useAppContext();
+        if (tempDir) {
+          api.setAppContext({
+            ...appContext,
+            internalDirectory: path.resolve(appContext.appDirectory, tempDir),
+          });
+        }
+      },
       async commands({ program }) {
         await devCommand(program, api);
 

--- a/packages/solutions/app-tools/src/types/config/output.ts
+++ b/packages/solutions/app-tools/src/types/config/output.ts
@@ -14,6 +14,7 @@ export interface SharedOutputConfig extends BuilderSharedOutputConfig {
   ssg?: SSGConfig;
   splitRouteChunks?: boolean;
   disableNodePolyfill?: boolean;
+  tempDir?: string;
 }
 
 export interface OutputUserConfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5826,6 +5826,29 @@ importers:
       '@modern-js/app-tools': link:../../../../../packages/solutions/app-tools
       '@modern-js/plugin-swc': link:../../../../../packages/cli/plugin-swc
 
+  tests/integration/temp-dir:
+    specifiers:
+      '@modern-js/app-tools': workspace:*
+      '@modern-js/plugin-swc': workspace:*
+      '@modern-js/runtime': workspace:*
+      '@types/node': ^14
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      react: ^18
+      react-dom: ^18
+      typescript: ^4
+    dependencies:
+      '@modern-js/runtime': link:../../../packages/runtime/plugin-runtime
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@modern-js/app-tools': link:../../../packages/solutions/app-tools
+      '@modern-js/plugin-swc': link:../../../packages/cli/plugin-swc
+      '@types/node': 14.18.35
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      typescript: 4.9.5
+
   tests/integration/worker/fixtures/worker-test:
     specifiers:
       '@modern-js-app/eslint-config': workspace:*

--- a/tests/integration/temp-dir/modern.config.ts
+++ b/tests/integration/temp-dir/modern.config.ts
@@ -5,10 +5,7 @@ export default defineConfig({
   runtime: {},
   output: {
     disableTsChecker: true,
+    tempDir: path.join('node_modules', '.temp-dir'),
   },
-  plugins: [
-    appTools({
-      tempDir: path.join('node_modules', '.temp-dir'),
-    }),
-  ],
+  plugins: [appTools({})],
 });

--- a/tests/integration/temp-dir/modern.config.ts
+++ b/tests/integration/temp-dir/modern.config.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+import appTools, { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  runtime: {},
+  output: {
+    disableTsChecker: true,
+  },
+  plugins: [
+    appTools({
+      tempDir: path.join('node_modules', '.temp-dir'),
+    }),
+  ],
+});

--- a/tests/integration/temp-dir/package.json
+++ b/tests/integration/temp-dir/package.json
@@ -1,0 +1,32 @@
+{
+  "private": true,
+  "name": "tmp-dir",
+  "version": "2.9.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "serve": "modern serve",
+    "new": "modern new",
+    "lint": "modern lint"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "eslintIgnore": [
+    "node_modules/",
+    "dist/"
+  ],
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/plugin-swc": "workspace:*",
+    "typescript": "^4",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@types/node": "^14"
+  }
+}

--- a/tests/integration/temp-dir/src/App.css
+++ b/tests/integration/temp-dir/src/App.css
@@ -1,0 +1,119 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
+    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+}
+
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  box-sizing: border-box;
+}
+
+.container {
+  min-height: 100vh;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+main {
+  padding: 5rem 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.footer {
+  width: 100%;
+  height: 80px;
+  border-top: 1px solid #eaeaea;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #470000;
+}
+
+.footer a {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+  color: #f4f4f4;
+  text-decoration: none;
+  font-size: 1.1rem;
+}
+
+.logo {
+  margin-bottom: 2rem;
+}
+
+.logo svg {
+  width: 450px;
+  height: 132px;
+}
+
+.description {
+  text-align: center;
+  line-height: 1.5;
+  font-size: 1.5rem;
+}
+
+.code {
+  background: #fafafa;
+  border-radius: 5px;
+  padding: 0.75rem;
+  font-size: 1.1rem;
+  font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
+    Bitstream Vera Sans Mono, Courier New, monospace;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    width: 100%;
+    flex-direction: column;
+  }
+}
+
+.grid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 800px;
+  margin-top: 3rem;
+}
+
+.card {
+  margin: 1rem;
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100px;
+  color: inherit;
+  text-decoration: none;
+  border: 1px solid #470000;
+  color: #470000;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  width: 45%;
+}
+
+.card:hover,
+.card:focus,
+.card:active {
+  transform: scale(1.05);
+  transition: 0.1s ease-in-out;
+}
+
+.card h2 {
+  font-size: 1.5rem;
+  margin: 0;
+  padding: 0;
+}

--- a/tests/integration/temp-dir/src/App.tsx
+++ b/tests/integration/temp-dir/src/App.tsx
@@ -1,0 +1,36 @@
+import './App.css';
+
+const App = () => (
+  <div className="container">
+    <main>
+      <div className="logo">
+        <img
+          src="https://lf3-static.bytednsdoc.com/obj/eden-cn/ylaelkeh7nuhfnuhf/modernjs-cover.png"
+          width="300"
+          alt="Modern.js Logo"
+        />
+      </div>
+      <p className="description">
+        Get started by editing <code className="code">src/App.tsx</code>
+      </p>
+      <div className="grid">
+        <a href="https://modernjs.dev/docs/start" className="card">
+          <h2>Quick Start</h2>
+        </a>
+        <a href="https://modernjs.dev/docs/guides" className="card">
+          <h2>Handbook</h2>
+        </a>
+        <a href="https://modernjs.dev/docs/apis" className="card">
+          <h2>API Reference </h2>
+        </a>
+      </div>
+    </main>
+    <footer className="footer">
+      <a href="https://modernjs.dev" target="_blank" rel="noopener noreferrer">
+        Powered by Modern.js
+      </a>
+    </footer>
+  </div>
+);
+
+export default App;

--- a/tests/integration/temp-dir/src/modern-app-env.d.ts
+++ b/tests/integration/temp-dir/src/modern-app-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@modern-js/runtime/types/router' />
+/// <reference types='@modern-js/plugin-testing/types' />
+/// <reference types='@modern-js/plugin-garfish/type' />
+/// <reference types='@modern-js/plugin-express/types' />
+/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/temp-dir/tests/index.test.js
+++ b/tests/integration/temp-dir/tests/index.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { modernBuild } = require('../../../utils/modernTestUtils');
+
+const appDir = path.resolve(__dirname, '../');
+
+function existsSync(filePath) {
+  return fs.existsSync(path.join(appDir, filePath));
+}
+
+describe('test temp-dir', () => {
+  let buildRes;
+  beforeAll(async () => {
+    buildRes = await modernBuild(appDir);
+  });
+
+  it(`should get right alias build!`, async () => {
+    expect(buildRes.code === 0).toBe(true);
+    expect(existsSync('node_modules/.temp-dir/main')).toBe(true);
+    expect(existsSync('node_modules/.temp-dir/.runtime-exports')).toBe(true);
+  });
+});

--- a/tests/integration/temp-dir/tsconfig.json
+++ b/tests/integration/temp-dir/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "shared", "config"]
+}


### PR DESCRIPTION
## Summary

Modern.js will create tempDir for the real webpack entry before build. If there is multiple config in one app, they can not build together. Now we support a new params for `@modern-js/app-tools`:

```ts
import path from 'path';
import appTools, { defineConfig } from '@modern-js/app-tools';

export default defineConfig({
  output: {
    tempDir: path.join('node_modules', '.temp-dir'),
  },
  plugins: [appTools({})],
});

```

<!--
copilot:summary
-->

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
