### PR TITLE
fix(types): fix type error of Rspack

### DIFF
--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -123,6 +123,8 @@ export const pageType = "blank";
     },
     builderConfig: {
       tools: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+        // @ts-ignore
         rspack: {
           plugins: [demoRuntimeModule],
         },


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71a6bb4</samp>

This pull request improves the code quality and functionality of the `builder-rspack-provider` and `doc-plugin-preview` packages. It refactors and validates the `splitChunks` option for better webpack bundling, and adds comments to handle a TypeScript error in the `docConfig` object.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 71a6bb4</samp>

*  Refactor and validate `splitChunks` configuration for webpack ([link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L2),[link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L125-R180),[link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96R195-R196),[link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L158-R207))
  * Remove unused import of `OptimizationSplitChunksOptions` from `@rspack/core` ([link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L2))
  * Extract `formatCacheGroups` function to handle `cacheGroups` option of `splitChunks` ([link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L125-R180))
  * Add `@ts-ignore` comment to suppress TypeScript error caused by type mismatch between `splitChunks` and `RspackSplitChunks` ([link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96R195-R196))
  * Remove unsupported properties `minRemainingSize` and `enforceSizeThreshold` from returned object of `formatSplitChunks` function ([link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-e7d9d12795a17ffec2898c856d94aace95d5dbf013113769fc0c2cc20c620e96L158-R207))
* Add `@ts-ignore` comment to suppress TypeScript error caused by use of `pageType` property on `docConfig` object in `packages/cli/doc-plugin-preview/src/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3860/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR126-R127))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
