### PR TITLE
fix(rspack-provider): failed to resolve core-js

### DIFF
--- a/.changeset/lemon-wolves-rescue.md
+++ b/.changeset/lemon-wolves-rescue.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(rspack-provider): failed to resolve core-js
+
+fix(rspack-provider): 修复找不到 core-js 的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/swc.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/swc.ts
@@ -26,6 +26,11 @@ export const builderPluginSwc = (): BuilderPlugin => ({
     api.modifyBundlerChain(async (chain, { isServer, isServiceWorker }) => {
       const config = api.getNormalizedConfig();
       addCoreJsEntry({ chain, config, isServer, isServiceWorker });
+
+      // Use the built-in core-js dependency, same as `babelPluginLockCorejsVersion`
+      chain.resolve.alias.merge({
+        'core-js': path.dirname(require.resolve('core-js')),
+      });
     });
 
     api.modifyRspackConfig(async (rspackConfig, { target }) => {

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1822,6 +1822,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
     },
   ],
   "resolve": {
+    "alias": {
+      "core-js": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+    },
     "conditionNames": [
       "require",
       "node",

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/swc.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/swc.test.ts.snap
@@ -170,6 +170,11 @@ exports[`plugins/swc > should disable preset_env in target other than web 1`] = 
       "src/index.js",
     ],
   },
+  "resolve": {
+    "alias": {
+      "core-js": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+    },
+  },
 }
 `;
 
@@ -192,6 +197,11 @@ exports[`plugins/swc > should disable preset_env mode 1`] = `
     "main": [
       "src/index.js",
     ],
+  },
+  "resolve": {
+    "alias": {
+      "core-js": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+    },
   },
 }
 `;
@@ -299,6 +309,11 @@ exports[`plugins/swc > should has correct core-js 3`] = `
     "main": [
       "src/index.js",
     ],
+  },
+  "resolve": {
+    "alias": {
+      "core-js": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+    },
   },
 }
 `;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e457cd</samp>

Fix a bug in the `@modern-js/builder-rspack-provider` plugin that caused an error when resolving `core-js`. Use an alias to point to the plugin's own `core-js` dependency instead of requiring the user to install it.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e457cd</samp>

*  Fix `core-js` resolution error in `@modern-js/builder-rspack-provider` plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3895/files?diff=unified&w=0#diff-40472263d401ace07efe02124aba4a15a2890aec689e94f1f13868aec4d94a1aR29-R33), [link](https://github.com/web-infra-dev/modern.js/pull/3895/files?diff=unified&w=0#diff-7ea4907b421f7ad5de654c522ecc43a13e559b98cb8bddb3459fb116ace55697R1-R7))
  * Add alias for `core-js` module to use built-in dependency in `swc.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3895/files?diff=unified&w=0#diff-40472263d401ace07efe02124aba4a15a2890aec689e94f1f13868aec4d94a1aR29-R33))
  * Bump package version with patch level and update changelog in `.changeset/lemon-wolves-rescue.md` ([link](https://github.com/web-infra-dev/modern.js/pull/3895/files?diff=unified&w=0#diff-7ea4907b421f7ad5de654c522ecc43a13e559b98cb8bddb3459fb116ace55697R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
