### PR TITLE
fix(builder): should not print file size of LICENSE.text

### DIFF
--- a/.changeset/gold-dingos-occur.md
+++ b/.changeset/gold-dingos-occur.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': patch
+---
+
+fix(builder): should not print file size of LICENSE.text
+
+fix(builder): 打印文件体积时忽略 LICENSE.text

--- a/packages/builder/builder/src/plugins/fileSize.ts
+++ b/packages/builder/builder/src/plugins/fileSize.ts
@@ -12,8 +12,9 @@ import {
 } from '@modern-js/builder-shared';
 import type { DefaultBuilderPlugin } from '@modern-js/builder-shared';
 
-/** Filter source map files */
-export const filterAsset = (asset: string) => !/\.map$/.test(asset);
+/** Filter source map and license files */
+export const filterAsset = (asset: string) =>
+  !/\.map$/.test(asset) && !/\.LICENSE\.txt$/.test(asset);
 
 const getAssetColor = (size: number) => {
   if (size > 300 * 1000) {

--- a/packages/builder/builder/tests/plugins/fileSize.test.ts
+++ b/packages/builder/builder/tests/plugins/fileSize.test.ts
@@ -7,6 +7,8 @@ describe('plugins/fileSize', () => {
     expect(filterAsset('dist/a.css')).toBeTruthy();
     expect(filterAsset('dist/a.js.map')).toBeFalsy();
     expect(filterAsset('dist/b.css.map')).toBeFalsy();
+    expect(filterAsset('dist/a.js.LICENSE.txt')).toBeFalsy();
+    expect(filterAsset('dist/b.css.LICENSE.txt')).toBeFalsy();
     expect(filterAsset('dist/a.png')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

![飞书20230524-104756](https://github.com/web-infra-dev/modern.js/assets/7237365/6f855744-40e0-4858-b935-bf699278cb15)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9cccf0d</samp>

This pull request fixes the issue of printing irrelevant file sizes of `LICENSE.txt` files in the `@modern-js/builder` package. It updates the `filterAsset` function in the `fileSize` plugin, adds a changeset file, and adds test cases for the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9cccf0d</samp>

*  Add a changeset file to document the patch update for the `@modern-js/builder` package and the fix for the file size issue ([link](https://github.com/web-infra-dev/modern.js/pull/3746/files?diff=unified&w=0#diff-cc610b22494148496f57e1fad455c1608f493ec14cd074bfc90c3c4c5495f2adR1-R7))
*  Modify the `filterAsset` function in the `fileSize` plugin to exclude the `LICENSE.txt` files from the assets ([link](https://github.com/web-infra-dev/modern.js/pull/3746/files?diff=unified&w=0#diff-6ea934f4ff87cceb10e4b242f1d4bd387385ba4bb5eba12d71ed78e34a1ae944L15-R17))
*  Add two test cases to the `fileSize.test.ts` file to check the `filterAsset` function ([link](https://github.com/web-infra-dev/modern.js/pull/3746/files?diff=unified&w=0#diff-8eee9b8d6b1a47fdd739aa8db0aa75f439830f42a1faaea378664159b88af3aeR10-R11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
