### PR TITLE
fix(builder): webpack version mismatch for fork-ts-checker-webpack-plugin

### DIFF
--- a/.changeset/odd-crabs-share.md
+++ b/.changeset/odd-crabs-share.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): fix the misalignment of the webpack version that fork-ts-checker-webpack-plugin depends on
+
+fix(builder): 修复 fork-ts-checker-webpack-plugin 依赖的 webpack 版本错位问题

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -108,6 +108,7 @@
     "caniuse-lite": "^1.0.30001451",
     "cheerio": "1.0.0-rc.12",
     "source-map": "^0.7.4",
+    "webpack": "^5.82.1",
     "webpack-sources": "^3.2.3",
     "zod": "^3.20.2",
     "zod-validation-error": "^0.3.0"

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -121,8 +121,7 @@
     "@types/node": "^14",
     "html-webpack-plugin": "5.5.0",
     "terser": "^5.14.1",
-    "typescript": "^5",
-    "webpack": "^5.82.1"
+    "typescript": "^5"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,7 @@ importers:
       cheerio: 1.0.0-rc.12
       fork-ts-checker-webpack-plugin: 8.0.0_b73sldshwrlnhikvubwhfqvrfa
       source-map: 0.7.4
+      webpack: 5.82.1
       webpack-sources: 3.2.3
       zod: 3.20.2
       zod-validation-error: 0.3.0_zod@3.20.2
@@ -169,7 +170,6 @@ importers:
       html-webpack-plugin: 5.5.0_webpack@5.82.1
       terser: 5.17.3
       typescript: 5.0.4
-      webpack: 5.82.1
 
   packages/builder/builder-webpack-provider:
     specifiers:


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ccfc084</samp>

This pull request fixes a webpack version bug in the `@modern-js/builder-shared` package by adding webpack as a dependency with a compatible version range. This change affects the `.changeset/odd-crabs-share.md` and `packages/builder/builder-shared/package.json` files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ccfc084</samp>

*  Fix webpack version bug for fork-ts-checker-webpack-plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3764/files?diff=unified&w=0#diff-8ef39cca89b51adeb03914f3aad76b79509daa192de32ea0b302425dff6683d2R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3764/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9R111))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
