### PR TITLE
fix(doc-core): build error when doc path includes "."

### DIFF
--- a/.changeset/tame-zebras-wait.md
+++ b/.changeset/tame-zebras-wait.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): build error when doc path includes "."
+
+fix(doc-core): 当文档路径包含 "." 时，构建失败

--- a/packages/cli/doc-core/src/node/plugins/autoNavAndSidebar/index.ts
+++ b/packages/cli/doc-core/src/node/plugins/autoNavAndSidebar/index.ts
@@ -156,7 +156,8 @@ export async function detectFilePath(rawPath: string) {
   const extensions = ['.mdx', '.md'];
   // The params doesn't have extension name, so we need to try to find the file with the extension name.
   let realPath = rawPath;
-  if (rawPath.indexOf('.') === -1) {
+  const filename = path.basename(rawPath);
+  if (filename.indexOf('.') === -1) {
     const pathWithExtension = extensions.map(ext => `${rawPath}${ext}`);
     const pathExistInfo = await Promise.all(
       pathWithExtension.map(p => fs.pathExists(p)),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5612497</samp>

This pull request fixes a bug in the `@modern-js/doc-core` package that caused the build to fail when the doc path includes a dot character. It also adds a changeset file to document the patch version update and the bug fix message in both English and Chinese.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5612497</samp>

*  Fix bug where build fails when doc path includes a dot character ([link](https://github.com/web-infra-dev/modern.js/pull/3822/files?diff=unified&w=0#diff-07ee447bb8d18e889220f920a4d479a4d297a14d0d11fa446fd4bf93d53c4693L159-R160), [link](https://github.com/web-infra-dev/modern.js/pull/3822/files?diff=unified&w=0#diff-47bdbf37a2040a50344f557394510d4475b65f92385d7e9284577ad341796cc5R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
