### PR TITLE
fix: should only watch file-based routes changes

### DIFF
--- a/.changeset/sour-cobras-cheat.md
+++ b/.changeset/sour-cobras-cheat.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: should only watch file-based routes changes
+fix: 只有基于文件的路由（约定式路由）需要被监听变化

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -113,7 +113,7 @@ export default ({
 
         pagesDir = entrypoints
           .map(point => point.entry)
-          // only file-based routes should be watched
+          // should only watch file-based routes
           .filter(entry => entry && !path.extname(entry))
           .concat(nestedRouteEntries);
 

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -113,7 +113,8 @@ export default ({
 
         pagesDir = entrypoints
           .map(point => point.entry)
-          .filter(Boolean)
+          // only file-based routes should be watched
+          .filter(entry => entry && !path.extname(entry))
           .concat(nestedRouteEntries);
 
         originEntrypoints = cloneDeep(entrypoints);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f99bdf</samp>

This pull request fixes a bug in the `@modern-js/app-tools` package that caused unnecessary reloads when dynamic or custom routes changed. It adds a changeset file to document the patch version bump and the bug fix details.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f99bdf</samp>

*  Add a changeset file to document the fixes for the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/3742/files?diff=unified&w=0#diff-d359753e316fe09fda5f463f4494759f9f2513c19316ea8b1bb2020efb7e3038R1-R6))
*  Filter out entries with extensions from the `pagesDir` variable in the `analyze` module of the `@modern-js/app-tools` package, to only collect file-based routes directories ([link](https://github.com/web-infra-dev/modern.js/pull/3742/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L116-R117))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
