### PR TITLE
feat(app-tools): SSR mode support async entry

### DIFF
--- a/.changeset/chilly-ducks-perform.md
+++ b/.changeset/chilly-ducks-perform.md
@@ -4,3 +4,4 @@
 ---
 
 chore: ssr mode support async entry
+chore: ssr 模式支持异步入口

--- a/.changeset/chilly-ducks-perform.md
+++ b/.changeset/chilly-ducks-perform.md
@@ -3,5 +3,5 @@
 '@modern-js/prod-server': patch
 ---
 
-chore: ssr mode support async entry
-chore: ssr 模式支持异步入口
+feat: ssr mode support async entry
+feat: ssr 模式支持异步入口

--- a/.changeset/chilly-ducks-perform.md
+++ b/.changeset/chilly-ducks-perform.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/prod-server': patch
+---
+
+chore: ssr mode support async entry

--- a/packages/server/prod-server/src/libs/render/ssr.ts
+++ b/packages/server/prod-server/src/libs/render/ssr.ts
@@ -78,7 +78,7 @@ export const render = async (
   context.metrics = createMetrics(context, ctx.metrics);
 
   runner.extendSSRContext(context);
-  const bundleJSContent = await require(bundleJS);
+  const bundleJSContent = await Promise.resolve(require(bundleJS));
   const serverRender = bundleJSContent[SERVER_RENDER_FUNCTION_NAME];
   const content = await cache(serverRender, ctx)(context);
 

--- a/packages/server/prod-server/src/libs/render/ssr.ts
+++ b/packages/server/prod-server/src/libs/render/ssr.ts
@@ -78,7 +78,8 @@ export const render = async (
   context.metrics = createMetrics(context, ctx.metrics);
 
   runner.extendSSRContext(context);
-  const serverRender = require(bundleJS)[SERVER_RENDER_FUNCTION_NAME];
+  const bundleJSContent = await require(bundleJS);
+  const serverRender = bundleJSContent[SERVER_RENDER_FUNCTION_NAME];
   const content = await cache(serverRender, ctx)(context);
 
   const { url, status = 302 } = context.redirection;

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -6,6 +6,7 @@ import {
   isSSGEntry,
   isUseSSRBundle,
   logger,
+  SERVER_RENDER_FUNCTION_NAME,
 } from '@modern-js/utils';
 import { IAppContext, PluginAPI } from '@modern-js/core';
 import type {
@@ -294,13 +295,13 @@ export const generateCode = async (
         );
         if (ssr) {
           rawAsyncEntryCode = `
-          export const serverRender = async (...args) => {
-            let exports = await ${rawAsyncEntryCode};
-            if(exports.default instanceof Promise){
-              exports = await exports.default;
-              return exports.default.serverRender.apply(null, args);
+          export const ${SERVER_RENDER_FUNCTION_NAME} = async (...args) => {
+            let entry = await ${rawAsyncEntryCode};
+            if (entry.default instanceof Promise){
+              entry = await entry.default;
+              return entry.default.${SERVER_RENDER_FUNCTION_NAME}.apply(null, args);
             }
-            return exports.serverRender.apply(null, args);
+            return entry.${SERVER_RENDER_FUNCTION_NAME}.apply(null, args);
           };
           if(typeof window!=='undefined'){
             ${rawAsyncEntryCode}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

support `source.enableAsyncEntry` works on ssr mode

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

`source.enableAsyncEntry` will enable async entry , and it works smoothly on csr mode .

But ssr mode doesn't support it ,cause it need some change with entry code and server consumer .

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
