### PR TITLE
fix: should only restart when file is watched

### DIFF
--- a/.changeset/afraid-crews-work.md
+++ b/.changeset/afraid-crews-work.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: should only restart when changed file is watched
+fix: 只有在变化的文件被监听是才重启


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06a7d00</samp>

This pull request fixes a bug in the `@modern-js/app-tools` package that caused the app to restart unnecessarily when any file in the app directory changed. It updates the dev server logic to watch only specific files that are relevant to the app configuration, and adds a `.changeset` file to document the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06a7d00</samp>

*  Add a markdown file to generate changelogs and version updates for the `@modern-js/app-tools` package, with fix messages in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3900/files?diff=unified&w=0#diff-b89a5dacc1a6d65e3df8d67e94b22a61270bebac4daee8a8b627e0d883aa513bR1-R6))
*  Declare a new variable `watchedFiles` to store the paths of the files that are watched by the dev server, and a helper function `isWatched` to check if a file is in the `watchedFiles` array ([link](https://github.com/web-infra-dev/modern.js/pull/3900/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR154-R160))
*  Update the `watchedFiles` array with the result of the `generateWatchFiles` function, which returns a promise of the files that should be watched by the dev server based on the app and config directories ([link](https://github.com/web-infra-dev/modern.js/pull/3900/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL276-R288))
*  Replace the condition that restarts the app on file change events, to only restart if the changed file is in the `watchedFiles` array, using the `isWatched` function. This fixes the bug that caused unnecessary restarts when files outside the `srcDirectory` were changed ([link](https://github.com/web-infra-dev/modern.js/pull/3900/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL283-R299))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
