### PR TITLE
fix: add missing type definitions

### DIFF
--- a/.changeset/angry-swans-perform.md
+++ b/.changeset/angry-swans-perform.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/types': patch
+---
+
+fix: add missing type definitions
+fix: 添加遗漏的类型定义

--- a/packages/toolkit/types/server/hook.d.ts
+++ b/packages/toolkit/types/server/hook.d.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse, IncomingHttpHeaders } from 'http';
 
 export type CookieAPI = {
   /**


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 20cf670</samp>

This change fixes a TypeScript compatibility issue in the `@modern-js/types` package and adds a `.changeset` file to document the fix and prepare for a release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 20cf670</samp>

* Fix TypeScript errors in `@modern-js/types` package by adding missing types and correcting existing ones (F1

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
