### PR TITLE
fix: api only check

### DIFF
--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -61,6 +61,7 @@ export default ({
         const apiOnly = await isApiOnly(
           appContext.appDirectory,
           resolvedConfig.source?.entriesDir,
+          appContext.apiDirectory,
         );
         await hookRunners.addRuntimeExports();
 

--- a/packages/solutions/app-tools/src/commands/serve.ts
+++ b/packages/solutions/app-tools/src/commands/serve.ts
@@ -17,6 +17,7 @@ export const start = async (api: PluginAPI<AppTools<'shared'>>) => {
   const apiOnly = await isApiOnly(
     appContext.appDirectory,
     userConfig?.source?.entriesDir,
+    appContext.apiDirectory,
   );
   const serverInternalPlugins = await getServerInternalPlugins(api);
 

--- a/packages/toolkit/utils/src/cli/is/project.ts
+++ b/packages/toolkit/utils/src/cli/is/project.ts
@@ -43,14 +43,34 @@ export const isPackageInstalled = (
   }
 };
 
+/**
+ * Check is api only project
+ * 1. env --api-only
+ * 2. exist ${apiDir}/ && not exist ${entryDir}/
+ *
+ * @param appDirectory
+ * @param entryDir default 'src'
+ * @param apiDir default 'api'
+ * @returns boolean
+ */
 export const isApiOnly = async (
   appDirectory: string,
   entryDir?: string,
+  apiDir?: string,
 ): Promise<boolean> => {
-  const srcDir = path.join(appDirectory, entryDir ?? 'src');
-  const existSrc = await fs.pathExists(srcDir);
+  const existApi = await fs.pathExists(
+    path.join(appDirectory, apiDir ?? 'api'),
+  );
+  const existSrc = await fs.pathExists(
+    path.join(appDirectory, entryDir ?? 'src'),
+  );
   const options = minimist(getArgv());
-  return !existSrc || Boolean(options['api-only']);
+  // env first
+  if (options['api-only']) {
+    return true;
+  }
+  // exist api/ && not exist ${entryDir}/
+  return existApi && !existSrc;
 };
 
 export const isWebOnly = async () => {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 304234a</samp>

Improved the detection of API-only projects in `isApiOnly` function. Added support for `--api-only` option in `modern init` command.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 304234a</samp>

* Support API-only project creation and detection by:
  - Checking and prioritizing `--api-only` option in `isApiOnly` function ([link](https://github.com/web-infra-dev/modern.js/pull/3880/files?diff=unified&w=0#diff-071fb6b53421d4b231cc8fd2e6e8a03b189f58b3e553076b73ef48612d347a0cL51-R60))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
