### PR TITLE
fix(doc-core): remove dark class when darkMode is false

### DIFF
--- a/.changeset/polite-plants-push.md
+++ b/.changeset/polite-plants-push.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): remove dark class when darkMode is false
+
+fix(doc-core): 当 darkMode 为 false 时，移除 dark 类

--- a/packages/cli/doc-core/src/theme-default/logic/useAppearance.ts
+++ b/packages/cli/doc-core/src/theme-default/logic/useAppearance.ts
@@ -1,3 +1,4 @@
+import siteData from 'virtual-site-data';
 import { APPEARANCE_KEY } from '@/shared/utils';
 
 declare global {
@@ -16,6 +17,11 @@ const setClass = (dark: boolean): void => {
 };
 
 const updateAppearance = (): void => {
+  const disableDarkMode = siteData.themeConfig.darkMode === false;
+  if (disableDarkMode) {
+    setClass(false);
+    return;
+  }
   // We set the MODERN_THEME as a global variable to determine whether the theme is dark or light.
   if (window.MODERN_THEME) {
     setClass(window.MODERN_THEME === 'dark');


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9def309</samp>

Fixed a dark mode bug in the `@modern-js/doc-core` package by adding a dependency on `virtual-site-data` and checking the theme configuration. Updated the changeset file to reflect the patch version and the bug fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9def309</samp>

*  Fix dark mode bug in `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/3854/files?diff=unified&w=0#diff-59fab328cb282b294e071862705544fe4bc974990473b0acce2d8314fe233f82R1-R7))
  * Import `virtual-site-data` module to access theme configuration in `useAppearance.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3854/files?diff=unified&w=0#diff-32c3ac612f0b335101249da52f3efae93bca8b1b5614ae90e163053f29c0d1aaR1))
  * Check `darkMode` option and remove `dark` class from document body if `false` in `useAppearance.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3854/files?diff=unified&w=0#diff-32c3ac612f0b335101249da52f3efae93bca8b1b5614ae90e163053f29c0d1aaR20-R24))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
