### PR TITLE
feat(builder): add arco config to transformImport by default

### DIFF
--- a/.changeset/gorgeous-rockets-hope.md
+++ b/.changeset/gorgeous-rockets-hope.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-doc': patch
+'@modern-js/builder': patch
+---
+
+feat(builder): add arco config to transformImport by default
+
+feat(builder): 默认增加 arco 的 transformImport 配置

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -70,6 +70,7 @@
     "webpack": "^5.82.1"
   },
   "devDependencies": {
+    "@arco-design/web-react": "^2.46.0",
     "@modern-js/e2e": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",

--- a/packages/builder/builder-rspack-provider/src/shared/plugin.ts
+++ b/packages/builder/builder-rspack-provider/src/shared/plugin.ts
@@ -6,6 +6,7 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
     import('../plugins/transition').then(m => m.builderPluginTransition()),
     import('../plugins/basic').then(m => m.builderPluginBasic()),
     plugins.antd(),
+    plugins.arco(),
     plugins.entry(),
     // plugins.cache(),
     plugins.target(),

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -23,6 +23,17 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "libraryName": "antd",
         "style": true,
       },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "es",
+        "libraryName": "@arco-design/web-react",
+        "style": true,
+      },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "react-icon",
+        "libraryName": "@arco-design/web-react/icon",
+      },
     ],
     "presetEnv": {
       "coreJs": "3.30",
@@ -721,6 +732,17 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "libraryDirectory": "es",
         "libraryName": "antd",
         "style": true,
+      },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "es",
+        "libraryName": "@arco-design/web-react",
+        "style": true,
+      },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "react-icon",
+        "libraryName": "@arco-design/web-react/icon",
       },
     ],
     "presetEnv": {
@@ -1430,6 +1452,17 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
         "libraryName": "antd",
         "style": true,
       },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "lib",
+        "libraryName": "@arco-design/web-react",
+        "style": true,
+      },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "react-icon-cjs",
+        "libraryName": "@arco-design/web-react/icon",
+      },
     ],
     "presetEnv": {
       "targets": [
@@ -1855,6 +1888,17 @@ exports[`tools.rspack > should match snapshot 1`] = `
         "libraryDirectory": "es",
         "libraryName": "antd",
         "style": true,
+      },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "es",
+        "libraryName": "@arco-design/web-react",
+        "style": true,
+      },
+      {
+        "camelToDashComponentName": false,
+        "libraryDirectory": "react-icon",
+        "libraryName": "@arco-design/web-react/icon",
       },
     ],
     "presetEnv": {

--- a/packages/builder/builder-rspack-provider/tests/plugins/swc.test.ts
+++ b/packages/builder/builder-rspack-provider/tests/plugins/swc.test.ts
@@ -4,7 +4,7 @@ import { builderPluginEntry } from '@builder/plugins/entry';
 import { createBuilder } from '../helper';
 import { builderPluginSwc } from '@/plugins/swc';
 import { BuilderConfig } from '@/types';
-import { builderAntdPlugin } from '~/../builder/src/plugins/antd';
+import { builderPluginAntd } from '~/../builder/src/plugins/antd';
 
 describe('plugins/swc', () => {
   it('should disable preset_env in target other than web', async () => {
@@ -98,7 +98,7 @@ describe('plugins/swc', () => {
       entry: {
         main: './src/index.js',
       },
-      plugins: [builderPluginSwc(), builderPluginEntry(), builderAntdPlugin()],
+      plugins: [builderPluginSwc(), builderPluginEntry(), builderPluginAntd()],
       builderConfig: {
         source: {
           transformImport: false,
@@ -121,7 +121,7 @@ describe('plugins/swc', () => {
       entry: {
         main: './src/index.js',
       },
-      plugins: [builderPluginSwc(), builderPluginEntry(), builderAntdPlugin()],
+      plugins: [builderPluginSwc(), builderPluginEntry(), builderPluginAntd()],
     });
 
     const {

--- a/packages/builder/builder-shared/src/test-stub/helper.ts
+++ b/packages/builder/builder-shared/src/test-stub/helper.ts
@@ -29,6 +29,7 @@ export const mockBuilderPlugins: Plugins = {
   svg: genMockPlugin('builder-plugin-svg'),
   html: genMockPlugin('builder-plugin-html'),
   antd: genMockPlugin('antd'),
+  arco: genMockPlugin('arco'),
   tsChecker: genMockPlugin('builder-plugin-ts-checker'),
   checkSyntax: genMockPlugin('builder-plugin-check-syntax'),
 };

--- a/packages/builder/builder-shared/src/types/plugin.ts
+++ b/packages/builder/builder-shared/src/types/plugin.ts
@@ -52,6 +52,7 @@ export type Plugins = {
   svg: PluginsFn;
   html: PluginsFn;
   antd: PluginsFn;
+  arco: PluginsFn;
   tsChecker: PluginsFn;
   checkSyntax: PluginsFn;
 };

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -109,6 +109,7 @@
     "webpack": "^5.82.1"
   },
   "devDependencies": {
+    "@arco-design/web-react": "^2.46.0",
     "@modern-js/e2e": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/caniuse-lite": "^1.0.1",

--- a/packages/builder/builder-webpack-provider/src/shared/plugin.ts
+++ b/packages/builder/builder-webpack-provider/src/shared/plugin.ts
@@ -34,6 +34,7 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
     plugins.cleanOutput?.(),
     import('../plugins/hmr').then(m => m.builderPluginHMR()),
     plugins.antd(),
+    plugins.arco(),
     plugins.svg(),
     import('../plugins/pug').then(m => m.builderPluginPug()),
     plugins.checkSyntax(),

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -471,6 +471,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "antd",
                 ],
                 [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "es",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
+                ],
+                [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
@@ -589,6 +608,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                     "style": true,
                   },
                   "antd",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "es",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
@@ -1337,6 +1375,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                   "antd",
                 ],
                 [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "es",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
+                ],
+                [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
@@ -1461,6 +1518,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                     "style": true,
                   },
                   "antd",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "es",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
@@ -2149,6 +2225,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "antd",
                 ],
                 [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "lib",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon-cjs",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
+                ],
+                [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
@@ -2271,6 +2366,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                     "style": true,
                   },
                   "antd",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "lib",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon-cjs",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
@@ -2885,6 +2999,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "antd",
                 ],
                 [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "es",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
+                ],
+                [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
@@ -3009,6 +3142,25 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                     "style": true,
                   },
                   "antd",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "es",
+                    "libraryName": "@arco-design/web-react",
+                    "style": true,
+                  },
+                  "@arco-design/web-react",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-import/index.js",
+                  {
+                    "camel2DashComponentName": false,
+                    "libraryDirectory": "react-icon",
+                    "libraryName": "@arco-design/web-react/icon",
+                  },
+                  "@arco-design/web-react/icon",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",

--- a/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it } from 'vitest';
 import { builderPluginBasic } from '@/plugins/basic';
 import { createStubBuilder } from '@/stub';
 import { builderPluginBabel } from '@/plugins/babel';
-import { builderAntdPlugin } from '~/../builder/src/plugins/antd';
+import { builderPluginAntd } from '~/../builder/src/plugins/antd';
 
 describe('webpackConfig', () => {
   it('should allow tools.webpack to return config', async () => {
@@ -230,7 +230,7 @@ describe('webpackConfig', () => {
   it('should not set default pluginImport for Babel', async () => {
     // camelToDashComponentName
     const builder = await createStubBuilder({
-      plugins: [builderPluginBabel(), builderAntdPlugin()],
+      plugins: [builderPluginBabel(), builderPluginAntd()],
     });
     const config = await builder.unwrapWebpackConfig();
 
@@ -246,7 +246,7 @@ describe('webpackConfig', () => {
   it('should not have any pluginImport in Babel', async () => {
     // camelToDashComponentName
     const builder = await createStubBuilder({
-      plugins: [builderPluginBabel(), builderAntdPlugin()],
+      plugins: [builderPluginBabel(), builderPluginAntd()],
       builderConfig: {
         source: {
           transformImport: false,

--- a/packages/builder/builder/src/plugins/antd.ts
+++ b/packages/builder/builder/src/plugins/antd.ts
@@ -4,7 +4,7 @@ import type {
   DefaultBuilderPlugin,
 } from '@modern-js/builder-shared';
 
-export const builderAntdPlugin = (): DefaultBuilderPlugin => ({
+export const builderPluginAntd = (): DefaultBuilderPlugin => ({
   name: `builder-plugin-antd`,
 
   setup(api) {
@@ -38,7 +38,7 @@ export const builderAntdPlugin = (): DefaultBuilderPlugin => ({
   },
 });
 
-function useSSR(target: BuilderTarget | BuilderTarget[]) {
+export function useSSR(target: BuilderTarget | BuilderTarget[]) {
   return (Array.isArray(target) ? target : [target]).some(item =>
     ['node', 'service-worker'].includes(item),
   );

--- a/packages/builder/builder/src/plugins/arco.ts
+++ b/packages/builder/builder/src/plugins/arco.ts
@@ -1,0 +1,45 @@
+import { isPackageInstalled } from '@modern-js/utils';
+import { useSSR } from './antd';
+import type { DefaultBuilderPlugin } from '@modern-js/builder-shared';
+
+export const builderPluginArco = (): DefaultBuilderPlugin => ({
+  name: `builder-plugin-arco`,
+
+  setup(api) {
+    const ARCO_NAME = '@arco-design/web-react';
+    const ARCO_ICON = `${ARCO_NAME}/icon`;
+
+    api.modifyBuilderConfig(builderConfig => {
+      const { transformImport = [] } = builderConfig.source || {};
+
+      if (
+        transformImport === false ||
+        !isPackageInstalled(ARCO_NAME, api.context.rootPath)
+      ) {
+        return;
+      }
+
+      const isUseSSR = useSSR(api.context.target);
+
+      if (!transformImport?.some(item => item.libraryName === ARCO_NAME)) {
+        transformImport.push({
+          libraryName: ARCO_NAME,
+          libraryDirectory: isUseSSR ? 'lib' : 'es',
+          camelToDashComponentName: false,
+          style: true,
+        });
+      }
+
+      if (!transformImport?.some(item => item.libraryName === ARCO_ICON)) {
+        transformImport.push({
+          libraryName: ARCO_ICON,
+          libraryDirectory: isUseSSR ? 'react-icon-cjs' : 'react-icon',
+          camelToDashComponentName: false,
+        });
+      }
+
+      builderConfig.source ||= {};
+      builderConfig.source.transformImport = transformImport;
+    });
+  },
+});

--- a/packages/builder/builder/src/plugins/index.ts
+++ b/packages/builder/builder/src/plugins/index.ts
@@ -36,7 +36,8 @@ export const plugins: Plugins = {
     ),
   assetsRetry: () =>
     import('./assetsRetry').then(m => m.builderPluginAssetsRetry()),
-  antd: () => import('./antd').then(m => m.builderAntdPlugin()),
+  antd: () => import('./antd').then(m => m.builderPluginAntd()),
+  arco: () => import('./arco').then(m => m.builderPluginArco()),
   tsChecker: () => import('./tsChecker').then(m => m.builderPluginTsChecker()),
   checkSyntax: () =>
     import('./checkSyntax').then(m => m.builderPluginCheckSyntax()),

--- a/packages/document/builder-doc/docs/en/config/source/transformImport.md
+++ b/packages/document/builder-doc/docs/en/config/source/transformImport.md
@@ -1,48 +1,74 @@
 Used to import the code and style of the component library on demand, which is equivalent to [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import).
 
-The difference from [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import) is that `source.transformImport` is not coupled with Babel. The Builder will automatically identify whether the currently used tools is Babel, SWC or Rspack, and apply the corresponding on-demand import configuration.
+The difference between it and [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import) is that `source.transformImport` is not coupled with Babel. Builder will automatically identify whether the currently used tools is Babel, SWC or Rspack, and apply the corresponding on-demand import configuration.
 
 - **Type:**
 
 ```ts
-type Config = false | Array<{
-  libraryName: string;
-  libraryDirectory?: string;
-  style?: string | boolean;
-  styleLibraryDirectory?: string;
-  camelToDashComponentName?: boolean;
-  transformToDefaultImport?: boolean;
-  customName?: ((member: string) => string | undefined) | string;
-  customStyleName?: ((member: string) => string | undefined) | string;
-}>;
+type Config =
+  | false
+  | Array<{
+      libraryName: string;
+      libraryDirectory?: string;
+      style?: string | boolean;
+      styleLibraryDirectory?: string;
+      camelToDashComponentName?: boolean;
+      transformToDefaultImport?: boolean;
+      customName?: ((member: string) => string | undefined) | string;
+      customStyleName?: ((member: string) => string | undefined) | string;
+    }>;
 ```
 
 - **Default:**
 
-When the [antd component library](https://www.npmjs.com/package/antd) &lt;= 4.x version is installed in the project, Builder will automatically add the corresponding on-demand import configuration. The default configuration is as follows:
+When the [Ant Design component library](https://www.npmjs.com/package/antd) &lt;= 4.x version is installed in the project, Builder will automatically add the following default configurations:
 
 ```js
-{
+const defaultAntdConfig = {
   libraryName: 'antd',
-  libraryDirectory: target === 'node' ? 'lib' : 'es',
+  libraryDirectory: isServer ? 'lib' : 'es',
   style: true,
-}
+};
 ```
 
-You can manually set `transformImport: false` to turn off the default behavior of transformImport.
+When the [Arco Design component library](https://www.npmjs.com/package/@arco-design/web-react) is installed in the project, Builder will automatically add the following default configurations:
 
-For example, when you use `externals` to avoid bundling antd, because `transformImport` will convert the imported path of antd by default, the matching path changes and externals cannot take effect. At this time, you can set `transformImport: false` to avoid this problem.
+```js
+const defaultArcoConfig = [
+  {
+    libraryName: '@arco-design/web-react',
+    libraryDirectory: isServer ? 'lib' : 'es',
+    camelToDashComponentName: false,
+    style: true,
+  },
+  {
+    libraryName: '@arco-design/web-react/icon',
+    libraryDirectory: isServer ? 'react-icon-cjs' : 'react-icon',
+    camelToDashComponentName: false,
+  },
+];
+```
+
+:::tip
+When you add configurations for `antd` or `@arco-design/web-react`, the priority will be higher than the default configurations mentioned above.
+:::
 
 ### Example
 
 When using the above antd default configuration:
 
 ```js
-{
-  libraryName: 'antd',
-  libraryDirectory: 'es',
-  style: true,
-}
+export default {
+  source: {
+    transformImport: [
+      {
+        libraryName: 'antd',
+        libraryDirectory: 'es',
+        style: true,
+      },
+    ],
+  },
+};
 ```
 
 The source code is as follows:
@@ -57,6 +83,20 @@ It will be transformed into:
 import Button from 'antd/es/button';
 import 'antd/es/button/style';
 ```
+
+### Disable Default Config
+
+You can manually set `transformImport: false` to disable the default config.
+
+```js
+export default {
+  source: {
+    transformImport: false,
+  },
+};
+```
+
+For example, if you use `externals` to avoid bundling antd, because `transformImport` will convert the imported path of antd by default, the matching path changes and externals cannot take effect. At this time, you can disable `transformImport` to avoid this problem.
 
 ### Configuration
 

--- a/packages/document/builder-doc/docs/zh/config/source/transformImport.md
+++ b/packages/document/builder-doc/docs/zh/config/source/transformImport.md
@@ -1,48 +1,74 @@
 用于按需引入组件库的代码和样式，能力等价于 [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import)。
 
-与 [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import) 的区别在于，`source.transformImport` 不与 Babel 耦合。Builder 会自动识别当前使用的编译工具是 Babel、SWC 还是 Rspack，并添加相应的按需引入配置。
+它与 [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import) 的区别在于，`source.transformImport` 不与 Babel 耦合。Builder 会自动识别当前使用的编译工具是 Babel、SWC 还是 Rspack，并添加相应的按需引入配置。
 
 - **类型：**
 
 ```ts
-type Config = false | Array<{
-  libraryName: string;
-  libraryDirectory?: string;
-  style?: string | boolean;
-  styleLibraryDirectory?: string;
-  camelToDashComponentName?: boolean;
-  transformToDefaultImport?: boolean;
-  customName?: ((member: string) => string | undefined) | string;
-  customStyleName?: ((member: string) => string | undefined) | string;
-}>;
+type Config =
+  | false
+  | Array<{
+      libraryName: string;
+      libraryDirectory?: string;
+      style?: string | boolean;
+      styleLibraryDirectory?: string;
+      camelToDashComponentName?: boolean;
+      transformToDefaultImport?: boolean;
+      customName?: ((member: string) => string | undefined) | string;
+      customStyleName?: ((member: string) => string | undefined) | string;
+    }>;
 ```
 
 - **默认值：**
 
-当项目中安装了 [antd 组件库](https://www.npmjs.com/package/antd) &lt;= 4.x 版本时，Builder 会自动添加对应的按需引入配置，默认配置如下：
+当项目中安装了 [Ant Design 组件库](https://www.npmjs.com/package/antd) &lt;= 4.x 版本时，Builder 会自动添加以下默认配置：
 
 ```js
-{
+const defaultAntdConfig = {
   libraryName: 'antd',
-  libraryDirectory: target === 'node' ? 'lib' : 'es',
+  libraryDirectory: isServer ? 'lib' : 'es',
   style: true,
-}
+};
 ```
 
-你可以手动设置 `transformImport: false` 来关掉 transformImport 的默认行为。
+当项目中安装了 [Arco Design 组件库](https://www.npmjs.com/package/@arco-design/web-react) 时，Builder 会自动添加以下默认配置：
 
-比如，当你使用了 `externals` 来避免打包 antd 时，由于 `transformImport` 默认会转换 antd 的引用路径，导致匹配的路径发生了变化，因此 externals 无法生效。此时你可以设置 `transformImport: false` 来避免该问题。
+```js
+const defaultArcoConfig = [
+  {
+    libraryName: '@arco-design/web-react',
+    libraryDirectory: isServer ? 'lib' : 'es',
+    camelToDashComponentName: false,
+    style: true,
+  },
+  {
+    libraryName: '@arco-design/web-react/icon',
+    libraryDirectory: isServer ? 'react-icon-cjs' : 'react-icon',
+    camelToDashComponentName: false,
+  },
+];
+```
+
+:::tip
+当你添加了 `antd` 或 `@arco-design/web-react` 相关的配置时，优先级会高于上述默认配置。
+:::
 
 ### 示例
 
 当使用上述 antd 默认配置：
 
 ```js
-{
-  libraryName: 'antd',
-  libraryDirectory: 'es',
-  style: true,
-}
+export default {
+  source: {
+    transformImport: [
+      {
+        libraryName: 'antd',
+        libraryDirectory: 'es',
+        style: true,
+      },
+    ],
+  },
+};
 ```
 
 源代码如下：
@@ -57,6 +83,20 @@ import { Button } from 'antd';
 import Button from 'antd/es/button';
 import 'antd/es/button/style';
 ```
+
+### 禁用默认配置
+
+你可以手动设置 `transformImport: false` 来关掉 transformImport 的默认行为。
+
+```js
+export default {
+  source: {
+    transformImport: false,
+  },
+};
+```
+
+比如，当你使用了 `externals` 来避免打包 antd 时，由于 `transformImport` 默认会转换 antd 的引用路径，导致匹配的路径发生了变化，因此 externals 无法正确生效，此时你可以设置关闭 `transformImport` 来避免该问题。
 
 ### 配置
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4216,6 +4216,16 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
+  tests/e2e/builder/cases/import-arco:
+    specifiers:
+      '@arco-design/web-react': ^2.46.0
+      react: ^18
+      react-dom: ^18
+    dependencies:
+      '@arco-design/web-react': 2.46.1_biqbaboplfbrettd7655fr4n2y
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+
   tests/e2e/builder/cases/node-polyfill:
     specifiers:
       react: ^18
@@ -6009,6 +6019,31 @@ packages:
 
   /@arco-design/transformable/1.0.2:
     resolution: {integrity: sha512-Wq3zOf7RAKxwRWaQ2t0u8QoLSWlPG7pJV6GdUyPQ++QiD9n0zXycmwRiNVzSep8GY9Ur5PCLBiCs7B92CaUwcA==}
+    dev: false
+
+  /@arco-design/web-react/2.46.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-XjG44rODJklDu++OApvxjt/TbRrgkNqVq6grt/H+9skysm46jFn2SwhuSljBHmjo11LtIeB1m/OMPMaFtafeYg==}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@arco-design/color': 0.4.0
+      '@babel/runtime': 7.21.5
+      b-tween: 0.3.3
+      b-validate: 1.4.4
+      compute-scroll-into-view: 1.0.17
+      dayjs: 1.11.3
+      lodash: 4.17.21
+      number-precision: 1.5.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-focus-lock: 2.9.1_react@18.2.0
+      react-transition-group: 4.4.2_biqbaboplfbrettd7655fr4n2y
+      resize-observer-polyfill: 1.5.1
+      scroll-into-view-if-needed: 2.2.20
+      shallowequal: 1.1.0
+    transitivePeerDependencies:
+      - '@types/react'
     dev: false
 
   /@arco-design/web-react/2.46.1_rj7ozvcq3uehdlnj3cbwzbi5ce:
@@ -26935,6 +26970,24 @@ packages:
       use-callback-ref: 1.3.0_iapumuv4e6jcjznwuxpf4tt22e
       use-sidecar: 1.1.2_iapumuv4e6jcjznwuxpf4tt22e
 
+  /react-focus-lock/2.9.1_react@18.2.0:
+    resolution: {integrity: sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.5
+      focus-lock: 0.11.2
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-clientside-effect: 1.2.6_react@18.2.0
+      use-callback-ref: 1.3.0_react@18.2.0
+      use-sidecar: 1.1.2_react@18.2.0
+    dev: false
+
   /react-helmet-async/1.3.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
     peerDependencies:
@@ -30655,6 +30708,20 @@ packages:
       react: 18.2.0
       tslib: 2.4.0
 
+  /use-callback-ref/1.3.0_react@18.2.0:
+    resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      react: 18.2.0
+      tslib: 2.4.0
+    dev: false
+
   /use-sidecar/1.1.2_iapumuv4e6jcjznwuxpf4tt22e:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -30669,6 +30736,21 @@ packages:
       detect-node-es: 1.1.0
       react: 18.2.0
       tslib: 2.4.0
+
+  /use-sidecar/1.1.2_react@18.2.0:
+    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.2.0
+      tslib: 2.4.0
+    dev: false
 
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,7 @@ importers:
 
   packages/builder/builder-rspack-provider:
     specifiers:
+      '@arco-design/web-react': ^2.46.0
       '@babel/core': ^7.21.8
       '@babel/preset-typescript': ^7.21.5
       '@modern-js/builder-shared': workspace:*
@@ -117,6 +118,7 @@ importers:
       rspack-plugin-virtual-module: 0.1.0
       webpack: 5.82.1
     devDependencies:
+      '@arco-design/web-react': 2.46.1_biqbaboplfbrettd7655fr4n2y
       '@modern-js/e2e': link:../../toolkit/e2e
       '@scripts/vitest-config': link:../../../scripts/vitest-config
       '@types/node': 14.18.35
@@ -179,6 +181,7 @@ importers:
 
   packages/builder/builder-webpack-provider:
     specifiers:
+      '@arco-design/web-react': ^2.46.0
       '@modern-js/babel-preset-app': workspace:*
       '@modern-js/babel-preset-base': workspace:*
       '@modern-js/builder-shared': workspace:*
@@ -227,6 +230,7 @@ importers:
       ts-loader: 9.4.1_b73sldshwrlnhikvubwhfqvrfa
       webpack: 5.82.1
     devDependencies:
+      '@arco-design/web-react': 2.46.1_biqbaboplfbrettd7655fr4n2y
       '@modern-js/e2e': link:../../toolkit/e2e
       '@scripts/vitest-config': link:../../../scripts/vitest-config
       '@types/caniuse-lite': 1.0.1
@@ -6044,7 +6048,6 @@ packages:
       shallowequal: 1.1.0
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /@arco-design/web-react/2.46.1_rj7ozvcq3uehdlnj3cbwzbi5ce:
     resolution: {integrity: sha512-XjG44rODJklDu++OApvxjt/TbRrgkNqVq6grt/H+9skysm46jFn2SwhuSljBHmjo11LtIeB1m/OMPMaFtafeYg==}
@@ -26986,7 +26989,6 @@ packages:
       react-clientside-effect: 1.2.6_react@18.2.0
       use-callback-ref: 1.3.0_react@18.2.0
       use-sidecar: 1.1.2_react@18.2.0
-    dev: false
 
   /react-helmet-async/1.3.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==}
@@ -30720,7 +30722,6 @@ packages:
     dependencies:
       react: 18.2.0
       tslib: 2.4.0
-    dev: false
 
   /use-sidecar/1.1.2_iapumuv4e6jcjznwuxpf4tt22e:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
@@ -30750,7 +30751,6 @@ packages:
       detect-node-es: 1.1.0
       react: 18.2.0
       tslib: 2.4.0
-    dev: false
 
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}

--- a/tests/e2e/builder/cases/import-arco/index.test.ts
+++ b/tests/e2e/builder/cases/import-arco/index.test.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+
+test('should import arco correctly', async () => {
+  const builder = await build(
+    {
+      cwd: __dirname,
+      entry: { index: path.resolve(__dirname, './src/index.ts') },
+    },
+    undefined,
+    false,
+  );
+
+  const files = await builder.unwrapOutputJSON();
+
+  expect(
+    Object.keys(files).find(
+      file => file.includes('lib-arco') && file.includes('.js'),
+    ),
+  ).toBeTruthy();
+  expect(
+    Object.keys(files).find(
+      file => file.includes('lib-arco') && file.includes('.css'),
+    ),
+  ).toBeTruthy();
+});

--- a/tests/e2e/builder/cases/import-arco/package.json
+++ b/tests/e2e/builder/cases/import-arco/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "@e2e/webpack-builder-import-arco",
+  "version": "2.9.0",
+  "dependencies": {
+    "@arco-design/web-react": "^2.46.0",
+    "react": "^18",
+    "react-dom": "^18"
+  }
+}

--- a/tests/e2e/builder/cases/import-arco/src/index.ts
+++ b/tests/e2e/builder/cases/import-arco/src/index.ts
@@ -1,0 +1,3 @@
+import { Button, AutoComplete } from '@arco-design/web-react';
+
+console.log(Button, AutoComplete);

--- a/tests/e2e/builder/cases/import-arco/tsconfig.json
+++ b/tests/e2e/builder/cases/import-arco/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"],
+      "@scripts/*": ["../../scripts/*"]
+    }
+  },
+  "include": ["src", "*.test.ts"]
+}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eaa6be9</samp>

This pull request adds support for on-demand import of the Arco Design component library in the builder packages. It also improves the documentation and testing of the `source.transformImport` config. It introduces a new `arco` plugin that handles the import transformation for the Arco Design components and icons, and respects the user-defined config and the builder target. It updates the antd plugin module to follow the plugin function naming convention and expose a SSR detection utility. It adds a changeset file to document the version bumps and the change descriptions.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eaa6be9</samp>

*  Add `arco` plugin to support on-demand import for Arco Design component library ([link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-9c09796bb9593836c398dbbe112387c94c45180426120aa80634fad89cd9cd23R9), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-56881c88eb6e58ebb910d406d326445eedc84f98fd5657dbe8b521273dccae1dR32), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-4c75dce90f0a7863955bff1cb7775d7899bacad0b43b1d4853df17b73eb7f713R55), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-4431b7932e2e3e172520a85ab7448dad5a4fb6e777bc78061c720f58932c292dR37), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-a423c763a2f0166220b11e19f40e48875c0eeec3a1c4352d0192273bef84ac0eR1-R45), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-e3fc27480bc47768df9bb4063fb595be103a469f9e40399da2ffc8d68604273dL39-R40))
*  Rename `builderAntdPlugin` to `builderPluginAntd` for consistency ([link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-266a128dbe0dbe9468a8e5c2a951307124a94d579b3dee10683973ffa475ad9cL7-R7))
*  Export `useSSR` helper function from `antd` plugin module ([link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-266a128dbe0dbe9468a8e5c2a951307124a94d579b3dee10683973ffa475ad9cL41-R41))
*  Update `source.transformImport` config document in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-d3fef330431aa9ebec88851139ab8c710e43e425f3d5ab29d64d3c38a857d11fL3-R55), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-d3fef330431aa9ebec88851139ab8c710e43e425f3d5ab29d64d3c38a857d11fL41-R71), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-d3fef330431aa9ebec88851139ab8c710e43e425f3d5ab29d64d3c38a857d11fR87-R100), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-6b3de39874324118d71401bf769213f1b2dae3bec70e803a9277701d6b8f2185L3-R55), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-6b3de39874324118d71401bf769213f1b2dae3bec70e803a9277701d6b8f2185L41-R71), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-6b3de39874324118d71401bf769213f1b2dae3bec70e803a9277701d6b8f2185R87-R100))
*  Add changeset file to document version bumps and change descriptions ([link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-727ba040b2f40aab3b2b7c6dd62b153927c35928cbb0ccdbda83c2c4ea11a2b1R1-R9))
*  Add test case for `import-arco` scenario in `tests/e2e/builder/cases/import-arco` ([link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-21febda6c0ec973f8676292380fa8ea2a28c7993ecf7365a79b1b9eb034972ebR1-R27), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-210a0c7804373457e5abfd1fa0bec1db41f0bbcb33b5f6a155e2ffdb284cdb85R1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-effe6a02575e1d4123661677e03d78c594654378979883ac66c661e2be15ef38R1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/3785/files?diff=unified&w=0#diff-3455807c9a987554768b8a750f95891c23a1e93cfa69c506794e5a7f9b6ce292R1-R15))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
