### PR TITLE
fix(builder-shared): the webworker should not check is a client compiler

### DIFF
--- a/.changeset/selfish-pigs-sing.md
+++ b/.changeset/selfish-pigs-sing.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder-shared): the webworker should not check is a client compiler.
+fix(builder-shared): webworker 不应该被判定为客户端 compiler

--- a/packages/builder/builder-shared/src/devServer.ts
+++ b/packages/builder/builder-shared/src/devServer.ts
@@ -238,19 +238,12 @@ export const isClientCompiler = (compiler: {
 }) => {
   const { target } = compiler.options;
 
-  // if target not contains `node`, it's a client compiler
+  // if target not contains `node` or `webworker`, it's a client compiler
   if (target) {
     if (Array.isArray(target)) {
-      return !target.includes('node');
+      return !target.includes('node') && !target.includes('webworker');
     }
-    return target !== 'node';
-  }
-
-  if (target) {
-    if (Array.isArray(target)) {
-      return !target.includes('service-worker');
-    }
-    return target !== 'service-worker';
+    return target !== 'node' && target !== 'webworker';
   }
 
   return compiler.name === 'client';


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f005386</samp>

This pull request fixes a bug in the dev server that affected webworker compilers. It updates the `isClientCompiler` function in `devServer.ts` and adds a changeset file for the `@modern-js/builder-shared` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f005386</samp>

* Fix bug where webworker compiler was treated as client compiler in dev server ([link](https://github.com/web-infra-dev/modern.js/pull/3839/files?diff=unified&w=0#diff-1876b89358da5214f40c6a33a70fd6ca415b4222d9ae36cbe1f701dfa4fe083aL241-R248))
* Add changeset file for patch updates of `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/3839/files?diff=unified&w=0#diff-b9fbeab79803943bb3488f8fb8f825b97e9ab8ac0932fbdf65b6e2acd04d2f4fR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
