### PR TITLE
fix(builder): support array in output.externals when use Rspack

### DIFF
--- a/.changeset/rare-days-return.md
+++ b/.changeset/rare-days-return.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): support array in output.externals when use Rspack
+
+fix(builder): 在使用 Rspack 构建时，output.externals 支持数组

--- a/packages/builder/builder-rspack-provider/src/config/validate/output.ts
+++ b/packages/builder/builder-rspack-provider/src/config/validate/output.ts
@@ -5,6 +5,6 @@ export const outputConfigSchema: z.ZodType<OutputConfig> =
   sharedOutputConfigSchema
     .extend({
       convertToRem: z.union([z.boolean(), z.instanceof(Object)]),
-      externals: z.record(z.string()),
+      externals: z.any(),
     })
     .partial();

--- a/packages/builder/builder-rspack-provider/src/config/validate/output.ts
+++ b/packages/builder/builder-rspack-provider/src/config/validate/output.ts
@@ -2,9 +2,4 @@ import { sharedOutputConfigSchema, z } from '@modern-js/builder-shared';
 import type { OutputConfig } from '../../types';
 
 export const outputConfigSchema: z.ZodType<OutputConfig> =
-  sharedOutputConfigSchema
-    .extend({
-      convertToRem: z.union([z.boolean(), z.instanceof(Object)]),
-      externals: z.any(),
-    })
-    .partial();
+  sharedOutputConfigSchema;

--- a/packages/builder/builder-rspack-provider/src/types/config/output.ts
+++ b/packages/builder/builder-rspack-provider/src/types/config/output.ts
@@ -3,7 +3,7 @@ import type {
   NormalizedSharedOutputConfig,
   RemOptions,
 } from '@modern-js/builder-shared';
-import type { Builtins } from '@rspack/core';
+import type { Builtins, Externals } from '@rspack/core';
 
 export type OutputConfig = SharedOutputConfig & {
   /**
@@ -17,7 +17,7 @@ export type OutputConfig = SharedOutputConfig & {
   /**
    * At build time, prevent some `import` dependencies from being packed into bundles in your code, and instead fetch them externally at runtime.
    */
-  externals?: Record<string, string>;
+  externals?: Externals;
 };
 
 export type NormalizedOutputConfig = OutputConfig &

--- a/packages/builder/builder-shared/src/schema/output.ts
+++ b/packages/builder/builder-shared/src/schema/output.ts
@@ -87,6 +87,7 @@ export const sharedOutputConfigSchema = z.partialObj({
   dataUriLimit: z.union([z.number(), DataUriLimitSchema]),
   legalComments: LegalCommentsSchema,
   cleanDistPath: z.boolean(),
+  convertToRem: z.union([z.boolean(), z.instanceof(Object)]),
   cssModuleLocalIdentName: z.string(),
   disableCssExtract: z.boolean(),
   disableMinimize: z.boolean(),
@@ -101,6 +102,7 @@ export const sharedOutputConfigSchema = z.partialObj({
   enableCssModuleTSDeclaration: z.boolean(),
   enableInlineScripts: z.union([z.boolean(), z.instanceof(RegExp)]),
   enableInlineStyles: z.union([z.boolean(), z.instanceof(RegExp)]),
+  externals: z.any(),
   overrideBrowserslist: z.union([
     z.array(z.string()),
     z.record(BuilderTargetSchema, z.array(z.string())),

--- a/packages/builder/builder-webpack-provider/src/config/validate/output.ts
+++ b/packages/builder/builder-webpack-provider/src/config/validate/output.ts
@@ -14,7 +14,5 @@ export const outputConfigSchema: z.ZodType<OutputConfig> =
   sharedOutputConfigSchema
     .extend({
       copy: z.union([CopyPluginOptionsSchema, CopyPluginPatternsSchema]),
-      convertToRem: z.union([z.boolean(), z.instanceof(Object)]),
-      externals: z.any(),
     })
     .partial();

--- a/packages/document/builder-doc/docs/en/config/output/externals.md
+++ b/packages/document/builder-doc/docs/en/config/output/externals.md
@@ -6,10 +6,6 @@ At build time, prevent some `import` dependencies from being packed into bundles
 
 For more information, please see: [webpack Externals](https://webpack.js.org/configuration/externals/)
 
-:::tip
-When using Rspack as the bundler, only the `Record<string, string>` type is supported.
-:::
-
 ### Example
 
 Exclude the `react-dom` dependency from the build product. To get this module at runtime, the value of `react-dom` will globally retrieve the `ReactDOM` variable.

--- a/packages/document/builder-doc/docs/zh/config/output/externals.md
+++ b/packages/document/builder-doc/docs/zh/config/output/externals.md
@@ -5,10 +5,6 @@
 
 详情请见: [webpack 外部扩展 (Externals)](https://webpack.docschina.org/configuration/externals/)
 
-:::tip
-在使用 Rspack 作为打包工具时，只支持 `Record<string, string>` 类型。
-:::
-
 ### 示例
 
 将 `react-dom` 依赖从构建产物中剔除。为了在运行时获取这个模块, `react-dom` 的值将全局检索 `ReactDOM` 变量。


### PR DESCRIPTION
## Summary

reference: https://github.com/modern-js-dev/rspack/blob/a6e9f0287911b087050131459cc9af2f5ef78104/packages/rspack/src/config/types.ts#L406

![tcEcbLxejI](https://github.com/web-infra-dev/modern.js/assets/22373761/40fddd95-9265-4435-8ec0-5236035c0149)


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95c47f7</samp>

This pull request fixes the support for array values in the `output.externals` config option when using Rspack as the bundler. It updates the type definitions, validation schema, and documentation for the `@modern-js/builder-rspack-provider` and `@modern-js/document` packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95c47f7</samp>

*  Add changeset file for patch update of `@modern-js/builder-rspack-provider` package ([link](https://github.com/web-infra-dev/modern.js/pull/3768/files?diff=unified&w=0#diff-b8e5def07422042ab2ce5d6b55e1061b61ad15e361070b2e9c32f45d28da027dR1-R7))
*  Relax validation schema and update type definition for output.externals config option in `@modern-js/builder-rspack-provider` package, using `Externals` type from `@rspack/core` ([link](https://github.com/web-infra-dev/modern.js/pull/3768/files?diff=unified&w=0#diff-e524d13b34378b73e0c008099b11dbb5f1a565d43e8d73f456349d1c4a306995L8-R8), [link](https://github.com/web-infra-dev/modern.js/pull/3768/files?diff=unified&w=0#diff-b4426d64229419c039cbc656717ea034f5298b43e482f9b52245704a3fcf8bc3L6-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3768/files?diff=unified&w=0#diff-b4426d64229419c039cbc656717ea034f5298b43e482f9b52245704a3fcf8bc3L20-R20))
*  Remove tip section from English and Chinese documentation for output.externals config option in `@modern-js/document` package, as Rspack now supports array values ([link](https://github.com/web-infra-dev/modern.js/pull/3768/files?diff=unified&w=0#diff-71f5980b2189b66a9dc7a167ff8280bab01b3089f40794f38f58160ec12416edL9-L12), [link](https://github.com/web-infra-dev/modern.js/pull/3768/files?diff=unified&w=0#diff-ef4c22bcaae14d9895043a362f7a697c7ac9f218e8052ce5a97fcc5c137c6752L8-L11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
