### PR TITLE
fix: custom page written into the same file

### DIFF
--- a/.changeset/chilly-ducks-crash.md
+++ b/.changeset/chilly-ducks-crash.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): custom page written into the same file
+
+fix(doc-core): 自定义页面写入到同一个文件

--- a/packages/cli/doc-core/src/node/route/RouteService.ts
+++ b/packages/cli/doc-core/src/node/route/RouteService.ts
@@ -125,9 +125,8 @@ export class RouteService {
     // 2. external pages added by plugins
     const externalPages = await this.#pluginDriver.addPages(this.getRoutes());
 
-    let index = 0;
     await Promise.all(
-      externalPages.map(async route => {
+      externalPages.map(async (route, index) => {
         const { routePath, content, filepath } = route;
         // case1: specify the filepath
         if (filepath) {
@@ -140,7 +139,6 @@ export class RouteService {
           const filepath = await this.#writeTempFile(index, content);
           const routeInfo = this.#generateRouteInfo(routePath, filepath);
           this.addRoute(routeInfo);
-          index++;
         }
       }),
     );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68d3fbe</samp>

This pull request fixes a bug in the doc-core package that caused custom pages to be overwritten. It also refactors the RouteService class to simplify the code and updates the patch version with a changeset file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68d3fbe</samp>

* Fix bug in doc-core package that caused custom pages to be written into the same file instead of separate files ([link](https://github.com/web-infra-dev/modern.js/pull/3778/files?diff=unified&w=0#diff-73602f319d6c39218f8abe6db0033d8df38d1779d7462f69b98e9e70890c7fe1R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3778/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086L143))
* Simplify code in RouteService class by using map callback index parameter instead of separate index variable ([link](https://github.com/web-infra-dev/modern.js/pull/3778/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086L128-R129))
* Add changeset file to document patch version update and bug fix for doc-core package, with Chinese translation ([link](https://github.com/web-infra-dev/modern.js/pull/3778/files?diff=unified&w=0#diff-73602f319d6c39218f8abe6db0033d8df38d1779d7462f69b98e9e70890c7fe1R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
