### PR TITLE
fix(builder): add autoprefixer deps into webpack-provider

### DIFF
--- a/.changeset/odd-crabs-share.md
+++ b/.changeset/odd-crabs-share.md
@@ -2,6 +2,6 @@
 '@modern-js/builder-shared': patch
 ---
 
-fix(builder): fix the misalignment of the webpack version that fork-ts-checker-webpack-plugin depends on
+fix(builder): fix the misalignment of the dependencies version that fork-ts-checker-webpack-plugin and autoprefixer depends on
 
-fix(builder): 修复 fork-ts-checker-webpack-plugin 依赖的 webpack 版本错位问题
+fix(builder): 修复 fork-ts-checker-webpack-plugin 和 autoprefixer 的依赖版本错位问题

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -96,6 +96,7 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.9",
+    "caniuse-lite": "^1.0.30001451",
     "css-minimizer-webpack-plugin": "5.0.0",
     "cssnano": "6.0.0",
     "html-webpack-plugin": "5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,7 @@ importers:
       '@types/caniuse-lite': ^1.0.1
       '@types/node': ^14
       antd: '4'
+      caniuse-lite: ^1.0.30001451
       css-minimizer-webpack-plugin: 5.0.0
       cssnano: 6.0.0
       html-webpack-plugin: 5.5.0
@@ -208,6 +209,7 @@ importers:
       '@modern-js/types': link:../../toolkit/types
       '@modern-js/utils': link:../../toolkit/utils
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.9_2sh2n464chklv3oeyrys3t3hwy
+      caniuse-lite: 1.0.30001451
       css-minimizer-webpack-plugin: 5.0.0_webpack@5.82.1
       cssnano: 6.0.0_postcss@8.4.21
       html-webpack-plugin: 5.5.0_webpack@5.82.1


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e717df8</samp>

This pull request fixes a version mismatch issue between webpack and autoprefixer that caused incorrect CSS prefixing. It also updates the change log and adds the caniuse-lite dependency to `builder-webpack-provider` for better browser compatibility data.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e717df8</samp>

*  Add caniuse-lite dependency to builder-webpack-provider package to use latest browser compatibility data for autoprefixer ([link](https://github.com/web-infra-dev/modern.js/pull/3765/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1R99))
* Update change log message to include autoprefixer dependency fix in builder package ([link](https://github.com/web-infra-dev/modern.js/pull/3765/files?diff=unified&w=0#diff-8ef39cca89b51adeb03914f3aad76b79509daa192de32ea0b302425dff6683d2L5-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
