### PR TITLE
fix(dev-server): adjust HMR connection log level

### DIFF
--- a/.changeset/sixty-mangos-love.md
+++ b/.changeset/sixty-mangos-love.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server': patch
+---
+
+fix(dev-server): adjust hmr connection log level
+
+fix(dev-server): 调整 hmr 连接的日志级别

--- a/packages/server/server/src/dev-tools/dev-middleware/hmr-client/index.ts
+++ b/packages/server/server/src/dev-tools/dev-middleware/hmr-client/index.ts
@@ -28,9 +28,9 @@ const socketUrl = createSocketUrl(__resourceQuery);
 const connection = new WebSocket(socketUrl);
 
 connection.onopen = function () {
-  if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+  if (typeof console !== 'undefined' && typeof console.info === 'function') {
     // Notify users that the HMR has successfully connected.
-    console.debug('[HMR] connected.');
+    console.info('[HMR] connected.');
   }
 };
 
@@ -39,7 +39,7 @@ connection.onopen = function () {
 // when developer stops the server.
 connection.onclose = function () {
   if (typeof console !== 'undefined' && typeof console.info === 'function') {
-    console.debug('[HMR] disconnected. Refresh the page if necessary.');
+    console.info('[HMR] disconnected. Refresh the page if necessary.');
   }
 };
 


### PR DESCRIPTION
## Summary

Change the HMR connection log level from `debug` to `info` as Chrome does not display `console.debug` by default.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4945dcc</samp>

This pull request fixes a logging issue in the `hmr-client` module of the `@modern-js/server` package and updates the changeset file accordingly. The fix improves the visibility and usability of the HMR feature for the users.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4945dcc</samp>

* Lower log level of HMR connection and disconnection messages to `info` for better visibility and troubleshooting ([link](https://github.com/web-infra-dev/modern.js/pull/3755/files?diff=unified&w=0#diff-7cdf9a674c72d3a2c1f9762d9f97a5d858f7443950b59c70415e32e785869b82L31-R33),[link](https://github.com/web-infra-dev/modern.js/pull/3755/files?diff=unified&w=0#diff-7cdf9a674c72d3a2c1f9762d9f97a5d858f7443950b59c70415e32e785869b82L42-R42))
* Add changeset file for patch update of `@modern-js/server` package with summary of fix in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3755/files?diff=unified&w=0#diff-d1e1d2cfb6ff6bac7d55805ff171206f888ee96d3194acfa07a061eedad648f7R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
