### PR TITLE
fix: isApiOnly check error

### DIFF
--- a/packages/toolkit/utils/src/cli/is/project.ts
+++ b/packages/toolkit/utils/src/cli/is/project.ts
@@ -59,7 +59,7 @@ export const isApiOnly = async (
   apiDir?: string,
 ): Promise<boolean> => {
   const existApi = await fs.pathExists(
-    path.join(appDirectory, apiDir ?? 'api'),
+    apiDir ?? path.join(appDirectory, 'api'),
   );
   const existSrc = await fs.pathExists(
     path.join(appDirectory, entryDir ?? 'src'),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebb0c4d</samp>

Modified `isApiOnly` function to accept absolute paths for `apiDir`. This enables custom api directories in the toolkit.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ebb0c4d</samp>

*  Modify `isApiOnly` function to use absolute path for api directory ([link](https://github.com/web-infra-dev/modern.js/pull/3898/files?diff=unified&w=0#diff-071fb6b53421d4b231cc8fd2e6e8a03b189f58b3e553076b73ef48612d347a0cL62-R62))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
