### PR TITLE
feat: export router instance

### DIFF
--- a/.changeset/tricky-cherries-kick.md
+++ b/.changeset/tricky-cherries-kick.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: export react-router instance
+feat: 导出 react-router 路由实例

--- a/packages/document/main-doc/docs/en/apis/app/runtime/core/use-runtime-context.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/core/use-runtime-context.mdx
@@ -28,6 +28,7 @@ type RuntimeContext = {
     cookie: string;
   };
   store: ReduckStore;
+  router: RemixRouter;
 };
 
 function useRuntimeContext(): RuntimeContext;
@@ -42,6 +43,7 @@ function useRuntimeContext(): RuntimeContext;
   - `headers`: the header info of the request.
   - `cookie`: the cookie of the request.
 - `store`: when the runtime.state is enabled, this value is the reduck global `store`.
+- `router`: When the runtime.router is enabled, this value is the router instance object returned by React Router's `createBrowserRouter`/`createHashRouter`/`createStaticRouter` methods.
 
 ## Example
 

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/core/use-runtime-context.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/core/use-runtime-context.mdx
@@ -28,6 +28,7 @@ type RuntimeContext = {
     cookie: string;
   };
   store: ReduckStore;
+  router: RemixRouter;
 };
 
 function useRuntimeContext(): RuntimeContext;
@@ -42,6 +43,7 @@ function useRuntimeContext(): RuntimeContext;
   - `headers`：请求头信息。
   - `cookie`：请求的 cookie 信息。
 - `store`：在开启了 state 插件的时候，该值为 reduck 全局 `store`。
+- `router`：在开启 router 插件的时候，该值为 React Router 的 `createBrowserRouter`/`createHashRouter`/`createStaticRouter` 等方法返回的 router 实例对象。
 
 ## 示例
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -109,7 +109,7 @@ export const routerPlugin = ({
           }
 
           const router = createStaticRouter(routes, routerContext);
-          context.router = router;
+          context.remixRouter = router;
           context.routerContext = routerContext;
           context.routes = routes;
           // set routeManifest in context to be consistent with csr context
@@ -130,11 +130,12 @@ export const routerPlugin = ({
 
           const getRouteApp = () => {
             return (props => {
-              const { router, routerContext } = useContext(RuntimeReactContext);
+              const { remixRouter, routerContext } =
+                useContext(RuntimeReactContext);
               return (
                 <App {...props}>
                   <StaticRouterProvider
-                    router={router}
+                    router={remixRouter}
                     context={routerContext!}
                     hydrate={false}
                   />
@@ -153,6 +154,17 @@ export const routerPlugin = ({
 
           return next({
             App: RouteApp,
+          });
+        },
+        pickContext: ({ context, pickedContext }, next) => {
+          const { remixRouter } = context;
+
+          return next({
+            context,
+            pickedContext: {
+              ...pickedContext,
+              router: remixRouter,
+            },
           });
         },
       };

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   createBrowserRouter,
   createHashRouter,
@@ -10,7 +10,7 @@ import {
 } from '@modern-js/utils/runtime/router';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { parsedJSONFromElement } from '@modern-js/utils/runtime-browser';
-import { Plugin } from '../../core';
+import { Plugin, RuntimeReactContext } from '../../core';
 import { modifyRoutes as modifyRoutesHook } from './hooks';
 import { deserializeErrors, renderRoutes, urlJoin } from './utils';
 import type { RouterConfig, Routes } from './types';
@@ -114,6 +114,9 @@ export const routerPlugin = ({
                     hydrationData,
                   });
 
+              const runtimeContext = useContext(RuntimeReactContext);
+              runtimeContext.remixRouter = router;
+
               return (
                 <App {...props}>
                   <RouterProvider router={router} />
@@ -135,6 +138,17 @@ export const routerPlugin = ({
 
           return next({
             App: RouteApp,
+          });
+        },
+        pickContext: ({ context, pickedContext }, next) => {
+          const { remixRouter } = context;
+
+          return next({
+            context,
+            pickedContext: {
+              ...pickedContext,
+              router: remixRouter,
+            },
           });
         },
       };

--- a/packages/runtime/plugin-runtime/src/runtimeContext.ts
+++ b/packages/runtime/plugin-runtime/src/runtimeContext.ts
@@ -1,5 +1,8 @@
 import { Store } from '@modern-js-reduck/store';
-import type { StaticHandlerContext } from '@modern-js/utils/runtime/remix-router';
+import {
+  type StaticHandlerContext,
+  type Router,
+} from '@modern-js/utils/runtime/remix-router';
 import { createContext } from 'react';
 import { createLoaderManager } from './core/loader/loaderManager';
 import { runtime } from './core/plugin';
@@ -33,6 +36,7 @@ export interface BaseTRuntimeContext {
   response?: SSRServerContext['response'];
   // store type
   store?: Store;
+  router?: Router;
 }
 
 export interface TRuntimeContext extends BaseTRuntimeContext {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

Export the router instance created by react-router, in order to allow users to use the router in a imperative way .

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 576a6bf</samp>

*  Add a changeset file to document the patch version update and the new features of exporting the react-router instance ([link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-28fce66c8ae4ae22e5377c9b3cc86630e51d36a4e93157d43282b0f1c1794e2cR1-R6))
* Rename the `router` property of the context object to `remixRouter` on both server and browser sides to avoid confusion with the exported react-router instance ([link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL112-R112), [link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL133-R138), [link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6R117-R119))
* Add a `pickContext` hook to the `routerPlugin` on both server and browser sides to copy the `remixRouter` property from the context object to the pickedContext object, which is exported to the user ([link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddR159-R169), [link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6R143-R153))
* Add an optional `router` property to the `BaseTRuntimeContext` interface, which is the remix-router instance that can be accessed by the plugins and the user ([link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-4595ffb4279d876e3775dd27729e152216eb78769ca4fc488af43d53cc0cde64L2-R5), [link](https://github.com/web-infra-dev/modern.js/pull/3780/files?diff=unified&w=0#diff-4595ffb4279d876e3775dd27729e152216eb78769ca4fc488af43d53cc0cde64R39))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
