### PR TITLE
feat: the runtime package export loadable_bundler_plugin

### DIFF
--- a/.changeset/itchy-tools-vanish.md
+++ b/.changeset/itchy-tools-vanish.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': minor
+---
+
+feat: the runtime package export `loadable_bundler_plugin`
+feat: runtime 包导出 `loadable_bundler_plugin`

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -89,7 +89,7 @@
       "types": "./dist/types/router/runtime/server.d.ts",
       "default": "./dist/esm/router/runtime/server.js"
     },
-    "./loadable_bundler_plugin": {
+    "./loadable-bundler-plugin": {
       "jsnext:source": "./src/ssr/cli/loadable-bundler-plugin.ts",
       "types": "./dist/types/ssr/cli/loadable-bundler-plugin.d.ts",
       "default": "./dist/cjs/ssr/cli/loadable-bundler-plugin.js"
@@ -136,7 +136,7 @@
       "router/server": [
         "./dist/types/router/runtime/server.d.ts"
       ],
-      "loadable_bundler_plugin": [
+      "loadable-bundler-plugin": [
         "./dist/types/ssr/cli/loadable-bundler-plugin.d.ts"
       ]
     }

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -88,6 +88,11 @@
       "jsnext:source": "./src/router/runtime/server.ts",
       "types": "./dist/types/router/runtime/server.d.ts",
       "default": "./dist/esm/router/runtime/server.js"
+    },
+    "./loadable_bundler_plugin": {
+      "jsnext:source": "./src/ssr/cli/loadable-bundler-plugin.ts",
+      "types": "./dist/types/ssr/cli/loadable-bundler-plugin.d.ts",
+      "default": "./dist/cjs/ssr/cli/loadable-bundler-plugin.js"
     }
   },
   "typesVersions": {
@@ -130,6 +135,9 @@
       ],
       "router/server": [
         "./dist/types/router/runtime/server.d.ts"
+      ],
+      "loadable_bundler_plugin": [
+        "./dist/types/ssr/cli/loadable-bundler-plugin.d.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7705cd</samp>

This pull request enhances the `@modern-js/runtime` package with code splitting and server-side rendering capabilities using `@loadable/component`. It also adds a changeset file to document the new features and a Chinese translation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7705cd</samp>

*  Add `loadable_bundler_plugin` module to `@modern-js/plugin-runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/3713/files?diff=unified&w=0#diff-a90f331e2d4e9320efe81c8af64349df4b94c4c63c247993e91f00bcfc1a8561R91-R95), [link](https://github.com/web-infra-dev/modern.js/pull/3713/files?diff=unified&w=0#diff-a90f331e2d4e9320efe81c8af64349df4b94c4c63c247993e91f00bcfc1a8561R138-R140))
* Update changeset file for `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/3713/files?diff=unified&w=0#diff-5e93d8369d8f9ef62446c742e7a55b6bd9ade21cec4419befc2bbdbd5f1fe05fR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
