### PR TITLE
docs: add rspack upgrade guide

### DIFF
--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -68,7 +68,7 @@ When Rspack is enabled for building through dev / build, the current version of 
 
 ![rspack_version_log](https://lf3-static.bytednsdoc.com/obj/eden-cn/6221eh7uhbfvhn/modern/img_v2_dfcf051f-21db-4741-a108-d9f7a82c3abg.png)
 
-### Modifying the Built-in Rspack Version
+### Override the Built-in Rspack Version
 
 You can override Rspack to a specific version using the capbilities provided by package managers such as pnpm, yarn, npm.
 

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -57,3 +57,41 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 :::tip
 When migrating from webpack to Rspack, there may have some differences in build and configuration capabilities. For more details, please refer to [Configuration Differences](https://modernjs.dev/builder/en/guide/advanced/rspack-start.html#migrating-from-webpack-to-rspack).
 :::
+
+## The Relationship between Rspack and Modern.js Versions
+
+Usually, the latest version of Rspack will be integrated into Modern.js. You can update the Modern.js-related dependencies and built-in Rspack to the latest version by using `npx modern upgrade` in your project.
+
+However, Modern.js uses a locked version dependency method (non-automatic upgrade) for Rspack. Due to differences in release cycles, the version of Rspack integrated into Modern.js may be behind the latest version of Rspack.
+
+When Rspack is enabled for building through dev / build, the current version of Rspack used in the framework will be printed automatically:
+
+![rspack_version_log](https://lf3-static.bytednsdoc.com/obj/eden-cn/6221eh7uhbfvhn/modern/img_v2_dfcf051f-21db-4741-a108-d9f7a82c3abg.png)
+
+### Modifying the Built-in Rspack Version
+
+You can modify Rspack to a specified version using the dependency upgrade method provided by package management tools such as pnpm / yarn / npm.
+
+For example, using pnpm, you can update the Rspack version with `overrides` as follows:
+
+```json title=package.json
+{
+  "pnpm": {
+    "overrides": {
+      "@rspack/core": "nightly",
+      "@rspack/dev-client": "nightly",
+      "@rspack/dev-middleware": "nightly",
+      "@rspack/plugin-html": "nightly",
+      "@rspack/postcss-loader": "nightly"
+    }
+  }
+}
+```
+
+:::tip What is Rspack Nightly Version
+The Rspack nightly build fully replicates the full release build for catching errors early.
+Usually it is available and any errors that arise will fixed promptly.
+However, if there are any break changes that require modern.js to modify the code, we recommend to wait for the next version of modern.js.
+:::
+
+More examples of using package management tools, please refer to: [Lock nested dependency](/guides/get-started/upgrade.html#lock-nested-dependency).

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -58,7 +58,7 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 When migrating from webpack to Rspack, there may have some differences in build and configuration capabilities. For more details, please refer to [Configuration Differences](https://modernjs.dev/builder/en/guide/advanced/rspack-start.html#migrating-from-webpack-to-rspack).
 :::
 
-## The Relationship between Rspack and Modern.js Versions
+## The relationship between Rspack and Modern.js versions
 
 Usually, the latest version of Rspack will be integrated into Modern.js. You can update the Modern.js-related dependencies and built-in Rspack to the latest version by using `npx modern upgrade` in your project.
 

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -70,7 +70,7 @@ When Rspack is enabled for building through dev / build, the current version of 
 
 ### Modifying the Built-in Rspack Version
 
-You can modify Rspack to a specified version using the dependency upgrade method provided by package management tools such as pnpm / yarn / npm.
+You can override Rspack to a specific version using the capbilities provided by package managers such as pnpm, yarn, npm.
 
 For example, if you are using pnpm, you can update the Rspack version with `overrides` as shown below:
 

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -72,7 +72,7 @@ When Rspack is enabled for building through dev / build, the current version of 
 
 You can modify Rspack to a specified version using the dependency upgrade method provided by package management tools such as pnpm / yarn / npm.
 
-For example, using pnpm, you can update the Rspack version with `overrides` as follows:
+For example, if you are using pnpm, you can update the Rspack version with `overrides` as shown below:
 
 ```json title=package.json
 {

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -94,4 +94,4 @@ Rspack 每天会从基于最新的代码自动构建发布 nightly 版本用于�
 通常情况下，这些版本是可用的。如果发现问题，我们会及时进行修复。但是，如果 Rspack 有一些 break change，需要 Modern.js 同步修改代码，那么我们建议等待下一个 Modern.js 版本再进行更新。
 :::
 
-更多包管理工具使用示例可参考：[锁定子依赖](/guides/get-started/upgrade.html#%E9%94%81%E5%AE%9A%E5%AD%90%E4%BE%9D%E8%B5%96)。
+如果想了解其他包管理工具锁定依赖版本的示例，可以参考：[锁定子依赖](/guides/get-started/upgrade.html#%E9%94%81%E5%AE%9A%E5%AD%90%E4%BE%9D%E8%B5%96)。

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -65,7 +65,7 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 
 但 Modern.js 对于 Rspack 的依赖方式为锁版本方式(非自动升级)，由于发版周期不同步等原因，可能会出现 Modern.js 内集成的 Rspack 版本落后于 Rspack 最新版本的情况。
 
-当通过 dev / build 执行 Rspack 构建时，会自动打印当前框架内所用的 Rspack 版本：
+当你执行 dev / build 命令时，Modern.js 会自动打印当前使用的 Rspack 版本：
 
 ![rspack_version_log](https://lf3-static.bytednsdoc.com/obj/eden-cn/6221eh7uhbfvhn/modern/img_v2_dfcf051f-21db-4741-a108-d9f7a82c3abg.png)
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -59,7 +59,7 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 从 webpack 迁移至 Rspack 时，存在一些构建能力和配置上的差异，详情可参考：[配置差异](https://modernjs.dev/builder/guide/advanced/rspack-start.html#从-webpack-迁移到-rspack)
 :::
 
-## Rspack 和 Modern.js 版本关系
+## Rspack 和 Modern.js 的版本关系
 
 通常情况下，Modern.js 内会集成 Rspack 的最新版本，通过 `npx modern upgrade` 即可将当前项目中的 Modern.js 相关依赖以及内置的 Rspack 更新至最新版本。
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -71,7 +71,7 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 
 #### 修改内置 Rspack 版本
 
-可通过 pnpm / yarn / npm 等包管理工具自带的依赖升级方式修改 Rspack 至指定版本。
+可以使用 pnpm / yarn / npm 等包管理工具自带的依赖升级功能来将 Rspack 强制升级到指定版本。
 
 以 pnpm 为例，可通过 `overrides` 以下依赖更新 Rspack 版本:
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -58,3 +58,40 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 :::tip
 从 webpack 迁移至 Rspack 时，存在一些构建能力和配置上的差异，详情可参考：[配置差异](https://modernjs.dev/builder/guide/advanced/rspack-start.html#从-webpack-迁移到-rspack)
 :::
+
+## Rspack 和 Modern.js 版本关系
+
+通常情况下，Modern.js 内会集成 Rspack 的最新版本，通过 `npx modern upgrade` 即可将当前项目中的 Modern.js 相关依赖以及内置的 Rspack 更新至最新版本。
+
+但 Modern.js 对于 Rspack 的依赖方式为锁版本方式(非自动升级)，由于发版周期不同步等原因，可能会出现 Modern.js 内集成的 Rspack 版本落后于 Rspack 最新版本的情况。
+
+当通过 dev / build 执行 Rspack 构建时，会自动打印当前框架内所用的 Rspack 版本：
+
+![rspack_version_log](https://lf3-static.bytednsdoc.com/obj/eden-cn/6221eh7uhbfvhn/modern/img_v2_dfcf051f-21db-4741-a108-d9f7a82c3abg.png)
+
+#### 修改内置 Rspack 版本
+
+可通过 pnpm / yarn / npm 等包管理工具自带的依赖升级方式修改 Rspack 至指定版本。
+
+以 pnpm 为例，可通过 `overrides` 以下依赖更新 Rspack 版本:
+
+```json title=package.json
+{
+  "pnpm": {
+    "overrides": {
+      "@rspack/core": "nightly",
+      "@rspack/dev-client": "nightly",
+      "@rspack/dev-middleware": "nightly",
+      "@rspack/plugin-html": "nightly",
+      "@rspack/postcss-loader": "nightly"
+    }
+  }
+}
+```
+
+:::tip Nightly 版本介绍
+Rspack 每天会从基于最新的代码自动构建发布 nightly 版本用于测试，以便及早发现错误。
+通常情况下它是可用的，当出现问题时我们会第一时间进行修复，但如果有一些 break change 需要 modern.js 同步修改代码，此时推荐等待下一个 modern.js 版本。
+:::
+
+更多包管理工具使用示例可参考：[锁定子依赖](/guides/get-started/upgrade.html#%E9%94%81%E5%AE%9A%E5%AD%90%E4%BE%9D%E8%B5%96)。

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -91,7 +91,7 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 
 :::tip Nightly 版本介绍
 Rspack 每天会从基于最新的代码自动构建发布 nightly 版本用于测试，以便及早发现错误。
-通常情况下它是可用的，当出现问题时我们会第一时间进行修复，但如果有一些 break change 需要 modern.js 同步修改代码，此时推荐等待下一个 modern.js 版本。
+通常情况下，这些版本是可用的。如果发现问题，我们会及时进行修复。但是，如果 Rspack 有一些 break change，需要 Modern.js 同步修改代码，那么我们建议等待下一个 Modern.js 版本再进行更新。
 :::
 
 更多包管理工具使用示例可参考：[锁定子依赖](/guides/get-started/upgrade.html#%E9%94%81%E5%AE%9A%E5%AD%90%E4%BE%9D%E8%B5%96)。

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -90,7 +90,7 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
 ```
 
 :::tip Nightly 版本介绍
-Rspack 每天会从基于最新的代码自动构建发布 nightly 版本用于测试，以便及早发现错误。
+每天，Rspack 会自动构建基于最新代码的 nightly 版本，用于测试和及早发现错误。
 通常情况下，这些版本是可用的。如果发现问题，我们会及时进行修复。但是，如果 Rspack 有一些 break change，需要 Modern.js 同步修改代码，那么我们建议等待下一个 Modern.js 版本再进行更新。
 :::
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3490c99</samp>

This pull request updates the documentation of Rspack, a web development toolchain, in both English and Chinese. It adds a new section that explains how to use different versions of Rspack with Modern.js, a web framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3490c99</samp>

*  Add a new section to the Rspack documentation in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3734/files?diff=unified&w=0#diff-eda7074c67ef707f70206cf9404950df1e4b9de3c8b7831a6c951b38af9403ceR60-R97), [link](https://github.com/web-infra-dev/modern.js/pull/3734/files?diff=unified&w=0#diff-6b5d7dabc07cedb68247471404a2ee5ea2426fb560961f24781a4ab144909737R61-R97))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
