### PR TITLE
fix(tailwind-plugin): should not add tools.babel config when not haveTwinMacro

### DIFF
--- a/.changeset/few-pigs-deny.md
+++ b/.changeset/few-pigs-deny.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-tailwindcss': patch
+---
+
+fix(tailwind): should not add tools.babel config when not haveTwinMacro
+
+fix(tailwind): 在没有命中 haveTwinMacro 时，不添加 tools.babel 配置

--- a/packages/cli/plugin-tailwind/src/cli.ts
+++ b/packages/cli/plugin-tailwind/src/cli.ts
@@ -142,22 +142,22 @@ export default (
               }
             },
 
-            babel(_, { addPlugins }) {
-              if (haveTwinMacro) {
-                initTailwindConfig();
-                addPlugins([
-                  [
-                    require.resolve('babel-plugin-macros'),
-                    {
-                      twin: {
-                        preset: supportCssInJsLibrary,
-                        config: internalTwConfigPath || tailwindConfig,
+            babel: haveTwinMacro
+              ? (_, { addPlugins }) => {
+                  initTailwindConfig();
+                  addPlugins([
+                    [
+                      require.resolve('babel-plugin-macros'),
+                      {
+                        twin: {
+                          preset: supportCssInJsLibrary,
+                          config: internalTwConfigPath || tailwindConfig,
+                        },
                       },
-                    },
-                  ],
-                ]);
-              }
-            },
+                    ],
+                  ]);
+                }
+              : undefined,
           },
         };
       },


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 676469a</samp>

This pull request fixes a bug in the `@modern-js/plugin-tailwindcss` package that added an unnecessary `tools.babel` config when `twin.macro` was not used. It also simplifies the logic for adding the `babel-plugin-macros` plugin in `cli.ts` and adds a Chinese translation for the fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 676469a</samp>

* Fix bug in `@modern-js/plugin-tailwindcss` that added unnecessary `tools.babel` config when not using `twin.macro` ([link](https://github.com/web-infra-dev/modern.js/pull/3858/files?diff=unified&w=0#diff-aec59a87927f0e4329221b905801bd29c9dd6d86092a774cc8dc033f3bafcd07R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3858/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dL145-R160))
* Simplify logic for adding `babel-plugin-macros` plugin to `tools.babel` config using ternary operator ([link](https://github.com/web-infra-dev/modern.js/pull/3858/files?diff=unified&w=0#diff-a7c5f07b8103f54cc7910493cc4598a797a04f0cd3f50d351753d1e86ce5742dL145-R160))
* Add Chinese translation of fix message to `.changeset/few-pigs-deny.md` ([link](https://github.com/web-infra-dev/modern.js/pull/3858/files?diff=unified&w=0#diff-aec59a87927f0e4329221b905801bd29c9dd6d86092a774cc8dc033f3bafcd07R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
