### PR TITLE
docs(builder): search result should not contain doc fragments

### DIFF
--- a/packages/document/builder-doc/modern.config.ts
+++ b/packages/document/builder-doc/modern.config.ts
@@ -174,7 +174,13 @@ export default defineConfig({
       experimentalMdxRs: true,
     },
     route: {
-      exclude: ['**/config/**'],
+      // exclude document fragments from routes
+      exclude: [
+        '**/zh/config/**',
+        '**/en/config/**',
+        '**/zh/shared/**',
+        '**/en/shared/**',
+      ],
     },
     themeConfig: {
       footer: {

--- a/packages/document/main-doc/modern.config.ts
+++ b/packages/document/main-doc/modern.config.ts
@@ -130,7 +130,8 @@ export default defineConfig({
       ],
     },
     route: {
-      exclude: ['scripts/**', '**/components/**'],
+      // exclude document fragments from routes
+      exclude: ['scripts/**', '**/zh/components/**', '**/en/components/**'],
     },
     builderConfig: {
       output: {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a5e28d</samp>

Exclude document fragments from generated routes in `modern.config.ts` files for document packages. This prevents the fragments from being treated as standalone pages in the documentation websites for the Modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a5e28d</samp>

*  Exclude document fragments from generated routes for document packages `builder-doc` and `main-doc` ([link](https://github.com/web-infra-dev/modern.js/pull/3759/files?diff=unified&w=0#diff-fc9e3b9be79489436a867bcdd7e7d56a5d8a90bd8c0390fdb2166410e494495fL177-R183), [link](https://github.com/web-infra-dev/modern.js/pull/3759/files?diff=unified&w=0#diff-2b922c5ce43b774ae4f1e3b58a99701031c70908fa0eab909028eb24631381fdL133-R134))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
