### PR TITLE
feat(dev-server): enable gzip compression, add devServer.compress config

### DIFF
--- a/.changeset/lovely-jars-roll.md
+++ b/.changeset/lovely-jars-roll.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-doc': patch
+'@modern-js/server': patch
+'@modern-js/types': patch
+---
+
+feat(dev-server): enable gzip compression, add devServer.compress config
+
+feat(dev-server): 默认启用 gzip 压缩，新增 devServer.compress 配置项

--- a/packages/builder/builder-shared/src/schema/tools.ts
+++ b/packages/builder/builder-shared/src/schema/tools.ts
@@ -23,6 +23,7 @@ const sharedDevServerConfigSchema = z.partialObj({
     ]),
   }),
   historyApiFallback: z.union([z.boolean(), z.record(z.unknown())]),
+  compress: z.boolean(),
   hot: z.boolean(),
   https: DevServerHttpsOptionsSchema,
   liveReload: z.boolean(),

--- a/packages/document/builder-doc/docs/en/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/en/config/tools/devServer.md
@@ -103,6 +103,23 @@ const defaultConfig = {
 
 The config of HMR client, which are usually used to set the WebSocket URL of HMR.
 
+#### compress
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to enable gzip compression for served static resources.
+
+If you want to disable the gzip compression, you can set `compress` to `false`:
+
+```ts
+export default {
+  devServer: {
+    compress: false,
+  },
+};
+```
+
 #### devMiddleware
 
 - **Type:**

--- a/packages/document/builder-doc/docs/en/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/en/config/tools/devServer.md
@@ -114,8 +114,10 @@ If you want to disable the gzip compression, you can set `compress` to `false`:
 
 ```ts
 export default {
-  devServer: {
-    compress: false,
+  tools: {
+    devServer: {
+      compress: false,
+    },
   },
 };
 ```

--- a/packages/document/builder-doc/docs/zh/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/devServer.md
@@ -103,6 +103,23 @@ const defaultConfig = {
 
 对应 HMR 客户端的配置，通常用于设置 HMR 对应的 WebSocket URL。
 
+#### compress
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+是否对静态资源启用 gzip 压缩。
+
+如果你需要禁用 gzip 压缩，可以将 `compress` 设置为 `false`：
+
+```ts
+export default {
+  devServer: {
+    compress: false,
+  },
+};
+```
+
 #### devMiddleware
 
 - **类型：**

--- a/packages/document/builder-doc/docs/zh/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/devServer.md
@@ -114,8 +114,10 @@ const defaultConfig = {
 
 ```ts
 export default {
-  devServer: {
-    compress: false,
+  tools: {
+    devServer: {
+      compress: false,
+    },
   },
 };
 ```

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -53,8 +53,8 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.5.1",
-    "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
+    "http-compression": "1.0.6",
     "minimatch": "^3.0.4",
     "path-to-regexp": "^6.2.0",
     "ws": "^8.2.0"
@@ -64,7 +64,6 @@
     "@scripts/build": "workspace:*",
     "@scripts/jest-config": "workspace:*",
     "@types/connect-history-api-fallback": "^1.3.5",
-    "@types/compression": "^1.7.2",
     "@types/jest": "^29",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^14",

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -52,17 +52,19 @@
     "@modern-js/server-utils": "workspace:*",
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1",
+    "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
     "minimatch": "^3.0.4",
     "path-to-regexp": "^6.2.0",
-    "ws": "^8.2.0",
-    "@swc/helpers": "0.5.1"
+    "ws": "^8.2.0"
   },
   "devDependencies": {
     "@modern-js/server-core": "workspace:*",
     "@scripts/build": "workspace:*",
     "@scripts/jest-config": "workspace:*",
     "@types/connect-history-api-fallback": "^1.3.5",
+    "@types/compression": "^1.7.2",
     "@types/jest": "^29",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^14",

--- a/packages/server/server/src/constants.ts
+++ b/packages/server/server/src/constants.ts
@@ -16,6 +16,7 @@ export const getDefaultDevOptions = (): DevServerOptions => {
     devMiddleware: { writeToDisk: true },
     watch: true,
     hot: true,
+    compress: true,
     liveReload: true,
   };
 };

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -130,6 +130,14 @@ export class ModernDevServer extends ModernServer {
   private async applyDefaultMiddlewares(app: Server) {
     const { pwd, dev, devMiddleware } = this;
 
+    // compression should be the first middleware
+    if (dev.compress) {
+      const { default: compression } = await import('compression');
+      this.addHandler((ctx, next) => {
+        (compression() as RequestHandler)(ctx.req, ctx.res, next);
+      });
+    }
+
     this.addHandler((ctx: ModernServerContext, next: NextFunction) => {
       // allow hmr request cross-domain, because the user may use global proxy
       ctx.res.setHeader('Access-Control-Allow-Origin', '*');

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -132,9 +132,12 @@ export class ModernDevServer extends ModernServer {
 
     // compression should be the first middleware
     if (dev.compress) {
-      const { default: compression } = await import('compression');
+      const { default: compression } = await import('http-compression');
       this.addHandler((ctx, next) => {
-        (compression() as RequestHandler)(ctx.req, ctx.res, next);
+        compression({
+          gzip: true,
+          brotli: false,
+        })(ctx.req, ctx.res, next);
       });
     }
 

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -132,6 +132,8 @@ export class ModernDevServer extends ModernServer {
 
     // compression should be the first middleware
     if (dev.compress) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error http-compression does not provide a type definition
       const { default: compression } = await import('http-compression');
       this.addHandler((ctx, next) => {
         compression({

--- a/packages/server/server/src/type.d.ts
+++ b/packages/server/server/src/type.d.ts
@@ -1,1 +1,0 @@
-declare module 'http-compression';

--- a/packages/server/server/src/type.d.ts
+++ b/packages/server/server/src/type.d.ts
@@ -1,0 +1,1 @@
+declare module 'http-compression';

--- a/packages/toolkit/types/server/devServer.d.ts
+++ b/packages/toolkit/types/server/devServer.d.ts
@@ -24,6 +24,8 @@ export type DevServerOptions = {
     host?: string;
     protocol?: string;
   };
+  /** Whether to enable gzip compression */
+  compress?: boolean;
   devMiddleware?: {
     writeToDisk?: boolean | ((filename: string) => boolean);
     outputFileSystem?: Record<string, any>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3042,14 +3042,13 @@ importers:
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@swc/helpers': 0.5.1
-      '@types/compression': ^1.7.2
       '@types/connect-history-api-fallback': ^1.3.5
       '@types/jest': ^29
       '@types/minimatch': ^3.0.5
       '@types/node': ^14
       '@types/ws': ^7.4.7
-      compression: ^1.7.4
       connect-history-api-fallback: ^2.0.0
+      http-compression: 1.0.6
       jest: ^29
       minimatch: ^3.0.4
       node-mocks-http: ^1.11.0
@@ -3068,8 +3067,8 @@ importers:
       '@modern-js/types': link:../../toolkit/types
       '@modern-js/utils': link:../../toolkit/utils
       '@swc/helpers': 0.5.1
-      compression: 1.7.4
       connect-history-api-fallback: 2.0.0
+      http-compression: 1.0.6
       minimatch: 3.1.2
       path-to-regexp: 6.2.1
       ws: 8.8.1
@@ -3077,7 +3076,6 @@ importers:
       '@modern-js/server-core': link:../core
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
-      '@types/compression': 1.7.2
       '@types/connect-history-api-fallback': 1.3.5
       '@types/jest': 29.4.4
       '@types/minimatch': 3.0.5
@@ -13860,6 +13858,7 @@ packages:
     resolution: {integrity: sha512-lwEL4M/uAGWngWFLSG87ZDr2kLrbuR8p7X+QZB1OQlT+qkHsCPDVFnHPyXf4Vyl4yDDorNY+mAhosxkCvppatg==}
     dependencies:
       '@types/express': 4.17.13
+    dev: false
 
   /@types/connect-history-api-fallback/1.3.5:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
@@ -22159,6 +22158,11 @@ packages:
 
   /http-cache-semantics/4.1.0:
     resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
+
+  /http-compression/1.0.6:
+    resolution: {integrity: sha512-Yy9VFT/0fJhbpSHmqA34CJKZDXLnHoQUP2wbFXY7duOx3nc9Qf8MVJezaXTP7IirvJ9DmUv/vm7qFNu/RntdWw==}
+    engines: {node: '>= 4'}
+    dev: false
 
   /http-deceiver/1.2.7:
     resolution: {integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3068,7 +3068,6 @@ importers:
       '@modern-js/types': link:../../toolkit/types
       '@modern-js/utils': link:../../toolkit/utils
       '@swc/helpers': 0.5.1
-      '@types/compression': 1.7.2
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       minimatch: 3.1.2
@@ -3078,6 +3077,7 @@ importers:
       '@modern-js/server-core': link:../core
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
+      '@types/compression': 1.7.2
       '@types/connect-history-api-fallback': 1.3.5
       '@types/jest': 29.4.4
       '@types/minimatch': 3.0.5
@@ -13860,7 +13860,6 @@ packages:
     resolution: {integrity: sha512-lwEL4M/uAGWngWFLSG87ZDr2kLrbuR8p7X+QZB1OQlT+qkHsCPDVFnHPyXf4Vyl4yDDorNY+mAhosxkCvppatg==}
     dependencies:
       '@types/express': 4.17.13
-    dev: false
 
   /@types/connect-history-api-fallback/1.3.5:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3042,11 +3042,13 @@ importers:
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@swc/helpers': 0.5.1
+      '@types/compression': ^1.7.2
       '@types/connect-history-api-fallback': ^1.3.5
       '@types/jest': ^29
       '@types/minimatch': ^3.0.5
       '@types/node': ^14
       '@types/ws': ^7.4.7
+      compression: ^1.7.4
       connect-history-api-fallback: ^2.0.0
       jest: ^29
       minimatch: ^3.0.4
@@ -3066,6 +3068,8 @@ importers:
       '@modern-js/types': link:../../toolkit/types
       '@modern-js/utils': link:../../toolkit/utils
       '@swc/helpers': 0.5.1
+      '@types/compression': 1.7.2
+      compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       minimatch: 3.1.2
       path-to-regexp: 6.2.1
@@ -13815,7 +13819,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 18.11.17
+      '@types/node': 14.18.35
 
   /@types/body-scroll-lock/3.1.0:
     resolution: {integrity: sha512-3owAC4iJub5WPqRhxd8INarF2bWeQq1yQHBgYhN0XLBJMpd5ED10RrJ3aKiAwlTyL5wK7RkBD4SZUQz2AAAMdA==}
@@ -13867,7 +13871,7 @@ packages:
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.11.17
+      '@types/node': 14.18.35
 
   /@types/content-disposition/0.5.5:
     resolution: {integrity: sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==}
@@ -14431,7 +14435,7 @@ packages:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.11.17
+      '@types/node': 14.18.35
 
   /@types/signal-exit/3.0.1:
     resolution: {integrity: sha512-OSitN9PP9E/c4tlt1Qdj3CAz5uHD9Da5rhUqlaKyQRCX1T7Zdpbk6YdeZbR2eiE2ce+NMBgVnMxGqpaPSNQDUQ==}


### PR DESCRIPTION
## Summary

Enable gzip compression by default, and add devServer.compress config. Keep the behaviour consistent with [webpack-dev-server](https://webpack.docschina.org/configuration/dev-server/#devservercompress).

We use [http-compression](https://github.com/Kikobeats/http-compression) rather than [compression](https://github.com/expressjs/compression), because compression [does not support http2](https://github.com/expressjs/compression/issues/122) and has not been maintained for a long time.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27c2188</samp>

This pull request adds a new feature to the `@modern-js/server` package, which is to enable gzip compression for the dev server. The feature is controlled by a new `compress` option in the dev server config, which is `true` by default. The pull request also updates the dependencies, the schema, the changeset, and the documentation for the feature.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27c2188</samp>

*  Add `compress` property to dev server config schema and documentation ([link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-61ad4c9c4759d986fb9c8138d1f12cb15e3f468d48a93b8fc29e38ceeca21cb8R26), [link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-0a714ddc474c7a425c13ae672e264ac547893c9283cc43e155d06d121f6329beR106-R122), [link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-69d3b93a9b57afe8f5e9d592ac1aac80306d6ba8399f930dffd1c3aa7aa6f606R106-R122))
*  Enable gzip compression for dev server by default using `compression` middleware ([link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-4e5229a5eda5177170934d4faa8f34e6413ab98d6652b8173bbc236a97251b31L55-R60), [link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-4e5229a5eda5177170934d4faa8f34e6413ab98d6652b8173bbc236a97251b31R67), [link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-30d4bc97dac1a007a0823ed2ff4d87a3ab9cc90c2d1b2f52002a4befc1357448R19), [link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aR133-R140))
*  Document new feature and bump patch versions in changeset file ([link](https://github.com/web-infra-dev/modern.js/pull/3723/files?diff=unified&w=0#diff-6cd8779ce620d6ba37927295dafc4150cb4b7e4250ea88cfc49a851bd96a50e4R1-R10))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
