### PR TITLE
fix(doc-core): mdx flatten path resolve

### DIFF
--- a/.changeset/silent-actors-marry.md
+++ b/.changeset/silent-actors-marry.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): mdx flatten path resolve
+
+fix(doc-core): mdx 文件扁平化过程中路径解析错误

--- a/packages/cli/doc-core/src/node/runtimeModule/siteData.ts
+++ b/packages/cli/doc-core/src/node/runtimeModule/siteData.ts
@@ -242,7 +242,6 @@ async function extractPageData(
             );
           }
         });
-
         // TODO: we will find a more efficient way to do this
         const flattenContent = await flattenMdxContent(
           frontmatter.__content,


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7c74cc</samp>

This pull request fixes a bug in the `@modern-js/doc-core` package that caused path resolution errors during the mdx file flattening process. It also updates the package version and the changelog using the `@changesets/cli` tool.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7c74cc</samp>

*  Add a changeset file to describe the patch version update and the bug fix for the `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/3756/files?diff=unified&w=0#diff-a713e3ec03ca9c8f08652b4dabdde202565cc65b980490f8463cdc290466b884R1-R7))
*  Fix the path resolution error during the mdx file flattening process by creating a resolver with the alias configuration from the `docConfig.ts` file and using it to resolve the import paths in the mdx files ([link](https://github.com/web-infra-dev/modern.js/pull/3756/files?diff=unified&w=0#diff-2ce8de590c529b28f3a2bf80a62718455661c3ad2ba9e4efb2de10b59093d5ebL10-R12), [link](https://github.com/web-infra-dev/modern.js/pull/3756/files?diff=unified&w=0#diff-2ce8de590c529b28f3a2bf80a62718455661c3ad2ba9e4efb2de10b59093d5ebL57-R67))
*  Remove an empty line from the `siteData.ts` file for code style improvement ([link](https://github.com/web-infra-dev/modern.js/pull/3756/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL245))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
