### PR TITLE
fix(doc-core): theme config normalize error

### DIFF
--- a/.changeset/little-baboons-rush.md
+++ b/.changeset/little-baboons-rush.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): theme config normalize error
+
+fix(doc-core): 主题配置规范化错误

--- a/packages/cli/doc-core/src/node/runtimeModule/siteData.ts
+++ b/packages/cli/doc-core/src/node/runtimeModule/siteData.ts
@@ -28,6 +28,7 @@ import {
   SEARCH_INDEX_NAME,
   addLeadingSlash,
   isExternalUrl,
+  withoutBase,
 } from '@/shared/utils';
 
 let pages: PageIndexInfo[] | undefined;
@@ -69,7 +70,7 @@ export function normalizeThemeConfig(
     if (
       !currentLang ||
       !link ||
-      link.startsWith(`/${currentLang}`) ||
+      withoutBase(link, base).startsWith(`/${currentLang}`) ||
       isExternalUrl(link)
     ) {
       return link;
@@ -211,7 +212,6 @@ export function normalizeThemeConfig(
     themeConfig.sidebar = normalizeSidebar(themeConfig?.sidebar);
     themeConfig.nav = normalizeNav(themeConfig?.nav);
   }
-
   return themeConfig as NormalizedDefaultThemeConfig;
 }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 881b8ad</samp>

This pull request fixes a bug in the `doc-core` package that caused incorrect links in theme config files with different languages. It adds a new function to the `SiteData` interface and updates the site data module accordingly. It also includes a changeset file with a patch version update and a bilingual fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 881b8ad</samp>

* Add a changeset file to describe the patch version update and the fix for the theme config normalization error in the doc-core package ([link](https://github.com/web-infra-dev/modern.js/pull/3803/files?diff=unified&w=0#diff-38c803dfeaf353b49207424f85d413c20b66c94f43142ddd51558d184b3ff7e0R1-R7))
* Fix the theme config normalization error by adding a `withoutBase` function to the `SiteData` interface and using it to check the language prefix of the links ([link](https://github.com/web-infra-dev/modern.js/pull/3803/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaR31), [link](https://github.com/web-infra-dev/modern.js/pull/3803/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL72-R73))
* Remove an empty line from the end of the `siteData.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/3803/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL214))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
