### PR TITLE
fix(plugin-module-polyfill): unable parsing in ts ambient context, set plugin options optional

### DIFF
--- a/.changeset/funny-houses-pump.md
+++ b/.changeset/funny-houses-pump.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-polyfill': patch
+---
+
+fix: unable parsing within a ts ambient context, and set plugin options optional
+fix: 关闭在ts环境中的解析，并将插件参数设为可选

--- a/packages/module/plugin-module-polyfill/src/index.ts
+++ b/packages/module/plugin-module-polyfill/src/index.ts
@@ -1,23 +1,20 @@
 import type { CliPlugin, ModuleTools } from '@modern-js/module-tools';
 import { babelPlugin } from '@modern-js/libuild-plugin-babel';
 
-export const ModulePolyfillPlugin = (options: {
+export const ModulePolyfillPlugin = (options?: {
   targets?: Record<string, string> | string;
 }): CliPlugin<ModuleTools> => ({
   name: '@modern-js/plugin-module-polyfill',
   setup: () => ({
     modifyLibuild(config) {
       const plugins = [
-        [
-          require('@babel/plugin-syntax-typescript'),
-          { isTSX: true, dts: true },
-        ],
+        [require('@babel/plugin-syntax-typescript'), { isTSX: true }],
         [require('@babel/plugin-syntax-jsx')],
         [
           require('babel-plugin-polyfill-corejs3'),
           {
             method: 'usage-pure',
-            targets: options.targets,
+            targets: options?.targets,
           },
         ],
       ];


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fab20aa</samp>

This pull request improves the `ModulePolyfillPlugin` function, documents the bug fixes for the `@modern-js/plugin-module-polyfill` package, and adds the `@babel/plugin-proposal-decorators` plugin to the `@modern-js/plugin-testing` package and its babel transformer. These changes enhance the flexibility, robustness, and syntax support of the modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fab20aa</samp>

*  Add changeset file to document patch version update and bug fixes for `@modern-js/plugin-module-polyfill` package ([link](https://github.com/web-infra-dev/modern.js/pull/3773/files?diff=unified&w=0#diff-8f891aa423f56fca43b3c23cd4ad1221805b452eb868010e51fe9cfbc2ee3e64R1-R6))
*  Make `options` parameter optional and update type annotation for `ModulePolyfillPlugin` function in `plugin-module-polyfill/src/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3773/files?diff=unified&w=0#diff-f1422e71fb4e6e98b900309262f2a66f4919ba89379193235051e64a461d7192L4-R4))
*  Disable parsing of TypeScript declaration files by `@babel/plugin-syntax-typescript` plugin in `plugin-module-polyfill/src/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3773/files?diff=unified&w=0#diff-f1422e71fb4e6e98b900309262f2a66f4919ba89379193235051e64a461d7192L11-R11))
*  Add nullish coalescing operator to access `options.targets` in `plugin-module-polyfill/src/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3773/files?diff=unified&w=0#diff-f1422e71fb4e6e98b900309262f2a66f4919ba89379193235051e64a461d7192L20-R17))
*  Add `@babel/plugin-proposal-decorators` dependency to `@modern-js/plugin-testing` package in `plugin-testing/package.json` ([link](https://github.com/web-infra-dev/modern.js/pull/3773/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bR115))
*  Add `@babel/plugin-proposal-decorators` plugin with legacy option to `babelTransformer` function in `plugin-testing/src/base/config/transformer/babelTransformer.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3773/files?diff=unified&w=0#diff-bbadaf480f80ba20b903dafd7dbf55a487867d8cb3741abb1746971638d6ac47R13-R20))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
