### PR TITLE
fix: 404 error caused by not validate id in demo component

### DIFF
--- a/.changeset/proud-schools-melt.md
+++ b/.changeset/proud-schools-melt.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-plugin-preview': patch
+---
+
+fix: 404 error caused by not validate id in demo component
+fix: 在demo组件里id未合法化导致的404错误

--- a/packages/cli/doc-plugin-preview/src/codeToDemo.ts
+++ b/packages/cli/doc-plugin-preview/src/codeToDemo.ts
@@ -6,8 +6,8 @@ import type { RouteMeta } from '@modern-js/doc-core';
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
+import { toValidVarName } from './utils';
 import { demoRoutes } from '.';
-
 /**
  * remark plugin to transform code to demo
  */
@@ -121,18 +121,3 @@ const getASTNodeImport = (name: string, from: string) =>
       },
     },
   } as MdxjsEsm);
-
-/**
- * Converts a string to a valid variable name. If the string is already a valid variable name, returns the original string.
- * @param str - The string to convert.
- * @returns The converted string.
- */
-export const toValidVarName = (str: string): string => {
-  // Check if the string is a valid variable name
-  if (/^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(str)) {
-    return str; // If it is a valid variable name, return the original string
-  } else {
-    // If it is not a valid variable name, convert it to a valid variable name
-    return str.replace(/[^0-9a-zA-Z_$]/g, '_').replace(/^([0-9])/, '_$1');
-  }
-};

--- a/packages/cli/doc-plugin-preview/src/components/demo.tsx
+++ b/packages/cli/doc-plugin-preview/src/components/demo.tsx
@@ -1,13 +1,15 @@
 import { demos } from 'virtual-meta';
 import { createElement } from 'react';
 import { NoSSR, useLocation } from '@modern-js/doc-core/runtime';
+import { toValidVarName } from '../utils';
 
 export default function Demo() {
   // get the id from the pathname
   const { pathname } = useLocation();
   const id = pathname.split('/').pop();
+  const validId = toValidVarName(id || '');
   // get component from virtual-meta
-  const result = demos.flat().find(item => item.id === id);
+  const result = demos.flat().find(item => item.id === validId);
   if (result) {
     return <NoSSR>{createElement(result.component)}</NoSSR>;
   } else {

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -1,7 +1,8 @@
 import path, { join } from 'path';
 import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
 import type { DocPlugin, RouteMeta } from '@modern-js/doc-core';
-import { remarkCodeToDemo, toValidVarName } from './codeToDemo';
+import { remarkCodeToDemo } from './codeToDemo';
+import { toValidVarName } from './utils';
 
 export type Options = {
   /**

--- a/packages/cli/doc-plugin-preview/src/utils.ts
+++ b/packages/cli/doc-plugin-preview/src/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Converts a string to a valid variable name. If the string is already a valid variable name, returns the original string.
+ * @param str - The string to convert.
+ * @returns The converted string.
+ */
+export const toValidVarName = (str: string): string => {
+  // Check if the string is a valid variable name
+  if (/^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(str)) {
+    return str; // If it is a valid variable name, return the original string
+  } else {
+    // If it is not a valid variable name, convert it to a valid variable name
+    return str.replace(/[^0-9a-zA-Z_$]/g, '_').replace(/^([0-9])/, '_$1');
+  }
+};


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a54d656</samp>

This pull request refactors the `codeToDemo` module and fixes a 404 error in the `demo` component. It extracts the `toValidVarName` function to a `utils` module and uses it to validate the pathname id before finding the demo component. It also adds a changeset file to document the fixes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a54d656</samp>

*  Extract the `toValidVarName` function from the `codeToDemo` module and move it to the `utils` module to avoid code duplication and improve code organization ([link](https://github.com/web-infra-dev/modern.js/pull/3844/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL9-R10), [link](https://github.com/web-infra-dev/modern.js/pull/3844/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL124-L138), [link](https://github.com/web-infra-dev/modern.js/pull/3844/files?diff=unified&w=0#diff-f109d1dc301f214fab545e234962b6ad39b7509b6d39c4078aee95704f01751eR1-R14)).

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
