### PR TITLE
chore: remove pnpm deprecated warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,28 @@
     "overrides": {
       "@types/react": "^18",
       "@types/react-dom": "^18"
+    },
+    "allowedDeprecatedVersions": {
+      "formidable": "1.2.6",
+      "hast": "1.0.0",
+      "sourcemap-codec": "1.4.8",
+      "uuid-browser": "3.1.0",
+      "stable": "0.1.8",
+      "js-polyfills": "0.1.43",
+      "picturefill": "3.0.3",
+      "string-similarity": "4.0.4",
+      "querystring": "0.2.0",
+      "source-map-resolve": "0.6.0 || 0.5.3",
+      "@formatjs/intl-utils": "3.8.4",
+      "debug": "4.1.1",
+      "sane": "4.1.0",
+      "@npmcli/move-file": "1.1.2",
+      "uuid": "3.4.0",
+      "chokidar": "2.1.8",
+      "fsevents": "1.2.13",
+      "source-map-url": "0.4.1",
+      "urix": "0.1.0",
+      "resolve-url": "0.2.1"
     }
   }
 }


### PR DESCRIPTION
## Summary

Ref: https://github.com/pnpm/pnpm/issues/4306

FIx:

<img width="892" alt="Screen Shot 2023-05-30 at 11 05 20" src="https://github.com/web-infra-dev/modern.js/assets/7237365/9099b70a-48dc-4ff0-b37b-8864f6ed9b5e">


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1435144</samp>

This pull request adds a new `package.json` field to allow using deprecated dependencies with npm 7. This helps the modern.js project to migrate smoothly and avoid installation issues.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1435144</samp>

*  Add `allowedDeprecatedVersions` field to `package.json` to specify deprecated dependencies ([link](https://github.com/web-infra-dev/modern.js/pull/3796/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R95-R116))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
