### PR TITLE
docs(main): fix broken links

### DIFF
--- a/packages/document/builder-doc/docs/en/config/output/cssModules.md
+++ b/packages/document/builder-doc/docs/en/config/output/cssModules.md
@@ -20,7 +20,7 @@ The `auto` configuration option allows CSS modules to be automatically enabled b
 
 Type description:
 
-- `undefined`: According to the [output.disableCssModuleExtension](/api/config-output.html#outputdisablecssmoduleextension) configuration item to determine which style files to enable CSS modules.
+- `undefined`: According to the [output.disableCssModuleExtension](https://modernjs.dev/builder/en/api/config-output.html#outputdisablecssmoduleextension) configuration item to determine which style files to enable CSS modules.
 - `true`: enable CSS modules for all files matching `/\.module\.\w+$/i.test(filename)` regexp.
 - `false`: disables CSS Modules.
 - `RegExp`: enable CSS modules for all files matching `/RegExp/i.test(filename)` regexp.

--- a/packages/document/builder-doc/docs/en/config/tools/webpack.md
+++ b/packages/document/builder-doc/docs/en/config/tools/webpack.md
@@ -299,4 +299,4 @@ export default {
 
 - **Type:** `(name: string) => string`
 
-Get the path to the builder built-in dependencies, same as [webpackChain#getCompiledPath](/api/config-tools.html#tools.webpackchain).
+Get the path to the builder built-in dependencies, same as [webpackChain#getCompiledPath](https://modernjs.dev/builder/en/api/config-tools.html#toolswebpackchain).

--- a/packages/document/builder-doc/docs/en/guide/basic/css-modules.md
+++ b/packages/document/builder-doc/docs/en/guide/basic/css-modules.md
@@ -38,7 +38,7 @@ export default () => {
 
 By default, only files ending in `*.module.css` are treated CSS Modules.
 
-If you want to treat all CSS files in the source directory as CSS Modules, you can enable the [output.disableCssModuleExtension](/en/api/config-output.html#outputdisablecssmoduleextension) config, for example:
+If you want to treat all CSS files in the source directory as CSS Modules, you can enable the [output.disableCssModuleExtension](https://modernjs.dev/builder/en/api/config-output.html#outputdisablecssmoduleextension) config, for example:
 
 ```ts
 export default {

--- a/packages/document/builder-doc/docs/zh/config/output/cssModules.md
+++ b/packages/document/builder-doc/docs/zh/config/output/cssModules.md
@@ -20,7 +20,7 @@ auto 配置项允许基于文件名自动启用 CSS 模块。
 
 类型说明：
 
-- `undefined`: 根据 [output.disableCssModuleExtension](/api/config-output.html#outputdisablecssmoduleextension) 配置项决定为哪些样式文件启用 CSS 模块。
+- `undefined`: 根据 [output.disableCssModuleExtension](https://modernjs.dev/builder/api/config-output.html#outputdisablecssmoduleextension) 配置项决定为哪些样式文件启用 CSS 模块。
 - `true`: 为所有匹配 `/\.module\.\w+$/i.test(filename)` 正则表达式的文件启用 CSS 模块。
 - `false`: 禁用 CSS 模块。
 - `RegExp`: 为所有匹配 `/RegExp/i.test(filename)` 正则表达式的文件禁用 CSS 模块。

--- a/packages/document/builder-doc/docs/zh/config/tools/webpack.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/webpack.md
@@ -299,4 +299,4 @@ export default {
 
 - **类型：** `(name: string) => string`
 
-获取 builder 内置依赖的所在路径，等价于 [webpackChain#getCompiledPath](/api/config-tools.html#tools.webpackchain)。
+获取 builder 内置依赖的所在路径，等价于 [webpackChain#getCompiledPath](https://modernjs.dev/builder/api/config-tools.html#toolswebpackchain)。

--- a/packages/document/builder-doc/docs/zh/guide/basic/css-modules.md
+++ b/packages/document/builder-doc/docs/zh/guide/basic/css-modules.md
@@ -38,7 +38,7 @@ export default () => {
 
 在默认情况下，只有 `*.module.css` 结尾的文件才被视为 CSS Modules 模块。
 
-如果你想将源码目录下的所有 CSS 文件当做 CSS Modules 模块进行处理，可以通过开启 [output.disableCssModuleExtension](/api/config-output.html#outputdisablecssmoduleextension) 来实现，比如：
+如果你想将源码目录下的所有 CSS 文件当做 CSS Modules 模块进行处理，可以通过开启 [output.disableCssModuleExtension](https://modernjs.dev/builder/api/config-output.html#outputdisablecssmoduleextension) 来实现，比如：
 
 ```ts
 export default {


### PR DESCRIPTION
## Summary

Fix some broken links:

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/0113bdb3-c40c-4d3e-ae5d-1dc7c4b25fd3)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8bb4957</samp>

Update the links to the `output.disableCssModuleExtension` configuration item in the documentation files to use absolute URLs instead of relative ones. This fixes the broken links when the documentation is hosted on different domains or paths.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8bb4957</samp>

* Updated the links to the `output.disableCssModuleExtension` configuration item in the documentation files to use absolute URLs instead of relative ones ([link](https://github.com/web-infra-dev/modern.js/pull/3885/files?diff=unified&w=0#diff-8fe526ccbcdf45660ab0e461c26a6e9c628735e8f7d1b8716edbff2891505c27L23-R23), [link](https://github.com/web-infra-dev/modern.js/pull/3885/files?diff=unified&w=0#diff-c23a2b35d900caaf70e880df366673f703b1740c361ff7f0a58faf7159684074L302-R302), [link](https://github.com/web-infra-dev/modern.js/pull/3885/files?diff=unified&w=0#diff-5a67625a6943a6e4ad0438fdaa587983ff9d969533db914437078368d34ba2f6L41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/3885/files?diff=unified&w=0#diff-7beec25165c02df7b7a3f310cacb01ce0870d7054d62eff6786bd4114b8dece8L23-R23), [link](https://github.com/web-infra-dev/modern.js/pull/3885/files?diff=unified&w=0#diff-eb7212575e45e234478eeeae2e0c56b9237f8d18dc9c5ad68564b1531d8dcd72L302-R302), [link](https://github.com/web-infra-dev/modern.js/pull/3885/files?diff=unified&w=0#diff-abaf1823347c0f3df554163945591f98af57d14d9a285aa8bf6e55befd603206L41-R41))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
