### PR TITLE
fix(doc-plugin-preview): build error in first time

### DIFF
--- a/.changeset/two-lions-compete.md
+++ b/.changeset/two-lions-compete.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/doc-plugin-preview': patch
+'@modern-js/doc-core': patch
+---
+
+fix(doc-plugin-preview): preview plugin build error
+
+fix(doc-plugin-preview): 预览插件构建错误

--- a/packages/cli/doc-core/src/shared/types/Plugin.ts
+++ b/packages/cli/doc-core/src/shared/types/Plugin.ts
@@ -64,7 +64,7 @@ export interface DocPlugin {
     config: DocConfig,
     isProd: boolean,
     routes: RouteMeta[],
-  ) => AdditionalPage[];
+  ) => AdditionalPage[] | Promise<AdditionalPage[]>;
   /**
    * Add addition ssg routes, for dynamic routes.
    */

--- a/packages/cli/doc-plugin-preview/mdx-meta-loader.cjs
+++ b/packages/cli/doc-plugin-preview/mdx-meta-loader.cjs
@@ -1,47 +1,15 @@
-const { join } = require('path');
-const { routeMeta } = require('./dist');
+const { demoMeta } = require('./dist');
 
-module.exports = async function (source) {
+module.exports = async function () {
   const callback = this.async();
-  const { createProcessor } = await import('@mdx-js/mdx');
-  const { visit } = await import('unist-util-visit');
-  const { default: fs } = await import('@modern-js/utils/fs-extra');
   try {
-    const processor = createProcessor();
-    const ast = processor.parse(source);
-    let index = 1;
-    const meta = [];
-    visit(ast, 'code', node => {
-      if (node.lang === 'jsx' || node.lang === 'tsx') {
-        const { value } = node;
-        const { pageName } = routeMeta.find(
-          meta => meta.absolutePath === this.resourcePath,
-        );
-        const id = `${pageName}_${index++}`;
-
-        const demoDir = join(
-          process.cwd(),
-          'node_modules',
-          '.modern-doc',
-          `virtual-demo`,
-        );
-        const virtualModulePath = join(demoDir, `${id}.tsx`);
-        const item = {
-          id,
-          virtualModulePath,
-        };
-        meta.push(item);
-        fs.ensureDirSync(join(demoDir));
-        fs.writeFileSync(virtualModulePath, value);
-      }
-    });
     const result = `
-      ${meta
+      ${demoMeta
         .map(item => {
           return `import Demo_${item.id} from '${item.virtualModulePath}';`;
         })
         .join('\n')}
-      export default [${meta
+      export default [${demoMeta
         .map(item => {
           return `{
             "id": "${item.id}",

--- a/packages/cli/doc-plugin-preview/mdx-meta-loader.cjs
+++ b/packages/cli/doc-plugin-preview/mdx-meta-loader.cjs
@@ -2,14 +2,15 @@ const { demoMeta } = require('./dist');
 
 module.exports = async function () {
   const callback = this.async();
+  const demos = demoMeta[this.resourcePath] || [];
   try {
     const result = `
-      ${demoMeta
+      ${demos
         .map(item => {
           return `import Demo_${item.id} from '${item.virtualModulePath}';`;
         })
         .join('\n')}
-      export default [${demoMeta
+      export default [${demos
         .map(item => {
           return `{
             "id": "${item.id}",

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -14,7 +14,10 @@ export type Options = {
 // eslint-disable-next-line import/no-mutable-exports
 export let routeMeta: RouteMeta[];
 export const demoRoutes: { path: string }[] = [];
-export const demoMeta: { id: string; virtualModulePath: string }[] = [];
+export const demoMeta: Record<
+  string,
+  { id: string; virtualModulePath: string }[]
+> = {};
 
 /**
  * The plugin is used to preview component.
@@ -63,10 +66,15 @@ export function pluginPreview(options?: Options): DocPlugin {
                 );
 
                 const virtualModulePath = join(demoDir, `${id}.tsx`);
-                demoMeta.push({
-                  id,
-                  virtualModulePath,
-                });
+                demoMeta[filepath] = demoMeta[filepath] ?? [];
+                const isExist = demoMeta[filepath].find(item => item.id === id);
+                if (!isExist) {
+                  demoMeta[filepath].push({
+                    id,
+                    virtualModulePath,
+                  });
+                }
+
                 fs.ensureDirSync(join(demoDir));
                 fs.writeFileSync(virtualModulePath, value);
               }

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -14,6 +14,7 @@ export type Options = {
 // eslint-disable-next-line import/no-mutable-exports
 export let routeMeta: RouteMeta[];
 export const demoRoutes: { path: string }[] = [];
+export const demoMeta: { id: string; virtualModulePath: string }[] = [];
 
 /**
  * The plugin is used to preview component.
@@ -60,13 +61,20 @@ export function pluginPreview(options?: Options): DocPlugin {
                   '.modern-doc',
                   `virtual-demo`,
                 );
-                const virtualModulePath = join(demoDir, `${id}.tsx`);
 
+                const virtualModulePath = join(demoDir, `${id}.tsx`);
+                demoMeta.push({
+                  id,
+                  virtualModulePath,
+                });
                 fs.ensureDirSync(join(demoDir));
                 fs.writeFileSync(virtualModulePath, value);
               }
             });
-          } catch (e) {}
+          } catch (e) {
+            console.error(e);
+            throw e;
+          }
         }),
       );
       /**

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path, { join } from 'path';
 import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
 import type { DocPlugin, RouteMeta } from '@modern-js/doc-core';
 import { remarkCodeToDemo } from './codeToDemo';
@@ -26,7 +26,7 @@ export function pluginPreview(options?: Options): DocPlugin {
 
   return {
     name: '@modern-js/doc-plugin-preview',
-    addPages(_config, _isProd, routes) {
+    async addPages(_config, _isProd, routes) {
       // init routeMeta
       routeMeta = routes;
       // only addPages in mobile mode
@@ -34,6 +34,41 @@ export function pluginPreview(options?: Options): DocPlugin {
         return [];
       }
       const files = routes.map(route => route.absolutePath);
+      // Write the demo code ahead of time
+      // Fix: rspack build error because demo file is not exist, probably the demo file was written in rspack build process?
+      await Promise.all(
+        files.map(async (filepath, _index) => {
+          const { createProcessor } = await import('@mdx-js/mdx');
+          const { visit } = await import('unist-util-visit');
+          const { default: fs } = await import('@modern-js/utils/fs-extra');
+          try {
+            const processor = createProcessor();
+            const source = await fs.readFile(filepath, 'utf-8');
+            const ast = processor.parse(source);
+            let index = 1;
+            visit(ast, 'code', (node: any) => {
+              if (node.lang === 'jsx' || node.lang === 'tsx') {
+                const { value } = node;
+                const { pageName } = routeMeta.find(
+                  meta => meta.absolutePath === filepath,
+                )!;
+                const id = `${pageName}_${index++}`;
+
+                const demoDir = join(
+                  process.cwd(),
+                  'node_modules',
+                  '.modern-doc',
+                  `virtual-demo`,
+                );
+                const virtualModulePath = join(demoDir, `${id}.tsx`);
+
+                fs.ensureDirSync(join(demoDir));
+                fs.writeFileSync(virtualModulePath, value);
+              }
+            });
+          } catch (e) {}
+        }),
+      );
       /**
        * expect the meta of each demo file is like this:
        * {

--- a/tests/integration/doc/fixtures/plugin/modern.config.ts
+++ b/tests/integration/doc/fixtures/plugin/modern.config.ts
@@ -7,10 +7,6 @@ export default defineConfig({
   plugins: [docTools()],
   doc: {
     root: path.join(__dirname, 'doc'),
-    plugins: [
-      docPluginDemo(),
-      // FIXME: demo not found error
-      pluginPreview({ isMobile: true }),
-    ],
+    plugins: [docPluginDemo(), pluginPreview({ isMobile: true })],
   },
 });

--- a/tests/integration/doc/fixtures/plugin/modern.config.ts
+++ b/tests/integration/doc/fixtures/plugin/modern.config.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import docTools, { defineConfig } from '@modern-js/doc-tools';
-// import { pluginPreview } from '@modern-js/doc-plugin-preview';
+import { pluginPreview } from '@modern-js/doc-plugin-preview';
 import { docPluginDemo } from './plugin';
 
 export default defineConfig({
@@ -10,7 +10,7 @@ export default defineConfig({
     plugins: [
       docPluginDemo(),
       // FIXME: demo not found error
-      // pluginPreview({ isMobile: true })
+      pluginPreview({ isMobile: true }),
     ],
   },
 });


### PR DESCRIPTION
## Summary

Build error in first time when applying doc-plugin-preview.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7cb4fc4</samp>

This pull request fixes a bug and enhances the functionality of the `@modern-js/doc-plugin-preview` plugin, which allows previewing doc pages in the browser. It uses the `path` module to create demo code file paths, writes the demo code files ahead of time, and simplifies the `mdx-meta-loader.cjs` module. It also updates the `DocPlugin` interface and the doc integration test fixture to support the plugin.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7cb4fc4</samp>

*  Add changeset file to document patch updates and bug fix for `@modern-js/doc-plugin-preview` and `@modern-js/doc-core` packages ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-a8f28b6a643f41b364e74ba457d022ac224f1a8fb1cda5abbbfc3548ff4a6863R1-R8))
*  Allow `addPages` method in `DocPlugin` interface to return a promise of `AdditionalPage[]` to support async logic of writing demo code files ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-fcbad2de417f238c600c4131d79ef12dd4ddb45908a4f0097639791f7b4b27a5L67-R67))
*  Simplify `mdx-meta-loader.cjs` module by importing `demoMeta` array from `@modern-js/doc-plugin-preview` plugin instead of generating it from source code ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-86ffe8b13b6c863c0d95f393a4206f18b422427e2f0d75f6383233aa8b5c71e0L1-R12))
  *  Import `join` function from `path` module to create demo code file paths ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaL1-R1))
  *  Add `demoMeta` array to store id and virtual module path of each demo code file ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR17))
  *  Make `addPages` method async to use `Promise.all` function to write demo code files ahead of time in parallel ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaL29-R30))
  *  Add logic of writing demo code files ahead of time in `addPages` method by parsing ast, visiting code nodes, extracting demo code, generating id and virtual module path, and writing files to disk ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR38-R79))
*  Enable and test `@modern-js/doc-plugin-preview` plugin in integration test fixture for doc plugin by removing comment in `modern.config.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-040cd191471118bc1891e5319efd67e3f067180875c36311f7870f8b24524959L3-R3),[link](https://github.com/web-infra-dev/modern.js/pull/3820/files?diff=unified&w=0#diff-040cd191471118bc1891e5319efd67e3f067180875c36311f7870f8b24524959L13-R13))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
