### PR TITLE
fix(doc-core): polyfills are not injected

### DIFF
--- a/.changeset/poor-bananas-compare.md
+++ b/.changeset/poor-bananas-compare.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): polyfills are not injected
+
+fix(doc-core): 修复 polyfills 未注入的问题

--- a/packages/cli/doc-core/src/node/createBuilder.ts
+++ b/packages/cli/doc-core/src/node/createBuilder.ts
@@ -97,7 +97,8 @@ async function createInternalBuildConfig(
         // `root` must be a relative path in Builder
         root: path.isAbsolute(outDir) ? path.relative(cwd, outDir) : outDir,
       },
-      polyfill: 'usage',
+      // TODO: switch to 'usage' if Rspack supports it
+      polyfill: 'entry',
       svgDefaultExport: 'component',
       disableTsChecker: true,
       // Disable production source map, it is useless for doc site


### PR DESCRIPTION
## Summary

<img width="770" alt="Screen Shot 2023-06-06 at 10 39 47" src="https://github.com/web-infra-dev/modern.js/assets/7237365/704ca98d-3b90-41a6-be51-a5f73b587e32">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1ded65</samp>

This pull request fixes a bug in the `@modern-js/doc-core` package that caused polyfills to be missing in the documentation site. It updates the `polyfill` option in the build config and adds a changeset file to document the patch version update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c1ded65</samp>

* Fix polyfill injection issue for `@modern-js/doc-core` package by changing `polyfill` option from `'usage'` to `'entry'` in internal build config ([link](https://github.com/web-infra-dev/modern.js/pull/3850/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554L100-R101))
* Add TODO comment to remind switching back to `'usage'` option if `Rspack` supports it in the future ([link](https://github.com/web-infra-dev/modern.js/pull/3850/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554L100-R101))
* Add changeset file to document patch version update and bug fix for `@modern-js/doc-core` package with bilingual description ([link](https://github.com/web-infra-dev/modern.js/pull/3850/files?diff=unified&w=0#diff-2959ccc6074d2e4578a48e5d49fdec573d7381cb0b4535a5e26a39c2cf360f44R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
