### PR TITLE
feat: ssr runtime need webpack.output.chunkLoadingGlobal pass to loadableReady

### DIFF
--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -184,11 +184,18 @@ export default (): CliPlugin<AppTools> => ({
           imports,
         };
       },
-      modifyEntryRuntimePlugins({ entrypoint, plugins }: any) {
+      modifyEntryRuntimePlugins({ entrypoint, plugins, bundlerConfigs }) {
         if (ssrConfigMap.get(entrypoint.entryName)) {
+          const chunkLoadingGlobal = bundlerConfigs?.find(
+            config => config.name === 'client',
+          )?.output?.chunkLoadingGlobal;
+
           plugins.push({
             name: PLUGIN_IDENTIFIER,
-            options: JSON.stringify(ssrConfigMap.get(entrypoint.entryName)),
+            options: JSON.stringify({
+              ...(ssrConfigMap.get(entrypoint.entryName) || {}),
+              chunkLoadingGlobal,
+            }),
           });
         }
         return {

--- a/packages/runtime/plugin-runtime/src/ssr/index.tsx
+++ b/packages/runtime/plugin-runtime/src/ssr/index.tsx
@@ -54,6 +54,10 @@ export const ssr = (config: SSRPluginConfig): Plugin => ({
         return stringSSRHydrate();
 
         function stringSSRHydrate() {
+          const loadableReadyOptions: any = {
+            chunkLoadingGlobal: config.chunkLoadingGlobal,
+          };
+
           // client render and server prefetch use same logic
           if (
             renderLevel === RenderLevel.CLIENT_RENDER ||
@@ -71,11 +75,11 @@ export const ssr = (config: SSRPluginConfig): Plugin => ({
                 );
                 SSRApp = hoistNonReactStatics(SSRApp, App);
                 ModernHydrate(<SSRApp />);
-              });
+              }, loadableReadyOptions);
             } else {
               loadableReady(() => {
                 ModernHydrate(<App context={hydrateContext} />, callback);
-              });
+              }, loadableReadyOptions);
             }
           } else {
             // unknown renderlevel or renderlevel is server prefetch.

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
@@ -8,6 +8,7 @@ export { RuntimeContext, RenderLevel };
 
 export type SSRPluginConfig = {
   crossorigin?: boolean | 'anonymous' | 'use-credentials';
+  chunkLoadingGlobal?: string;
 } & Exclude<ServerUserConfig['ssr'], boolean>;
 
 export type ServerRenderOptions = {

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -265,6 +265,7 @@ export const generateIndexCode = async ({
     internalSrcAlias,
     internalDirAlias,
     internalDirectory,
+    packageName,
   } = appContext;
 
   await Promise.all(

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -22,6 +22,8 @@ import {
   AppTools,
   ImportSpecifier,
   ImportStatement,
+  Rspack,
+  webpack,
 } from '../types';
 import * as templates from './templates';
 import { getClientRoutes, getClientRoutesLegacy } from './getClientRoutes';
@@ -115,14 +117,12 @@ export const generateCode = async (
   const hookRunners = api.useHookRunners();
 
   const isV5 = isRouterV5(config);
-  const { mountId } = config.html;
   const getRoutes = isV5 ? getClientRoutesLegacy : getClientRoutes;
 
   await Promise.all(entrypoints.map(generateEntryCode));
 
   async function generateEntryCode(entrypoint: Entrypoint) {
-    const { entryName, isAutoMount, customBootstrap, fileSystemRoutes } =
-      entrypoint;
+    const { entryName, isAutoMount, fileSystemRoutes } = entrypoint;
     if (isAutoMount) {
       // generate routes file for file system routes entrypoint.
       if (fileSystemRoutes) {
@@ -233,7 +233,43 @@ export const generateCode = async (
           code,
           'utf8',
         );
+
+        // !modify the entrypoint.entry
+        const entryFile = path.resolve(
+          internalDirectory,
+          `./${entryName}/${ENTRY_POINT_FILE_NAME}`,
+        );
+        entrypoint.entry = entryFile;
       }
+    }
+  }
+};
+
+export const generateIndexCode = async ({
+  appContext,
+  api,
+  entrypoints,
+  bundlerConfigs,
+  config,
+}: {
+  appContext: IAppContext;
+  api: PluginAPI<AppTools<'shared'>>;
+  entrypoints: Entrypoint[];
+  config: AppNormalizedConfig<'shared'>;
+  bundlerConfigs?: webpack.Configuration[] | Rspack.Configuration[];
+}) => {
+  const hookRunners = api.useHookRunners();
+  const { mountId } = config.html;
+  const {
+    srcDirectory,
+    internalSrcAlias,
+    internalDirAlias,
+    internalDirectory,
+  } = appContext;
+
+  await Promise.all(
+    entrypoints.map(async entrypoint => {
+      const { entryName, customBootstrap, fileSystemRoutes } = entrypoint;
 
       // call modifyEntryImports hook
       const { imports: importStatements } =
@@ -252,6 +288,7 @@ export const generateCode = async (
       const { plugins } = await hookRunners.modifyEntryRuntimePlugins({
         entrypoint,
         plugins: [],
+        bundlerConfigs: bundlerConfigs as any,
       });
 
       // call modifyEntryRenderFunction hook
@@ -282,7 +319,6 @@ export const generateCode = async (
         internalDirectory,
         `./${entryName}/${ENTRY_POINT_FILE_NAME}`,
       );
-      entrypoint.entry = entryFile;
 
       // generate entry file.
       if (config.source.enableAsyncEntry) {
@@ -322,6 +358,6 @@ export const generateCode = async (
       } else {
         fs.outputFileSync(entryFile, code, 'utf8');
       }
-    }
-  }
+    }),
+  );
 };

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -24,6 +24,7 @@ import {
   APP_INIT_EXPORTED,
   APP_INIT_IMPORTED,
 } from './constants';
+import { generateIndexCode } from './generateCode';
 
 const debug = createDebugger('plugin-analyze');
 
@@ -162,6 +163,13 @@ export default ({
             async onBeforeBuild({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
               await generateRoutes(appContext);
+              await generateIndexCode({
+                appContext,
+                config: resolvedConfig,
+                entrypoints,
+                api,
+                bundlerConfigs,
+              });
               await hookRunners.beforeBuild({
                 bundlerConfigs:
                   bundlerConfigs as unknown as webpack.Configuration[],
@@ -190,6 +198,13 @@ export default ({
 
             async onBeforeCreateCompiler({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
+              await generateIndexCode({
+                appContext,
+                config: resolvedConfig,
+                entrypoints,
+                api,
+                bundlerConfigs,
+              });
               // run modernjs framework `beforeCreateCompiler` hook
               await hookRunners.beforeCreateCompiler({
                 bundlerConfigs:

--- a/packages/solutions/app-tools/src/types/hooks.ts
+++ b/packages/solutions/app-tools/src/types/hooks.ts
@@ -45,6 +45,9 @@ export type AppToolsHooks<B extends Bundler = 'webpack'> = {
   modifyEntryRuntimePlugins: AsyncWaterfall<{
     entrypoint: Entrypoint;
     plugins: RuntimePlugin[];
+    bundlerConfigs?: B extends 'rspack'
+      ? Rspack.Configuration[]
+      : webpack.Configuration[];
   }>;
   modifyEntryRenderFunction: AsyncWaterfall<{
     entrypoint: Entrypoint;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46c5947</samp>

This pull request adds SSR support to the app-tools and plugin-runtime packages by introducing a new `chunkLoadingGlobal` option for the SSR plugin and using it to improve the hydration logic and the code generation. It also refactors the generateCode module to use the Rspack and webpack modules and simplify the entry code generation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46c5947</samp>

*  Add `chunkLoadingGlobal` property to SSR plugin options and pass it to `loadableReady` function calls for SSR hydration ([link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L187-R198), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-1d68f5f1af4a1f2639aada724010dd1a59c8a08d80883f532c11d85d3a99868fR57-R60), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-1d68f5f1af4a1f2639aada724010dd1a59c8a08d80883f532c11d85d3a99868fL74-R82), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-7bb2b37d7c4c35db7a1d3fbfbd76ed3192cc5ca45a0a749df4661179ad395c32R11))
*  Move entrypoint.entry modification logic from `generateEntryCode` to `generateIndexCode` and export the latter function ([link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L236-R274), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L285), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1R27), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1R165-R171), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1R200-R206))
*  Add `bundlerConfigs` property to `modifyEntryRuntimePlugins` hook options and pass it to SSR plugin in `generateIndexCode` ([link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0R25-R26), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0R292), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-042c0864d94c683d2cc46e22752f744d1be4a31661ede69b34cc13b23697f9feR48-R50))
*  Wrap `generateEntryCode` in `Promise.all` for parallel execution ([link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L325-R363))
*  Remove unused variables and properties from `generateCode` module ([link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L118), [link](https://github.com/web-infra-dev/modern.js/pull/3752/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L124-R125))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
