### PR TITLE
chore: update module plugin docs and readme

### DIFF
--- a/.changeset/soft-crews-attack.md
+++ b/.changeset/soft-crews-attack.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/plugin-module-main-fields': patch
+'@modern-js/plugin-module-polyfill': patch
+'@modern-js/plugin-module-banner': patch
+'@modern-js/plugin-module-import': patch
+'@modern-js/plugin-module-target': patch
+'@modern-js/plugin-module-babel': patch
+---
+
+chore: update module plugin docs and readme
+chore: 更新模块插件的文档和readme

--- a/packages/document/module-doc/docs/en/plugins/official-list/overview.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/overview.md
@@ -5,3 +5,5 @@
 * [@modern-js/plugin-module-import](./plugin-import.md)：Use SWC to provide the same ability as [`babel-plugin-import`](https://github.com/umijs/babel-plugin-import).
 * [@modern-js/plugin-module-banner](./plugin-banner.md)：Add custom content, such as copyright information, to the top and bottom of each JS and CSS file.
 * [@modern-js/plugin-module-node-polyfill](./plugin-node-polyfill.mdx)： Inject Polyfills of Node core modules in the browser side.
+* [@modern-js/plugin-module-polyfill](./plugin-polyfill.md)：Inject polyfill for unsupported features used in your code.
+* [@modern-js/plugin-module-babel](./plugin-babel.md)：Use babel to transform your code.

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.md
@@ -1,0 +1,56 @@
+# Babel Plugin
+
+:::tip
+Normally, we don't need to use Babel to transform our code, this plugin is only used as a downgrade.
+:::
+
+## Quick start
+
+### Install
+
+```bash
+# npm
+npm install @modern-js/plugin-module-babel -D
+
+# yarn
+yarn add @modern-js/plugin-module-babel -D
+
+# pnpm
+pnpm add @modern-js/plugin-module-babel -D
+```
+
+### Register
+
+You can install the plugin with the following command:
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBabel } from '@modern-js/plugin-module-babel';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginBabel(),
+  ],
+});
+```
+
+## Config
+
+See [babel options](https://babeljs.io/docs/options).
+
+Here is an example with `@babel/preset-env` configured
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBabel } from '@modern-js/plugin-module-babel';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginBabel({
+      presets: [['@babel/preset-env']],
+    }),
+  ],
+});
+```

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-banner.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-banner.md
@@ -17,19 +17,18 @@ yarn add @modern-js/plugin-module-banner -D
 pnpm add @modern-js/plugin-module-banner -D
 ```
 
-
 ### Register
 
 You can install the plugin with the following command:
 
 ```ts
-import moduleTools, defineConfig from '@modern-js/module-tools';
-import pluginBanner from '@modern-js/plugin-module-banner';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBanner } from '@modern-js/plugin-module-banner';
 
 export default defineConfig({
   plugins: [
     moduleTools(),
-    pluginBanner({
+    modulePluginBanner({
       banner: {
         js: '//comment',
         css: '/*comment*/',
@@ -48,7 +47,9 @@ Note: CSS comments do not support the `//comment` syntax. Refer to [【CSS Comme
 ### Add copyright information at the top of a JS file
 
 ```ts
-import pluginBanner from '@modern-js/plugin-module-banner';
+import { modulePluginBanner } from '@modern-js/plugin-module-banner';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+
 
 const copyRight = `/*
  © Copyright 2020 xxx.com or one of its affiliates.
@@ -62,7 +63,8 @@ const copyRight = `/*
 
 export default defineConfig({
   plugins: [
-    pluginBanner({
+    moduleTools(),
+    modulePluginBanner({
       banner: {
         js: copyRight,
       },
@@ -73,7 +75,7 @@ export default defineConfig({
 
 ## Configuration
 
-* **Type:**
+* **Type**
 
 ```ts
 type BannerOptions = {

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-import.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-import.md
@@ -28,13 +28,13 @@ pnpm add @modern-js/plugin-module-import -D
 In Module Tools, you can register plugins in the following way:
 
 ```ts
-import moduleTools, defineConfig from '@modern-js/module-tools';
-import moduleImport from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig  } from '@modern-js/module-tools';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
 
 export default defineConfig({
   plugins: [
     moduleTools(),
-    moduleImport({
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'antd',
         style: true,
@@ -65,11 +65,13 @@ The elements of the array are configuration objects for `babel-plugin-import`, w
 **Example:**
 
 ```ts
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig  } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    moduleTools(),
+    modulePluginImport({
       pluginImport: [
         // babel-plugin-import`s options config
         {
@@ -108,13 +110,14 @@ import { MyButton as Btn } from 'foo';
 
 Add the following configuration on the right-hand side:
 
-
 ```ts
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig  } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    moduleTools(),
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'foo',
         customName: 'foo/es/{{ member }}'
@@ -129,11 +132,11 @@ export default defineConfig({
 The `{{ member }}` in it will be replaced with the corresponding import member.
 
 ```ts focus=8:8
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'foo',
         customName: 'foo/es/{{ member }}'
@@ -142,7 +145,6 @@ export default defineConfig({
   ],
 });
 ```
-
 
 ---
 After transformation:
@@ -153,18 +155,18 @@ import Btn from 'foo/es/MyButton';
 
 </CH.Spotlight>
 
-
 Template `customName: 'foo/es/{{ member }}'` is the same as `` customName: (member) => `foo/es/${member}` ``, but template value has no performance overhead of Node-API.
 
 The template used here is [handlebars](https://handlebarsjs.com). There are some useful builtin tools, Take the above import statement as an example:
 
-
 ```ts focus=8:8
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig  } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    moduleTools(),
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'foo',
         customName: 'foo/es/{{ kebabCase member }}',

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-node-polyfill.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-node-polyfill.md
@@ -86,14 +86,13 @@ export default defineConfig({
 });
 ```
 
-
 ## Node Polyfills
 
 ### Globals
 
-- `Buffer`
-- `process`
-- `console`
+* `Buffer`
+* `process`
+* `console`
 
 When the above global variables are used directly in code, the corresponding polyfill will be injected.
 
@@ -103,34 +102,34 @@ const bufferData = Buffer.from('xxxx');
 
 ### Modules
 
-- `assert`
-- `buffer`
-- `console`
-- `constants`
-- `crypto`
-- `domain`
-- `events`
-- `http`
-- `https`
-- `os`
-- `path`
-- `punycode`
-- `process`
-- `querystring`
-- `stream`
-- `_stream_duplex`
-- `_stream_passthrough`
-- `_stream_readable`
-- `_stream_transform`
-- `_stream_writable`
-- `string_decoder`
-- `sys`
-- `timers`
-- `tty`
-- `url`
-- `util`
-- `vm`
-- `zlib`
+* `assert`
+* `buffer`
+* `console`
+* `constants`
+* `crypto`
+* `domain`
+* `events`
+* `http`
+* `https`
+* `os`
+* `path`
+* `punycode`
+* `process`
+* `querystring`
+* `stream`
+* `_stream_duplex`
+* `_stream_passthrough`
+* `_stream_readable`
+* `_stream_transform`
+* `_stream_writable`
+* `string_decoder`
+* `sys`
+* `timers`
+* `tty`
+* `url`
+* `util`
+* `vm`
+* `zlib`
 
 When the above module is referenced in code via import / require syntax, the corresponding polyfill will be injected.
 
@@ -142,16 +141,16 @@ const bufferData = Buffer.from('xxxx');
 
 ### Fallbacks
 
-- `child_process`
-- `cluster`
-- `dgram`
-- `dns`
-- `fs`
-- `module`
-- `net`
-- `readline`
-- `repl`
-- `tls`
+* `child_process`
+* `cluster`
+* `dgram`
+* `dns`
+* `fs`
+* `module`
+* `net`
+* `readline`
+* `repl`
+* `tls`
 
 Currently there is no polyfill for the above modules on the browser side, so when you import the above modules, it will automatically fallback to an empty object.
 

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
@@ -1,0 +1,68 @@
+# Polyfill Plugin
+
+:::tip
+Normally, we don't need to inject polyfill for npm packages, this step should be done on the web application framework side, but in some scenarios we need to inject polyfill in order to make our library run directly in low version browsers.
+
+Note that this plugin does not transform your code syntax, it only injects polyfill for unsupported functions used in your code, importing them as normal functions instead of polluting the global. You need to install the `core-js-pure` dependency
+:::
+
+## Quick start
+
+### Install
+
+```bash
+# npm
+npm install @modern-js/plugin-module-polyfill -D
+
+# yarn
+yarn add @modern-js/plugin-module-polyfill -D
+
+# pnpm
+pnpm add @modern-js/plugin-module-polyfill -D
+```
+
+### Register
+
+In Module Tools, you can register plugins in the following way:
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginPolyfill(),
+  ],
+});
+```
+
+## Config
+
+* **Type**
+
+```ts
+type options = {
+  targets?: Record<string, string> | string;
+}
+```
+
+### targets
+
+See [babel target](https://babeljs.io/docs/options#targets).
+
+This is a example.
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginPolyfill({
+      targets: "> 0.25%, not dead"
+    }),
+  ],
+});
+```

--- a/packages/document/module-doc/docs/zh/plugins/official-list/overview.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/overview.md
@@ -5,3 +5,5 @@
 * [@modern-js/plugin-module-import](./plugin-import.md)：使用 SWC 提供与 `babel-plugin-import` 一样的能力。
 * [@modern-js/plugin-module-banner](./plugin-banner.md)：为每个 JS 和 CSS 文件的顶部和底部添加自定义内容，例如版权信息。
 * [@modern-js/plugin-module-node-polyfill](./plugin-node-polyfill.mdx)：会自动注入 Node 核心模块在浏览器端的 polyfills。
+* [@modern-js/plugin-module-polyfill](./plugin-polyfill.md)：为你的代码中使用到的不支持的功能注入 polyfill。
+* [@modern-js/plugin-module-babel](./plugin-babel.md)：使用 babel 转换你的代码。

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
@@ -1,0 +1,56 @@
+# Babel 插件
+
+:::tip
+通常情况下，我们无需使用 Babel 转换我们的代码，此插件仅作为一种降级方式。
+:::
+
+## 快速开始
+
+### 安装
+
+```bash
+# npm
+npm install @modern-js/plugin-module-babel -D
+
+# yarn
+yarn add @modern-js/plugin-module-babel -D
+
+# pnpm
+pnpm add @modern-js/plugin-module-babel -D
+```
+
+### 注册插件
+
+在 Module Tools 中，你可以按照如下方式注册插件：
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBabel } from '@modern-js/plugin-module-babel';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginBabel(),
+  ],
+});
+```
+
+## 配置
+
+See [babel options](https://babeljs.io/docs/options)
+
+下面是一个配置了`@babel/preset-env`的例子：
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBabel } from '@modern-js/plugin-module-babel';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginBabel({
+      presets: [['@babel/preset-env']],
+    }),
+  ],
+});
+```

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-banner.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-banner.md
@@ -17,19 +17,18 @@ yarn add @modern-js/plugin-module-banner -D
 pnpm add @modern-js/plugin-module-banner -D
 ```
 
-
 ### 注册插件
 
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import moduleTools, defineConfig from '@modern-js/module-tools';
-import pluginBanner from '@modern-js/plugin-module-banner';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBanner } from '@modern-js/plugin-module-banner';
 
 export default defineConfig({
   plugins: [
     moduleTools(),
-    pluginBanner({
+    modulePluginBanner({
       banner: {
         js: '//comment',
         css: '/*comment*/',
@@ -48,7 +47,8 @@ export default defineConfig({
 ### 在 JS 文件顶部增加版权信息
 
 ```ts
-import pluginBanner from '@modern-js/plugin-module-banner';
+import { modulePluginBanner } from '@modern-js/plugin-module-banner';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
 
 const copyRight = `/*
  © Copyright 2020 xxx.com or one of its affiliates.
@@ -62,7 +62,8 @@ const copyRight = `/*
 
 export default defineConfig({
   plugins: [
-    pluginBanner({
+    moduleTools(),
+    modulePluginBanner({
       banner: {
         js: copyRight,
       },
@@ -73,7 +74,7 @@ export default defineConfig({
 
 ## 配置
 
-* 类型：
+* **类型：**
 
 ```ts
 type BannerOptions = {

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-import.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-import.md
@@ -29,13 +29,13 @@ pnpm add @modern-js/plugin-module-import -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import moduleTools, defineConfig from '@modern-js/module-tools';
-import moduleImport from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
 
 export default defineConfig({
   plugins: [
     moduleTools(),
-    moduleImport({
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'antd',
         style: true,
@@ -49,7 +49,7 @@ export default defineConfig({
 
 ## 配置
 
-* 类型：
+* **类型：**
 
 ```ts
 type Options = {
@@ -66,11 +66,13 @@ type Options = {
 使用示例：
 
 ```ts
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    moduleTools(),
+    modulePluginImport({
       pluginImport: [
         // babel-plugin-import 的 options 配置
         {
@@ -109,13 +111,14 @@ import { MyButton as Btn } from 'foo';
 
 添加右侧的配置：
 
-
 ```ts
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    moduleTools(),
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'foo',
         customName: 'foo/es/{{ member }}'
@@ -130,11 +133,13 @@ export default defineConfig({
 其中的 `{{ member }}` 会被替换为相应的引入成员
 
 ```ts focus=8:8
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    moduleTools(),
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'foo',
         customName: 'foo/es/{{ member }}'
@@ -143,7 +148,6 @@ export default defineConfig({
   ],
 });
 ```
-
 
 ---
 转换后:
@@ -154,17 +158,18 @@ import Btn from 'foo/es/MyButton';
 
 </CH.Spotlight>
 
-
 可以看出配置 `customName: "foo/es/{{ member }}"` 的效果等同于配置 `` customName: (member) => `foo/es/${member}`  `` ，但是不会有 Node-API 的调用开销。
 
 这里使用到的模版是 [handlebars](https://handlebarsjs.com)，模版配置中还内置了一些有用的辅助工具，还是以上面的导入语句为例，配置成：
 
 ```ts focus=8:8
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
-    moduleImport({
+    moduleTools(),
+    modulePluginImport({
       pluginImport: [{
         libraryName: 'foo',
         customName: 'foo/es/{{ kebabCase member }}',

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-node-polyfill.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-node-polyfill.md
@@ -39,7 +39,7 @@ export default defineConfig({
 
 ## 配置
 
-* 类型：
+* **类型：**
 
 ```ts
 type NodePolyfillOptions = {
@@ -86,14 +86,13 @@ export default defineConfig({
 });
 ```
 
-
 ## Node Polyfills
 
 ### Globals
 
-- `Buffer`
-- `process`
-- `console`
+* `Buffer`
+* `process`
+* `console`
 
 当你在代码中使用以上全局变量时，对应 polyfill 会被自动注入。
 
@@ -103,34 +102,34 @@ const bufferData = Buffer.from('xxxx');
 
 ### Modules
 
-- `assert`
-- `buffer`
-- `console`
-- `constants`
-- `crypto`
-- `domain`
-- `events`
-- `http`
-- `https`
-- `os`
-- `path`
-- `punycode`
-- `process`
-- `querystring`
-- `stream`
-- `_stream_duplex`
-- `_stream_passthrough`
-- `_stream_readable`
-- `_stream_transform`
-- `_stream_writable`
-- `string_decoder`
-- `sys`
-- `timers`
-- `tty`
-- `url`
-- `util`
-- `vm`
-- `zlib`
+* `assert`
+* `buffer`
+* `console`
+* `constants`
+* `crypto`
+* `domain`
+* `events`
+* `http`
+* `https`
+* `os`
+* `path`
+* `punycode`
+* `process`
+* `querystring`
+* `stream`
+* `_stream_duplex`
+* `_stream_passthrough`
+* `_stream_readable`
+* `_stream_transform`
+* `_stream_writable`
+* `string_decoder`
+* `sys`
+* `timers`
+* `tty`
+* `url`
+* `util`
+* `vm`
+* `zlib`
 
 当你通过 `require` 或 `import` 等语法在代码中引用以上模块时，对应 polyfill 会被注入。
 
@@ -142,16 +141,16 @@ const bufferData = Buffer.from('xxxx');
 
 ### Fallbacks
 
-- `child_process`
-- `cluster`
-- `dgram`
-- `dns`
-- `fs`
-- `module`
-- `net`
-- `readline`
-- `repl`
-- `tls`
+* `child_process`
+* `cluster`
+* `dgram`
+* `dns`
+* `fs`
+* `module`
+* `net`
+* `readline`
+* `repl`
+* `tls`
 
 目前浏览器端没有以上模块的 polyfill，因此当你引用以上模块时，会自动 fallback 为一个空对象。
 

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
@@ -1,0 +1,68 @@
+# Polyfill 插件
+
+:::tip
+通常情况下，我们不需要为 npm 包注入 polyfill，这一步应该在 Web 应用的框架侧完成，但是在某些场景，为了让我们的库能够直接运行在低版本浏览器里，我们需要注入 polyfill。
+
+请注意，此插件并不会转化你的代码语法，只会为你的代码中使用到的不支持的功能注入 polyfill，把它们作为普通函数导入而不是污染全局。你需要安装 `core-js-pure` 依赖
+:::
+
+## 快速开始
+
+### 安装
+
+```bash
+# npm
+npm install @modern-js/plugin-module-polyfill -D
+
+# yarn
+yarn add @modern-js/plugin-module-polyfill -D
+
+# pnpm
+pnpm add @modern-js/plugin-module-polyfill -D
+```
+
+### 注册插件
+
+在 Module Tools 中，你可以按照如下方式注册插件：
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginPolyfill(),
+  ],
+});
+```
+
+## 配置
+
+* **类型：**
+
+```ts
+type options = {
+  targets?: Record<string, string> | string;
+}
+```
+
+### targets
+
+See [babel target](https://babeljs.io/docs/options#targets).
+
+This is a example.
+
+```ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginPolyfill({
+      targets: "> 0.25%, not dead"
+    }),
+  ],
+});
+```

--- a/packages/module/plugin-module-babel/README.md
+++ b/packages/module/plugin-module-babel/README.md
@@ -6,12 +6,13 @@ You can add babel compile by the plugin before module-tools internal building.
 
 ## Usage
 
-```ts
-import { defineConfig } from '@modern-js/module-tools';
-import { ModulePluginBabel } from '@modern-js/plugin-module-main-fields';
+```ts modern.config.ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 export default defineConfig({
   plugins: [
-    ModulePluginBabel({
+    moduleTools(),
+    modulePluginBabel({
       internalPresetOptions: {
         // babel-plugin-import options
         import: {},

--- a/packages/module/plugin-module-babel/src/index.ts
+++ b/packages/module/plugin-module-babel/src/index.ts
@@ -5,7 +5,7 @@ export type Options = typeof babelPlugin extends (arg1: infer P) => void
   ? P
   : never;
 
-// deprecated export name
+// deprecated named export
 export const ModulePluginBabel = (
   options?: Options,
 ): CliPlugin<ModuleTools> => ({
@@ -18,5 +18,5 @@ export const ModulePluginBabel = (
   }),
 });
 
-// right export name
+// right named export
 export { ModulePluginBabel as modulePluginBabel };

--- a/packages/module/plugin-module-banner/README.md
+++ b/packages/module/plugin-module-banner/README.md
@@ -2,6 +2,25 @@
 
 The banner plugin of Modern.js Module Tools.
 
+## Usage
+
+```ts modern.config.ts
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginBanner } from '@modern-js/plugin-module-banner';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginBanner({
+      banner: {
+        js: '//comment',
+        css: '/*comment*/',
+      },
+    }),
+  ],
+});
+```
+
 ## Documentation
 
 - [English Documentation](https://modernjs.dev/module-tools/en)

--- a/packages/module/plugin-module-banner/src/index.ts
+++ b/packages/module/plugin-module-banner/src/index.ts
@@ -1,6 +1,6 @@
 import type { CliPlugin, ModuleTools } from '@modern-js/module-tools';
 
-export default (options: {
+export const modulePluginBanner = (options: {
   banner: { js?: string; css?: string };
   footer?: { js?: string; css?: string };
 }): CliPlugin<ModuleTools> => ({
@@ -24,3 +24,6 @@ export default (options: {
     },
   }),
 });
+
+// deprecated default export
+export default modulePluginBanner;

--- a/packages/module/plugin-module-doc/src/index.ts
+++ b/packages/module/plugin-module-doc/src/index.ts
@@ -2,7 +2,9 @@ import type { CliPlugin, ModuleTools } from '@modern-js/module-tools';
 import type { PluginOptions } from './types';
 import { run } from './features';
 
-export default (pluginOptions?: PluginOptions): CliPlugin<ModuleTools> => ({
+export const modulePluginDoc = (
+  pluginOptions?: PluginOptions,
+): CliPlugin<ModuleTools> => ({
   name: '@modern-js/plugin-module-doc',
   setup: api => ({
     registerDev() {
@@ -43,3 +45,6 @@ export default (pluginOptions?: PluginOptions): CliPlugin<ModuleTools> => ({
 });
 
 export { PluginOptions };
+
+// deprecated default export
+export default modulePluginDoc;

--- a/packages/module/plugin-module-import/README.md
+++ b/packages/module/plugin-module-import/README.md
@@ -8,12 +8,12 @@ A Library author don't want to "pollute" the global scope with the polyfills you
 
 ## Usage
 
-```ts
+```ts modern.config.ts
 import { defineConfig } from '@modern-js/module-tools';
-import moduleImport from '@modern-js/plugin-module-import';
+import { modulePluginImport } from '@modern-js/plugin-module-import';
 
 export default defineConfig({
-  plugins: [moduleImport({
+  plugins: [modulePluginImport({
     pluginImport: [
       {
           libraryName: 'antd',

--- a/packages/module/plugin-module-import/src/index.ts
+++ b/packages/module/plugin-module-import/src/index.ts
@@ -2,7 +2,7 @@ import type { CliPlugin, ModuleTools } from '@modern-js/module-tools';
 import type { ImportItem } from '@modern-js/libuild-plugin-swc';
 import { swcTransformPluginName } from '@modern-js/libuild-plugin-swc';
 
-export default (options: {
+export const modulePluginImport = (options: {
   pluginImport?: ImportItem[];
 }): CliPlugin<ModuleTools> => ({
   name: '@modern-js/plugin-module-import',
@@ -42,3 +42,6 @@ export default (options: {
     },
   }),
 });
+
+// deprecated default export
+export default modulePluginImport;

--- a/packages/module/plugin-module-main-fields/README.md
+++ b/packages/module/plugin-module-main-fields/README.md
@@ -1,32 +1,5 @@
-# @modern-js/plugin-module-main-fields
+# Deprecated Package
 
-The main fields plugin of Modern.js Module Tools.
+This package will be deprecated when next major version release and will no longer be maintained.
 
-You can set [mainFields](https://esbuild.github.io/api/#target) extended module-tools's default behavior by the plugin.
-
-## Usage
-
-```ts
-import { defineConfig } from '@modern-js/module-tools';
-import { ModuleMainFieldsPlugin } from '@modern-js/plugin-module-main-fields';
-export default defineConfig({
-  plugins: [
-    ModuleMainFieldsPlugin({
-      mainFields: ['module', 'main', 'jsnext'],
-    }),
-  ],
-});
-```
-
-## Documentation
-
-- [English Documentation](https://modernjs.dev/module-tools/en)
-- [中文文档](https://modernjs.dev/module-tools/)
-
-## Contributing
-
-Please read the [Contributing Guide](https://github.com/web-infra-dev/modern.js/blob/main/CONTRIBUTING.md).
-
-## License
-
-Modern.js is [MIT licensed](https://github.com/web-infra-dev/modern.js/blob/main/LICENSE).
+In 2.x, you can still use it.

--- a/packages/module/plugin-module-polyfill/README.md
+++ b/packages/module/plugin-module-polyfill/README.md
@@ -9,14 +9,18 @@ A Library author don't want to "pollute" the global scope with the polyfills you
 ## Usage
 
 ```ts
-import { defineConfig } from '@modern-js/module-tools';
-import { ModulePolyfillPlugin } from '@modern-js/plugin-module-polyfill';
+import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
+
 export default defineConfig({
-  plugins: [ModulePolyfillPlugin({
-    targets: {
-      ios: '9';
-    }
-  })],
+  plugins: [
+    moduleTools(),
+    modulePluginPolyfill({
+      targets: {
+        ios: '9';
+      }
+    })
+  ],
 });
 ```
 

--- a/packages/module/plugin-module-polyfill/src/index.ts
+++ b/packages/module/plugin-module-polyfill/src/index.ts
@@ -1,6 +1,7 @@
 import type { CliPlugin, ModuleTools } from '@modern-js/module-tools';
 import { babelPlugin } from '@modern-js/libuild-plugin-babel';
 
+// deprecated named export
 export const ModulePolyfillPlugin = (options?: {
   targets?: Record<string, string> | string;
 }): CliPlugin<ModuleTools> => ({
@@ -27,3 +28,6 @@ export const ModulePolyfillPlugin = (options?: {
     },
   }),
 });
+
+// right named export
+export { ModulePolyfillPlugin as modulePluginPolyfill };

--- a/packages/module/plugin-module-target/README.md
+++ b/packages/module/plugin-module-target/README.md
@@ -1,41 +1,13 @@
-# @modern-js/plugin-module-target
+# Deprecated Package
 
-The target plugin of Modern.js Module Tools.
+This package will be deprecated when next major version release and will no longer be maintained.
 
-You can set [target](https://esbuild.github.io/api/#target) instead of module-tools's [`target`](https://modernjs.dev/module-tools/en/api/config/build-config.html#target) api by the plugin.
+In 2.x, you can still use it.
 
-**Note: It may not work correctly**
+We recommend that you use an alternative solution instead.
 
-## Usage
+## Alternatives
 
-```ts
-import { defineConfig } from '@modern-js/module-tools';
-import { ModuleTargetPlugin } from '@modern-js/plugin-module-target';
-export default defineConfig({
-  plugins: [
-    ModuleTargetPlugin({
-      target: [
-        'es2020',
-        'chrome58',
-        'edge16',
-        'firefox57',
-        'node12',
-        'safari11',
-      ],
-    }),
-  ],
-});
-```
+- [esbuildOptions](https://modernjs.dev/module-tools/api/config/build-config.html#esbuildoptions)
 
-## Documentation
-
-- [English Documentation](https://modernjs.dev/module-tools/en)
-- [中文文档](https://modernjs.dev/module-tools/)
-
-## Contributing
-
-Please read the [Contributing Guide](https://github.com/web-infra-dev/modern.js/blob/main/CONTRIBUTING.md).
-
-## License
-
-Modern.js is [MIT licensed](https://github.com/web-infra-dev/modern.js/blob/main/LICENSE).
+You can use esbuildOptions to set esbuild target directly after 2.14.0.


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 361c7f4</samp>

This pull request updates several module plugins and their documentation to use a consistent naming convention for their exports, deprecating the old default exports and recommending the new named exports. It also adds two new module plugins, `@modern-js/plugin-module-polyfill` and `@modern-js/plugin-module-babel`, and their documentation pages in English and Chinese. Additionally, it marks the `@modern-js/plugin-module-main-fields` plugin as deprecated and updates the readme files of all the module plugins with the correct file name for the configuration file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 361c7f4</samp>

*  Add and update documentation pages for two new official plugins, `@modern-js/plugin-module-polyfill` and `@modern-js/plugin-module-babel`, in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-763c8398e48df7a8d71966585ff22e6d9699df62cc570728f5cccacfb2d09cb2R8-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-e4f5cee8cfb9499f9abed1bf1714327eedcad5f2db666a25441bba80cfd7fde6R1-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-999e57e70d33d6d85988f13c3544961a8c0fb8328d1abdec2009a066de7e174aR1-R54), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-b2273ae139c48c3568d433561df7a8b7ce2289d980ca6a92aa0dad539e6c87f1R8-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-df490092786f10ce9c53f9e808c3361a6610a5d9e467bc81656989ad05f0afa5R1-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-f3289067f803f0fb66eda5447f70ef5a03ad417aefba72b1b2b3c10ebcf08948R1-R54))
*  Update documentation pages for three existing official plugins, `@modern-js/plugin-module-banner`, `@modern-js/plugin-module-import`, and `@modern-js/plugin-module-doc`, in both English and Chinese, to use named exports instead of deprecated default exports, and to fix some minor issues ([link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8b554dae261d03774d8298df38967f7eeadc0e2b57315f965f0dd7d26015bf72L20), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8b554dae261d03774d8298df38967f7eeadc0e2b57315f965f0dd7d26015bf72L27-R31), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8b554dae261d03774d8298df38967f7eeadc0e2b57315f965f0dd7d26015bf72L51-R50), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8b554dae261d03774d8298df38967f7eeadc0e2b57315f965f0dd7d26015bf72L65-R64), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8672a35326a899aa27f28cb54c395233c9b754ca8f50d7fa9d7d2b10cfd4ff0aL32-R37), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8672a35326a899aa27f28cb54c395233c9b754ca8f50d7fa9d7d2b10cfd4ff0aL68-R72), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8672a35326a899aa27f28cb54c395233c9b754ca8f50d7fa9d7d2b10cfd4ff0aL113-R117), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8672a35326a899aa27f28cb54c395233c9b754ca8f50d7fa9d7d2b10cfd4ff0aL132-R136), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-8672a35326a899aa27f28cb54c395233c9b754ca8f50d7fa9d7d2b10cfd4ff0aL163-R167), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-861f1bd72fe9beb1927e0a4200e2b9d67335c966fac949850841e01a22ce6885L20), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-861f1bd72fe9beb1927e0a4200e2b9d67335c966fac949850841e01a22ce6885L27-R31), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-861f1bd72fe9beb1927e0a4200e2b9d67335c966fac949850841e01a22ce6885L51-R50), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-861f1bd72fe9beb1927e0a4200e2b9d67335c966fac949850841e01a22ce6885L65-R64), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-fb16a99173cc6a82e0f68021bc37319fafd9eda34f552bb8ddb5a1eb6213c088L33-R38), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-fb16a99173cc6a82e0f68021bc37319fafd9eda34f552bb8ddb5a1eb6213c088L69-R73), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-fb16a99173cc6a82e0f68021bc37319fafd9eda34f552bb8ddb5a1eb6213c088L114-R118), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-fb16a99173cc6a82e0f68021bc37319fafd9eda34f552bb8ddb5a1eb6213c088L133-R137), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-fb16a99173cc6a82e0f68021bc37319fafd9eda34f552bb8ddb5a1eb6213c088L163-R167), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-f9d76df0ab20ff0e46c28528a653a39ee264c362416fa19619938df0ff29cad3L5-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-f9d76df0ab20ff0e46c28528a653a39ee264c362416fa19619938df0ff29cad3R48-R50))
*  Update readme files for four official plugins, `@modern-js/plugin-module-babel`, `@modern-js/plugin-module-banner`, `@modern-js/plugin-module-import`, and `@modern-js/plugin-module-main-fields`, to reflect the latest usage and deprecation status ([link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-a4e09de14a816008489fd319fdcaa4bdd8ed8c7e4985ebb3b137dde1d8f1a065L9-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-aefec705a95a7c9bcaaf5fa07eb0e771824c18abab214ef578c6f3a8496eec97R5-R23), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-ec66e20f4cb293b23eacdda66d29366d2ad6ff260dada8f93e306af26bf1300eL11-R16), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-23c32111595e027c7b85ffe580efbcc01ed269433c81da12b7cac0936fc910e0L1-R5))
*  Update source code files for five official plugins, `@modern-js/plugin-module-babel`, `@modern-js/plugin-module-banner`, `@modern-js/plugin-module-import`, `@modern-js/plugin-module-doc`, and `@modern-js/plugin-module-polyfill`, to use consistent naming conventions for named exports, and to add deprecation warnings for default exports ([link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-f8fa9c790144a806bdbf089a240f9b7765ad0acef0a27750a763b8598f1ac110L8-R8), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-f8fa9c790144a806bdbf089a240f9b7765ad0acef0a27750a763b8598f1ac110L21-R21), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-7a0d261bc40b2044e6b5acf4a51ca320551713c6bcf67823600c7e24da08aa6eL3-R3), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-7a0d261bc40b2044e6b5acf4a51ca320551713c6bcf67823600c7e24da08aa6eR27-R29), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-fc00854d8766ad246d4e32140b63c6d09fd815edaabe27001ac1528df07050f2L5-R5), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-fc00854d8766ad246d4e32140b63c6d09fd815edaabe27001ac1528df07050f2R45-R47), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-f1422e71fb4e6e98b900309262f2a66f4919ba89379193235051e64a461d7192R4), [link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-f1422e71fb4e6e98b900309262f2a66f4919ba89379193235051e64a461d7192R31-R33))
*  Add a changeset file to document the patch updates for the official plugins and the chore of updating their docs and readme ([link](https://github.com/web-infra-dev/modern.js/pull/3782/files?diff=unified&w=0#diff-db144c5d4d115ed0d26b8c2f01931d1b554b2c3353110e8565c6260957fc2561R1-R10))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
