### PR TITLE
fix(plugin-esbuild): set minify format to iife when target is web

### DIFF
--- a/.changeset/quick-hairs-doubt.md
+++ b/.changeset/quick-hairs-doubt.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-esbuild': patch
+---
+
+fix(plugin-esbuild): set minify format to iife when target is web
+
+fix(plugin-esbuild): 当 target 为 web 时，将压缩的 format 设置为 iife

--- a/packages/builder/plugin-esbuild/src/index.ts
+++ b/packages/builder/plugin-esbuild/src/index.ts
@@ -18,13 +18,13 @@ export function builderPluginEsbuild(
     name: 'builder-plugin-esbuild',
 
     setup(api) {
-      api.modifyWebpackChain(async (chain, { CHAIN_ID, isProd }) => {
+      api.modifyWebpackChain(async (chain, { CHAIN_ID, isProd, target }) => {
         const builderConfig = api.getNormalizedConfig();
         const compiledEsbuildLoaderPath = require.resolve(
           '../compiled/esbuild-loader',
         );
 
-        const options = {
+        const options: PluginEsbuildOptions = {
           loader: {
             target: 'es2015',
             charset: builderConfig.output.charset,
@@ -32,6 +32,7 @@ export function builderPluginEsbuild(
           minimize: {
             css: true,
             target: 'es2015',
+            format: target === 'web' ? 'iife' : undefined,
           },
           ...userOptions,
         };

--- a/packages/builder/plugin-esbuild/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-esbuild/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,54 @@
 // Vitest Snapshot v1
 
+exports[`plugins/esbuild > should not set format iife when target is not web 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/compiled/esbuild-loader/index.js",
+            "options": {
+              "charset": "ascii",
+              "loader": "jsx",
+              "target": "es2015",
+            },
+          },
+        ],
+      },
+      {
+        "test": /\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/compiled/esbuild-loader/index.js",
+            "options": {
+              "charset": "ascii",
+              "loader": "tsx",
+              "target": "es2015",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "optimization": {
+    "minimizer": [
+      ESBuildMinifyPlugin {
+        "options": {
+          "css": true,
+          "format": undefined,
+          "legalComments": "inline",
+          "minify": true,
+          "target": "es2015",
+        },
+        "transform": [Function],
+      },
+    ],
+  },
+}
+`;
+
 exports[`plugins/esbuild > should set esbuild minimizer in production 1`] = `
 {
   "module": {
@@ -37,6 +86,7 @@ exports[`plugins/esbuild > should set esbuild minimizer in production 1`] = `
       ESBuildMinifyPlugin {
         "options": {
           "css": true,
+          "format": "iife",
           "legalComments": "inline",
           "minify": true,
           "target": "es2015",

--- a/packages/builder/plugin-esbuild/tests/index.test.ts
+++ b/packages/builder/plugin-esbuild/tests/index.test.ts
@@ -24,4 +24,17 @@ describe('plugins/esbuild', () => {
 
     process.env.NODE_ENV = 'test';
   });
+
+  it('should not set format iife when target is not web', async () => {
+    process.env.NODE_ENV = 'production';
+    const builder = await createStubBuilder({
+      plugins: [builderPluginEsbuild()],
+      builderConfig: {},
+      target: 'node',
+    });
+    const config = await builder.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+
+    process.env.NODE_ENV = 'test';
+  });
 });

--- a/packages/document/builder-doc/docs/en/plugins/plugin-esbuild.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-esbuild.mdx
@@ -150,6 +150,7 @@ type MinimizeOptions = EsbuildMinifyOptions | false | undefined;
 const defaultOptions = {
   css: true,
   target: 'es2015',
+  format: builderTarget === 'web' ? 'iife' : undefined,
 };
 ```
 

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-esbuild.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-esbuild.mdx
@@ -150,6 +150,7 @@ type MinimizeOptions = EsbuildMinifyOptions | false | undefined;
 const defaultOptions = {
   css: true,
   target: 'es2015',
+  format: builderTarget === 'web' ? 'iife' : undefined,
 };
 ```
 


### PR DESCRIPTION
## Summary

Keep the default format the same as `esbuild-loader` v3. We cannot bump esbuild-loader v3 now because it requires Node.js >= 16.

> The default is iife when esbuild is configured to support a low target, because esbuild injects helper functions at the top of the code. On the web, having functions declared at the top of a script can pollute the global scope. In some cases, this can lead to a variable collision error. By setting format: 'iife', esbuild wraps the helper functions in an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) to prevent them from polluting the global.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

https://github.com/esbuild-kit/esbuild-loader/commit/a9e8e7e1630ab11371f88f9349cad7ebbce57efc

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
