### PR TITLE
docs: fix reset command

### DIFF
--- a/.changeset/clean-dolphins-tan.md
+++ b/.changeset/clean-dolphins-tan.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/main-doc': patch
+---
+
+docs: fix reset command

--- a/packages/document/main-doc/docs/zh/community/contributing-guide.mdx
+++ b/packages/document/main-doc/docs/zh/community/contributing-guide.mdx
@@ -120,7 +120,7 @@ pnpm run prepare
 如果你需要清理项目中的所有 `node_modules/*`，执行 `reset` 命令：
 
 ```sh
-pnpm 运行重置
+pnpm run reset
 ```
 
 ---


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 660a12d</samp>

This pull request fixes a typo in the Chinese contributing guide and adds a changeset file for the `@modern-js/main-doc` package. The changeset documents the fix for the reset command in the documentation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 660a12d</samp>

* Add a changeset file to document the patch update for the `@modern-js/main-doc` package ([link](https://github.com/web-infra-dev/modern.js/pull/3842/files?diff=unified&w=0#diff-b59f60a85e83d3893af78538ff40d405e15c2c0fd28c9b49ea3a4bb47533dfecR1-R5))
* Fix a typo in the Chinese version of the contributing guide, replacing `pnpm 运行重置` with `pnpm run reset` ([link](https://github.com/web-infra-dev/modern.js/pull/3842/files?diff=unified&w=0#diff-25c0eea6053bdd2ad7859f9ea172c377a9ce817a342b1c53726e530251779a16L123-R123))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
