### PR TITLE
fix: use path.resolve instead path.join for distPath

### DIFF
--- a/.changeset/two-toys-serve.md
+++ b/.changeset/two-toys-serve.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix: use path.resolve instead path.join for distPath
+fix: 使用 path.resolve 代替 path.join 处理产物目录

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -126,7 +126,7 @@ export class ModernServer implements ModernServerInterface {
     require('ignore-styles');
 
     this.pwd = pwd;
-    this.distDir = path.join(pwd, config.output.path || 'dist');
+    this.distDir = path.resolve(pwd, config.output.path || 'dist');
     this.workDir = this.distDir;
     this.conf = config;
     debug('server conf', this.conf);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5945c2f</samp>

This pull request fixes a bug in the `@modern-js/prod-server` package that could cause errors when resolving the directory for the production build files. It uses `path.resolve` instead of `path.join` for the `distPath` option in the `ModernServer` class and updates the changelog accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5945c2f</samp>

* Fix `distDir` resolution for `ModernServer` constructor ([link](https://github.com/web-infra-dev/modern.js/pull/3804/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL129-R129))
* Update changelog for `@modern-js/prod-server` package with bug fixes ([link](https://github.com/web-infra-dev/modern.js/pull/3804/files?diff=unified&w=0#diff-a0df839bdcec9a2d0867117e3bf96738fb383891b28d4b5cab785d8a85638556R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
