### PR TITLE
fix(security): support nonce in streaming SSR

### DIFF
--- a/.changeset/clever-clouds-kiss.md
+++ b/.changeset/clever-clouds-kiss.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/utils': patch
+---
+
+fix: support nonce in streaming SSR
+fix: 在 streaming SSR 中支持 nonce

--- a/packages/runtime/plugin-runtime/src/router/runtime/DeferredDataScripts.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/DeferredDataScripts.node.tsx
@@ -58,7 +58,7 @@ const preResolvedFnStr = `function p(e,r){return void 0!==r?Promise.reject(new E
  * DeferredDataScripts only renders in server side,
  * it doesn't need to be hydrated in client side.
  */
-const DeferredDataScripts = () => {
+const DeferredDataScripts = (props?: { nonce?: string }) => {
   const context = useContext(DataRouterContext);
   const { staticContext } = context || {};
   const hydratedRef = useRef(false);
@@ -98,6 +98,7 @@ const DeferredDataScripts = () => {
             if (pendingKeys.has(key)) {
               deferredDataScripts.push(
                 <DeferredDataScript
+                  nonce={props?.nonce}
                   key={`${routeId} | ${key}`}
                   data={deferredData.data[key]}
                   dataKey={key}
@@ -153,6 +154,7 @@ const DeferredDataScripts = () => {
       {!hydratedRef.current && (
         <script
           async
+          nonce={props?.nonce}
           suppressHydrationWarning
           dangerouslySetInnerHTML={{ __html: deferredScripts[0] }}
         />
@@ -167,10 +169,12 @@ const DeferredDataScript = ({
   data,
   routeId,
   dataKey,
+  nonce,
 }: {
   data: any;
   routeId: string;
   dataKey: string;
+  nonce?: string;
 }) => {
   return (
     <Suspense>
@@ -178,12 +182,17 @@ const DeferredDataScript = ({
         <Await
           resolve={data}
           errorElement={
-            <ErrorDeferredDataScript routeId={routeId} dataKey={dataKey} />
+            <ErrorDeferredDataScript
+              routeId={routeId}
+              dataKey={dataKey}
+              nonce={nonce}
+            />
           }
         >
           {(data: any) => (
             <script
               async
+              nonce={nonce}
               suppressHydrationWarning
               dangerouslySetInnerHTML={{
                 __html: `_ROUTER_DATA.r(${JSON.stringify(
@@ -201,14 +210,17 @@ const DeferredDataScript = ({
 const ErrorDeferredDataScript = ({
   routeId,
   dataKey,
+  nonce,
 }: {
   routeId: string;
   dataKey: string;
+  nonce?: string;
 }) => {
   const error = useAsyncError() as Error;
 
   return (
     <script
+      nonce={nonce}
       suppressHydrationWarning
       dangerouslySetInnerHTML={{
         __html: `_ROUTER_DATA.r(${JSON.stringify(routeId)}, ${JSON.stringify(

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -82,7 +82,7 @@ export const routerPlugin = ({
             return next({ context });
           }
 
-          const { request, mode: ssrMode } = context.ssrContext!;
+          const { request, mode: ssrMode, nonce } = context.ssrContext!;
           const baseUrl = request.baseUrl as string;
           const _basename =
             baseUrl === '/' ? urlJoin(baseUrl, basename) : baseUrl;
@@ -93,6 +93,9 @@ export const routerPlugin = ({
                 renderRoutes({
                   routesConfig,
                   ssrMode,
+                  props: {
+                    nonce,
+                  },
                 }),
               );
 

--- a/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
+++ b/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
@@ -21,11 +21,15 @@ export const transformNestedRoutes = (routes: NestedRoute[]) => {
   return createRoutesFromElements(routeElements);
 };
 
+type DeferredDataComponentType = (props?: {
+  nonce?: string;
+}) => JSX.Element | null;
+
 export const renderNestedRoute = (
   nestedRoute: NestedRoute,
   options: {
     parent?: NestedRoute;
-    DeferredDataComponent?: () => JSX.Element | null;
+    DeferredDataComponent?: DeferredDataComponentType;
     props?: Record<string, any>;
   } = {},
 ) => {
@@ -74,7 +78,7 @@ export const renderNestedRoute = (
         <>
           <Component {...props} />
           {typeof document === 'undefined' && DeferredDataComponent && (
-            <DeferredDataComponent />
+            <DeferredDataComponent nonce={props?.nonce} />
           )}
         </>
       );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e55800</samp>

This pull request adds support for using `nonce` in streaming server-side rendering (SSR) with nested routes. `nonce` is a security attribute that helps prevent cross-site scripting attacks. The pull request updates the `@modern-js/runtime` and `@modern-js/utils` packages and modifies the files `DeferredDataScripts.node.tsx`, `plugin.node.tsx`, and `nestedRoutes.tsx`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e55800</samp>

*  Add a changeset file to describe the patch updates for `@modern-js/runtime` and `@modern-js/utils` packages, which fix the nonce support in streaming SSR ([link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-a82433fbbb5a5c2b6161442f6fcc2b287f1a16664762f1e54348bdb550a5eec8R1-R7))
*  Modify the `@modern-js/runtime` package to accept and pass the `nonce` prop to the components and script elements that are responsible for rendering the deferred data scripts for the nested routes in streaming SSR ([link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L61-R61), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75R101), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75R157), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L170-R177), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L181-R189), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75R195), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75L204-R217), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-6f08952af86b396f206955f52fe2ece74cc5545b16a2d15f71d2f0f73d31dc75R223))
*  Modify the `routerPlugin` function in the `@modern-js/runtime` package to extract the `nonce` value from the `ssrContext` object and pass it to the `DeferredDataComponent` parameter of the `renderNestedRoute` function ([link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL85-R85), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddR96-R98))
*  Modify the `renderNestedRoute` function in the `@modern-js/utils` package to accept and render the `DeferredDataComponent` parameter, which can be a function that takes the `nonce` prop ([link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L24-R32), [link](https://github.com/web-infra-dev/modern.js/pull/3852/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L77-R81))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
