### PR TITLE
docs: fix modifyEntryExport hook example

### DIFF
--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -438,7 +438,7 @@ import type { CliPlugin } from '@modern-js/core';
 export default (): CliPlugin => ({
   setup(api) {
     return {
-      modifyEntryImports({ entrypoint, exportStatement }) {
+      modifyEntryExport({ entrypoint, exportStatement }) {
         return {
           entrypoint,
           exportStatement: [`export const foo = 'test'`, exportStatement].join(

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -438,7 +438,7 @@ import type { CliPlugin } from '@modern-js/core';
 export default (): CliPlugin => ({
   setup(api) {
     return {
-      modifyEntryImports({ entrypoint, exportStatement }) {
+      modifyEntryExport({ entrypoint, exportStatement }) {
         return {
           entrypoint,
           exportStatement: [`export const foo = 'test'`, exportStatement].join(


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c05db40</samp>

Renamed the `modifyEntryImports` hook to `modifyEntryExport` in the framework plugin documentation. Updated both the English and Chinese files to reflect this change.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c05db40</samp>

*  Rename `modifyEntryImports` hook to `modifyEntryExport` in documentation files ([link](https://github.com/web-infra-dev/modern.js/pull/3710/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L441-R441), [link](https://github.com/web-infra-dev/modern.js/pull/3710/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L441-R441))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
