### PR TITLE
fix(builder): print https URLs when devServer.https is true

### DIFF
--- a/.changeset/smart-drinks-flow.md
+++ b/.changeset/smart-drinks-flow.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder': patch
+'@modern-js/server': patch
+'@modern-js/utils': patch
+---
+
+fix(builder): print https URLs when devServer.https is true
+
+fix(builder): 当 devServer.https 为 true 时，输出 https 的 URLs

--- a/packages/builder/builder-shared/src/apply/output.ts
+++ b/packages/builder/builder-shared/src/apply/output.ts
@@ -80,7 +80,7 @@ function getPublicPath({
   } else if (typeof dev.assetPrefix === 'string') {
     publicPath = dev.assetPrefix;
   } else if (dev.assetPrefix === true) {
-    const protocol = dev.https ? 'https' : 'http';
+    const protocol = context.devServer?.https ? 'https' : 'http';
     const hostname = context.devServer?.hostname || DEFAULT_DEV_HOST;
     const port = context.devServer?.port || DEFAULT_PORT;
     if (hostname === DEFAULT_DEV_HOST) {

--- a/packages/builder/builder-shared/src/devServer.ts
+++ b/packages/builder/builder-shared/src/devServer.ts
@@ -119,9 +119,15 @@ export async function startDevServer<
       ? serverOptions?.dev?.host
       : DEFAULT_DEV_HOST;
 
+  const https =
+    typeof serverOptions?.dev === 'object' && serverOptions?.dev?.https
+      ? Boolean(serverOptions?.dev?.https)
+      : false;
+
   options.context.devServer = {
     hostname: host,
     port,
+    https,
   };
 
   const server = await createDevServer(options, port, serverOptions, compiler);
@@ -145,7 +151,7 @@ export async function startDevServer<
         debug('listen dev server done');
 
         const { getAddressUrls } = await import('@modern-js/utils');
-        const protocol = builderConfig.dev?.https ? 'https' : 'http';
+        const protocol = https ? 'https' : 'http';
         let urls = getAddressUrls(protocol, port, builderConfig.dev?.host);
 
         if (printURLs) {

--- a/packages/builder/builder-shared/src/types/context.ts
+++ b/packages/builder/builder-shared/src/types/context.ts
@@ -26,6 +26,7 @@ export type BuilderContext = {
   devServer?: {
     hostname: string;
     port: number;
+    https: boolean;
   };
   bundlerType: BundlerType;
 };

--- a/packages/builder/builder/src/plugins/startUrl.ts
+++ b/packages/builder/builder/src/plugins/startUrl.ts
@@ -22,7 +22,8 @@ export function builderPluginStartUrl(): DefaultBuilderPlugin {
         }
 
         const config = api.getNormalizedConfig();
-        const { https, startUrl, beforeStartUrl } = config.dev;
+        const { startUrl, beforeStartUrl } = config.dev;
+        const { https } = api.context.devServer || {};
 
         if (!startUrl) {
           return;

--- a/packages/server/server/src/dev-tools/https/index.ts
+++ b/packages/server/server/src/dev-tools/https/index.ts
@@ -20,7 +20,7 @@ export const genHttpsOptions = async (
     } catch (err) {
       const packageManager = await getPackageManager(pwd);
       const command = chalk.yellow.bold(
-        `${packageManager} install devcert@1.2.2 -D`,
+        `${packageManager} add devcert@1.2.2 -D`,
       );
       logger.error(
         `You have enabled "dev.https" option, but the "devcert" package is not installed.`,

--- a/packages/toolkit/utils/src/cli/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/cli/prettyInstructions.ts
@@ -81,8 +81,10 @@ export const prettyInstructions = (appContext: any, config: any) => {
       checkedEntries: string[];
     };
 
+  const isHttps = isDev() && appContext.builder?.context.devServer?.https;
+
   const urls = getAddressUrls(
-    config.dev.https && isDev() ? 'https' : 'http',
+    isHttps ? 'https' : 'http',
     port,
     config.dev?.host,
   );

--- a/packages/toolkit/utils/tests/__snapshots__/prettyInstructions.test.ts.snap
+++ b/packages/toolkit/utils/tests/__snapshots__/prettyInstructions.test.ts.snap
@@ -17,3 +17,19 @@ exports[`prettyInstructions basic usage 1`] = `
   > Network:  http://10.100.100.100:8080/
 "
 `;
+
+exports[`prettyInstructions should print host correctly 1`] = `
+"App running at:
+
+  > Network:  http://my-host:8080/
+"
+`;
+
+exports[`prettyInstructions should print https URLs 1`] = `
+"App running at:
+
+  > Local:    https://localhost:8080/
+  > Network:  https://11.11.111.11:8080/
+  > Network:  https://10.100.100.100:8080/
+"
+`;

--- a/packages/toolkit/utils/tests/prettyInstructions.test.ts
+++ b/packages/toolkit/utils/tests/prettyInstructions.test.ts
@@ -44,6 +44,23 @@ const mockNetworkInterfaces = {
   ],
 };
 
+const mockEntrypoints = [
+  {
+    entryName: 'main',
+    entry: '/example/node_modules/.modern-js/main/index.js',
+    isAutoMount: true,
+    customBootstrap: false,
+  },
+];
+
+const mockServerRoute = {
+  urlPath: '/',
+  entryName: 'main',
+  entryPath: 'html/main/index.html',
+  isSPA: true,
+  isSSR: false,
+};
+
 jest.mock('os', () => {
   const originalModule = jest.requireActual('os');
   return {
@@ -71,22 +88,9 @@ jest.mock('../compiled/chalk', () => {
 describe('prettyInstructions', () => {
   test('basic usage', () => {
     const mockAppContext = {
-      entrypoints: [
-        {
-          entryName: 'main',
-          entry: '/example/node_modules/.modern-js/main/index.js',
-          isAutoMount: true,
-          customBootstrap: false,
-        },
-      ],
+      entrypoints: mockEntrypoints,
       serverRoutes: [
-        {
-          urlPath: '/',
-          entryName: 'main',
-          entryPath: 'html/main/index.html',
-          isSPA: true,
-          isSSR: false,
-        },
+        mockServerRoute,
         {
           urlPath: '/api',
           isApi: true,
@@ -98,13 +102,52 @@ describe('prettyInstructions', () => {
       port: 8080,
       apiOnly: false,
     };
-    const mockConfig = {
-      dev: {
-        https: true,
+
+    const message = prettyInstructions(mockAppContext, {});
+
+    expect(message).toMatchSnapshot();
+  });
+
+  test('should print https URLs', () => {
+    const { NODE_ENV } = process.env;
+    process.env.NODE_ENV = 'development';
+
+    const mockAppContext = {
+      entrypoints: mockEntrypoints,
+      serverRoutes: [mockServerRoute],
+      port: 8080,
+      apiOnly: false,
+      builder: {
+        context: {
+          devServer: {
+            https: true,
+          },
+        },
       },
     };
 
-    const message = prettyInstructions(mockAppContext, mockConfig);
+    const message = prettyInstructions(mockAppContext, {});
+
+    expect(message).toMatchSnapshot();
+
+    process.env.NODE_ENV = NODE_ENV;
+  });
+
+  test('should print host correctly', () => {
+    process.env.NODE_ENV = 'development';
+
+    const mockAppContext = {
+      entrypoints: mockEntrypoints,
+      serverRoutes: [mockServerRoute],
+      port: 8080,
+      apiOnly: false,
+    };
+
+    const message = prettyInstructions(mockAppContext, {
+      dev: {
+        host: 'my-host',
+      },
+    });
 
     expect(message).toMatchSnapshot();
   });
@@ -125,13 +168,7 @@ describe('prettyInstructions', () => {
       apiOnly: true,
     };
 
-    const mockConfig = {
-      dev: {
-        https: true,
-      },
-    };
-
-    const message = prettyInstructions(mockAppContext, mockConfig);
+    const message = prettyInstructions(mockAppContext, {});
 
     expect(message).toMatchSnapshot();
   });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02343f4</samp>

This pull request adds support for HTTPS protocol in the dev server and fixes the inconsistencies in the address URLs and the start URL. It also improves the test cases and the documentation for the `prettyInstructions` function and the `devcert` package installation. It affects the files `devServer.ts`, `output.ts`, `context.ts`, `startUrl.ts`, `https/index.ts`, `prettyInstructions.ts`, `prettyInstructions.test.ts`, and `.changeset/smart-drinks-flow.md`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02343f4</samp>

*  Add a changeset file to document the patch updates and the fix for printing https URLs ([link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-87c6ce96a075e616469a3ddce5037626c58f616585b0b17d75407c403a21429bR1-R10))
*  Fix the public path and the address URLs to use the actual dev server protocol from the `context.devServer.https` property instead of the `config.dev.https` option ([link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-5071b6a55bc61e45b3db5266c355c86bb495f414f628f6aebaf5584a1db86911L83-R83), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-1876b89358da5214f40c6a33a70fd6ca415b4222d9ae36cbe1f701dfa4fe083aL122-R130), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-1876b89358da5214f40c6a33a70fd6ca415b4222d9ae36cbe1f701dfa4fe083aL148-R154), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-c34ff43f17d2d0c781210201919e9f09aa0b0ab2cbf8dfd36dfad1cf243fdd50R29), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-86d692012bf5a218f0c2f3c2cef784e79958230948e6ddc17607e9f2bc2d5955L25-R26), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-e626d746b4e67834724a3c1c9cba4699911b3f8cfe2044411b5cba3ff00fd3cbL84-R87))
*  Change the package manager command to use `add` instead of `install` for installing the `devcert` package in the `genHttpsOptions` function ([link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-67df3fe2f25d20333aa245f079265f67ed47e7a9063178e760854b6f9fabc7b5L23-R23))
*  Add and modify test cases for the `prettyInstructions` function to cover different scenarios of the dev server protocol and host ([link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-d73a01fadab58ff34e705eebd3a2162847b77ff7d3d6746c333523f2e2159728R47-R63), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-d73a01fadab58ff34e705eebd3a2162847b77ff7d3d6746c333523f2e2159728L74-R94), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-d73a01fadab58ff34e705eebd3a2162847b77ff7d3d6746c333523f2e2159728L101-R154), [link](https://github.com/web-infra-dev/modern.js/pull/3868/files?diff=unified&w=0#diff-d73a01fadab58ff34e705eebd3a2162847b77ff7d3d6746c333523f2e2159728L128-R172))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
