### PR TITLE
chore: adjust output and package.json fields

### DIFF
--- a/.changeset/many-pots-guess.md
+++ b/.changeset/many-pots-guess.md
@@ -1,0 +1,12 @@
+---
+'@modern-js/plugin-module-node-polyfill': patch
+'@modern-js/plugin-module-main-fields': patch
+'@modern-js/plugin-module-polyfill': patch
+'@modern-js/plugin-module-banner': patch
+'@modern-js/plugin-module-import': patch
+'@modern-js/plugin-module-target': patch
+'@modern-js/plugin-module-babel': patch
+---
+
+chore: adjust output and package.json fields
+chore: 调整包的产物格式以及packgae.json里的字段

--- a/packages/module/plugin-module-babel/modern.config.js
+++ b/packages/module/plugin-module-babel/modern.config.js
@@ -4,11 +4,6 @@ module.exports = {
       format: 'cjs',
       target: 'es6',
       sourceMap: true,
-      // dts: false,
     },
-    // {
-    //   buildType: 'bundleless',
-    //   dts: { only: true },
-    // },
   ],
 };

--- a/packages/module/plugin-module-banner/modern.config.js
+++ b/packages/module/plugin-module-banner/modern.config.js
@@ -1,5 +1,9 @@
-const { nodeBuildConfig } = require('@scripts/build');
-
 module.exports = {
-  buildConfig: nodeBuildConfig,
+  buildConfig: [
+    {
+      format: 'cjs',
+      target: 'es6',
+      sourceMap: true,
+    },
+  ],
 };

--- a/packages/module/plugin-module-banner/package.json
+++ b/packages/module/plugin-module-banner/package.json
@@ -17,15 +17,13 @@
   ],
   "version": "2.21.1",
   "types": "./src/index.ts",
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "node": {
         "jsnext:source": "./src/index.ts",
-        "import": "./dist/esm/index.js",
-        "require": "./dist/cjs/index.js"
-      },
-      "default": "./dist/esm/index.js"
+        "require": "./dist/index.js"
+      }
     }
   },
   "scripts": {
@@ -58,6 +56,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/module/plugin-module-import/modern.config.js
+++ b/packages/module/plugin-module-import/modern.config.js
@@ -1,5 +1,9 @@
-const { nodeBuildConfig } = require('@scripts/build');
-
 module.exports = {
-  buildConfig: nodeBuildConfig,
+  buildConfig: [
+    {
+      format: 'cjs',
+      target: 'es6',
+      sourceMap: true,
+    },
+  ],
 };

--- a/packages/module/plugin-module-import/package.json
+++ b/packages/module/plugin-module-import/package.json
@@ -17,15 +17,13 @@
   ],
   "version": "2.21.1",
   "types": "./src/index.ts",
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "node": {
         "jsnext:source": "./src/index.ts",
-        "import": "./dist/esm/index.js",
-        "require": "./dist/cjs/index.js"
-      },
-      "default": "./dist/esm/index.js"
+        "require": "./dist/index.js"
+      }
     }
   },
   "scripts": {
@@ -59,6 +57,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/module/plugin-module-main-fields/package.json
+++ b/packages/module/plugin-module-main-fields/package.json
@@ -40,6 +40,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/module/plugin-module-node-polyfill/package.json
+++ b/packages/module/plugin-module-node-polyfill/package.json
@@ -47,6 +47,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/module/plugin-module-polyfill/package.json
+++ b/packages/module/plugin-module-polyfill/package.json
@@ -48,6 +48,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/index.d.ts"
   }
 }

--- a/packages/module/plugin-module-target/package.json
+++ b/packages/module/plugin-module-target/package.json
@@ -40,6 +40,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/index.d.ts"
   }
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c74185a</samp>

This pull request fixes and simplifies the package.json exports and types fields for several module plugins, and updates the build configurations to match the expected formats. It also adds a changeset file to automate the versioning and publishing process. These changes improve the compatibility and usability of the plugins for node users and the modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c74185a</samp>

*  Add a changeset file to specify the packages to be patched and the commit message ([link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-bb27eaec2c6c536d3f57308794f5c9ca1acc0727b832b6a0c7e0df2489855a6eR1-R12))
*  Remove the bundleless build configuration from the plugin-module-babel package to avoid errors with the modern.js framework ([link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-5f02106574f49a1ffb3dd7cdb7506c528055474ccc9a6a6d1d9603d860b806d6L7-R7))
*  Replace the nodeBuildConfig with custom build configurations for the plugin-module-banner and plugin-module-import packages to use the cjs format instead of the esm format, which is incompatible with the banner and import plugins ([link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-feddc48f8af97ea93e93dfaf9a75bfc029121c2578a6acd1f803a79c2fc5a393L1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-9ff905ad1d2374d73dc8ba1c889534efbb8bd752b20583acafa1d8b3cac3a5d4L1-R8))
*  Simplify the exports field in the package.json files of the plugin-module-banner and plugin-module-import packages to only support the node environment and the require method, and not the import or default options ([link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-d58057127355309a7f040223778b9f6804bce8773e0248b82e49dd7406acde9aL20-R26), [link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-ae0a24d7972e3a41d96d7489a3fae8466d2726cda6c58f82a1e4bb16957f477dL20-R26))
*  Fix the types field in the package.json files of the plugin-module-banner, plugin-module-import, plugin-module-main-fields, plugin-module-node-polyfill, plugin-module-polyfill, and plugin-module-target packages to point to the correct directory where the types are generated ([link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-d58057127355309a7f040223778b9f6804bce8773e0248b82e49dd7406acde9aL61-R59), [link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-ae0a24d7972e3a41d96d7489a3fae8466d2726cda6c58f82a1e4bb16957f477dL62-R60), [link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-cf118b1501841de7d954704e3c25e3ccfae2b9c3244b0ffb41f9f98bd148b8a8L43-R43), [link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-ea14e5d59256654745b1c894a64b1daf383e79753741ab39c50c4fe6cd146539L50-R50), [link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-1d7b8524a00b1900b4d44c4a76bb8e33de9aec27109ba3ab0a1000f44eeadcd2L51-R51), [link](https://github.com/web-infra-dev/modern.js/pull/3798/files?diff=unified&w=0#diff-fdb9984f1196cccfc22050ce4529d51adb5429d269b2fca15426bd8a75c4d25fL43-R43))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
