### PR TITLE
refactor: guard react router consistency

### DIFF
--- a/.changeset/good-eels-give.md
+++ b/.changeset/good-eels-give.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-data-loader': patch
+'@modern-js/runtime': patch
+'@modern-js/utils': patch
+---
+
+refactor: guard react-router version consistency
+refactor: 保证 react-router 相关包的版本一致性

--- a/packages/cli/plugin-data-loader/src/cli/createRequest.ts
+++ b/packages/cli/plugin-data-loader/src/cli/createRequest.ts
@@ -2,7 +2,7 @@
 /* eslint-disable node/prefer-global/url */
 import { compile } from 'path-to-regexp';
 import { redirect } from 'react-router-dom';
-import { type UNSAFE_DeferredData as DeferredData } from '@modern-js/utils/runtime/router';
+import { type UNSAFE_DeferredData as DeferredData } from '@modern-js/utils/runtime/remix-router';
 import {
   LOADER_ID_PARAM,
   DIRECT_PARAM,

--- a/packages/cli/plugin-data-loader/src/cli/data.ts
+++ b/packages/cli/plugin-data-loader/src/cli/data.ts
@@ -13,7 +13,7 @@
 import {
   UNSAFE_DeferredData as DeferredData,
   AbortedDeferredError,
-} from '@modern-js/utils/runtime/router';
+} from '@modern-js/utils/runtime/remix-router';
 
 const DEFERRED_VALUE_PLACEHOLDER_PREFIX = '__deferred_promise:';
 export async function parseDeferredReadableStream(

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -10,8 +10,8 @@ import {
   ErrorResponse,
   UNSAFE_DEFERRED_SYMBOL as DEFERRED_SYMBOL,
   type UNSAFE_DeferredData as DeferredData,
-  transformNestedRoutes,
-} from '@modern-js/utils/runtime/router';
+} from '@modern-js/utils/runtime/remix-router';
+import { transformNestedRoutes } from '@modern-js/utils/runtime/nested-routes';
 import { isPlainObject } from '@modern-js/utils/lodash';
 import { CONTENT_TYPE_DEFERRED, LOADER_ID_PARAM } from '../common/constants';
 import { matchEntry, ServerContext } from '../common/utils';

--- a/packages/cli/plugin-data-loader/src/runtime/response.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/response.ts
@@ -11,7 +11,7 @@ import { TextEncoder } from 'util';
 import {
   type UNSAFE_DeferredData as DeferredData,
   type TrackedPromise,
-} from '@modern-js/utils/runtime/router';
+} from '@modern-js/utils/runtime/remix-router';
 import { serializeJson } from '@modern-js/utils/runtime-node';
 
 function isTrackedPromise(value: any): value is TrackedPromise {

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -175,7 +175,6 @@
     "invariant": "^2.2.4",
     "react-helmet": "^6.1.0",
     "react-is": "^18",
-    "react-router-dom": "^6.8.1",
     "react-side-effect": "^2.1.1",
     "redux-logger": "^3.0.6",
     "styled-components": "^5.3.1",

--- a/packages/runtime/plugin-runtime/src/router/runtime/DeferredDataScripts.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/DeferredDataScripts.node.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/no-danger */
-import { TrackedPromise } from '@modern-js/utils/runtime/router';
+import { type TrackedPromise } from '@modern-js/utils/runtime/remix-router';
 import { Suspense, useEffect, useRef, useMemo, useContext } from 'react';
 import {
   Await,
   UNSAFE_DataRouterContext as DataRouterContext,
   useAsyncError,
-} from 'react-router-dom';
+} from '@modern-js/utils/runtime/router';
 import { serializeJson } from '@modern-js/utils/runtime-node';
 import { JSX_SHELL_STREAM_END_MARK } from '../../common';
 import { serializeErrors } from './utils';

--- a/packages/runtime/plugin-runtime/src/router/runtime/PrefetchLink.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/PrefetchLink.tsx
@@ -14,7 +14,7 @@ import {
   useMatches,
   NavLink as RouterNavLink,
   NavLinkProps as RouterNavLinkProps,
-} from 'react-router-dom';
+} from '@modern-js/utils/runtime/router';
 import { RuntimeReactContext } from '../../core';
 import { RouteAssets, RouteManifest } from './types';
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/hooks.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/hooks.ts
@@ -1,5 +1,5 @@
 import { createWaterfall } from '@modern-js/plugin';
-import { RouteObject } from 'react-router-dom';
+import { RouteObject } from '@modern-js/utils/runtime/router';
 
 const modifyRoutes = createWaterfall<RouteObject[]>();
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/index.ts
@@ -1,4 +1,4 @@
-import { useRouteLoaderData as useRouteData } from 'react-router-dom';
+import { useRouteLoaderData as useRouteData } from '@modern-js/utils/runtime/router';
 import { routerPlugin } from './plugin';
 import type { SingleRouteConfig, RouterConfig } from './types';
 
@@ -78,7 +78,7 @@ export type {
   Search,
   ShouldRevalidateFunction,
   To,
-} from 'react-router-dom';
+} from '@modern-js/utils/runtime/router';
 
 // Note: Keep in sync with react-router-dom exports!
 export {
@@ -144,9 +144,7 @@ export {
   createPath,
   unstable_useBlocker,
   unstable_usePrompt,
-} from 'react-router-dom';
-
-// `react-router-dom` has its own dependency: `@remix-run/router`.
-// In order to make sure `plugin-data-loader` and user's loaders(mainly `defer` API) depend on the singleton of `@remix-run/router`,
-// we export these API from the same package `@modern-js/utils/runtime`.
-export { defer, json, redirect } from '@modern-js/utils/runtime/router';
+  defer,
+  json,
+  redirect,
+} from '@modern-js/utils/runtime/router';

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
-import { createStaticHandler } from '@modern-js/utils/runtime/router';
+import { createStaticHandler } from '@modern-js/utils/runtime/remix-router';
 import {
   createStaticRouter,
   StaticRouterProvider,
-} from 'react-router-dom/server';
+} from '@modern-js/utils/runtime-node/router';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { createRoutesFromElements } from 'react-router-dom';
+import { createRoutesFromElements } from '@modern-js/utils/runtime/router';
 import { RuntimeReactContext } from '../../core';
 import type { Plugin } from '../../core';
 import { SSRServerContext } from '../../ssr/serverRender/types';

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -7,7 +7,7 @@ import {
   useMatches,
   useLocation,
   RouteObject,
-} from 'react-router-dom';
+} from '@modern-js/utils/runtime/router';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { parsedJSONFromElement } from '@modern-js/utils/runtime-browser';
 import { Plugin } from '../../core';

--- a/packages/runtime/plugin-runtime/src/router/runtime/server.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/server.ts
@@ -1,1 +1,1 @@
-export * from 'react-router-dom/server';
+export * from '@modern-js/utils/runtime-node/router';

--- a/packages/runtime/plugin-runtime/src/router/runtime/types.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/types.ts
@@ -1,4 +1,4 @@
-import type { RouteProps, RouteObject } from 'react-router-dom';
+import type { RouteProps, RouteObject } from '@modern-js/utils/runtime/router';
 import { PageRoute, NestedRoute } from '@modern-js/types';
 
 declare global {

--- a/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Route, isRouteErrorResponse } from '@modern-js/utils/runtime/router';
 import {
   type NestedRoute,
   type PageRoute,
@@ -7,11 +7,10 @@ import {
 } from '@modern-js/types';
 import {
   ErrorResponse,
-  isRouteErrorResponse,
-  type Router,
   type StaticHandlerContext,
-  renderNestedRoute,
-} from '@modern-js/utils/runtime/router';
+  type Router,
+} from '@modern-js/utils/runtime/remix-router';
+import { renderNestedRoute } from '@modern-js/utils/runtime/nested-routes';
 import { RouterConfig } from './types';
 import { DefaultNotFound } from './DefaultNotFound';
 import DeferredDataScripts from './DeferredDataScripts';

--- a/packages/runtime/plugin-runtime/src/router/runtime/withRouter.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/withRouter.tsx
@@ -1,7 +1,11 @@
 // legacy withRouter
 
 import React from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+} from '@modern-js/utils/runtime/router';
 
 export interface WithRouterProps {
   location: ReturnType<typeof useLocation>;

--- a/packages/runtime/plugin-runtime/src/runtimeContext.ts
+++ b/packages/runtime/plugin-runtime/src/runtimeContext.ts
@@ -1,5 +1,5 @@
 import { Store } from '@modern-js-reduck/store';
-import type { StaticHandlerContext } from '@modern-js/utils/runtime/router';
+import type { StaticHandlerContext } from '@modern-js/utils/runtime/remix-router';
 import { createContext } from 'react';
 import { createLoaderManager } from './core/loader/loaderManager';
 import { runtime } from './core/plugin';

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/bulidTemplate.before.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/bulidTemplate.before.ts
@@ -1,6 +1,6 @@
 import ReactHelmet, { HelmetData } from 'react-helmet';
 // Todo: This import will introduce router code, like remix, even if router config is false
-import { matchRoutes } from 'react-router-dom';
+import { matchRoutes } from '@modern-js/utils/runtime/router';
 import helmetReplace from '../helmet';
 import { RuntimeContext } from '../types';
 import { CSS_CHUNKS_PLACEHOLDER } from '../utils';

--- a/packages/runtime/plugin-runtime/tests/router/prefetch.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/router/prefetch.test.tsx
@@ -3,7 +3,7 @@ import {
   createMemoryRouter,
   LoaderFunctionArgs,
   RouterProvider,
-} from 'react-router-dom';
+} from '@modern-js/utils/runtime/router';
 import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import { Link } from '../../src/router';
 import { RuntimeReactContext } from '../../src';

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -104,6 +104,14 @@
         "types": "./dist/types/runtime/router.d.ts",
         "default": "./dist/esm/runtime/router.js"
       },
+      "./runtime/remix-router": {
+        "types": "./dist/types/runtime/remixRouter.d.ts",
+        "default": "./dist/esm/runtime/remixRouter.js"
+      },
+      "./runtime/nested-routes": {
+        "types": "./dist/types/runtime/nestedRoutes.d.ts",
+        "default": "./dist/esm/runtime/nestedRoutes.js"
+      },
       "./runtime-browser": {
         "jsnext:source": "./src/runtime-browser/index.d.ts",
         "default": "./dist/esm/runtime-browser/index.js"
@@ -111,6 +119,10 @@
       "./runtime-node": {
         "types": "./dist/types/runtime-node/index.d.ts",
         "default": "./dist/esm/runtime-node/index.js"
+      },
+      "./runtime-node/router": {
+        "types": "./dist/types/runtime-node/router.d.ts",
+        "default": "./dist/esm/runtime-node/router.js"
       },
       "./universal/constants": {
         "types": "./dist/types/universal/constants.d.ts",
@@ -161,11 +173,20 @@
       "runtime/router": [
         "./dist/types/runtime/router.d.ts"
       ],
+      "runtime/remix-router": [
+        "./dist/types/runtime/remixRouter.d.ts"
+      ],
+      "runtime/nested-routes": [
+        "./dist/types/runtime/nestedRoutes.d.ts"
+      ],
       "runtime-browser": [
         "./dist/types/runtime-browser/index.d.ts"
       ],
       "runtime-node": [
         "./dist/types/runtime-node/index.d.ts"
+      ],
+      "runtime-node/router": [
+        "./dist/types/runtime-node/router.d.ts"
       ],
       "universal/constants": [
         "./dist/types/universal/constants.d.ts"
@@ -255,13 +276,13 @@
     "caniuse-lite": "^1.0.30001451",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0",
-    "@remix-run/router": "^1.3.2",
+    "react-router-dom": "6.11.2",
+    "@remix-run/router": "1.6.2",
     "@swc/helpers": "0.5.1"
   },
   "peerDependencies": {
     "react": ">=17.0.0",
-    "react-dom": ">=17.0.0",
-    "react-router-dom": "^6.8.1"
+    "react-dom": ">=17.0.0"
   },
   "peerDependenciesMeta": {
     "react": {

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -43,7 +43,7 @@
       "default": "./dist/esm/runtime/remixRouter.js"
     },
     "./runtime/nested-routes": {
-      "jsnext:source": "./src/runtime/nestedRoutes.ts",
+      "jsnext:source": "./src/runtime/nestedRoutes.tsx",
       "default": "./dist/esm/runtime/nestedRoutes.js"
     },
     "./runtime-browser": {

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -38,6 +38,14 @@
       "jsnext:source": "./src/runtime/router.ts",
       "default": "./dist/esm/runtime/router.js"
     },
+    "./runtime/remix-router": {
+      "jsnext:source": "./src/runtime/remixRouter.ts",
+      "default": "./dist/esm/runtime/remixRouter.js"
+    },
+    "./runtime/nested-routes": {
+      "jsnext:source": "./src/runtime/nestedRoutes.ts",
+      "default": "./dist/esm/runtime/nestedRoutes.js"
+    },
     "./runtime-browser": {
       "jsnext:source": "./src/runtime-browser/index.ts",
       "default": "./dist/esm/runtime-browser/index.js"
@@ -45,6 +53,10 @@
     "./runtime-node": {
       "jsnext:source": "./src/runtime-node/index.ts",
       "default": "./dist/esm/runtime-node/index.js"
+    },
+    "./runtime-node/router": {
+      "jsnext:source": "./src/runtime-node/router.ts",
+      "default": "./dist/esm/runtime-node/router.js"
     },
     "./universal/constants": {
       "jsnext:source": "./src/universal/constants.ts",

--- a/packages/toolkit/utils/src/runtime-node/router.ts
+++ b/packages/toolkit/utils/src/runtime-node/router.ts
@@ -1,0 +1,1 @@
+export * from 'react-router-dom/server';

--- a/packages/toolkit/utils/src/runtime/router.ts
+++ b/packages/toolkit/utils/src/runtime/router.ts
@@ -1,2 +1,1 @@
-export * from './nestedRoutes';
-export * from './remixRouter';
+export * from 'react-router-dom';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2483,7 +2483,6 @@ importers:
       react-dom: ^18
       react-helmet: ^6.1.0
       react-is: ^18
-      react-router-dom: ^6.8.1
       react-side-effect: ^2.1.1
       redux-logger: ^3.0.6
       styled-components: ^5.3.1
@@ -2517,7 +2516,6 @@ importers:
       invariant: 2.2.4
       react-helmet: 6.1.0_react@18.2.0
       react-is: 18.2.0
-      react-router-dom: 6.8.1_biqbaboplfbrettd7655fr4n2y
       react-side-effect: 2.1.2_react@18.2.0
       redux-logger: 3.0.6
       styled-components: 5.3.5_7i5myeigehqah43i5u7wbekgba
@@ -3562,7 +3560,7 @@ importers:
   packages/toolkit/utils:
     specifiers:
       '@modern-js/types': workspace:*
-      '@remix-run/router': ^1.3.2
+      '@remix-run/router': 1.6.2
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
       '@swc/helpers': 0.5.1
@@ -3574,15 +3572,16 @@ importers:
       lodash: ^4.17.21
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
-      react-router-dom: ^6.8.1
+      react-router-dom: 6.11.2
       serialize-javascript: ^6.0.0
       typescript: ^5
       webpack: ^5.82.1
     dependencies:
-      '@remix-run/router': 1.3.2
+      '@remix-run/router': 1.6.2
       '@swc/helpers': 0.5.1
       caniuse-lite: 1.0.30001451
       lodash: 4.17.21
+      react-router-dom: 6.11.2_biqbaboplfbrettd7655fr4n2y
       serialize-javascript: 6.0.0
     devDependencies:
       '@modern-js/types': link:../types
@@ -3594,7 +3593,6 @@ importers:
       jest: 29.5.0_@types+node@14.18.35
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-router-dom: 6.8.1_biqbaboplfbrettd7655fr4n2y
       typescript: 5.0.4
       webpack: 5.82.1
 
@@ -11167,7 +11165,7 @@ packages:
       react-router-dom:
         optional: true
     dependencies:
-      '@remix-run/router': 1.3.2
+      '@remix-run/router': 1.6.2
       caniuse-lite: 1.0.30001451
       lodash: 4.17.21
       serialize-javascript: 6.0.1
@@ -11640,6 +11638,10 @@ packages:
 
   /@remix-run/router/1.3.2:
     resolution: {integrity: sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==}
+    engines: {node: '>=14'}
+
+  /@remix-run/router/1.6.2:
+    resolution: {integrity: sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==}
     engines: {node: '>=14'}
 
   /@remix-run/server-runtime/1.13.0:
@@ -29278,6 +29280,19 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
+  /react-router-dom/6.11.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.6.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router: 6.11.2_react@18.2.0
+    dev: false
+
   /react-router-dom/6.8.1_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==}
     engines: {node: '>=14'}
@@ -29316,6 +29331,16 @@ packages:
       react-is: 16.13.1
       tiny-invariant: 1.2.0
       tiny-warning: 1.0.3
+    dev: false
+
+  /react-router/6.11.2_react@18.2.0:
+    resolution: {integrity: sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.6.2
+      react: 18.2.0
     dev: false
 
   /react-router/6.8.1_react@18.2.0:


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

The versions of `react-router-dom` and `@remix-run/router` must match exactly. `@modern-js/plugin-data-loader` has a direct dependency on `@remix-run/router`, while `@modern-js/runtime` depends on it transitively through `react-router-dom`. To ensure version consistency, we have moved packages related to react-router to `@modern-js/utils`. Packages in modernjs now import router-related APIs from `@modern-js/utils`.

Additionally, due to a change in the DeferredData check logic in react-router (see https://github.com/remix-run/react-router/pull/10247), we can now directly export APIs such as `defer` from `react-router-dom` instead of from `@remix-run/router`.


## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e09080</samp>

*  Refactor the router-related code in the `@modern-js/utils` package and its consumers to use more specific and modular submodules ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-11d382118af0b9e02cea623de0313c26c484e99b59379f3dca8d29f2fba68855L5-R5),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-559dce1252a50d8e79421b77352cf6dfeeba6b7899ef7ccb8d72961da2638961L16-R16),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL13-R14),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-e5d3000568dd542f17232de0295e5de4017093c9ed0ef53e30db5ec9de619e0dL14-R14),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L8-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-f833fcd6bf4996a092d00d98c3f38ac3aeb6bce1aa31ec0d2ea8c24e527e789fL2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a2ba2aef031ad97c2b7c5dfd1a62d150661a28f360bedf74aeb67d2f800f601eL1-R1),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a2ba2aef031ad97c2b7c5dfd1a62d150661a28f360bedf74aeb67d2f800f601eL81-R81),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a2ba2aef031ad97c2b7c5dfd1a62d150661a28f360bedf74aeb67d2f800f601eL147-R150),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL2-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-934dc3d75c61021e0950f9c7d402d5349ca1ed2443c2df0892a671779699b475L1-R1),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-c4fdad7c2445a9e1efe143f33158a41d176d4f0d3bcc3ca84fd00243f6d4e647L1-R1),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L10-R13),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-adaf9a3d941a58745c1cfc3fb2bf84f26869eabaaeae198160a20bb61492333dL4-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-4595ffb4279d876e3775dd27729e152216eb78769ca4fc488af43d53cc0cde64L2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a2bf57dfb80cf787cf6b866e09c202590ccd1863dc995b4d56353e69478d9f8cL3-R3),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R107-R114),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R123-R126),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R176-R181),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R188-R190),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-20ad3701d063632345519f46fb06296bfd40250004623fc18342d7ecbd2321e8R1))
  * Create a new submodule `@modern-js/utils/runtime/remix-router` that contains the types and functions related to the `@remix-run/router` package, such as `UNSAFE_DeferredData`, `defer`, and `redirect` ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L10-R13),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R107-R114),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R176-R181),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-20ad3701d063632345519f46fb06296bfd40250004623fc18342d7ecbd2321e8R1))
  * Create a new submodule `@modern-js/utils/runtime/nested-routes` that contains the functions related to the nested routes feature, such as `transformNestedRoutes` and `renderNestedRoute` ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL13-R14),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L10-R13),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R107-R114),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R176-R181))
  * Create a new submodule `@modern-js/utils/runtime-node/router` that re-exports some of the types and functions from `react-router-dom/server` and adds some custom ones, such as `createStaticHandler` and `StaticHandlerContext` ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL2-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-934dc3d75c61021e0950f9c7d402d5349ca1ed2443c2df0892a671779699b475L1-R1),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R123-R126),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R188-R190),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-20ad3701d063632345519f46fb06296bfd40250004623fc18342d7ecbd2321e8R1))
  * Update the import paths of the types and functions from `react-router-dom` to use the re-exported versions from `@modern-js/utils/runtime/router`, which ensures consistency and avoids multiple versions of `react-router-dom` ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L8-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-508b4bf5abff27d01f24c266f4087bc467a96c1c7476ba62875a501db162fb41L17-R17),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-f833fcd6bf4996a092d00d98c3f38ac3aeb6bce1aa31ec0d2ea8c24e527e789fL2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a2ba2aef031ad97c2b7c5dfd1a62d150661a28f360bedf74aeb67d2f800f601eL1-R1),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a2ba2aef031ad97c2b7c5dfd1a62d150661a28f360bedf74aeb67d2f800f601eL81-R81),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L10-R10),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-c4fdad7c2445a9e1efe143f33158a41d176d4f0d3bcc3ca84fd00243f6d4e647L1-R1),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-adaf9a3d941a58745c1cfc3fb2bf84f26869eabaaeae198160a20bb61492333dL4-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a2bf57dfb80cf787cf6b866e09c202590ccd1863dc995b4d56353e69478d9f8cL3-R3))
  * Update the dependencies and peer dependencies of the `@modern-js/utils` package to remove the `@remix-run/router` dependency, update the `react-router-dom` dependency to the exact version `6.11.2`, and remove the `react-router-dom` peer dependency ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L258-R285))
* Remove the `react-router-dom` dependency from the `@modern-js/runtime` package, since it is not directly used by the package, but only re-exported from the `@modern-js/utils/runtime/router` module ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-a90f331e2d4e9320efe81c8af64349df4b94c4c63c247993e91f00bcfc1a8561L178))
* Add a changeset file that describes the changes made to the packages `@modern-js/plugin-data-loader`, `@modern-js/runtime`, and `@modern-js/utils`, and includes the commit message in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3724/files?diff=unified&w=0#diff-b8e144099cee3a69a36341ea2025520cdcad1fbab39d251d8fba8110b2571bb6R1-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
