### PR TITLE
fix(doc-tools): medium-zoom plugin error in windows

### DIFF
--- a/.changeset/quiet-geese-rescue.md
+++ b/.changeset/quiet-geese-rescue.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-plugin-medium-zoom': patch
+---
+
+fix(doc-tools): medium-zoom plugin error in windows
+
+fix(doc-tools): medium-zoom 插件在 windows 下报错

--- a/packages/cli/doc-plugin-medium-zoom/src/index.ts
+++ b/packages/cli/doc-plugin-medium-zoom/src/index.ts
@@ -7,11 +7,14 @@ import type { DocPlugin } from '../../doc-core';
  * The plugin is used to add medium-zoom to the doc site.
  */
 export function pluginMediumZoom(): DocPlugin {
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const __dirname = path
+    .dirname(fileURLToPath(import.meta.url))
+    // Fix: adapt windows
+    .replace(/\\/g, '/');
   return {
     name: '@modern-js/doc-plugin-medium-zoom',
     globalUIComponents: [
-      path.join(__dirname, '../src/components/MediumZoom.tsx'),
+      path.posix.join(__dirname, '../src/components/MediumZoom.tsx'),
     ],
   };
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7ac790</samp>

This pull request fixes a bug in the `doc-plugin-medium-zoom` package that prevents it from working on windows platforms. It also adds a changeset file to document the patch version update and the changelog message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7ac790</samp>

* Fix medium-zoom plugin error on windows paths ([link](https://github.com/web-infra-dev/modern.js/pull/3726/files?diff=unified&w=0#diff-ebfb45aeaa19797b782cd9b59bac9c8d9902532bf14960eed8988c4e7e467673L10-R17), [link](https://github.com/web-infra-dev/modern.js/pull/3726/files?diff=unified&w=0#diff-e4e3fe05f57a6c7a06bfbeed823d80bd330f9a0ecd0c5e453e1cd9f4cb481152R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
