### PR TITLE
feat(testing): support decorators legacy

### DIFF
--- a/.changeset/shiny-falcons-tap.md
+++ b/.changeset/shiny-falcons-tap.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-testing': patch
+---
+
+feat: support decorators legacy
+feat: babel-jest 支持装饰器语法

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -112,6 +112,7 @@
     "@modern-js-reduck/store": "^1.0.3",
     "@modern-js/babel-compiler": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@babel/plugin-proposal-decorators": "^7.18.0",
     "@modern-js/babel-preset-app": "workspace:*",
     "@modern-js/plugin": "workspace:*",
     "@modern-js/prod-server": "workspace:*",

--- a/packages/runtime/plugin-testing/src/base/config/transformer/babelTransformer.ts
+++ b/packages/runtime/plugin-testing/src/base/config/transformer/babelTransformer.ts
@@ -10,6 +10,14 @@ const babelTransformer = (babelJest.createTransformer as any)?.({
       },
     ],
   ],
+  plugins: [
+    [
+      require.resolve('@babel/plugin-proposal-decorators'),
+      {
+        version: 'legacy',
+      },
+    ],
+  ],
   configFile: false,
   babelrc: false,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2507,6 +2507,7 @@ importers:
   packages/runtime/plugin-testing:
     specifiers:
       '@babel/core': ^7.18.0
+      '@babel/plugin-proposal-decorators': ^7.18.0
       '@babel/preset-env': ^7.18.0
       '@jest/types': ^29.5.0
       '@modern-js-reduck/plugin-auto-actions': ^1.0.2
@@ -2546,6 +2547,7 @@ importers:
       yargs: ^17.0.1
     dependencies:
       '@babel/core': 7.20.5
+      '@babel/plugin-proposal-decorators': 7.18.2_@babel+core@7.20.5
       '@babel/preset-env': 7.20.2_@babel+core@7.20.5
       '@jest/types': 29.5.0
       '@modern-js-reduck/plugin-auto-actions': 1.1.6_ey2tb66lspd63dpe7kr4h74444
@@ -6274,7 +6276,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.5
-    dev: true
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -6354,7 +6355,6 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-create-class-features-plugin/7.18.6:
     resolution: {integrity: sha512-YfDzdnoxHGV8CzqHGyCbFvXg5QESPFkXlHtvdCkesLjjVMT2Adxe4FGUR5ChIb3DxSaXO12iIOCWoXdsUVwnqw==}
@@ -6839,7 +6839,6 @@ packages:
       charcodes: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-decorators/7.18.6_@babel+core@7.20.5:
     resolution: {integrity: sha512-gAdhsjaYmiZVxx5vTMiRfj31nB7LhwBJFMSLzeDxc7X4tKLixup0+k9ughn0RcpBrv9E3PBaXJW7jF5TCihAOg==}
@@ -12759,7 +12758,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.5
       '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.5
-      '@babel/plugin-proposal-decorators': 7.18.6_@babel+core@7.20.5
+      '@babel/plugin-proposal-decorators': 7.18.2_@babel+core@7.20.5
       '@babel/plugin-proposal-export-default-from': 7.18.6_@babel+core@7.20.5
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.5
       '@babel/plugin-proposal-object-rest-spread': 7.20.2_@babel+core@7.20.5
@@ -17001,7 +17000,6 @@ packages:
   /charcodes/0.2.0:
     resolution: {integrity: sha512-Y4kiDb+AM4Ecy58YkuZrrSRJBDQdQ2L+NyS1vHHFtNtUjgutcZfx3yp1dAONI/oPaPmyGfCLx5CxL+zauIMyKQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /chardet/0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87f41c2</samp>

This pull request adds support for decorators in the test files that use the `plugin-testing` package. It does this by installing the `@babel/plugin-proposal-decorators` dependency and configuring the `babelTransformer` function to use it.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87f41c2</samp>

*  Add `@babel/plugin-proposal-decorators` dependency to enable decorators in test files ([link](https://github.com/web-infra-dev/modern.js/pull/3707/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bR115))
*  Modify `babelTransformer` function to include the plugin with the `version: 'legacy'` option for compatibility with TypeScript ([link](https://github.com/web-infra-dev/modern.js/pull/3707/files?diff=unified&w=0#diff-bbadaf480f80ba20b903dafd7dbf55a487867d8cb3741abb1746971638d6ac47R13-R20))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
