### PR TITLE
feat(app-tools): add isFirstCompile param to afterDev hook

### DIFF
--- a/.changeset/loud-pears-argue.md
+++ b/.changeset/loud-pears-argue.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat(app-tools): add isFirstCompile param to afterDev hook
+
+feat(app-tools): 为 afterDev 钩子增加 isFirstCompile 参数

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -260,9 +260,9 @@ export default (): CliPlugin => ({
 ### `afterDev`
 
 - Function: Tasks to be executed after the main process of `dev` command
-- Execution Stage: Executed after the project is started when running the `dev` command
+- Execution Stage: It is executed after each compilation is completed when running the `dev` command
 - Hook Model: AsyncWorkflow
-- Type: `AsyncWorkflow<void, unknown>`
+- Type: `AsyncWorkflow<{ isFirstCompile: boolean }, unknown>`
 - Usage Example:
 
 ```ts
@@ -273,6 +273,24 @@ export default (): CliPlugin => ({
     return {
       afterDev: () => {
         // do something
+      },
+    };
+  },
+});
+```
+
+`afterDev` will be executed after each compilation is completed, you can use the `isFirstCompile` param to determine whether it is the first compilation:
+
+```ts
+import type { CliPlugin } from '@modern-js/core';
+
+export default (): CliPlugin => ({
+  setup(api) {
+    return {
+      afterDev: ({ isFirstCompile }) => {
+        if (isFirstCompile) {
+          // do something
+        }
       },
     };
   },
@@ -776,7 +794,7 @@ export default (): Plugin => ({
           );
         };
         return next({
-          App: hoistNonReactStatics(AppWrapper, App)
+          App: hoistNonReactStatics(AppWrapper, App),
         });
       },
     };

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -2,6 +2,7 @@
 title: Hook 列表
 sidebar_position: 8
 ---
+
 # Hook 列表
 
 在 Modern.js 中暴露了三类插件：CLI、Runtime、Server。下面列举下各类中的 Hook：
@@ -166,7 +167,6 @@ export default (): CliPlugin => ({
 });
 ```
 
-
 ### `commands`
 
 - 功能：为 command 添加新的命令
@@ -260,9 +260,9 @@ export default (): CliPlugin => ({
 ### `afterDev`
 
 - 功能：运行 dev 主流程的之后的任务
-- 执行阶段：`dev` 命令运行时，项目启动完成之后执行
+- 执行阶段：运行 `dev` 命令时，每一次编译完成后执行
 - Hook 模型：AsyncWorkflow
-- 类型：`AsyncWorkflow<void, unknown>`
+- 类型：`AsyncWorkflow<{ isFirstCompile: boolean }, unknown>`
 - 使用示例：
 
 ```ts
@@ -273,6 +273,24 @@ export default (): CliPlugin => ({
     return {
       afterDev: () => {
         // do something
+      },
+    };
+  },
+});
+```
+
+`afterDev` 会在每一次编译完成后执行，你可以通过 `isFirstCompile` 参数来判断是否为首次编译：
+
+```ts
+import type { CliPlugin } from '@modern-js/core';
+
+export default (): CliPlugin => ({
+  setup(api) {
+    return {
+      afterDev: ({ isFirstCompile }) => {
+        if (isFirstCompile) {
+          // do something
+        }
       },
     };
   },
@@ -778,7 +796,7 @@ export default (): Plugin => ({
           );
         };
         return next({
-          App: hoistNonReactStatics(AppWrapper, App)
+          App: hoistNonReactStatics(AppWrapper, App),
         });
       },
     };

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -179,7 +179,7 @@ export default ({
             async onDevCompileDone({ isFirstCompile }) {
               const hookRunners = api.useHookRunners();
               if (process.stdout.isTTY || isFirstCompile) {
-                hookRunners.afterDev();
+                hookRunners.afterDev({ isFirstCompile });
 
                 if (isFirstCompile) {
                   printInstructions(hookRunners, appContext, normalizedConfig);

--- a/packages/solutions/app-tools/src/types/hooks.ts
+++ b/packages/solutions/app-tools/src/types/hooks.ts
@@ -76,7 +76,7 @@ export type AppToolsHooks<B extends Bundler = 'webpack'> = {
 
   // beforeCreateBuilder
   beforeDev: AsyncWorkflow<void, unknown>;
-  afterDev: AsyncWorkflow<void, unknown>;
+  afterDev: AsyncWorkflow<{ isFirstCompile: boolean }, unknown>;
   beforeCreateCompiler: AsyncWorkflow<
     {
       bundlerConfigs?: B extends 'rspack'


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b824f9</samp>

This pull request adds a new feature to the `afterDev` hook in the `@modern-js/app-tools` package, which allows the hook to know whether it is the first compilation or not. It also improves the documentation and type definition of the hook in both English and Chinese. The changes are documented in a changeset file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b824f9</samp>

*  Add `isFirstCompile` parameter to `afterDev` hook to enable conditional tasks after each compilation ([link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-02adbc41f62cec2309dc9c51b5cd4e896ce50abd671e09cb1dc19bb1edb8f852R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L182-R182), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-042c0864d94c683d2cc46e22752f744d1be4a31661ede69b34cc13b23697f9feL79-R79))
*  Update English and Chinese documentation of `afterDev` hook in `framework-plugin` guide to reflect the new feature and provide usage examples ([link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L263-R265), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4R282-R299), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L779-R797), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5R5), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L169), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L263-R265), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5R282-R299), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L781-R799))
*  Fix minor formatting issues in documentation by adding trailing commas to `next` function calls ([link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L779-R797), [link](https://github.com/web-infra-dev/modern.js/pull/3748/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L781-R799))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
