### PR TITLE
fix(builder): rule.loader support undefined in rspack

### DIFF
--- a/.changeset/curvy-carrots-joke.md
+++ b/.changeset/curvy-carrots-joke.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): rule.loader support undefined in rspack
+
+fix(builder): 使用 rspack 构建时, rule.loader 允许为空

--- a/packages/builder/builder-rspack-provider/src/core/formatConfig.ts
+++ b/packages/builder/builder-rspack-provider/src/core/formatConfig.ts
@@ -38,7 +38,7 @@ export const formatRule = (rule: BundlerRule): RspackRule => {
     return rule as RspackRule;
   }
 
-  const formatRuleUse = (use: typeof rule['use']) => {
+  const formatRuleUse = (use: (typeof rule)['use']) => {
     if (!use) {
       return undefined;
     }
@@ -56,10 +56,6 @@ export const formatRule = (rule: BundlerRule): RspackRule => {
         return {
           loader: content,
         };
-      }
-
-      if (!content.loader) {
-        throw new Error(`loader is required in rule.use`);
       }
 
       return {
@@ -125,7 +121,7 @@ export const formatSplitChunks = (
   }
 
   const formatCacheGroups = (
-    cacheGroups?: NonNullable<typeof splitChunks['cacheGroups']>,
+    cacheGroups?: NonNullable<(typeof splitChunks)['cacheGroups']>,
   ) => {
     if (!cacheGroups) {
       return cacheGroups;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0ce9c4</samp>

This pull request fixes TypeScript errors and improves webpack configuration formatting in the `@modern-js/builder-rspack-provider` package. It also adds a changeset file to document the patch version update and the fix message for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0ce9c4</samp>

* Fix TypeScript syntax errors in webpack rule and split chunks configuration functions ([link](https://github.com/web-infra-dev/modern.js/pull/3800/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/3800/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L128-R124)) in `formatConfig.ts`

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
