### PR TITLE
feat(generator): using typescript v5 for new projects

### DIFF
--- a/.changeset/thin-rice-watch.md
+++ b/.changeset/thin-rice-watch.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/module-generator': patch
+'@modern-js/doc-generator': patch
+'@modern-js/mwa-generator': patch
+---
+
+feat(generator): using typescript v5 for new projects
+
+feat(generator): 新项目默认使用 typescript v5

--- a/packages/generator/generators/doc-generator/templates/package.json.handlebars
+++ b/packages/generator/generators/doc-generator/templates/package.json.handlebars
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@types/node": "^16.18.16",
-    "typescript": "^4.9.4"
+    "typescript": "^5.0.4"
   }
 }

--- a/packages/generator/generators/module-generator/src/index.ts
+++ b/packages/generator/generators/module-generator/src/index.ts
@@ -165,7 +165,7 @@ export const handleTemplateFile = async (
 
   if (language === Language.TS) {
     const updateInfo: Record<string, string> = {
-      'devDependencies.typescript': '~4.9.4',
+      'devDependencies.typescript': '~5.0.4',
       'devDependencies.@types/jest': '~29.2.4',
       'devDependencies.@types/node': '~16.11.7',
       'devDependencies.@types/react': '~18.0.26',

--- a/packages/generator/generators/mwa-generator/src/index.ts
+++ b/packages/generator/generators/mwa-generator/src/index.ts
@@ -158,7 +158,7 @@ export const handleTemplateFile = async (
         query: {},
         update: {
           $set: {
-            'devDependencies.typescript': '~4.9.4',
+            'devDependencies.typescript': '~5.0.4',
             'devDependencies.@types/jest': '~29.2.4',
             'devDependencies.@types/node': '~16.11.7',
             'devDependencies.@types/react': '~18.0.26',

--- a/packages/generator/generators/mwa-generator/templates/base-template/package.json.handlebars
+++ b/packages/generator/generators/mwa-generator/templates/base-template/package.json.handlebars
@@ -44,6 +44,6 @@
     "lint-staged": "~13.1.0",
     "prettier": "~2.8.1",
     "husky": "~8.0.1",
-     "rimraf": "~3.0.2"
+    "rimraf": "~3.0.2"
   }
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc6882c</samp>

This pull request updates the generator packages to use typescript v5 for new projects. It also fixes a minor syntax error in the `mwa-generator` template file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc6882c</samp>

*  Bump patch version and use typescript v5 for generator packages (.changeset/thin-rice-watch.md, [link](https://github.com/web-infra-dev/modern.js/pull/3772/files?diff=unified&w=0#diff-931d70a93359624b14de8501778ed94698986af02050b031f0dded363a227e2aL19-R19), [link](https://github.com/web-infra-dev/modern.js/pull/3772/files?diff=unified&w=0#diff-9137b753d380ee75081e96abed2d7f0f51b89faba28df1ef02bb43f09f2e52a2L168-R168), [link](https://github.com/web-infra-dev/modern.js/pull/3772/files?diff=unified&w=0#diff-ddd1b67c44baab015cbb25f185e6ca426e4029c33d3898ebba0ff441f57248e5L161-R161))
*  Fix syntax error in mwa-generator template file ([link](https://github.com/web-infra-dev/modern.js/pull/3772/files?diff=unified&w=0#diff-672dad358267d8800b5d8b02a2dac1001a000d35d2965535118f3c06a8dfafa9L47-R47))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
