### PR TITLE
fix: templateByEntries should have a higher priority than appContext.htmlTemplates

### DIFF
--- a/.changeset/few-sloths-prove.md
+++ b/.changeset/few-sloths-prove.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: templateByEntries should have a higher priority than appContext.htmlTemplates
+fix: templateByEntries 的优先级需要比 appContext.htmlTemplates 更高

--- a/packages/document/builder-doc/docs/en/config/html/templateByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/templateByEntries.md
@@ -11,7 +11,7 @@ The usage is same as `template`, and you can use the "entry name" as the key to 
 
 ```js
 export default {
-  output: {
+  html: {
     template: './static/index.html',
     templateByEntries: {
       foo: './src/pages/foo/index.html',

--- a/packages/document/builder-doc/docs/zh/config/html/templateByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/templateByEntries.md
@@ -11,7 +11,7 @@
 
 ```js
 export default {
-  output: {
+  html: {
     template: './static/index.html',
     templateByEntries: {
       foo: './src/pages/foo/index.html',

--- a/packages/solutions/app-tools/src/builder/generator/createBuilderProviderConfig.ts
+++ b/packages/solutions/app-tools/src/builder/generator/createBuilderProviderConfig.ts
@@ -8,8 +8,8 @@ export function createBuilderProviderConfig<B extends Bundler>(
   const htmlConfig = { ...resolveConfig.html };
   if (!htmlConfig.template) {
     htmlConfig.templateByEntries = {
-      ...htmlConfig.templateByEntries,
       ...appContext.htmlTemplates,
+      ...htmlConfig.templateByEntries,
     };
   }
   const config = {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42f1bf3</samp>

This pull request fixes a bug and updates the documentation for the `templateByEntries` option in the `@modern-js/app-tools` package. The bug fix ensures that the user-defined HTML templates are correctly applied, and the documentation reflects the correct configuration syntax.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42f1bf3</samp>

*  Add a changeset file for patch updates of `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/3791/files?diff=unified&w=0#diff-3d0073728c552f364283fe42dac751e9f099782f9748f1c02f4a04857eac9e8bR1-R6))
*  Fix the logic for merging `templateByEntries` and `appContext.htmlTemplates` options in `createBuilderProviderConfig` function ([link](https://github.com/web-infra-dev/modern.js/pull/3791/files?diff=unified&w=0#diff-4aa4b995cb44464bf051a475c31feff1d2c53b2bb52e67016fca941d87fa4300L11-R12))
*  Update the documentation for `templateByEntries` option in both English and Chinese versions ([link](https://github.com/web-infra-dev/modern.js/pull/3791/files?diff=unified&w=0#diff-98a558fc36ba6f0e6a1ede0c8cff677cde6f77a6f56d2b243529b87cad85800dL14-R14), [link](https://github.com/web-infra-dev/modern.js/pull/3791/files?diff=unified&w=0#diff-25f321256ad6963ff551f99c416d3c3215b71148d1c62599b1736c758513a8b4L14-R14))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
