### PR TITLE
fix(builder): support filter css modules file by cssLoader.modules.auto RegExp

### DIFF
--- a/.changeset/gorgeous-waves-provide.md
+++ b/.changeset/gorgeous-waves-provide.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): support filter css modules file by tools.cssLoader.auto Regexp
+
+fix(builder): 支持过滤 css modules 文件根据 tools.cssLoader.auto 正则配置

--- a/.changeset/gorgeous-waves-provide.md
+++ b/.changeset/gorgeous-waves-provide.md
@@ -2,6 +2,6 @@
 '@modern-js/builder-shared': patch
 ---
 
-fix(builder): support filter css modules file by tools.cssLoader.auto Regexp
+fix(builder): support filter css modules file by cssLoader.modules.auto Regexp
 
-fix(builder): 支持过滤 css modules 文件根据 tools.cssLoader.auto 正则配置
+fix(builder): 支持过滤 css modules 文件根据 tools.cssLoader.modules.auto 正则配置

--- a/packages/builder/builder-shared/src/utils.ts
+++ b/packages/builder/builder-shared/src/utils.ts
@@ -95,7 +95,7 @@ export type CssLoaderModules =
   | boolean
   | string
   | {
-      auto: boolean | ((filename: string) => boolean);
+      auto: boolean | RegExp | ((filename: string) => boolean);
     };
 
 export const isCssModules = (filename: string, modules: CssLoaderModules) => {
@@ -112,6 +112,8 @@ export const isCssModules = (filename: string, modules: CssLoaderModules) => {
 
   if (typeof auto === 'boolean') {
     return auto && CSS_MODULES_REGEX.test(filename);
+  } else if (auto instanceof RegExp) {
+    return auto.test(filename);
   } else if (typeof auto === 'function') {
     return auto(filename);
   }

--- a/packages/builder/builder-shared/tests/utils.test.ts
+++ b/packages/builder/builder-shared/tests/utils.test.ts
@@ -41,6 +41,18 @@ it('check isCssModules', () => {
       },
     }),
   ).toBeFalsy();
+
+  expect(
+    isCssModules('src/index.module.css', {
+      auto: /\.module\./i,
+    }),
+  ).toBeTruthy();
+
+  expect(
+    isCssModules('src/index.css', {
+      auto: /\.module\./i,
+    }),
+  ).toBeFalsy();
 });
 
 it('getCssModulesAutoRule', () => {

--- a/tests/e2e/builder/cases/css/css-modules-ts-declaration/index.test.ts
+++ b/tests/e2e/builder/cases/css/css-modules-ts-declaration/index.test.ts
@@ -6,12 +6,18 @@ import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
+const generatorTempDir = async (testDir: string) => {
+  await fs.emptyDir(testDir);
+  await fs.copy(join(fixtures, 'src'), testDir);
+
+  return () => fs.remove(testDir);
+};
+
 webpackOnlyTest(
   'should generator ts declaration correctly for css modules auto true',
   async () => {
     const testDir = join(fixtures, 'test-src-1');
-    await fs.emptyDir(testDir);
-    await fs.copy(join(fixtures, 'src'), testDir);
+    const clear = await generatorTempDir(testDir);
 
     await build(
       {
@@ -37,6 +43,8 @@ webpackOnlyTest(
         encoding: 'utf-8',
       }),
     ).toMatch(/'the-b-class': string;/);
+
+    await clear();
   },
 );
 
@@ -44,8 +52,7 @@ webpackOnlyTest(
   'should generator ts declaration correctly for css modules auto function',
   async () => {
     const testDir = join(fixtures, 'test-src-2');
-    await fs.emptyDir(testDir);
-    await fs.copy(join(fixtures, 'src'), testDir);
+    const clear = await generatorTempDir(testDir);
 
     await build(
       {
@@ -74,5 +81,43 @@ webpackOnlyTest(
     expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeFalsy();
     expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
     expect(fs.existsSync(join(testDir, './d.global.less.d.ts'))).toBeTruthy();
+
+    await clear();
+  },
+);
+
+webpackOnlyTest(
+  'should generator ts declaration correctly for css modules auto Regexp',
+  async () => {
+    const testDir = join(fixtures, 'test-src-3');
+    const clear = await generatorTempDir(testDir);
+
+    await build(
+      {
+        cwd: __dirname,
+        entry: { index: resolve(testDir, 'index.js') },
+      },
+      {
+        output: {
+          disableSourceMap: true,
+          enableCssModuleTSDeclaration: true,
+        },
+        tools: {
+          cssLoader: {
+            modules: {
+              auto: /\.module\./i,
+            },
+          },
+        },
+      },
+      false,
+    );
+
+    expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
+    expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
+    expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
+    expect(fs.existsSync(join(testDir, './d.global.less.d.ts'))).toBeFalsy();
+
+    await clear();
   },
 );


### PR DESCRIPTION
## Summary

support filter css modules file by tools.cssLoader.auto RegExp
<img width="610" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/513392bd-9d8d-42b2-9275-1dd4d95ce1a9">


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 50cf964</samp>

This pull request adds support for a `RegExp` option for css modules in the `@modern-js/builder-shared` package, which enhances the css loader functionality. It also updates the type definition, the test suites, and the changeset file for this feature.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 50cf964</samp>

*  Add a changeset file to describe the patch version update and the fix message for the `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-cf494fdaad18a9f19688b441accccf5eaa59e0f0439ca312044270620ae33f14R1-R7))
*  Allow the `auto` property of `CssLoaderModules` to be a `RegExp` and use it to test the filename in the `isCssModules` function in `utils.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-f9c985b0f23d62cb02ed8771ea0ae73d03dacc267fdffeaa886c9b084da1cb25L98-R98), [link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-f9c985b0f23d62cb02ed8771ea0ae73d03dacc267fdffeaa886c9b084da1cb25R115-R116))
*  Add test cases to verify the `isCssModules` function with the `RegExp` option in `utils.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-02644056f87f63cbf99efcb191a94c648dddef2fab9016d6a421e2a0895c7711R44-R55))
*  Refactor the `css-modules-ts-declaration` test suite to use a helper function `generatorTempDir` that creates and clears a temporary directory for each test case in `index.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L9-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952R46-R47), [link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L47-R55), [link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L77-R123))
*  Add a test case to check the generated ts declaration files for css modules with the `RegExp` option in `index.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3887/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L77-R123))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
