### PR TITLE
Revert "feat: ssr runtime need webpack.output.chunkLoadingGlobal pass…

### DIFF
--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -184,18 +184,11 @@ export default (): CliPlugin<AppTools> => ({
           imports,
         };
       },
-      modifyEntryRuntimePlugins({ entrypoint, plugins, bundlerConfigs }) {
+      modifyEntryRuntimePlugins({ entrypoint, plugins }: any) {
         if (ssrConfigMap.get(entrypoint.entryName)) {
-          const chunkLoadingGlobal = bundlerConfigs?.find(
-            config => config.name === 'client',
-          )?.output?.chunkLoadingGlobal;
-
           plugins.push({
             name: PLUGIN_IDENTIFIER,
-            options: JSON.stringify({
-              ...(ssrConfigMap.get(entrypoint.entryName) || {}),
-              chunkLoadingGlobal,
-            }),
+            options: JSON.stringify(ssrConfigMap.get(entrypoint.entryName)),
           });
         }
         return {

--- a/packages/runtime/plugin-runtime/src/ssr/index.tsx
+++ b/packages/runtime/plugin-runtime/src/ssr/index.tsx
@@ -54,10 +54,6 @@ export const ssr = (config: SSRPluginConfig): Plugin => ({
         return stringSSRHydrate();
 
         function stringSSRHydrate() {
-          const loadableReadyOptions: any = {
-            chunkLoadingGlobal: config.chunkLoadingGlobal,
-          };
-
           // client render and server prefetch use same logic
           if (
             renderLevel === RenderLevel.CLIENT_RENDER ||
@@ -75,11 +71,11 @@ export const ssr = (config: SSRPluginConfig): Plugin => ({
                 );
                 SSRApp = hoistNonReactStatics(SSRApp, App);
                 ModernHydrate(<SSRApp />);
-              }, loadableReadyOptions);
+              });
             } else {
               loadableReady(() => {
                 ModernHydrate(<App context={hydrateContext} />, callback);
-              }, loadableReadyOptions);
+              });
             }
           } else {
             // unknown renderlevel or renderlevel is server prefetch.

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
@@ -8,7 +8,6 @@ export { RuntimeContext, RenderLevel };
 
 export type SSRPluginConfig = {
   crossorigin?: boolean | 'anonymous' | 'use-credentials';
-  chunkLoadingGlobal?: string;
 } & Exclude<ServerUserConfig['ssr'], boolean>;
 
 export type ServerRenderOptions = {

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -24,7 +24,6 @@ import {
   APP_INIT_EXPORTED,
   APP_INIT_IMPORTED,
 } from './constants';
-import { generateIndexCode } from './generateCode';
 
 const debug = createDebugger('plugin-analyze');
 
@@ -163,13 +162,6 @@ export default ({
             async onBeforeBuild({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
               await generateRoutes(appContext);
-              await generateIndexCode({
-                appContext,
-                config: resolvedConfig,
-                entrypoints,
-                api,
-                bundlerConfigs,
-              });
               await hookRunners.beforeBuild({
                 bundlerConfigs:
                   bundlerConfigs as unknown as webpack.Configuration[],
@@ -198,13 +190,6 @@ export default ({
 
             async onBeforeCreateCompiler({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
-              await generateIndexCode({
-                appContext,
-                config: resolvedConfig,
-                entrypoints,
-                api,
-                bundlerConfigs,
-              });
               // run modernjs framework `beforeCreateCompiler` hook
               await hookRunners.beforeCreateCompiler({
                 bundlerConfigs:

--- a/packages/solutions/app-tools/src/types/hooks.ts
+++ b/packages/solutions/app-tools/src/types/hooks.ts
@@ -45,9 +45,6 @@ export type AppToolsHooks<B extends Bundler = 'webpack'> = {
   modifyEntryRuntimePlugins: AsyncWaterfall<{
     entrypoint: Entrypoint;
     plugins: RuntimePlugin[];
-    bundlerConfigs?: B extends 'rspack'
-      ? Rspack.Configuration[]
-      : webpack.Configuration[];
   }>;
   modifyEntryRenderFunction: AsyncWaterfall<{
     entrypoint: Entrypoint;


### PR DESCRIPTION
… to loadableReady (#3752)"

This reverts commit a2690ac628977486e0ccb28f2e419d152fee14ec.

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5d11ce</samp>

This pull request simplifies and refactors the code related to SSR plugin and entrypoint generation in the `modern.js` framework. It removes unused code and parameters, such as the `chunkLoadingGlobal` option and the `bundlerConfigs` property, and delegates the SSR entry code generation to the SSR plugin. It also improves the readability and maintainability of the code by using destructuring and moving some logic to different modules.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5d11ce</samp>

*  Remove `chunkLoadingGlobal` option from SSR plugin config type and `loadableReady` function calls ([link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-7bb2b37d7c4c35db7a1d3fbfbd76ed3192cc5ca45a0a749df4661179ad395c32L11), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-1d68f5f1af4a1f2639aada724010dd1a59c8a08d80883f532c11d85d3a99868fL57-L60), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-1d68f5f1af4a1f2639aada724010dd1a59c8a08d80883f532c11d85d3a99868fL78-R78))
*  Remove `bundlerConfigs` parameter from `generateIndexCode` function and SSR plugin options ([link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L187-R191), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L25-L26), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L292), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-042c0864d94c683d2cc46e22752f744d1be4a31661ede69b34cc13b23697f9feL48-L50))
*  Move SSR entry code generation logic from `generateIndexCode` function to `generateEntryCode` function in `generateCode.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L236-R237), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0R285), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L362-R326), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L27), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L166-L172), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L201-L207))
*  Add `mountId` and `customBootstrap` variables to `generateEntryCode` function to use the values from `config.html` and `entrypoint` objects ([link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0R118), [link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L125-R125))
*  Remove unused imports from `generateCode.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3770/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L25-L26))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
