### PR TITLE
feat: ssr runtime need webpack.output.chunkLoadingGlobal pass to loadableReady

### DIFF
--- a/.changeset/chilly-insects-wash.md
+++ b/.changeset/chilly-insects-wash.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': minor
+'@modern-js/app-tools': minor
+---
+
+feat: ssr runtime need webpack.output.chunkLoadingGlobal pass to loadableReady
+feat: ssr runtime 需要传递 webpack.output.chunnkLoadingGlobal 给 loadableReady

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -184,11 +184,17 @@ export default (): CliPlugin<AppTools> => ({
           imports,
         };
       },
-      modifyEntryRuntimePlugins({ entrypoint, plugins }: any) {
+      modifyEntryRuntimePlugins({ entrypoint, plugins, bundlerConfigs }) {
         if (ssrConfigMap.get(entrypoint.entryName)) {
+          const chunkLoadingGlobal = bundlerConfigs?.find(
+            config => config.name === 'client',
+          )?.output?.chunkLoadingGlobal;
           plugins.push({
             name: PLUGIN_IDENTIFIER,
-            options: JSON.stringify(ssrConfigMap.get(entrypoint.entryName)),
+            options: JSON.stringify({
+              ...(ssrConfigMap.get(entrypoint.entryName) || {}),
+              chunkLoadingGlobal,
+            }),
           });
         }
         return {

--- a/packages/runtime/plugin-runtime/src/ssr/index.tsx
+++ b/packages/runtime/plugin-runtime/src/ssr/index.tsx
@@ -61,6 +61,9 @@ export const ssr = (config: SSRPluginConfig): Plugin => ({
           ) {
             ModernRender(<App context={context} />);
           } else if (renderLevel === RenderLevel.SERVER_RENDER) {
+            const loadableReadyOptions: any = {
+              chunkLoadingGlobal: config.chunkLoadingGlobal,
+            };
             if (isReact18()) {
               loadableReady(() => {
                 // callback: https://github.com/reactwg/react-18/discussions/5
@@ -71,11 +74,11 @@ export const ssr = (config: SSRPluginConfig): Plugin => ({
                 );
                 SSRApp = hoistNonReactStatics(SSRApp, App);
                 ModernHydrate(<SSRApp />);
-              });
+              }, loadableReadyOptions);
             } else {
               loadableReady(() => {
                 ModernHydrate(<App context={hydrateContext} />, callback);
-              });
+              }, loadableReadyOptions);
             }
           } else {
             // unknown renderlevel or renderlevel is server prefetch.

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
@@ -8,6 +8,7 @@ export { RuntimeContext, RenderLevel };
 
 export type SSRPluginConfig = {
   crossorigin?: boolean | 'anonymous' | 'use-credentials';
+  chunkLoadingGlobal?: string;
 } & Exclude<ServerUserConfig['ssr'], boolean>;
 
 export type ServerRenderOptions = {

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -239,7 +239,7 @@ export const generateCode = async (
         internalDirectory,
         `./${entryName}/${ENTRY_POINT_FILE_NAME}`,
       );
-      entrypoint.entry = entryFile;
+      entrypoint.internalEntry = entryFile;
     }
   }
 };
@@ -320,8 +320,6 @@ export const generateIndexCode = async ({
           internalDirectory,
           `./${entryName}/${ENTRY_POINT_FILE_NAME}`,
         );
-        entrypoint.entry = entryFile;
-
         // generate entry file.
         if (config.source.enableAsyncEntry) {
           let rawAsyncEntryCode = `import('./${ENTRY_BOOTSTRAP_FILE_NAME}');`;

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -320,7 +320,7 @@ export const generateIndexCode = async ({
           internalDirectory,
           `./${entryName}/${ENTRY_POINT_FILE_NAME}`,
         );
-        // entrypoint.entry = entryFile;
+        entrypoint.entry = entryFile;
 
         // generate entry file.
         if (config.source.enableAsyncEntry) {

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -22,6 +22,8 @@ import {
   AppTools,
   ImportSpecifier,
   ImportStatement,
+  Rspack,
+  webpack,
 } from '../types';
 import * as templates from './templates';
 import { getClientRoutes, getClientRoutesLegacy } from './getClientRoutes';
@@ -115,14 +117,12 @@ export const generateCode = async (
   const hookRunners = api.useHookRunners();
 
   const isV5 = isRouterV5(config);
-  const { mountId } = config.html;
   const getRoutes = isV5 ? getClientRoutesLegacy : getClientRoutes;
 
   await Promise.all(entrypoints.map(generateEntryCode));
 
   async function generateEntryCode(entrypoint: Entrypoint) {
-    const { entryName, isAutoMount, customBootstrap, fileSystemRoutes } =
-      entrypoint;
+    const { entryName, isAutoMount, fileSystemRoutes } = entrypoint;
     if (isAutoMount) {
       // generate routes file for file system routes entrypoint.
       if (fileSystemRoutes) {
@@ -235,93 +235,132 @@ export const generateCode = async (
         );
       }
 
-      // call modifyEntryImports hook
-      const { imports: importStatements } =
-        await hookRunners.modifyEntryImports({
-          entrypoint,
-          imports: getDefaultImports({
-            entrypoint,
-            srcDirectory,
-            internalSrcAlias,
-            internalDirAlias,
-            internalDirectory,
-          }),
-        });
-
-      // call modifyEntryRuntimePlugins hook
-      const { plugins } = await hookRunners.modifyEntryRuntimePlugins({
-        entrypoint,
-        plugins: [],
-      });
-
-      // call modifyEntryRenderFunction hook
-      const { code: renderFunction } =
-        await hookRunners.modifyEntryRenderFunction({
-          entrypoint,
-          code: templates.renderFunction({
-            plugins,
-            customBootstrap,
-            fileSystemRoutes,
-          }),
-        });
-
-      // call modifyEntryExport hook
-      const { exportStatement } = await hookRunners.modifyEntryExport({
-        entrypoint,
-        exportStatement: 'export default AppWrapper;',
-      });
-
-      const code = templates.index({
-        mountId: mountId as string,
-        imports: createImportStatements(importStatements),
-        renderFunction,
-        exportStatement,
-      });
-
       const entryFile = path.resolve(
         internalDirectory,
         `./${entryName}/${ENTRY_POINT_FILE_NAME}`,
       );
       entrypoint.entry = entryFile;
-
-      // generate entry file.
-      if (config.source.enableAsyncEntry) {
-        let rawAsyncEntryCode = `import('./${ENTRY_BOOTSTRAP_FILE_NAME}');`;
-        const ssr = getEntryOptions(
-          entryName,
-          config.server.ssr,
-          config.server.ssrByEntries,
-          packageName,
-        );
-        if (ssr) {
-          rawAsyncEntryCode = `
-          export const ${SERVER_RENDER_FUNCTION_NAME} = async (...args) => {
-            let entry = await ${rawAsyncEntryCode};
-            if (entry.default instanceof Promise){
-              entry = await entry.default;
-              return entry.default.${SERVER_RENDER_FUNCTION_NAME}.apply(null, args);
-            }
-            return entry.${SERVER_RENDER_FUNCTION_NAME}.apply(null, args);
-          };
-          if(typeof window!=='undefined'){
-            ${rawAsyncEntryCode}
-          }
-          `;
-        }
-        const { code: asyncEntryCode } = await hookRunners.modifyAsyncEntry({
-          entrypoint,
-          code: rawAsyncEntryCode,
-        });
-        fs.outputFileSync(entryFile, asyncEntryCode, 'utf8');
-
-        const bootstrapFile = path.resolve(
-          internalDirectory,
-          `./${entryName}/${ENTRY_BOOTSTRAP_FILE_NAME}`,
-        );
-        fs.outputFileSync(bootstrapFile, code, 'utf8');
-      } else {
-        fs.outputFileSync(entryFile, code, 'utf8');
-      }
     }
   }
+};
+
+export const generateIndexCode = async ({
+  appContext,
+  api,
+  entrypoints,
+  config,
+  bundlerConfigs,
+}: {
+  appContext: IAppContext;
+  api: PluginAPI<AppTools<'shared'>>;
+  entrypoints: Entrypoint[];
+  config: AppNormalizedConfig<'shared'>;
+  bundlerConfigs?: webpack.Configuration[] | Rspack.Configuration[];
+}) => {
+  const hookRunners = api.useHookRunners();
+  const { mountId } = config.html;
+  const {
+    srcDirectory,
+    internalSrcAlias,
+    internalDirAlias,
+    internalDirectory,
+    packageName,
+  } = appContext;
+
+  await Promise.all(
+    entrypoints.map(async entrypoint => {
+      const { entryName, isAutoMount, customBootstrap, fileSystemRoutes } =
+        entrypoint;
+      if (isAutoMount) {
+        // call modifyEntryImports hook
+        const { imports: importStatements } =
+          await hookRunners.modifyEntryImports({
+            entrypoint,
+            imports: getDefaultImports({
+              entrypoint,
+              srcDirectory,
+              internalSrcAlias,
+              internalDirAlias,
+              internalDirectory,
+            }),
+          });
+
+        // call modifyEntryRuntimePlugins hook
+        const { plugins } = await hookRunners.modifyEntryRuntimePlugins({
+          entrypoint,
+          plugins: [],
+          bundlerConfigs: bundlerConfigs as any,
+        });
+
+        // call modifyEntryRenderFunction hook
+        const { code: renderFunction } =
+          await hookRunners.modifyEntryRenderFunction({
+            entrypoint,
+            code: templates.renderFunction({
+              plugins,
+              customBootstrap,
+              fileSystemRoutes,
+            }),
+          });
+
+        // call modifyEntryExport hook
+        const { exportStatement } = await hookRunners.modifyEntryExport({
+          entrypoint,
+          exportStatement: 'export default AppWrapper;',
+        });
+
+        const code = templates.index({
+          mountId: mountId as string,
+          imports: createImportStatements(importStatements),
+          renderFunction,
+          exportStatement,
+        });
+
+        const entryFile = path.resolve(
+          internalDirectory,
+          `./${entryName}/${ENTRY_POINT_FILE_NAME}`,
+        );
+        // entrypoint.entry = entryFile;
+
+        // generate entry file.
+        if (config.source.enableAsyncEntry) {
+          let rawAsyncEntryCode = `import('./${ENTRY_BOOTSTRAP_FILE_NAME}');`;
+          const ssr = getEntryOptions(
+            entryName,
+            config.server.ssr,
+            config.server.ssrByEntries,
+            packageName,
+          );
+          if (ssr) {
+            rawAsyncEntryCode = `
+        export const ${SERVER_RENDER_FUNCTION_NAME} = async (...args) => {
+          let entry = await ${rawAsyncEntryCode};
+          if (entry.default instanceof Promise){
+            entry = await entry.default;
+            return entry.default.${SERVER_RENDER_FUNCTION_NAME}.apply(null, args);
+          }
+          return entry.${SERVER_RENDER_FUNCTION_NAME}.apply(null, args);
+        };
+        if(typeof window!=='undefined'){
+          ${rawAsyncEntryCode}
+        }
+        `;
+          }
+          const { code: asyncEntryCode } = await hookRunners.modifyAsyncEntry({
+            entrypoint,
+            code: rawAsyncEntryCode,
+          });
+          fs.outputFileSync(entryFile, asyncEntryCode, 'utf8');
+
+          const bootstrapFile = path.resolve(
+            internalDirectory,
+            `./${entryName}/${ENTRY_BOOTSTRAP_FILE_NAME}`,
+          );
+          fs.outputFileSync(bootstrapFile, code, 'utf8');
+        } else {
+          fs.outputFileSync(entryFile, code, 'utf8');
+        }
+      }
+    }),
+  );
 };

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -162,7 +162,6 @@ export default ({
             appContext,
             async onBeforeBuild({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
-              const entrypoints = cloneDeep(originEntrypoints);
               await generateRoutes(appContext);
               await generateIndexCode({
                 appContext,
@@ -199,7 +198,6 @@ export default ({
 
             async onBeforeCreateCompiler({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
-              const entrypoints = cloneDeep(originEntrypoints);
               await generateIndexCode({
                 appContext,
                 config: resolvedConfig,

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -24,6 +24,7 @@ import {
   APP_INIT_EXPORTED,
   APP_INIT_IMPORTED,
 } from './constants';
+import { generateIndexCode } from './generateCode';
 
 const debug = createDebugger('plugin-analyze');
 
@@ -161,7 +162,15 @@ export default ({
             appContext,
             async onBeforeBuild({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
+              const entrypoints = cloneDeep(originEntrypoints);
               await generateRoutes(appContext);
+              await generateIndexCode({
+                appContext,
+                config: resolvedConfig,
+                entrypoints,
+                api,
+                bundlerConfigs,
+              });
               await hookRunners.beforeBuild({
                 bundlerConfigs:
                   bundlerConfigs as unknown as webpack.Configuration[],
@@ -190,6 +199,14 @@ export default ({
 
             async onBeforeCreateCompiler({ bundlerConfigs }) {
               const hookRunners = api.useHookRunners();
+              const entrypoints = cloneDeep(originEntrypoints);
+              await generateIndexCode({
+                appContext,
+                config: resolvedConfig,
+                entrypoints,
+                api,
+                bundlerConfigs,
+              });
               // run modernjs framework `beforeCreateCompiler` hook
               await hookRunners.beforeCreateCompiler({
                 bundlerConfigs:

--- a/packages/solutions/app-tools/src/builder/generator/createBuilderOptions.ts
+++ b/packages/solutions/app-tools/src/builder/generator/createBuilderOptions.ts
@@ -12,15 +12,16 @@ export function createBuilderOptions(
   type Entries = Record<string, string[]>;
   const entries: Entries = {};
   const { entrypoints = [], checkedEntries } = appContext;
-  for (const { entryName, entry } of entrypoints) {
+  for (const { entryName, internalEntry, entry } of entrypoints) {
     if (checkedEntries && !checkedEntries.includes(entryName)) {
       continue;
     }
+    const finalEntry = internalEntry || entry;
 
     if (entryName in entries) {
-      entries[entryName].push(entry);
+      entries[entryName].push(finalEntry);
     } else {
-      entries[entryName] = [entry];
+      entries[entryName] = [finalEntry];
     }
   }
 

--- a/packages/solutions/app-tools/src/types/hooks.ts
+++ b/packages/solutions/app-tools/src/types/hooks.ts
@@ -45,6 +45,9 @@ export type AppToolsHooks<B extends Bundler = 'webpack'> = {
   modifyEntryRuntimePlugins: AsyncWaterfall<{
     entrypoint: Entrypoint;
     plugins: RuntimePlugin[];
+    bundlerConfigs?: B extends 'rspack'
+      ? Rspack.Configuration[]
+      : webpack.Configuration[];
   }>;
   modifyEntryRenderFunction: AsyncWaterfall<{
     entrypoint: Entrypoint;

--- a/packages/toolkit/types/cli/index.d.ts
+++ b/packages/toolkit/types/cli/index.d.ts
@@ -8,6 +8,7 @@ export type { Config as JestConfigTypes } from '@jest/types';
 export interface Entrypoint {
   entryName: string;
   entry: string;
+  internalEntry?: string;
   nestedRoutesEntry?: string;
   pageRoutesEntry?: string;
   isAutoMount?: boolean;

--- a/tests/integration/ssr/fixtures/base/modern.config.ts
+++ b/tests/integration/ssr/fixtures/base/modern.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
   server: {
     ssr: true,
   },
+  tools: {
+    webpack(config) {
+      config.output!.chunkLoadingGlobal = 'hello xxx';
+    },
+  },
   plugins: [
     appTools({
       bundler: bundler === 'rspack' ? 'experimental-rspack' : 'webpack',

--- a/tests/integration/ssr/test/base.test.js
+++ b/tests/integration/ssr/test/base.test.js
@@ -1,6 +1,7 @@
 const { join } = require('path');
 const path = require('path');
 const puppeteer = require('puppeteer');
+const { fs } = require('@modern-js/utils');
 const {
   launchApp,
   getPort,
@@ -45,6 +46,13 @@ async function redirectInLoader(page, appPort) {
   expect(body).not.toMatch(/Redirect page/);
 }
 
+async function checkIsPassChunkLoadingGlobal() {
+  const modernJsDir = join(fixtureDir, 'base', 'node_modules', '.modern-js');
+  const entryFilePath = join(modernJsDir, 'main', 'index.jsx');
+  const content = await fs.readFile(entryFilePath, 'utf-8');
+  expect(content).toMatch(/chunkLoadingGlobal/);
+}
+
 describe('Traditional SSR', () => {
   let app,
     appPort,
@@ -77,6 +85,10 @@ describe('Traditional SSR', () => {
 
   it(`basic usage`, async () => {
     await basicUsage(page, appPort);
+  });
+
+  it(`should pass chunkLoadingGlobal`, async () => {
+    await checkIsPassChunkLoadingGlobal();
   });
 
   it.skip(`client navigation works`, async () => {


### PR DESCRIPTION


## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0750be</samp>

This pull request adds a feature to the `@modern-js/runtime` and `@modern-js/app-tools` packages that allows users to customize the `chunkLoadingGlobal` option for SSR. This option controls the global variable name for loading chunks in SSR mode. The pull request also updates the SSR integration test and the code generation logic to support this feature. It also adds type annotations, changeset files, and some code refactoring.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0750be</samp>

*  Add a changeset file to document the minor version updates and the features added to the `@modern-js/runtime` and `@modern-js/app-tools` packages ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-b3e2fa35ce998f0af07be65fd0f204b3010b1f0ec1e3f63a1273ffd385d4dddaR1-R7))
*  Pass the `bundlerConfigs` parameter to the `modifyEntryRuntimePlugins` hook in the `@modern-js/runtime` package to allow the plugins to access the webpack configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L187-R197))
*  Add and pass the `chunkLoadingGlobal` option to the `loadableReady` function calls in the `stringSSRHydrate` function in the `@modern-js/runtime` package to load the chunks correctly for SSR ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-1d68f5f1af4a1f2639aada724010dd1a59c8a08d80883f532c11d85d3a99868fR64-R66), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-1d68f5f1af4a1f2639aada724010dd1a59c8a08d80883f532c11d85d3a99868fL74-R81), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-7bb2b37d7c4c35db7a1d3fbfbd76ed3192cc5ca45a0a749df4661179ad395c32R11))
*  Refactor the `generateCode` function in the `@modern-js/app-tools` package to split the logic of generating the entry code and the index code, and pass the `bundlerConfigs` parameter to the `generateIndexCode` function ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0R25-R26), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L118), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L124-R125), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L238-R365))
*  Call the `generateIndexCode` function with the `bundlerConfigs` parameter in the `onBeforeBuild` and `onBeforeWatch` hooks in the `analyze` module in the `@modern-js/app-tools` package to generate the index code with the correct webpack configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1R27), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L164-R173), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1R202-R209))
*  Add the `bundlerConfigs` parameter to the `AppToolsHooks` type in the `@modern-js/app-tools` package to type the hooks that are exposed by the app tools plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-042c0864d94c683d2cc46e22752f744d1be4a31661ede69b34cc13b23697f9feR48-R50))
*  Modify the `modern.config.ts` file in the `base` fixture for the SSR integration test to set the `chunkLoadingGlobal` option to a different value than the default one ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-3049dbd53f1a49f318077e2b0f9721496029743a14723ed66b6d7eab71c34f0eR12-R16))
*  Add a test case and a helper function in the `base.test.js` file for the SSR integration test to verify that the `chunkLoadingGlobal` option is correctly passed from the webpack configuration to the runtime plugin and the `loadableReady` function ([link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-1a2c1cf226f106f06ed79b504ed0226786716fdb346e9d9b34ec2c632034ea70R4), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-1a2c1cf226f106f06ed79b504ed0226786716fdb346e9d9b34ec2c632034ea70R49-R55), [link](https://github.com/web-infra-dev/modern.js/pull/3788/files?diff=unified&w=0#diff-1a2c1cf226f106f06ed79b504ed0226786716fdb346e9d9b34ec2c632034ea70R90-R93))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
