### PR TITLE
docs(main): update router doc

### DIFF
--- a/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
@@ -182,7 +182,7 @@ Routes generated from file directories named with `[$]` will be treated as dynam
 
 The `routes/user/[id$]/page.tsx` file will be converted to the `/user/:id?` route. All routes under `/user` will match this route, and the `id` parameter is optional. This route is usually used to distinguish between **creation** and **editing**.
 
-In the component, you can use [useParams](/apis/app/runtime/router/router#useparams) to obtain the corresponding named parameter.
+In the component, you can use [useParams](/apis/app/runtime/router/router#useparams) to get the corresponding named parameter.
 
 In the loader, params will be passed as the input parameter of the [loader function](/guides/basic-features/data-fetch#loader-function), and you can get the parameter value through `params.xxx`.
 
@@ -191,7 +191,7 @@ In the loader, params will be passed as the input parameter of the [loader funct
 If you create a `$.tsx` file under the routes directory, it will be treated as the catch-all routing component. When there is no matching route, this component will be rendered.
 
 :::note
-`$.tsx` can be considered as a special `page` route component. When there is a `layout` component in the current directory, `$.tsx` will be rendered as a child component of `layout`.
+`$.tsx` can be considered as a special `page` route component. When there is a `layout.tsx` file in the current directory, `$.tsx` will be rendered as a child component of `layout`.
 :::
 
 For example, the following directory structure:
@@ -215,7 +215,7 @@ params['*']; // => 'aaa/bbb'
 
 ### No-path Layout
 
-When the directory name starts with `__`, the corresponding directory name will not be converted to an actual route path. For example, the following file directory:
+When the directory name starts with `__`, the directory name will not be converted to an actual route path. For example, the following file directory:
 
 ```bash
 .
@@ -449,7 +449,7 @@ However, this also brings a problem: if the chunk corresponding to the route has
 
 In this case, you can define a `Loading` component to display a custom `Loading` component before the static resources are loaded.
 
-To further improve the user experience and reduce loading time, Modern.js supports defining the `prefetch` attribute on the Link component to preload static resources and data. The `prefetch` attribute has three optional values:
+To further improve the user experience and reduce loading time, Modern.js supports defining the `prefetch` attribute on the Link component to preload static resources and data.
 
 ```tsx
 <Link prefetch="intent" to="page">
@@ -460,6 +460,8 @@ To further improve the user experience and reduce loading time, Modern.js suppor
 - Preloading data currently only preloads the data returned by the [Data Loader](/guides/basic-features/data-fetch) in SSR projects.
 
 :::
+
+The `prefetch` attribute has three optional values:
 
 - `none`: default value, no prefetching, no additional behavior.
 - `intent`: This is the value we recommend for most scenarios. When you hover over the Link, the corresponding chunk and data defined in the data loader will be loaded automatically. When you move the mouse away, the loading will be cancelled automatically. In our tests, even fast clicks can reduce loading time by about 200ms.
@@ -504,8 +506,6 @@ export default () => {
 Modern.js provides a series of optimizations for resource loading and rendering for conventional routing by default, and provides out-of-the-box SSR capabilities. When using self-controlled routing, developers need to encapsulate these capabilities themselves. It is recommended to use conventional routing.
 :::
 
-When using self-controlled routing, if the developer turns off the [`runtime.router`](/configure/app/runtime/router) configuration and uses `react-router-dom` directly, they also need to wrap it according to the React Router documentation.
-
 ## Other
 
 By default, Modern.js will enable the built-in routing scheme, which is React Router.
@@ -518,7 +518,9 @@ export default defineConfig({
 });
 ```
 
-Modern.js exposes the API of React Router from the `@modern-js/runtime/router` namespace for developers to use, ensuring that developers and Modern.js use the same code. In addition, in this case, the React Router code will be bundled into the JS output. If the project already has its own routing scheme or does not need to use client-side routing, this feature can be turned off.
+As mentioned above, when the [`runtime.router`](/configure/app/runtime/router) configuration is enabled, Modern.js will export the API of React Router from the `@modern-js/runtime/router` namespace for developers to use, ensuring that developers and Modern.js are using the same code, and automatically wrapping the `Provider` component according to the router configuration. In addition, in this case, the code of React Router will be packed into the JS output.
+
+If the project already has its own routing plan or does not need to use client-side routing, this feature can be disabled.
 
 ```js
 export default defineConfig({
@@ -527,3 +529,5 @@ export default defineConfig({
   },
 });
 ```
+
+As mentioned above, if the [`runtime.router`](/configure/app/runtime/router) configuration is disabled and `react-router-dom` is used directly for project routing management, the `Provider` needs to be wrapped according to the React Router documentation.

--- a/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
@@ -449,7 +449,7 @@ export const init = (context: RuntimeContext) => {
 在约定式路由下， Modern.js 会根据路由，自动地对路由进行分片，当用户访问具体的路由时，会自动加载对应的分片，这样可以有效地减少首屏加载的时间。但这也带来了一个问题，当用户访问一个路由时，如果该路由对应的分片还未加载完成，就会出现白屏的情况。
 这种情况下你可以通过定义 `Loading` 组件，在静态资源加载完成前，展示一个自定义的 `Loading` 组件。
 
-为了进一步提升用户体验，减少 loading 的时间，Modern.js 支持在 Link 组件上定义 `prefetch` 属性，可以提前对静态资源和数据进行加载， `prefetch` 属性有三个可选值：
+为了进一步提升用户体验，减少 loading 的时间，Modern.js 支持在 Link 组件上定义 `prefetch` 属性，可以提前对静态资源和数据进行加载：
 
 ```tsx
 <Link prefetch="intent" to="page">
@@ -460,6 +460,8 @@ export const init = (context: RuntimeContext) => {
 - 对数据的预加载目前只会预加载 SSR 项目中 [Data Loader](/guides/basic-features/data-fetch) 中返回的数据。
 
 :::
+
+`prefetch` 属性有三个可选值：
 
 - `none`， 默认值，不会做 prefetch，没有任何额外的行为。
 - `intent`，这是我们推荐大多数场景下使用的值，当你把鼠标放在 Link 上时，会自动开始加载对应的分片和 Data Loader 中定义的数据，当鼠标移开时，会自动取消加载。在我们的测试中，即使是快速点击，也能减少大约 200ms 的加载时间。
@@ -505,8 +507,6 @@ export default () => {
 Modern.js 默认对约定式路由做了一系列资源加载及渲染上的优化，并且提供了开箱即用的 SSR 能力，而这些能力，在使用自控路由时，都需要开发者自行封装，推荐开发者使用约定式路由。
 :::
 
-使用自控式路由时，如果开发者关闭了 [`runtime.router`](/configure/app/runtime/router) 配置，并直接使用 `react-router-dom`，那还需要根据 React Router 文档自行包裹 `Provider`。
-
 ## 其他路由方案
 
 默认情况下，Modern.js 会开启内置的路由方案，即 React Router。
@@ -519,7 +519,9 @@ export default defineConfig({
 });
 ```
 
-Modern.js 从 `@modern-js/runtime/router` 命名空间暴露了 React Router 的 API 供开发者使用，保证开发者和 Modern.js 中使用同一份代码。另外，这种情况下，React Router 的代码会被打包到 JS 产物中。如果项目已经有自己的路由方案，或者不需要使用客户端路由，可以关闭这个功能。
+如上述配置，当开启 [`runtime.router`](/configure/app/runtime/router) 配置时，Modern.js 会从 `@modern-js/runtime/router` 命名空间导出 React Router 的 API 供开发者使用，保证开发者和 Modern.js 中使用同一份代码，并自动根据 router 配置包裹 `Provider` 组件。另外，这种情况下，React Router 的代码会被打包到 JS 产物中。
+
+如果项目已经有自己的路由方案，或者不需要使用客户端路由，可以关闭这个功能。
 
 ```js
 export default defineConfig({
@@ -529,5 +531,6 @@ export default defineConfig({
 });
 ```
 
+如上述配置， 如果关闭了 [`runtime.router`](/configure/app/runtime/router) 配置，并直接使用 `react-router-dom` 进行项目路由管理时，还需要根据 React Router 文档自行包裹 `Provider`。
 
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e7f4ab</samp>

This pull request improves the documentation of the routes feature in the `modern.js` package for both English and Chinese readers. It fixes errors, adds details, and removes outdated information in the `routes.mdx` files under the `packages/document/main-doc/docs` directory. It also synchronizes the Chinese version with the English version.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e7f4ab</samp>

*  Fix typos, add missing file extension, and remove redundant word in the English documentation of the routes feature (`packages/document/main-doc/docs/en/guides/basic-features/routes.mdx`) ([link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L185-R185), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L194-R194), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L218-R218))
* Split long paragraph, add missing sentence, remove outdated paragraph, update and rephrase paragraph, and add new paragraph in the English documentation of the routes feature (`packages/document/main-doc/docs/en/guides/basic-features/routes.mdx`) to improve the clarity, readability, and accuracy of the document ([link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L452-R452), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134R464-R465), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L507-L508), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L521-R524), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134R532-R533))
* Apply the corresponding changes to the Chinese documentation of the routes feature (`packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx`) to keep it consistent and up-to-date with the English version ([link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L452-R452), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2R464-R465), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L508-L509), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L522-R525), [link](https://github.com/web-infra-dev/modern.js/pull/3797/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2R534))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
