### PR TITLE
chore(generator): update codesmith version

### DIFF
--- a/.changeset/three-clouds-shake.md
+++ b/.changeset/three-clouds-shake.md
@@ -1,0 +1,33 @@
+---
+'@modern-js/module-test-generator': patch
+'@modern-js/tailwindcss-generator': patch
+'@modern-js/dependence-generator': patch
+'@modern-js/changeset-generator': patch
+'@modern-js/generator-generator': patch
+'@modern-js/router-v5-generator': patch
+'@modern-js/storybook-generator': patch
+'@modern-js/monorepo-generator': patch
+'@modern-js/packages-generator': patch
+'@modern-js/upgrade-generator': patch
+'@modern-js/module-generator': patch
+'@modern-js/rspack-generator': patch
+'@modern-js/server-generator': patch
+'@modern-js/entry-generator': patch
+'@modern-js/base-generator': patch
+'@modern-js/repo-generator': patch
+'@modern-js/test-generator': patch
+'@modern-js/bff-generator': patch
+'@modern-js/doc-generator': patch
+'@modern-js/mwa-generator': patch
+'@modern-js/ssg-generator': patch
+'@modern-js/generator-common': patch
+'@modern-js/generator-plugin': patch
+'@modern-js/generator-utils': patch
+'@modern-js/new-action': patch
+'@modern-js/upgrade': patch
+'@modern-js/create': patch
+---
+
+chore(generator): update codesmith version
+
+chore(generator): 更新 codesmith 版本

--- a/packages/generator/generator-common/package.json
+++ b/packages/generator/generator-common/package.json
@@ -37,13 +37,13 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@modern-js/codesmith-formily": "2.2.3",
+    "@modern-js/codesmith-formily": "2.2.5",
     "@modern-js/plugin-i18n": "workspace:*",
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/utils": "workspace:*",
     "@scripts/build": "workspace:*",
     "@scripts/jest-config": "workspace:*",

--- a/packages/generator/generator-plugin/package.json
+++ b/packages/generator/generator-plugin/package.json
@@ -13,11 +13,11 @@
     "test": "jest"
   },
   "dependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-git": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
-    "@modern-js/codesmith-api-npm": "2.2.3",
-    "@modern-js/codesmith-formily": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-git": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
+    "@modern-js/codesmith-api-npm": "2.2.5",
+    "@modern-js/codesmith-formily": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/new-action": "workspace:*",

--- a/packages/generator/generator-utils/package.json
+++ b/packages/generator/generator-utils/package.json
@@ -42,7 +42,7 @@
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
     "@scripts/build": "workspace:*",
     "@scripts/jest-config": "workspace:*",
     "@types/jest": "^29",

--- a/packages/generator/generators/base-generator/package.json
+++ b/packages/generator/generators/base-generator/package.json
@@ -30,8 +30,8 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@scripts/build": "workspace:*",

--- a/packages/generator/generators/bff-generator/package.json
+++ b/packages/generator/generators/bff-generator/package.json
@@ -30,9 +30,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/changeset-generator/package.json
+++ b/packages/generator/generators/changeset-generator/package.json
@@ -29,8 +29,8 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@scripts/build": "workspace:*",
     "@scripts/jest-config": "workspace:*",

--- a/packages/generator/generators/dependence-generator/package.json
+++ b/packages/generator/generators/dependence-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",

--- a/packages/generator/generators/doc-generator/package.json
+++ b/packages/generator/generators/doc-generator/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "@modern-js/base-generator": "workspace:*",
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",

--- a/packages/generator/generators/entry-generator/package.json
+++ b/packages/generator/generators/entry-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-handlebars": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-handlebars": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",

--- a/packages/generator/generators/generator-generator/package.json
+++ b/packages/generator/generators/generator-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/module-generator": "workspace:*",

--- a/packages/generator/generators/module-generator/package.json
+++ b/packages/generator/generators/module-generator/package.json
@@ -31,9 +31,9 @@
   "devDependencies": {
     "@modern-js/base-generator": "workspace:*",
     "@modern-js/changeset-generator": "workspace:*",
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/module-test-generator/package.json
+++ b/packages/generator/generators/module-test-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/monorepo-generator/package.json
+++ b/packages/generator/generators/monorepo-generator/package.json
@@ -31,9 +31,9 @@
   "devDependencies": {
     "@modern-js/base-generator": "workspace:*",
     "@modern-js/changeset-generator": "workspace:*",
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",

--- a/packages/generator/generators/mwa-generator/package.json
+++ b/packages/generator/generators/mwa-generator/package.json
@@ -30,9 +30,9 @@
   },
   "devDependencies": {
     "@modern-js/base-generator": "workspace:*",
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/entry-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",

--- a/packages/generator/generators/packages-generator/package.json
+++ b/packages/generator/generators/packages-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@scripts/build": "workspace:*",

--- a/packages/generator/generators/repo-generator/package.json
+++ b/packages/generator/generators/repo-generator/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "@modern-js/base-generator": "workspace:*",
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-plugin": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/router-v5-generator/package.json
+++ b/packages/generator/generators/router-v5-generator/package.json
@@ -29,8 +29,8 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/rspack-generator/package.json
+++ b/packages/generator/generators/rspack-generator/package.json
@@ -29,8 +29,8 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/server-generator/package.json
+++ b/packages/generator/generators/server-generator/package.json
@@ -30,9 +30,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/dependence-generator": "workspace:*",

--- a/packages/generator/generators/ssg-generator/package.json
+++ b/packages/generator/generators/ssg-generator/package.json
@@ -29,8 +29,8 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/storybook-generator/package.json
+++ b/packages/generator/generators/storybook-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/tailwindcss-generator/package.json
+++ b/packages/generator/generators/tailwindcss-generator/package.json
@@ -29,8 +29,8 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/test-generator/package.json
+++ b/packages/generator/generators/test-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/dependence-generator": "workspace:*",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",

--- a/packages/generator/generators/upgrade-generator/package.json
+++ b/packages/generator/generators/upgrade-generator/package.json
@@ -29,9 +29,9 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-api-app": "2.2.3",
-    "@modern-js/codesmith-api-json": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-api-app": "2.2.5",
+    "@modern-js/codesmith-api-json": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",

--- a/packages/generator/new-action/package.json
+++ b/packages/generator/new-action/package.json
@@ -36,8 +36,8 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@modern-js/codesmith": "2.2.3",
-    "@modern-js/codesmith-formily": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
+    "@modern-js/codesmith-formily": "2.2.5",
     "@modern-js/generator-common": "workspace:*",
     "@modern-js/generator-utils": "workspace:*",
     "@modern-js/utils": "workspace:*",

--- a/packages/toolkit/create/package.json
+++ b/packages/toolkit/create/package.json
@@ -43,7 +43,7 @@
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
-    "@modern-js/codesmith": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
     "@modern-js/generator-plugin-plugin": "workspace:*",
     "@modern-js/plugin-i18n": "workspace:*",
     "@modern-js/repo-generator": "workspace:*",

--- a/packages/toolkit/upgrade/package.json
+++ b/packages/toolkit/upgrade/package.json
@@ -43,7 +43,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@modern-js/codesmith": "2.2.3",
+    "@modern-js/codesmith": "2.2.5",
     "@modern-js/plugin-i18n": "workspace:*",
     "@modern-js/utils": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1343,9 +1343,9 @@ importers:
 
   packages/generator/generator-common:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-formily': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-formily': 2.2.5
       '@modern-js/plugin-i18n': workspace:*
       '@modern-js/utils': workspace:*
       '@scripts/build': workspace:*
@@ -1356,12 +1356,12 @@ importers:
       jest: ^29
       typescript: ^5
     dependencies:
-      '@modern-js/codesmith-formily': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith-formily': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/plugin-i18n': link:../../cli/plugin-i18n
       '@swc/helpers': 0.5.1
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/utils': link:../../toolkit/utils
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
@@ -1372,11 +1372,11 @@ importers:
 
   packages/generator/generator-plugin:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-git': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
-      '@modern-js/codesmith-api-npm': 2.2.3
-      '@modern-js/codesmith-formily': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-git': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
+      '@modern-js/codesmith-api-npm': 2.2.5
+      '@modern-js/codesmith-formily': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/new-action': workspace:*
@@ -1394,11 +1394,11 @@ importers:
       jest: ^29
       typescript: ^5
     dependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-git': 2.2.3_@modern-js+codesmith@2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
-      '@modern-js/codesmith-api-npm': 2.2.3
-      '@modern-js/codesmith-formily': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-git': 2.2.5_@modern-js+codesmith@2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
+      '@modern-js/codesmith-api-npm': 2.2.5
+      '@modern-js/codesmith-formily': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/generator-common': link:../generator-common
       '@modern-js/generator-utils': link:../generator-utils
       '@modern-js/new-action': link:../new-action
@@ -1419,7 +1419,7 @@ importers:
 
   packages/generator/generator-utils:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/plugin-i18n': workspace:*
       '@modern-js/utils': workspace:*
@@ -1436,7 +1436,7 @@ importers:
       '@modern-js/utils': link:../../toolkit/utils
       '@swc/helpers': 0.5.1
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@scripts/build': link:../../../scripts/build
       '@scripts/jest-config': link:../../../scripts/jest-config
       '@types/jest': 29.2.6
@@ -1446,8 +1446,8 @@ importers:
 
   packages/generator/generators/base-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@scripts/build': workspace:*
@@ -1457,8 +1457,8 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@scripts/build': link:../../../../scripts/build
@@ -1470,9 +1470,9 @@ importers:
 
   packages/generator/generators/bff-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/plugin-i18n': workspace:*
@@ -1483,9 +1483,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/plugin-i18n': link:../../../cli/plugin-i18n
@@ -1498,8 +1498,8 @@ importers:
 
   packages/generator/generators/changeset-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@scripts/build': workspace:*
       '@scripts/jest-config': workspace:*
@@ -1508,8 +1508,8 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/generator-common': link:../../generator-common
       '@scripts/build': link:../../../../scripts/build
       '@scripts/jest-config': link:../../../../scripts/jest-config
@@ -1520,9 +1520,9 @@ importers:
 
   packages/generator/generators/dependence-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/plugin-i18n': workspace:*
@@ -1533,9 +1533,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/plugin-i18n': link:../../../cli/plugin-i18n
@@ -1549,8 +1549,8 @@ importers:
   packages/generator/generators/doc-generator:
     specifiers:
       '@modern-js/base-generator': workspace:*
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/plugin-i18n': workspace:*
@@ -1562,8 +1562,8 @@ importers:
       typescript: ^5
     devDependencies:
       '@modern-js/base-generator': link:../base-generator
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/plugin-i18n': link:../../../cli/plugin-i18n
@@ -1576,9 +1576,9 @@ importers:
 
   packages/generator/generators/entry-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-handlebars': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-handlebars': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/plugin-i18n': workspace:*
@@ -1590,9 +1590,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-handlebars': 2.2.3_@modern-js+codesmith@2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-handlebars': 2.2.5_@modern-js+codesmith@2.2.5
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/plugin-i18n': link:../../../cli/plugin-i18n
@@ -1606,9 +1606,9 @@ importers:
 
   packages/generator/generators/generator-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/module-generator': workspace:*
@@ -1620,9 +1620,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/module-generator': link:../module-generator
@@ -1638,9 +1638,9 @@ importers:
     specifiers:
       '@modern-js/base-generator': workspace:*
       '@modern-js/changeset-generator': workspace:*
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1655,9 +1655,9 @@ importers:
     devDependencies:
       '@modern-js/base-generator': link:../base-generator
       '@modern-js/changeset-generator': link:../changeset-generator
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1672,9 +1672,9 @@ importers:
 
   packages/generator/generators/module-test-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1686,9 +1686,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1704,9 +1704,9 @@ importers:
     specifiers:
       '@modern-js/base-generator': workspace:*
       '@modern-js/changeset-generator': workspace:*
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/packages-generator': workspace:*
@@ -1720,9 +1720,9 @@ importers:
     devDependencies:
       '@modern-js/base-generator': link:../base-generator
       '@modern-js/changeset-generator': link:../changeset-generator
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/packages-generator': link:../packages-generator
@@ -1737,9 +1737,9 @@ importers:
   packages/generator/generators/mwa-generator:
     specifiers:
       '@modern-js/base-generator': workspace:*
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/entry-generator': workspace:*
       '@modern-js/generator-common': workspace:*
@@ -1755,9 +1755,9 @@ importers:
       typescript: ^5
     devDependencies:
       '@modern-js/base-generator': link:../base-generator
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/entry-generator': link:../entry-generator
       '@modern-js/generator-common': link:../../generator-common
@@ -1774,9 +1774,9 @@ importers:
 
   packages/generator/generators/packages-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@scripts/build': workspace:*
@@ -1786,9 +1786,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@scripts/build': link:../../../../scripts/build
@@ -1801,8 +1801,8 @@ importers:
   packages/generator/generators/repo-generator:
     specifiers:
       '@modern-js/base-generator': workspace:*
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/doc-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-plugin': workspace:*
@@ -1819,8 +1819,8 @@ importers:
       typescript: ^5
     devDependencies:
       '@modern-js/base-generator': link:../base-generator
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/doc-generator': link:../doc-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-plugin': link:../../generator-plugin
@@ -1838,8 +1838,8 @@ importers:
 
   packages/generator/generators/router-v5-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1851,8 +1851,8 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1866,8 +1866,8 @@ importers:
 
   packages/generator/generators/rspack-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1879,8 +1879,8 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1894,9 +1894,9 @@ importers:
 
   packages/generator/generators/server-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1907,9 +1907,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1922,8 +1922,8 @@ importers:
 
   packages/generator/generators/ssg-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1935,8 +1935,8 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1950,9 +1950,9 @@ importers:
 
   packages/generator/generators/storybook-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1964,9 +1964,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -1980,8 +1980,8 @@ importers:
 
   packages/generator/generators/tailwindcss-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -1992,8 +1992,8 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -2006,9 +2006,9 @@ importers:
 
   packages/generator/generators/test-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': workspace:*
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
@@ -2020,9 +2020,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/dependence-generator': link:../dependence-generator
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
@@ -2036,9 +2036,9 @@ importers:
 
   packages/generator/generators/upgrade-generator:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/plugin-i18n': workspace:*
@@ -2049,9 +2049,9 @@ importers:
       jest: ^29
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-app': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
-      '@modern-js/codesmith-api-json': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-app': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
+      '@modern-js/codesmith-api-json': 2.2.5
       '@modern-js/generator-common': link:../../generator-common
       '@modern-js/generator-utils': link:../../generator-utils
       '@modern-js/plugin-i18n': link:../../../cli/plugin-i18n
@@ -2064,8 +2064,8 @@ importers:
 
   packages/generator/new-action:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-formily': 2.2.3
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-formily': 2.2.5
       '@modern-js/generator-common': workspace:*
       '@modern-js/generator-utils': workspace:*
       '@modern-js/utils': workspace:*
@@ -2077,8 +2077,8 @@ importers:
       jest: ^29
       typescript: ^5
     dependencies:
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-formily': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-formily': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/generator-common': link:../generator-common
       '@modern-js/generator-utils': link:../generator-utils
       '@modern-js/utils': link:../../toolkit/utils
@@ -3460,7 +3460,7 @@ importers:
 
   packages/toolkit/create:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/generator-plugin-plugin': workspace:*
       '@modern-js/plugin-i18n': workspace:*
       '@modern-js/repo-generator': workspace:*
@@ -3473,7 +3473,7 @@ importers:
       ts-node: ^10.9.1
       typescript: ^5
     devDependencies:
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/generator-plugin-plugin': link:../../generator/plugins/generator-plugin
       '@modern-js/plugin-i18n': link:../../cli/plugin-i18n
       '@modern-js/repo-generator': link:../../generator/generators/repo-generator
@@ -3599,7 +3599,7 @@ importers:
 
   packages/toolkit/upgrade:
     specifiers:
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/plugin-i18n': workspace:*
       '@modern-js/upgrade-generator': workspace:*
       '@modern-js/utils': workspace:*
@@ -3611,7 +3611,7 @@ importers:
       ts-node: ^10.9.1
       typescript: ^5
     dependencies:
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/plugin-i18n': link:../../cli/plugin-i18n
       '@modern-js/utils': link:../utils
     devDependencies:
@@ -9432,19 +9432,19 @@ packages:
       redux: 4.2.0
     dev: false
 
-  /@modern-js/codesmith-api-app/2.2.3_bho3aw2byq52erp6eaxmeboo7i:
-    resolution: {integrity: sha512-TDQEHBgP/vOuRu/4SrRTpJdRW1KYnpugc5toRzOAYUOGFYsiJSNTHurBpkeYljPIJtSGqP+eVtS8s08POBMExQ==}
+  /@modern-js/codesmith-api-app/2.2.5_g6gqsypbjnpqx7w2a6bm33mugi:
+    resolution: {integrity: sha512-s3tZt553MgATJ8FaoztCrPOqvO1g+lNDfC+QfkzTgUoFWk9vefueQ/mqqj+AuAQC22S+hk6pdJ0HtOBkHWee7w==}
     peerDependencies:
-      '@modern-js/codesmith': ^2.2.3
+      '@modern-js/codesmith': ^2.2.5
     dependencies:
       '@babel/runtime': 7.21.5
-      '@modern-js/codesmith': 2.2.3
-      '@modern-js/codesmith-api-ejs': 2.2.3_@modern-js+codesmith@2.2.3
-      '@modern-js/codesmith-api-fs': 2.2.3_@modern-js+codesmith@2.2.3
-      '@modern-js/codesmith-api-git': 2.2.3_@modern-js+codesmith@2.2.3
-      '@modern-js/codesmith-api-handlebars': 2.2.3_@modern-js+codesmith@2.2.3
-      '@modern-js/codesmith-api-npm': 2.2.3
-      '@modern-js/codesmith-formily': 2.2.3_bho3aw2byq52erp6eaxmeboo7i
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-api-ejs': 2.2.5_@modern-js+codesmith@2.2.5
+      '@modern-js/codesmith-api-fs': 2.2.5_@modern-js+codesmith@2.2.5
+      '@modern-js/codesmith-api-git': 2.2.5_@modern-js+codesmith@2.2.5
+      '@modern-js/codesmith-api-handlebars': 2.2.5_@modern-js+codesmith@2.2.5
+      '@modern-js/codesmith-api-npm': 2.2.5
+      '@modern-js/codesmith-formily': 2.2.5_g6gqsypbjnpqx7w2a6bm33mugi
       '@modern-js/plugin-i18n': 2.18.0
       '@modern-js/utils': 2.18.0
       comment-json: 4.2.3
@@ -9458,53 +9458,53 @@ packages:
       - typescript
     dev: true
 
-  /@modern-js/codesmith-api-ejs/2.2.3_@modern-js+codesmith@2.2.3:
-    resolution: {integrity: sha512-ljfjiLVetV698V6Rig2/pX3j2S/p6U2seQEvrs7Kq+SsrVNAx2mKzMG60m0P+MZVw2aQCLq+k9ONPTqzQne1Ww==}
+  /@modern-js/codesmith-api-ejs/2.2.5_@modern-js+codesmith@2.2.5:
+    resolution: {integrity: sha512-hN4sJy+nnr2dPD/BwVLlNdYRQdTC1O2lltRBeEFYD43tD1yEagjWRtccAweoBIt379DsAqi2UKydsW5OvFge/Q==}
     peerDependencies:
-      '@modern-js/codesmith': ^2.2.3
+      '@modern-js/codesmith': ^2.2.5
     dependencies:
       '@babel/runtime': 7.21.5
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       ejs: 3.1.9
     dev: true
 
-  /@modern-js/codesmith-api-fs/2.2.3_@modern-js+codesmith@2.2.3:
-    resolution: {integrity: sha512-6MeBI49wRkr06Qwp2ALY7fFsFYeqTgL5tFRC5gdymBTpEd8svKrDUywOtTiakLP3njHFdY2SaPhbgF+Qpxawrg==}
+  /@modern-js/codesmith-api-fs/2.2.5_@modern-js+codesmith@2.2.5:
+    resolution: {integrity: sha512-DG0ylrbQMUrB0mz/QmxdGTtY3TbRmwdxpXbqPBH7qfIdxNN9wcR2jigTsV/AdboDPM2U9otQkdYtUy7r3lgXKw==}
     peerDependencies:
-      '@modern-js/codesmith': ^2.2.3
+      '@modern-js/codesmith': ^2.2.5
     dependencies:
       '@babel/runtime': 7.21.5
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
     dev: true
 
-  /@modern-js/codesmith-api-git/2.2.3_@modern-js+codesmith@2.2.3:
-    resolution: {integrity: sha512-wtWvJKlxfNVLov7A6UftO0Qpc0M1YVPDc1XagLytegD2jG483x4Ah+8FRvrKHWIO9bdBYDN+iCI7HWD6ZAmhBA==}
+  /@modern-js/codesmith-api-git/2.2.5_@modern-js+codesmith@2.2.5:
+    resolution: {integrity: sha512-XZab49Z7K6WGjsXoowGs3//nA1D6WCbwI9haRJ2qJ2p/DvqtpVq0cS/FZGuu/7tMK2HckZsHi3aMH08XGEDFIA==}
     peerDependencies:
-      '@modern-js/codesmith': ^2.2.3
+      '@modern-js/codesmith': ^2.2.5
     dependencies:
       '@babel/runtime': 7.21.5
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/utils': 2.18.0
     transitivePeerDependencies:
       - react
       - react-dom
       - react-router-dom
 
-  /@modern-js/codesmith-api-handlebars/2.2.3_@modern-js+codesmith@2.2.3:
-    resolution: {integrity: sha512-v0zmyPLxLdyjthV2Iq64SJxCpWNULVdrKS5njISXBlrpnCYv6DfeFLbv8bcvPHfR3YmsfVRPUWmrBTSCzFDScw==}
+  /@modern-js/codesmith-api-handlebars/2.2.5_@modern-js+codesmith@2.2.5:
+    resolution: {integrity: sha512-CXAMdRSaCVujIbKT7yP6DJ5qgiv/Eobwfbtm6nTkbmI0Qux5xqf/J69RVunNw+db/gL3CBWBiShS2GVLWh61/g==}
     peerDependencies:
-      '@modern-js/codesmith': ^2.2.3
+      '@modern-js/codesmith': ^2.2.5
     dependencies:
       '@babel/runtime': 7.21.5
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       handlebars: 4.7.7
     dev: true
 
-  /@modern-js/codesmith-api-json/2.2.3:
-    resolution: {integrity: sha512-XhmObUVtVBNQhh678J8OFPca+I46W52VtWVz8rUohJIryeYKaRy/SygdltYB6pHdvD0tYVc7TabCO5o///6F3A==}
+  /@modern-js/codesmith-api-json/2.2.5:
+    resolution: {integrity: sha512-E9uANiMKb4wKctwhF+uFhojsRctUxBiKcGL9OyKOCeLXCyXpOeNGYgbKjs1duatr2KtN7gUcSpy8UD1pGgPZeQ==}
     dependencies:
       '@babel/runtime': 7.21.5
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       comment-json: 4.2.3
       declaration-update: 0.0.2
     transitivePeerDependencies:
@@ -9514,11 +9514,11 @@ packages:
       - react-router-dom
       - supports-color
 
-  /@modern-js/codesmith-api-npm/2.2.3:
-    resolution: {integrity: sha512-eADSEtdx1SUw4nv4PEwa/Jzc3EmeJhSvQsceyOJ57l/D2lUpUI+EIqDJKVWx4KE+YBR88KuFsZow2m8GPBe/0g==}
+  /@modern-js/codesmith-api-npm/2.2.5:
+    resolution: {integrity: sha512-3WCzyZGMDVnLck+ZKQhRBznM69L+jQT8bZ90mZo+9dUzgS4GndsHTTCosNdQcvNDviaYWwFH02Js5fE2uiUdSA==}
     dependencies:
       '@babel/runtime': 7.21.5
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/utils': 2.18.0
     transitivePeerDependencies:
       - debug
@@ -9526,15 +9526,15 @@ packages:
       - react-dom
       - react-router-dom
 
-  /@modern-js/codesmith-formily/2.2.3_bho3aw2byq52erp6eaxmeboo7i:
-    resolution: {integrity: sha512-TP1Se8uHa5VxV+9ISumsMQPNJjLkl9rpPuCfJ8A3LozuBLWxr9rVVo3ZARRKSYAjG/GV6IpYoj6uboPWsDSUTA==}
+  /@modern-js/codesmith-formily/2.2.5_g6gqsypbjnpqx7w2a6bm33mugi:
+    resolution: {integrity: sha512-K2A+e/ptl3XoMlrCHIyAd+Oo49rwzQQrU8sOdwjRgQD/Ik4vNbIBSvZeTqU8ViYO2ZEk5IvffyTJw2ZbDNM99Q==}
     peerDependencies:
-      '@modern-js/codesmith': ^2.2.3
+      '@modern-js/codesmith': ^2.2.5
     dependencies:
       '@babel/runtime': 7.21.5
       '@formily/json-schema': 2.2.24_typescript@5.0.4
       '@formily/validator': 2.2.24
-      '@modern-js/codesmith': 2.2.3
+      '@modern-js/codesmith': 2.2.5
       '@modern-js/utils': 2.18.0
       inquirer: 8.2.5
     transitivePeerDependencies:
@@ -9543,8 +9543,8 @@ packages:
       - react-router-dom
       - typescript
 
-  /@modern-js/codesmith/2.2.3:
-    resolution: {integrity: sha512-5T9Pf2eOuiA8MVJ4WVGPOjb7t/HQXm506eTL949d/a/o20xofXYjqjxxeG/c4m8KwKpbPh8DVPyty2l5o6+bEw==}
+  /@modern-js/codesmith/2.2.5:
+    resolution: {integrity: sha512-crlaJqKT8iSLRTLOgTU7PCVWtXJ66ezM5CmKTRGdQYIEWx85Pmuj3lmupyXM3ecv4lhVzoonVs/nh3bS5ubeOQ==}
     dependencies:
       '@babel/runtime': 7.21.5
       '@modern-js/utils': 2.18.0
@@ -13811,8 +13811,10 @@ packages:
       ajv: 6.12.6
     dev: false
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -28221,7 +28223,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scroll-into-view-if-needed/2.2.20:


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb44cce</samp>

This pull request updates the codesmith dependency version and its related plugins for all the generator packages in the modern.js monorepo. This ensures that the generators use the latest features and bug fixes of codesmith, a tool for scaffolding code using templates and plugins. The pull request also adds a changeset file that specifies the packages that need to be patched and the reason for the patch.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb44cce</samp>

*  Add a changeset file to specify the packages that need to be patched and the reason for the patch ([link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-6e5fcc8697dd17e396eb2233aee45569f3876038ddaba04a601268e6bbe1e7a4R1-R31))
*  Update the codesmith dependency version from 2.2.3 to 2.2.5 in all the generator packages to ensure compatibility and stability with the latest codesmith release ([link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-225729deff87d0a9b065e14c85847ec318abb29e2c4e542001b8792a60e4dfecL40-R46), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-7d73ff8d2063f87311f3ace7f84dfbe2c54526138fc5a23bfc7f975cc2c7df08L16-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-d9061d8c34f313355554119fd137fc515129e4f768721d6fd3ac2fea1a25a683L45-R45), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-e7636ad59b2d995453069533c4333a26384dcb0cdc9c43e9d535c4dab88214bdL33-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-03b429766ce926b92d87b5841676f75f7cfa39231a3c603e657c25b72a191f32L33-R35), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-f009ade25b0c3afb4ff21d732688e68d776cbb5fdf2d10bb252f0177dce95f04L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-057c18d559bde0588a6ee142098c9844d9263394b5f91c17a3a8a3ef878560e7L32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-362bdad10bd78f71f210f6e5d7852c5dfbbd486b6bf5f5d041485cec633fab43L33-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-ecc71e19dc9cce82a681e6d1cc2403a27d60afcb54a1b72246751c2a409bd364L32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-989c0d6714d936151f926426af2fa12e8de76c604e17269da46432e6f96a4887L32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-63d011605457243472f3716e925d18a7b2af4905a888ce50ac64cecd08ffee7fL34-R36), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-e76e032b35378172c0a88e87eb3cbe7b1294ef328b37133c5bb154b2b32997beL32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-2db4756ff0b0326b4df138ec6ff6f777dedd4dbd679014abe5a816e3a46e5a91L34-R36), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-25e249731284215346d9a36be7c5811b0148643631587b8fc916c0b4450605f6L33-R35), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-56b420a0293f65602db387e571f26e6a0189f2f7564db567640115db8a432c4eL32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-c31b1febd7c048a1b81f2a841bd81270ea8b0e710d8a94854a05b28948c41526L33-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-0af5eaf01d57771bcaa5fdb47abfd6b467fd22d3720c484aab56be8e96c01c56L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-117b60b553ae1b77bf493590e04a7e46bf3e172c329d86af4e613f536d10f805L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-621200cbb00df5bc6632991906ab362668482b23a0ab1273747fec79b4fc0281L33-R35))
*  Update the codesmith-api-* dependency versions from 2.2.3 to 2.2.5 in the generator packages that use them to match the codesmith version and provide some common APIs for manipulating files, JSON, git, npm, app, and handlebars ([link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-7d73ff8d2063f87311f3ace7f84dfbe2c54526138fc5a23bfc7f975cc2c7df08L16-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-e7636ad59b2d995453069533c4333a26384dcb0cdc9c43e9d535c4dab88214bdL33-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-03b429766ce926b92d87b5841676f75f7cfa39231a3c603e657c25b72a191f32L33-R35), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-f009ade25b0c3afb4ff21d732688e68d776cbb5fdf2d10bb252f0177dce95f04L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-057c18d559bde0588a6ee142098c9844d9263394b5f91c17a3a8a3ef878560e7L32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-362bdad10bd78f71f210f6e5d7852c5dfbbd486b6bf5f5d041485cec633fab43L33-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-ecc71e19dc9cce82a681e6d1cc2403a27d60afcb54a1b72246751c2a409bd364L32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-989c0d6714d936151f926426af2fa12e8de76c604e17269da46432e6f96a4887L32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-63d011605457243472f3716e925d18a7b2af4905a888ce50ac64cecd08ffee7fL34-R36), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-e76e032b35378172c0a88e87eb3cbe7b1294ef328b37133c5bb154b2b32997beL32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-2db4756ff0b0326b4df138ec6ff6f777dedd4dbd679014abe5a816e3a46e5a91L34-R36), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-25e249731284215346d9a36be7c5811b0148643631587b8fc916c0b4450605f6L33-R35), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-56b420a0293f65602db387e571f26e6a0189f2f7564db567640115db8a432c4eL32-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-c31b1febd7c048a1b81f2a841bd81270ea8b0e710d8a94854a05b28948c41526L33-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-0af5eaf01d57771bcaa5fdb47abfd6b467fd22d3720c484aab56be8e96c01c56L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-117b60b553ae1b77bf493590e04a7e46bf3e172c329d86af4e613f536d10f805L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-621200cbb00df5bc6632991906ab362668482b23a0ab1273747fec79b4fc0281L33-R35))
*  Update the codesmith-formily dependency version from 2.2.3 to 2.2.5 in the `generator-common` package to match the codesmith version and integrate with Formily, a library for building forms ([link](https://github.com/web-infra-dev/modern.js/pull/3818/files?diff=unified&w=0#diff-225729deff87d0a9b065e14c85847ec318abb29e2c4e542001b8792a60e4dfecL40-R46))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
