### PR TITLE
fix(app-tools): should not delete internalDir in builder mode

### DIFF
--- a/.changeset/curly-peaches-compare.md
+++ b/.changeset/curly-peaches-compare.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): should not delete internalDir because we need guarantee the dev, build command correct.
+fix(app-tools): 不应该在非构建模式下删除 internalDir，因为我们需要保证这些构建模式的入口是正确的

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -5,7 +5,6 @@ import {
   fs,
   isApiOnly,
   minimist,
-  getCommand,
   isDevCommand,
   getArgv,
 } from '@modern-js/utils';
@@ -18,7 +17,12 @@ import { getSelectedEntries } from '../utils/getSelectedEntries';
 import { AppTools, webpack } from '../types';
 import { initialNormalizedConfig } from '../config';
 import { createBuilderGenerator } from '../builder';
-import { isPageComponentFile, parseModule, replaceWithAlias } from './utils';
+import {
+  checkIsBuildCommands,
+  isPageComponentFile,
+  parseModule,
+  replaceWithAlias,
+} from './utils';
 import {
   APP_CONFIG_NAME,
   APP_INIT_EXPORTED,
@@ -47,7 +51,9 @@ export default ({
         const hookRunners = api.useHookRunners();
 
         try {
-          fs.emptydirSync(appContext.internalDirectory);
+          if (checkIsBuildCommands()) {
+            fs.emptydirSync(appContext.internalDirectory);
+          }
         } catch {
           // FIXME:
         }
@@ -157,9 +163,7 @@ export default ({
         };
         api.setAppContext(appContext);
 
-        const command = getCommand();
-        const buildCommands = ['dev', 'start', 'build', 'inspect', 'deploy'];
-        if (buildCommands.includes(command)) {
+        if (checkIsBuildCommands()) {
           const normalizedConfig = api.useResolvedConfigContext();
           const createBuilderForModern = await createBuilderGenerator(bundler);
           const builder = await createBuilderForModern({

--- a/packages/solutions/app-tools/src/analyze/utils.ts
+++ b/packages/solutions/app-tools/src/analyze/utils.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import { isReact18, normalizeToPosixPath, fs as fse } from '@modern-js/utils';
+import {
+  isReact18,
+  normalizeToPosixPath,
+  fs as fse,
+  getCommand,
+} from '@modern-js/utils';
 import type { Entrypoint } from '@modern-js/types';
 import type { Loader } from 'esbuild';
 import { transform } from 'esbuild';
@@ -161,4 +166,11 @@ export const getServerCombinedModueFile = (
   entryName: string,
 ) => {
   return path.join(internalDirectory, entryName, 'server-loader-combined.js');
+};
+
+export const checkIsBuildCommands = () => {
+  const buildCommands = ['dev', 'start', 'build', 'inspect', 'deploy'];
+  const command = getCommand();
+
+  return buildCommands.includes(command);
 };


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0e3da1</samp>

This pull request fixes a bug in the `@modern-js/app-tools` package that affected the analysis of non-build commands. It refactors the `analyze/index.ts` file and adds a utility function in `analyze/utils.ts` to optimize the internal directory and the builder. It also updates the changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0e3da1</samp>

*  Fix bug that caused deletion of internal directory in non-build modes ([link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L50-R56), [link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L160-R166), [link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-0079e528411b9e11c7e8393a72120660449938bf82a9404088bbc310e3922a00R170-R176), [link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-201dd6a33d5a4d5aa2b04179a931d0bd8d913a441c06edb811d6cdcd7377d19aR1-R6))
  * Import and use `checkIsBuildCommands` function from `analyze/utils.ts` in `analyze/index.ts` to determine whether to empty internal directory and create builder for modern bundler ([link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L21-R26), [link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L50-R56), [link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L160-R166))
  * Define `checkIsBuildCommands` function in `analyze/utils.ts` using `getCommand` function from `@modern-js/utils` to check if current command is dev, start, build, inspect, or deploy ([link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-0079e528411b9e11c7e8393a72120660449938bf82a9404088bbc310e3922a00L3-R8), [link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-0079e528411b9e11c7e8393a72120660449938bf82a9404088bbc310e3922a00R170-R176))
  * Add changeset file to document patch update for `@modern-js/app-tools` package and provide Chinese translation of fix message ([link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-201dd6a33d5a4d5aa2b04179a931d0bd8d913a441c06edb811d6cdcd7377d19aR1-R6))
* Remove unused import of `getCommand` from `analyze/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3849/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
