### PR TITLE
feat(builder-cli): add `builder serve` command

### DIFF
--- a/.changeset/chilly-snakes-film.md
+++ b/.changeset/chilly-snakes-film.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-cli': patch
+---
+
+feat(builder-cli): add `builder serve` command
+
+feat(builder-cli): 新增 `builder serve` 命令

--- a/packages/builder/builder-cli/package.json
+++ b/packages/builder/builder-cli/package.json
@@ -44,7 +44,6 @@
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/node-bundle-require": "workspace:*",
-    "@modern-js/prod-server": "workspace:*",
     "@modern-js/utils": "workspace:*"
   },
   "devDependencies": {

--- a/packages/builder/builder-cli/package.json
+++ b/packages/builder/builder-cli/package.json
@@ -43,16 +43,15 @@
   "dependencies": {
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-shared": "workspace:*",
-    "@modern-js/node-bundle-require": "workspace:*"
+    "@modern-js/node-bundle-require": "workspace:*",
+    "@modern-js/prod-server": "workspace:*",
+    "@modern-js/utils": "workspace:*"
   },
   "devDependencies": {
-    "@modern-js/builder": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
-    "@modern-js/utils": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
-    "typescript": "^5",
-    "webpack": "^5.82.1"
+    "typescript": "^5"
   },
   "peerDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:^2.22.0",

--- a/packages/builder/builder-cli/src/commands.ts
+++ b/packages/builder/builder-cli/src/commands.ts
@@ -1,7 +1,7 @@
+import { join } from 'path';
 import { fs } from '@modern-js/utils';
 import { program } from '@modern-js/utils/commander';
-import { BuilderInstance } from '@modern-js/builder';
-import { join } from 'path';
+import type { BuilderInstance } from '@modern-js/builder';
 
 export function setupProgram(builder: BuilderInstance) {
   const pkgJson = join(__dirname, '../package.json');
@@ -21,6 +21,13 @@ export function setupProgram(builder: BuilderInstance) {
     .description('build the app for production')
     .action(async () => {
       await builder.build();
+    });
+
+  program
+    .command('serve')
+    .description('preview the production build locally')
+    .action(async () => {
+      await builder.serve();
     });
 
   program.parse();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,21 +78,21 @@ importers:
       '@modern-js/builder-shared': workspace:*
       '@modern-js/builder-webpack-provider': workspace:*
       '@modern-js/node-bundle-require': workspace:*
+      '@modern-js/prod-server': workspace:*
       '@modern-js/utils': workspace:*
       '@scripts/vitest-config': workspace:*
       typescript: ^5
-      webpack: ^5.82.1
     dependencies:
       '@modern-js/builder': link:../builder
       '@modern-js/builder-shared': link:../builder-shared
       '@modern-js/node-bundle-require': link:../../toolkit/node-bundle-require
+      '@modern-js/prod-server': link:../../server/prod-server
+      '@modern-js/utils': link:../../toolkit/utils
     devDependencies:
       '@modern-js/builder-rspack-provider': link:../builder-rspack-provider
       '@modern-js/builder-webpack-provider': link:../builder-webpack-provider
-      '@modern-js/utils': link:../../toolkit/utils
       '@scripts/vitest-config': link:../../../scripts/vitest-config
       typescript: 5.0.4
-      webpack: 5.82.1
 
   packages/builder/builder-rspack-provider:
     specifiers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,6 @@ importers:
       '@modern-js/builder-shared': workspace:*
       '@modern-js/builder-webpack-provider': workspace:*
       '@modern-js/node-bundle-require': workspace:*
-      '@modern-js/prod-server': workspace:*
       '@modern-js/utils': workspace:*
       '@scripts/vitest-config': workspace:*
       typescript: ^5
@@ -86,7 +85,6 @@ importers:
       '@modern-js/builder': link:../builder
       '@modern-js/builder-shared': link:../builder-shared
       '@modern-js/node-bundle-require': link:../../toolkit/node-bundle-require
-      '@modern-js/prod-server': link:../../server/prod-server
       '@modern-js/utils': link:../../toolkit/utils
     devDependencies:
       '@modern-js/builder-rspack-provider': link:../builder-rspack-provider


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a3f75e</samp>

Added a new `builder serve` command for local preview of production builds, and cleaned up some dependencies and imports in the `@modern-js/builder-cli` package. Also updated the `.changeset` folder with the change information.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a3f75e</samp>

* Add a new command `builder serve` to preview the production build locally ([link](https://github.com/web-infra-dev/modern.js/pull/3867/files?diff=unified&w=0#diff-841362388ef5971308480e140a2ad53473c2959062d06df71af8eded393123c7R26-R32))
* Remove unnecessary dependencies from `@modern-js/builder-cli` package ([link](https://github.com/web-infra-dev/modern.js/pull/3867/files?diff=unified&w=0#diff-f6b7b53aacfc32941f744f7d0ec86be3f6c93cb2f9763bbf6266820020c0b241L46-R53))
* Reorder imports and add type-only import for `BuilderInstance` in `commands.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3867/files?diff=unified&w=0#diff-841362388ef5971308480e140a2ad53473c2959062d06df71af8eded393123c7L1-R4))
* Add a markdown file to the `.changeset` folder for changelog and versioning ([link](https://github.com/web-infra-dev/modern.js/pull/3867/files?diff=unified&w=0#diff-1a14d9e044247e641676e5ef0663ab669ccdaba9957e0b6b02210c30e31f4036R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
