### PR TITLE
feat(changeset): optimize release note display

### DIFF
--- a/.changeset/cool-crews-type.md
+++ b/.changeset/cool-crews-type.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-changeset': minor
+'@modern-js/main-doc': minor
+---
+
+feat(changeset): optimize release note display
+
+feat(changeset): 优化生成 Release Note 文案

--- a/packages/cli/plugin-changeset/src/commands/releaseNote.ts
+++ b/packages/cli/plugin-changeset/src/commands/releaseNote.ts
@@ -107,11 +107,17 @@ export function getReleaseNoteLine(
   }
 
   const { repository, pullRequestId, summary, summary_zh, author } = commit;
-  const pullRequest = `https://github.com/${repository}/pull/${pullRequestId}`;
+  const pullRequest = pullRequestId
+    ? `https://github.com/${repository}/pull/${pullRequestId}`
+    : '';
   if (lang === 'en') {
-    return `- ${summary} by @${author} in ${pullRequest} \n`;
+    return `- ${summary} by @${author}${
+      pullRequest ? ` in ${pullRequest}` : ''
+    } \n`;
   }
-  return `- ${summary_zh} 由 @${author} 实现，详情可查看 ${pullRequest} \n`;
+  return `- ${summary_zh} 由 @${author} 实现${
+    pullRequest ? `， 详情可查看 ${pullRequest}` : ''
+  } \n`;
 }
 
 export async function genReleaseNote(options: ReleaseNoteOptions) {

--- a/packages/cli/plugin-changeset/src/commands/releaseNote.ts
+++ b/packages/cli/plugin-changeset/src/commands/releaseNote.ts
@@ -41,7 +41,10 @@ export type CustomReleaseNoteFunction =
         commit: string,
         commitObj: Commit,
       ) => Commit | Promise<Commit>;
-      getReleaseNoteLine?: (commit: Commit) => string | Promise<string>;
+      getReleaseNoteLine?: (
+        commit: Commit,
+        lang?: 'en' | 'zh',
+      ) => string | Promise<string>;
     }
   | undefined;
 
@@ -103,7 +106,7 @@ export function getReleaseNoteLine(
   lang: 'en' | 'zh' = 'en',
 ) {
   if (customReleaseNoteFunction?.getReleaseNoteLine) {
-    return customReleaseNoteFunction.getReleaseNoteLine(commit);
+    return customReleaseNoteFunction.getReleaseNoteLine(commit, lang);
   }
 
   const { repository, pullRequestId, summary, summary_zh, author } = commit;

--- a/packages/cli/plugin-changeset/src/commands/releaseNote.ts
+++ b/packages/cli/plugin-changeset/src/commands/releaseNote.ts
@@ -3,16 +3,32 @@ import resolveFrom from 'resolve-from';
 import { fs, execa } from '@modern-js/utils';
 import readChangesets from '@changesets/read';
 
+export enum CommitType {
+  Performance = 'performance',
+  Features = 'features',
+  BugFix = 'bugFix',
+  Doc = 'doc',
+  Other = 'other',
+}
+
 export interface Commit {
   id: string;
-  type: 'feature' | 'fix';
+  type: CommitType;
   repository?: string;
   pullRequestId?: string;
   author?: string;
   message: string; // commit message
-  summary: string; // changeset summary
+  summary: string; // changeset en ssummary
+  summary_zh: string; // changeset zh summary
   [key: string]: string | undefined;
 }
+
+export interface Changes {
+  en: Commit[];
+  zh: Commit[];
+}
+
+export type ReleaseNote = Record<CommitType, Changes>;
 
 interface ReleaseNoteOptions {
   repo?: string;
@@ -28,6 +44,40 @@ export type CustomReleaseNoteFunction =
       getReleaseNoteLine?: (commit: Commit) => string | Promise<string>;
     }
   | undefined;
+
+export const ChangesTitle = `What's Changed`;
+export const ChangesZhTitle = '更新内容';
+export const CommitTypeTitle = {
+  performance: 'Performance Improvements ⚡',
+  features: 'New Features 🎉',
+  bugFix: 'Bug Fixes 🐞',
+  doc: 'Docs update 📄',
+  other: 'Other Changes',
+};
+
+export const CommitTypeZhTitle = {
+  performance: '性能优化 ⚡',
+  features: '新特性 🎉',
+  bugFix: 'Bug 修复 🐞',
+  doc: '文档更新 📄',
+  other: '其他变更',
+};
+
+export function getCommitType(message: string) {
+  if (message.startsWith('perf')) {
+    return CommitType.Performance;
+  }
+  if (message.startsWith('feat')) {
+    return CommitType.Features;
+  }
+  if (message.startsWith('fix') || message.startsWith('hotfix')) {
+    return CommitType.BugFix;
+  }
+  if (message.startsWith('docs')) {
+    return CommitType.Doc;
+  }
+  return CommitType.Other;
+}
 
 export function getReleaseInfo(commit: string, commitObj: Commit) {
   const commitRegex = /(.*)\(#(\d*)\)/;
@@ -47,46 +97,21 @@ export function getReleaseInfo(commit: string, commitObj: Commit) {
   return commitObj;
 }
 
-function formatSummary(summary: string, pullRequestId?: string) {
-  const [firstLine, ...futureLines] = summary
-    .split('\n')
-    .map(l => l.trimRight());
-
-  let returnVal = firstLine;
-
-  if (futureLines.length > 0) {
-    if (pullRequestId) {
-      returnVal = `\n\n  ${returnVal}`;
-    } else {
-      returnVal = `\n  ${returnVal}`;
-    }
-    returnVal += `\n\n  ${futureLines
-      .filter(l => Boolean(l))
-      .map(l => l)
-      .join('\n\n')}`;
-  }
-  return returnVal;
-}
-
 export function getReleaseNoteLine(
   commit: Commit,
   customReleaseNoteFunction?: CustomReleaseNoteFunction,
+  lang: 'en' | 'zh' = 'en',
 ) {
   if (customReleaseNoteFunction?.getReleaseNoteLine) {
     return customReleaseNoteFunction.getReleaseNoteLine(commit);
   }
 
-  const { repository, pullRequestId, summary } = commit;
-  if (pullRequestId && repository) {
-    return `- [#${pullRequestId}](https://github.com/${repository}/pull/${pullRequestId}) ${formatSummary(
-      summary,
-      pullRequestId,
-    )}\n`;
+  const { repository, pullRequestId, summary, summary_zh, author } = commit;
+  const pullRequest = `https://github.com/${repository}/pull/${pullRequestId}`;
+  if (lang === 'en') {
+    return `- ${summary} by @${author} in ${pullRequest} \n`;
   }
-  if (pullRequestId) {
-    return `#${pullRequestId} ${formatSummary(summary, pullRequestId)}\n`;
-  }
-  return `${formatSummary(summary, pullRequestId)}\n`;
+  return `- ${summary_zh} 由 @${author} 实现，详情可查看 ${pullRequest} \n`;
 }
 
 export async function genReleaseNote(options: ReleaseNoteOptions) {
@@ -127,8 +152,13 @@ export async function genReleaseNote(options: ReleaseNoteOptions) {
     return '';
   }
 
-  const features: Commit[] = [];
-  const bugFix: Commit[] = [];
+  const releaseNote: ReleaseNote = {
+    [CommitType.Performance]: { en: [], zh: [] },
+    [CommitType.Features]: { en: [], zh: [] },
+    [CommitType.BugFix]: { en: [], zh: [] },
+    [CommitType.Doc]: { en: [], zh: [] },
+    [CommitType.Other]: { en: [], zh: [] },
+  };
 
   for (const changeset of changesets) {
     const { stdout } = await execa('git', [
@@ -137,14 +167,16 @@ export async function genReleaseNote(options: ReleaseNoteOptions) {
       `.changeset/${changeset.id}.md`,
     ]);
     const [id, message] = stdout.split('--');
+    const [firstLine, ...futureLines] = changeset.summary
+      .split('\n')
+      .map(l => l.trimRight());
     let commitObj: Commit = {
       id,
-      type: (message || changeset.summary).startsWith('fix')
-        ? 'fix'
-        : 'feature',
+      type: getCommitType(changeset.summary || message),
       repository,
       message: (message || changeset.summary).trim(),
-      summary: changeset.summary,
+      summary: firstLine,
+      summary_zh: futureLines.filter(l => Boolean(l)).join('\n'),
     };
 
     if (customReleaseNoteFunction?.getReleaseInfo) {
@@ -156,41 +188,45 @@ export async function genReleaseNote(options: ReleaseNoteOptions) {
       commitObj = getReleaseInfo(stdout, commitObj);
     }
 
-    if (commitObj.type === 'fix') {
-      bugFix.push(commitObj);
-    } else {
-      features.push(commitObj);
+    releaseNote[commitObj.type].en.push(commitObj);
+    if (commitObj.summary_zh) {
+      releaseNote[commitObj.type].zh.push(commitObj);
     }
   }
 
-  if (!features.length && !bugFix.length) {
-    console.warn(
-      'no release note found, you can run `pnpm run add` to add changeset',
-    );
-  }
-
-  let result = '';
-  if (features.length) {
-    result += '## Features:\n';
-    for (const commit of features) {
-      const releaseNote = await getReleaseNoteLine(
-        commit,
-        customReleaseNoteFunction,
-      );
-      result += releaseNote;
+  const result: { en: string; zh: string } = {
+    en: `## ${ChangesTitle}\n\n`,
+    zh: `## ${ChangesZhTitle}\n\n`,
+  };
+  // Flag contains zh content.
+  let flag = 0;
+  for (const [type, { en, zh }] of Object.entries(releaseNote)) {
+    if (en.length > 0) {
+      result.en += `### ${CommitTypeTitle[type as CommitType]}\n\n`;
+      for (const commit of en) {
+        const releaseNote = await getReleaseNoteLine(
+          commit,
+          customReleaseNoteFunction,
+          'en',
+        );
+        result.en += releaseNote;
+      }
+    }
+    if (zh.length > 0) {
+      flag = 1;
+      result.zh += `### ${CommitTypeZhTitle[type as CommitType]}\n\n`;
+      for (const commit of zh) {
+        const releaseNote = await getReleaseNoteLine(
+          commit,
+          customReleaseNoteFunction,
+          'zh',
+        );
+        result.zh += releaseNote;
+      }
     }
   }
 
-  if (bugFix.length) {
-    result += '## Bug Fix:\n';
-    for (const commit of bugFix) {
-      const releaseNote = await getReleaseNoteLine(
-        commit,
-        customReleaseNoteFunction,
-      );
-      result += releaseNote;
-    }
-  }
-  console.info(result);
-  return result;
+  const resultStr = flag ? `${result.en}\n\n${result.zh}` : result.en;
+  console.info(resultStr);
+  return resultStr;
 }

--- a/packages/cli/plugin-changeset/src/commands/releaseNote.ts
+++ b/packages/cli/plugin-changeset/src/commands/releaseNote.ts
@@ -107,17 +107,18 @@ export function getReleaseNoteLine(
   }
 
   const { repository, pullRequestId, summary, summary_zh, author } = commit;
-  const pullRequest = pullRequestId
-    ? `https://github.com/${repository}/pull/${pullRequestId}`
-    : '';
+  const pullRequest =
+    pullRequestId && repository
+      ? `https://github.com/${repository}/pull/${pullRequestId}`
+      : '';
   if (lang === 'en') {
-    return `- ${summary} by @${author}${
+    return `- ${summary}${author ? ` by @${author}` : ''}${
       pullRequest ? ` in ${pullRequest}` : ''
-    } \n`;
+    }\n`;
   }
-  return `- ${summary_zh} 由 @${author} 实现${
+  return `- ${summary_zh}${author ? ` 由 @${author} 实现` : ''}${
     pullRequest ? `， 详情可查看 ${pullRequest}` : ''
-  } \n`;
+  }\n`;
 }
 
 export async function genReleaseNote(options: ReleaseNoteOptions) {

--- a/packages/cli/plugin-changeset/tests/releaseNote.test.ts
+++ b/packages/cli/plugin-changeset/tests/releaseNote.test.ts
@@ -1,12 +1,18 @@
-import { getReleaseInfo, getReleaseNoteLine, Commit } from '../src/commands';
+import {
+  getReleaseInfo,
+  getReleaseNoteLine,
+  Commit,
+  CommitType,
+} from '../src/commands';
 
 describe('release note function test', () => {
   test('getReleaseInfo', () => {
     let commitObj: Commit = {
       id: '552d98d',
-      type: 'feature',
+      type: CommitType.Features,
       message: 'chore: update devcert version to 1.2.2 (#1222)',
       summary: 'chore: update devcert version to 1.2.2',
+      summary_zh: 'chore: 更新 devcert 版本到 1.2.2',
     };
     commitObj = getReleaseInfo(
       '552d98d--chore: update devcert version to 1.2.2 (#1222)--zhangsan',
@@ -18,67 +24,78 @@ describe('release note function test', () => {
   test('getReleaseNoteLine', () => {
     const commitObj: Commit = {
       id: '552d98d',
-      type: 'feature',
+      type: CommitType.Features,
       pullRequestId: '1222',
       message: 'chore: update devcert version to 1.2.2 (#1222)',
       summary: 'chore: update devcert version to 1.2.2',
-      author: 'zhangsan',
-    };
-    const line = getReleaseNoteLine(commitObj);
-    expect(line).toEqual('#1222 chore: update devcert version to 1.2.2\n');
-  });
-  test('getReleaseNoteLine with repository', () => {
-    const commitObj: Commit = {
-      id: '552d98d',
-      type: 'feature',
-      pullRequestId: '1222',
-      repository: 'web-infra-dev/modern.js',
-      message: 'chore: update devcert version to 1.2.2 (#1222)',
-      summary: 'chore: update devcert version to 1.2.2',
+      summary_zh: 'chore: 更新 devcert 版本到 1.2.2',
       author: 'zhangsan',
     };
     const line = getReleaseNoteLine(commitObj);
     expect(line).toEqual(
-      '- [#1222](https://github.com/web-infra-dev/modern.js/pull/1222) chore: update devcert version to 1.2.2\n',
+      '- chore: update devcert version to 1.2.2 by @zhangsan\n',
+    );
+  });
+  test('getReleaseNoteLine with repository', () => {
+    const commitObj: Commit = {
+      id: '552d98d',
+      type: CommitType.Features,
+      pullRequestId: '1222',
+      repository: 'web-infra-dev/modern.js',
+      message: 'chore: update devcert version to 1.2.2 (#1222)',
+      summary: 'chore: update devcert version to 1.2.2',
+      summary_zh: 'chore: 更新 devcert 版本到 1.2.2',
+      author: 'zhangsan',
+    };
+    const line = getReleaseNoteLine(commitObj);
+    expect(line).toEqual(
+      '- chore: update devcert version to 1.2.2 by @zhangsan in https://github.com/web-infra-dev/modern.js/pull/1222\n',
     );
   });
   test('getReleaseNoteLine without author', () => {
     const commitObj: Commit = {
       id: '552d98d',
-      type: 'feature',
+      type: CommitType.Features,
       pullRequestId: '1222',
       repository: 'web-infra-dev/modern.js',
       message: 'chore: update devcert version to 1.2.2 (#1222)',
       summary: 'chore: update devcert version to 1.2.2',
+      summary_zh: 'chore: 更新 devcert 版本到 1.2.2',
     };
     const line = getReleaseNoteLine(commitObj);
     expect(line).toEqual(
-      '- [#1222](https://github.com/web-infra-dev/modern.js/pull/1222) chore: update devcert version to 1.2.2\n',
+      '- chore: update devcert version to 1.2.2 in https://github.com/web-infra-dev/modern.js/pull/1222\n',
     );
   });
   test('getReleaseNoteLine without pullRequestId', () => {
     const commitObj: Commit = {
       id: '552d98d',
-      type: 'feature',
+      type: CommitType.Features,
       message: 'chore: update devcert version to 1.2.2 (#1222)',
       summary: 'chore: update devcert version to 1.2.2',
+      summary_zh: 'chore: 更新 devcert 版本到 1.2.2',
     };
     const line = getReleaseNoteLine(commitObj);
-    expect(line).toEqual('chore: update devcert version to 1.2.2\n');
+    expect(line).toEqual('- chore: update devcert version to 1.2.2\n');
   });
   test('getReleaseNoteLine multi line', () => {
     const commitObj: Commit = {
       id: '552d98d',
-      type: 'feature',
+      type: CommitType.Features,
       pullRequestId: '1222',
       repository: 'web-infra-dev/modern.js',
       message: 'chore: update devcert version to 1.2.2 (#1222)',
-      summary:
-        'chore: update devcert version to 1.2.2\n\nchore: 更新 devcert 版本到 1.2.2',
+      summary: 'chore: update devcert version to 1.2.2',
+      summary_zh: 'chore: 更新 devcert 版本到 1.2.2',
+      author: 'zhangsan',
     };
     const line = getReleaseNoteLine(commitObj);
+    const line2 = getReleaseNoteLine(commitObj, undefined, 'zh');
     expect(line).toEqual(
-      '- [#1222](https://github.com/web-infra-dev/modern.js/pull/1222) \n\n  chore: update devcert version to 1.2.2\n\n  chore: 更新 devcert 版本到 1.2.2\n',
+      '- chore: update devcert version to 1.2.2 by @zhangsan in https://github.com/web-infra-dev/modern.js/pull/1222\n',
+    );
+    expect(line2).toEqual(
+      '- chore: 更新 devcert 版本到 1.2.2 由 @zhangsan 实现， 详情可查看 https://github.com/web-infra-dev/modern.js/pull/1222\n',
     );
   });
 });


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/modern.js/assets/12605189/836cc6fb-4060-473d-89ce-8602bff90072)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 881cf7a</samp>

This pull request adds a new feature to the `cli` package that allows generating bilingual release notes from changesets and commits. It also updates the `plugin-changeset` package to support this feature and adds a changeset file to document the version bump and the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 881cf7a</samp>

*  Add a changeset file to document the changes and the version bump for each package ([link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-9241afdf8376e03b006f4535ff583b68f8088233b78ebf1e64dd761e1e79235eR1-R8))
*  Modify the types of the `Commit` and `ReleaseNoteOptions` interfaces to use an enum for commit type and include a Chinese summary and a repository name ([link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L6-R32))
*  Add constants and a function to determine the commit type based on the changeset summary or the commit message ([link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3R48-R81))
*  Modify the `getReleaseNoteLine` function to take a language parameter and return a different format of the release note line based on the language ([link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L50-R103))
*  Modify the `genReleaseNote` function to use a `releaseNote` object to store the commits by type and language, and generate the release note content in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L79-R114), [link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L130-R161), [link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L140-R179), [link](https://github.com/web-infra-dev/modern.js/pull/3779/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L159-R232))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
