### PR TITLE
fix(rspack-provider): should inject polyfill for web-worker target

### DIFF
--- a/.changeset/forty-boats-roll.md
+++ b/.changeset/forty-boats-roll.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(rspack-provider): should inject polyfill for web-worker target
+
+fix(rspack-provider): 修复 web-worker target 未注入 polyfill 的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/swc.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/swc.ts
@@ -23,9 +23,9 @@ export const builderPluginSwc = (): BuilderPlugin => ({
   name: 'builder-plugin-swc',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { isServer, isServiceWorker }) => {
+    api.modifyBundlerChain(async (chain, { target }) => {
       const config = api.getNormalizedConfig();
-      addCoreJsEntry({ chain, config, isServer, isServiceWorker });
+      addCoreJsEntry({ chain, config, target });
     });
 
     api.modifyRspackConfig(async (rspackConfig, { target }) => {

--- a/packages/builder/builder-shared/src/polyfill.ts
+++ b/packages/builder/builder-shared/src/polyfill.ts
@@ -1,26 +1,22 @@
-import { createVirtualModule } from './utils';
-import type { BundlerChain, SharedNormalizedConfig } from './types';
+import { createVirtualModule, isWebTarget } from './utils';
+import type {
+  BuilderTarget,
+  BundlerChain,
+  SharedNormalizedConfig,
+} from './types';
 import type WebpackChain from '../compiled/webpack-5-chain';
-
-const enableCoreJsEntry = (
-  config: SharedNormalizedConfig,
-  isServer: boolean,
-  isServiceWorker: boolean,
-) => config.output.polyfill === 'entry' && !isServer && !isServiceWorker;
 
 /** Add core-js-entry to every entries. */
 export function addCoreJsEntry({
   chain,
   config,
-  isServer,
-  isServiceWorker,
+  target,
 }: {
   chain: BundlerChain | WebpackChain;
   config: SharedNormalizedConfig;
-  isServer: boolean;
-  isServiceWorker: boolean;
+  target: BuilderTarget;
 }) {
-  if (enableCoreJsEntry(config, isServer, isServiceWorker)) {
+  if (config.output.polyfill === 'entry' && isWebTarget(target)) {
     const entryPoints = Object.keys(chain.entryPoints.entries() || {});
     const coreJsEntry = createVirtualModule('import "core-js";');
 

--- a/packages/builder/builder-shared/src/utils.ts
+++ b/packages/builder/builder-shared/src/utils.ts
@@ -85,8 +85,8 @@ export const isURL = (str: string) =>
 
 export * as z from './zod';
 
-export function isWebTarget(target: BuilderTarget | BuilderTarget[]): boolean {
-  return ['modern-web', 'web'].some(t =>
+export function isWebTarget(target: BuilderTarget | BuilderTarget[]) {
+  return ['modern-web', 'web', 'web-worker'].some(t =>
     (Array.isArray(target) ? target : [target]).includes(t as BuilderTarget),
   );
 }

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -160,7 +160,7 @@ export const builderPluginBabel = (): BuilderPlugin => ({
             .options(babelOptions);
         }
 
-        addCoreJsEntry({ chain, config, isServer, isServiceWorker });
+        addCoreJsEntry({ chain, config, target });
       },
     );
   },


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a752bd8</samp>

This pull request fixes the web-worker target polyfill issue by using the `target` parameter to determine whether to inject the core-js entry in the bundler chain. It also simplifies and refactors the code for the `builderPluginSwc`, `builderPluginBabel`, and `addCoreJsEntry` functions, and updates the changeset file accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a752bd8</samp>

*  Simplify the logic for injecting the core-js polyfill for web-related targets by using the `target` parameter instead of the `isServer` and `isServiceWorker` parameters ([link](https://github.com/web-infra-dev/modern.js/pull/3896/files?diff=unified&w=0#diff-40472263d401ace07efe02124aba4a15a2890aec689e94f1f13868aec4d94a1aL26-R28), [link](https://github.com/web-infra-dev/modern.js/pull/3896/files?diff=unified&w=0#diff-9fda5474bc8d71c8b3f1a9566e3c6f15515e6e8e04d5c832191adefafa6d6a8fL1-R19), [link](https://github.com/web-infra-dev/modern.js/pull/3896/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL163-R163))
*  Update the `isWebTarget` utility function to include the `web-worker` target as one of the web-related targets that require the polyfill ([link](https://github.com/web-infra-dev/modern.js/pull/3896/files?diff=unified&w=0#diff-f9c985b0f23d62cb02ed8771ea0ae73d03dacc267fdffeaa886c9b084da1cb25L88-R89))
*  Update the changeset file to indicate that the `builder-rspack-provider`, `builder-shared`, and `builder-webpack-provider` packages need to be patched with the fix for the web-worker target polyfill issue ([link](https://github.com/web-infra-dev/modern.js/pull/3896/files?diff=unified&w=0#diff-925deb8b1a9c922a105725c49996d94bc37df593d421bbc3da5d7c20f659fe24R1-R9))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
