### PR TITLE
fix: refactor the mock logic of BFF testing plugin

### DIFF
--- a/.changeset/dry-shrimps-tickle.md
+++ b/.changeset/dry-shrimps-tickle.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/plugin-testing': patch
+---
+
+fix: refactor the mock logic of BFF testing plugin
+fix: 修改 BFF 测试插件的 mock 逻辑

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -27,6 +27,7 @@
     ".": {
       "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/esm/index.js"
     },
     "./loadable": {

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -27,7 +27,6 @@
     ".": {
       "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
-      "require": "./dist/cjs/index.js",
       "default": "./dist/esm/index.js"
     },
     "./loadable": {

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -66,6 +66,15 @@
       "jsnext:source": "./src/base/index.ts",
       "types": "./dist/types/base/index.d.ts",
       "default": "./dist/cjs/base/index.js"
+    },
+    "./bff": {
+      "jsnext:source": "./src/runtime-testing/bff.ts",
+      "node": {
+        "import": "./dist/esm-node/runtime-testing/bff.js",
+        "require": "./dist/cjs/runtime-testing/bff.js"
+      },
+      "types": "./dist/types/runtime-testing/bff.d.ts",
+      "default": "./dist/esm/runtime-testing/bff.js"
     }
   },
   "typesVersions": {
@@ -93,6 +102,9 @@
       ],
       "base": [
         "./dist/types/base/index.d.ts"
+      ],
+      "bff": [
+        "./dist/types/runtime-testing/bff.d.ts"
       ]
     }
   },

--- a/packages/runtime/plugin-testing/src/cli/bff/setup.ts
+++ b/packages/runtime/plugin-testing/src/cli/bff/setup.ts
@@ -16,24 +16,6 @@ const setup = () => {
   const bff_info = (global as any)[bff_info_key];
   const prefix = bff_info?.modernUserConfig?.bff?.prefix;
   const httpMethodDecider = bff_info?.modernUserConfig?.bff?.httpMethodDecider;
-  const apiRouter = new ApiRouter({
-    apiDir: path.join(bff_info.appDir, './api'),
-    prefix,
-    httpMethodDecider,
-  });
-  const apiInfos = apiRouter.getApiHandlers();
-
-  const apiInfosByFile = apiInfos.reduce<Record<string, APIHandlerInfo[]>>(
-    (res, apiInfo) => {
-      if (!res[apiInfo.filename]) {
-        res[apiInfo.filename] = [];
-      }
-      res[apiInfo.filename].push(apiInfo);
-
-      return res;
-    },
-    {},
-  );
 
   let app:
     | ((
@@ -44,6 +26,30 @@ const setup = () => {
     | null = null;
 
   beforeAll(async () => {
+    const apiRouter = new ApiRouter({
+      apiDir: path.join(bff_info.appDir, './api'),
+      prefix,
+      httpMethodDecider,
+    });
+    const apiInfos = apiRouter.getApiHandlers();
+
+    const apiInfosByFile = apiInfos.reduce<Record<string, APIHandlerInfo[]>>(
+      (res, apiInfo) => {
+        if (!res[apiInfo.filename]) {
+          res[apiInfo.filename] = [];
+        }
+        res[apiInfo.filename].push(apiInfo);
+
+        return res;
+      },
+      {},
+    );
+
+    // The mockAPI function is executed before createApp to ensure that the mock can succeed
+    // createApp calls requireActual, so it is not affected by mock
+    // The mockAPI function is in the beforeAll hook, so developers can mock bff api (such as useContext), because jest.mock will be executed before this file in the test file
+    // The ideal execution sequence is: mock in test case -> mock in this file -> import in test case, so import lambda file should be in the test function
+    mockAPI(apiInfosByFile);
     if (!app) {
       app = await createApp(
         bff_info.appDir,
@@ -57,8 +63,6 @@ const setup = () => {
   afterAll(async () => {
     await closeServer();
   });
-
-  mockAPI(apiInfosByFile);
 };
 
 setup();

--- a/packages/runtime/plugin-testing/src/cli/index.ts
+++ b/packages/runtime/plugin-testing/src/cli/index.ts
@@ -75,6 +75,9 @@ export default (): CliPlugin<{
                 // The module-tools alias configuration is different and more specific than app-tools.
                 // So for the time being, the @ alias is configured here.
                 '@': path.join(appContext.appDirectory, 'src'),
+                '@modern-js/runtime/testing/bff': require.resolve(
+                  '@modern-js/plugin-testing/bff',
+                ),
                 '@modern-js/runtime/testing': testingExportsUtils.getPath(),
               },
             },

--- a/packages/runtime/plugin-testing/src/runtime-testing/base.ts
+++ b/packages/runtime/plugin-testing/src/runtime-testing/base.ts
@@ -1,4 +1,2 @@
 export { default as renderApp } from './customRender';
 export * from '@testing-library/react';
-
-export { request as testBff } from './request';

--- a/packages/runtime/plugin-testing/src/runtime-testing/bff.ts
+++ b/packages/runtime/plugin-testing/src/runtime-testing/bff.ts
@@ -22,4 +22,4 @@ function request(...args: any): SuperTest<Test> | Test {
   return res;
 }
 
-export { request };
+export { request as testBff };

--- a/packages/runtime/plugin-testing/types/index.d.ts
+++ b/packages/runtime/plugin-testing/types/index.d.ts
@@ -1,8 +1,13 @@
 import "@testing-library/react"
 import "@testing-library/jest-dom"
 import "../dist/types/runtime-testing"
+import "../dist/types/runtime-testing/bff"
 
 declare module '@modern-js/runtime/testing' {
   export * from '@testing-library/react';
-  export { renderApp, createStore, testBff } from '../dist/types/runtime-testing';
+  export { renderApp, createStore } from '../dist/types/runtime-testing';
+}
+
+declare module '@modern-js/runtime/testing/bff' {
+  export { testBff } from '../dist/types/runtime-testing/bff';
 }

--- a/tests/integration/api-service-koa/api/context/index.ts
+++ b/tests/integration/api-service-koa/api/context/index.ts
@@ -1,6 +1,6 @@
+import { useContext } from '@modern-js/runtime/koa';
+
 export const get = async () => {
-  const { useContext } = await import('@modern-js/runtime/koa');
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const ctx = useContext();
   const { res } = ctx;
   res.setHeader('x-id', '1');
@@ -10,8 +10,6 @@ export const get = async () => {
 };
 
 export const post = async () => {
-  const { useContext } = await import('@modern-js/runtime/koa');
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const ctx = useContext();
   return {
     message: ctx.message,

--- a/tests/integration/api-service-koa/api/index.ts
+++ b/tests/integration/api-service-koa/api/index.ts
@@ -1,4 +1,4 @@
-export default async () => ({
+export const get = async () => ({
   message: 'Hello Modern.js',
 });
 

--- a/tests/integration/api-service-koa/api/tests/context.test.ts
+++ b/tests/integration/api-service-koa/api/tests/context.test.ts
@@ -1,25 +1,9 @@
-import { get as getContext, post as postContext } from '../context';
-
 describe('context', () => {
   it('should support context', async () => {
+    const { get: getContext } = await import('../context');
     const data = await getContext();
     expect(data).toEqual({
       message: 'Hello Modern.js',
     });
-  });
-
-  it('should support mock useContext', async () => {
-    jest.doMock('@modern-js/runtime/koa', () => {
-      return {
-        __esModule: true,
-        useContext() {
-          return {
-            message: 'hello',
-          };
-        },
-      };
-    });
-    const data = await postContext();
-    expect(data.message).toEqual('hello');
   });
 });

--- a/tests/integration/api-service-koa/api/tests/index.test.ts
+++ b/tests/integration/api-service-koa/api/tests/index.test.ts
@@ -1,8 +1,8 @@
-import { testBff } from '@modern-js/runtime/testing';
-import get from '..';
+import { testBff } from '@modern-js/runtime/testing/bff';
 
 describe('basic usage', () => {
   it('should support get', async () => {
+    const { get } = await import('..');
     const data = await get();
     expect(data).toEqual({
       message: 'Hello Modern.js',
@@ -10,6 +10,7 @@ describe('basic usage', () => {
   });
 
   it('should support testBff', async () => {
+    const { get } = await import('..');
     await testBff(get)
       .expect('Content-Type', /json/)
       .expect(200, { message: 'Hello Modern.js' });

--- a/tests/integration/api-service-koa/api/tests/mock-context.test.ts
+++ b/tests/integration/api-service-koa/api/tests/mock-context.test.ts
@@ -1,0 +1,16 @@
+jest.mock('@modern-js/runtime/koa', () => {
+  return {
+    __esModule: true,
+    useContext: jest.fn(() => ({
+      message: 'hello',
+    })),
+  };
+});
+
+describe('context', () => {
+  it('should support mock useContext', async () => {
+    const { post: postContext } = await import('../context');
+    const data = await postContext();
+    expect(data.message).toEqual('hello');
+  });
+});


### PR DESCRIPTION
## Summary

1. Refactor the mock logic of the BFF test plugin to solve the problem that the BFF API is difficult to mock.
2. Separate test API for BFF from runtime/tesing, avoid the impact of front-end API.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74bdfbb</samp>

This pull request adds and refactors the bff testing plugin in the `plugin-testing` package, and updates the api-service-koa integration test to use the plugin and mock bff api. It also adds a changeset file to document the changes and versions. The purpose of this pull request is to improve the testing experience and consistency for developers who use the `@modern-js/runtime` framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74bdfbb</samp>

*  Add a changeset file to document the packages and versions affected by the pull request ([link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-679c66537ba7b42ab754e51fe9e6e735bd3ef8d411c2adfc101d10501934fd40R1-R7))
*  Refactor the mock logic of the bff testing plugin, and create the api router and the api infos after the app is created ([link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-f9940363aa4e834084a7a8b360e928055ce1204a3ade8fd6526c8cdd1aab4e36L19-R19), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-f9940363aa4e834084a7a8b360e928055ce1204a3ade8fd6526c8cdd1aab4e36R29-R52), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-f9940363aa4e834084a7a8b360e928055ce1204a3ade8fd6526c8cdd1aab4e36L60-L61))
*  Expose the bff testing plugin as a sub-module of the plugin-testing package, and add it to the runtime testing alias ([link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bR69-R77), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bR105-R107), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-03280beb0bbf5eaa5166abe24f86095e69cd4bbb15fbf4cdbd29f294b8a060aeR78-R80))
*  Rename the request module and function to the bff module and function in the runtime testing plugin, and remove the testBff export from the base module ([link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-ef7f658978d4dda8fd5d26bf14cf7c020c5a8e4d3e2ec24b39a91e54487c2d34L3-L4), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-10e17868b552c020e4bf4812ba258d7c6e977fb0e6eb00fac10b4aeff185204bL25-R25))
*  Modify the import of the bff testing plugin and the testBff function in the test modules, and use dynamic imports for the api modules that need to be mocked ([link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-16cdf6294e56543d5de824ee116775f09357f21f2595a6de77ba1f709e5e36c7L1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-f1d62bfe2b9687beeabc23f0f044c7c2242547cf84f826ef4040afc997f92b1cL1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-f1d62bfe2b9687beeabc23f0f044c7c2242547cf84f826ef4040afc997f92b1cR13))
*  Move the test case that mocks the useContext function from the context test module to a separate mock-context test module ([link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-16cdf6294e56543d5de824ee116775f09357f21f2595a6de77ba1f709e5e36c7L10-L24), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-78c8df7097ce14db0b1794d60b411fe07e22c47dc93d2862f771c3ef969c0b51R1-R16))
*  Simplify the import of the useContext function in the context api module, and modify the export of the index api module to a named export ([link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-d2e57ccf14db51a53f092fc439e389d50980a3e601fab4ac27270c8022ded7c9L1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-d2e57ccf14db51a53f092fc439e389d50980a3e601fab4ac27270c8022ded7c9L13-L14), [link](https://github.com/web-infra-dev/modern.js/pull/3810/files?diff=unified&w=0#diff-19fd300db6257ca686cc9576177bae11a80b5cce1efb66a9d34589bd7041bd03L1-R1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
