### PR TITLE
fix: remove micro generator bebel runtime dependencies

### DIFF
--- a/.changeset/hip-pugs-shout.md
+++ b/.changeset/hip-pugs-shout.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/generator-generator': patch
+---
+
+fix: remove micro generator bebel runtime dependencies
+
+fix: 移除微生成器模板中的 bebel runtime 依赖

--- a/packages/generator/generators/generator-generator/src/index.ts
+++ b/packages/generator/generators/generator-generator/src/index.ts
@@ -118,8 +118,6 @@ const handleTemplateFile = async (
     'scripts.prepare': `${packageManager as string} build`,
     'devDependencies.@modern-js/codesmith-api-app': '^2.0.0',
     'devDependencies.@modern-js/codesmith': '^2.0.0',
-    'devDependencies.@babel/runtime': '~7.18.0',
-    'dependencies.@babel/runtime': undefined,
     'peerDependencies.react': undefined,
   };
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 542dc66</samp>

This pull request fixes a bug that caused unnecessary babel runtime dependencies to be included in the micro generator template of the `@modern-js/generator-generator` package. It also adds a test file for the `new-action` command of the `modern web app framework`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 542dc66</samp>

* Remove unnecessary babel runtime dependencies from micro generator template ([link](https://github.com/web-infra-dev/modern.js/pull/3715/files?diff=unified&w=0#diff-04f87a1c1262cf4338ce0b6d084d38be0374b35144da64017c46a1aaaa4b38fdL121-L122), [link](https://github.com/web-infra-dev/modern.js/pull/3715/files?diff=unified&w=0#diff-a01f031d0767ada5bc422e68f69dae0071afb45a62fd284f194cc474c756e32cR1-R7))
* Add test file for `new-action` command ([link](https://github.com/web-infra-dev/modern.js/pull/3715/files?diff=unified&w=0#diff-8884f2270409874ef9fbc613fe7b0dddd9be5d2b26e73fb99ddbc679f4037b63R1-R3))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
