### PR TITLE
fix(doc-core): suspense runtime error

### DIFF
--- a/.changeset/shy-pumpkins-wait.md
+++ b/.changeset/shy-pumpkins-wait.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): suspense runtime error
+
+fix(doc-core): 异步组件运行时错误

--- a/packages/cli/doc-core/src/runtime/Content.tsx
+++ b/packages/cli/doc-core/src/runtime/Content.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { matchRoutes, useLocation } from 'react-router-dom';
 import { normalizeRoutePath } from './utils';
 
@@ -13,5 +14,5 @@ export const Content = () => {
   }
   const routesElement = matched[0].route.element;
 
-  return routesElement;
+  return <Suspense fallback={<></>}>{routesElement}</Suspense>;
 };


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3bb2025</samp>

This pull request adds `Suspense` support to the `@modern-js/doc-core` package, allowing lazy loading of documentation components and fixing a runtime error. It also updates the changeset file with a patch version and a bilingual message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3bb2025</samp>

*  Add changeset file for patch update of `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/3846/files?diff=unified&w=0#diff-8b5ba8f9725e2b589319b9897912a2fa0c47bac552197d065b0fee9ebf4c6927R1-R7))
*  Import `Suspense` component from React in `Content.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/3846/files?diff=unified&w=0#diff-4dc558feca5137c2aacd92ae0c22dc682581c9a67da5718349b95e2c8b082228R1))
*  Wrap `routesElement` in `Suspense` with empty fallback in `Content.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/3846/files?diff=unified&w=0#diff-4dc558feca5137c2aacd92ae0c22dc682581c9a67da5718349b95e2c8b082228L16-R17))
*  Fix suspense runtime error when using async components in documentation ([link](https://github.com/web-infra-dev/modern.js/pull/3846/files?diff=unified&w=0#diff-8b5ba8f9725e2b589319b9897912a2fa0c47bac552197d065b0fee9ebf4c6927R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3846/files?diff=unified&w=0#diff-4dc558feca5137c2aacd92ae0c22dc682581c9a67da5718349b95e2c8b082228R1), [link](https://github.com/web-infra-dev/modern.js/pull/3846/files?diff=unified&w=0#diff-4dc558feca5137c2aacd92ae0c22dc682581c9a67da5718349b95e2c8b082228L16-R17))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
