### PR TITLE
 fix: release note get use not right

### DIFF
--- a/.changeset/late-comics-clean.md
+++ b/.changeset/late-comics-clean.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-changeset': patch
+---
+
+fix: release note get use not right
+
+fix: 修复 Release Note 获取用户名称错误问题

--- a/packages/cli/plugin-changeset/package.json
+++ b/packages/cli/plugin-changeset/package.json
@@ -59,6 +59,7 @@
     "@modern-js/plugin-i18n": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "resolve-from": "^5.0.0",
+    "axios": "^1.2.1",
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {

--- a/packages/cli/plugin-changeset/tests/releaseNote.test.ts
+++ b/packages/cli/plugin-changeset/tests/releaseNote.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../src/commands';
 
 describe('release note function test', () => {
-  test('getReleaseInfo', () => {
+  test('getReleaseInfo', async () => {
     let commitObj: Commit = {
       id: '552d98d',
       type: CommitType.Features,
@@ -14,12 +14,11 @@ describe('release note function test', () => {
       summary: 'chore: update devcert version to 1.2.2',
       summary_zh: 'chore: 更新 devcert 版本到 1.2.2',
     };
-    commitObj = getReleaseInfo(
+    commitObj = await getReleaseInfo(
       '552d98d--chore: update devcert version to 1.2.2 (#1222)--zhangsan',
       commitObj,
     );
     expect(commitObj.pullRequestId).toEqual('1222');
-    expect(commitObj.author).toEqual('zhangsan');
   });
   test('getReleaseNoteLine', () => {
     const commitObj: Commit = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -898,6 +898,7 @@ importers:
       '@swc/helpers': 0.5.1
       '@types/jest': ^29
       '@types/node': ^14
+      axios: ^1.2.1
       jest: ^29
       resolve-from: ^5.0.0
       typescript: ^5
@@ -908,6 +909,7 @@ importers:
       '@modern-js/plugin-i18n': link:../plugin-i18n
       '@modern-js/utils': link:../../toolkit/utils
       '@swc/helpers': 0.5.1
+      axios: 1.2.1
       resolve-from: 5.0.0
     devDependencies:
       '@modern-js/core': link:../core
@@ -13738,8 +13740,10 @@ packages:
       ajv: 6.12.6
     dev: false
 
-  /ajv-formats/2.1.1:
+  /ajv-formats/2.1.1_ajv@8.11.0:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -28386,7 +28390,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1_ajv@8.11.0
       ajv-keywords: 5.1.0_ajv@8.11.0
 
   /scroll-into-view-if-needed/2.2.20:


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 967140f</samp>

This pull request improves the plugin-changeset package by adding a feature to fetch the author name from GitHub for the release note generation, and by fixing a bug in the test for this feature. It also updates the package version and the changeset file. It adds `axios` as a dependency and an option to pass a GitHub token to the `releaseNote` command.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 967140f</samp>

* Add axios dependency to plugin-changeset package to make HTTP requests to GitHub API ([link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-b9a2bef2486ee1019691b8e847f6fb9f5137254dfb6904825945c5000cf79f2fR62))
* Fix release note issue by fetching author name from GitHub API using axios and caching the result ([link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3R3), [link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3R37), [link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L85-R120), [link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L176-R206), [link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L198-R228))
* Add optional authToken parameter to ReleaseNoteOptions interface and use it or environment variable to authorize GitHub API requests ([link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3R37), [link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L85-R120))
* Change git log command to use email instead of name as author identifier to match GitHub API response ([link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L176-R206))
* Add await keywords to getReleaseInfo function calls and test function since it is now async ([link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad1324768427c25566537ba4daacd44625a1b039e5899e246a13d048b81c11d3L198-R228), [link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-98370b7615e1b37fad594a359dc681fe29a9570717c33939568ce481d8a24f66L9-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-98370b7615e1b37fad594a359dc681fe29a9570717c33939568ce481d8a24f66L17-R21))
* Add changeset file to document patch version update and fix for release note issue in both languages ([link](https://github.com/web-infra-dev/modern.js/pull/3834/files?diff=unified&w=0#diff-ad843628b617022ccf464cfe39db9adf7e87ad2c5299da95e02074b080360b2aR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
