### PR TITLE
fix(plugin-module-doc): adjust merge doc config logic, support to use…

### DIFF
--- a/.changeset/grumpy-papayas-think.md
+++ b/.changeset/grumpy-papayas-think.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+fix: adjust merge doc config logic, support to use custom locales
+fix: 调整合并文档配置的逻辑,支持用户自定义 locales

--- a/packages/module/plugin-module-doc/src/features/lanchDoc.ts
+++ b/packages/module/plugin-module-doc/src/features/lanchDoc.ts
@@ -1,8 +1,10 @@
 import path from 'path';
 import { fs, fastGlob } from '@modern-js/utils';
 import { pluginPreview } from '@modern-js/doc-plugin-preview';
+import type { UserConfig } from '@modern-js/doc-core';
 import { Options, ModuleDocgenLanguage } from '../types';
 import { remarkBuiltIn } from '../mdx/builtin';
+import { mergeModuleDocConfig } from '../utils';
 
 export async function launchDoc({
   languages,
@@ -16,7 +18,7 @@ export async function launchDoc({
   );
   const root = path.join(appDir, 'docs');
   const DEFAULT_LANG = languages[0];
-  const { dev, build, mergeDocConfig } = await import('@modern-js/doc-core');
+  const { dev, build } = await import('@modern-js/doc-core');
   const getLangPrefixInLink = (language: ModuleDocgenLanguage) =>
     language === DEFAULT_LANG ? '' : `/${language}`;
   const getSidebar = (lang: 'zh' | 'en') => {
@@ -45,7 +47,7 @@ export async function launchDoc({
       ],
     };
   };
-  const modernDocConfig = mergeDocConfig(
+  const modernDocConfig = mergeModuleDocConfig<UserConfig>(
     {
       doc: {
         root,

--- a/packages/module/plugin-module-doc/src/utils.ts
+++ b/packages/module/plugin-module-doc/src/utils.ts
@@ -1,0 +1,34 @@
+import _ from '@modern-js/utils/lodash';
+
+export const mergeModuleDocConfig = <T>(...configs: T[]): T =>
+  _.mergeWith(
+    {},
+    ...configs,
+    (target: unknown, source: unknown, key: string) => {
+      const pair = [target, source];
+      if (pair.some(_.isUndefined)) {
+        // fallback to lodash default merge behavior
+        return undefined;
+      }
+
+      // always use source override target, if source defined.
+      if (['locales'].includes(key)) {
+        return source ?? target;
+      }
+
+      // can not enable darkMode.
+      if (key === 'darkMode' && target === false) {
+        return false;
+      }
+
+      if (pair.some(_.isArray)) {
+        return [..._.castArray(target), ..._.castArray(source)];
+      }
+      // convert function to chained function
+      if (pair.some(_.isFunction)) {
+        return [target, source];
+      }
+      // fallback to lodash default merge behavior
+      return undefined;
+    },
+  );


### PR DESCRIPTION
… custom locales

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at defff0d</samp>

This pull request improves the module doc feature of the `@modern-js/plugin-module-doc` package by adding a custom function to merge the doc config objects and supporting user-defined locales. It also adds type annotations and a changeset file for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at defff0d</samp>

*  Add a custom utility function `mergeModuleDocConfig` to merge doc config objects for the module doc feature ([link](https://github.com/web-infra-dev/modern.js/pull/3897/files?diff=unified&w=0#diff-a42fef309c4851be5e4185d33ea84a2fad4f04acf4a8b90f8241ca5ee78f7902R1-R34))
*  Use the `mergeModuleDocConfig` function instead of the `mergeDocConfig` function from `@modern-js/doc-core` in the `launchDoc` feature, and pass the `UserConfig` type as a generic parameter ([link](https://github.com/web-infra-dev/modern.js/pull/3897/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L48-R50), [link](https://github.com/web-infra-dev/modern.js/pull/3897/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L4-R7))
*  Remove the unused import of the `mergeDocConfig` function from `@modern-js/doc-core` in the `launchDoc` feature ([link](https://github.com/web-infra-dev/modern.js/pull/3897/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L19-R21))
*  Add a changeset file to document the patch updates for the `@modern-js/plugin-module-doc` package, and the issues fixed by the custom merge logic and the locales support ([link](https://github.com/web-infra-dev/modern.js/pull/3897/files?diff=unified&w=0#diff-32cbfdb3a80893ff3322ea02116d9d1efa332df7a261466d3afb9eee39c52c05R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
