### PR TITLE
fix(plugin-lint): remove codeframe formatter

### DIFF
--- a/.changeset/lucky-books-end.md
+++ b/.changeset/lucky-books-end.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-lint': patch
+---
+
+fix(plugin-lint): remove codeframe formatter
+
+fix(plugin-lint): 移除 codeframe formatter

--- a/packages/cli/plugin-lint/package.json
+++ b/packages/cli/plugin-lint/package.json
@@ -44,7 +44,6 @@
     "@modern-js/utils": "workspace:*",
     "cross-spawn": "^7.0.1",
     "eslint": "^8.28.0",
-    "eslint-formatter-codeframe": "^7.32.1",
     "husky": "^8.0.0",
     "@swc/helpers": "0.5.1"
   },

--- a/packages/cli/plugin-lint/src/lint.ts
+++ b/packages/cli/plugin-lint/src/lint.ts
@@ -27,7 +27,6 @@ export default () => {
 
   rawArgs.push(...ensureOption(args, 'ext', exts));
   rawArgs.push(...ensureOption(args, 'fix', true));
-  rawArgs.push(...ensureOption(args, 'format', 'codeframe'));
 
   // default ignore pattern
   ['node_modules/', 'dist/', 'output/', 'output_resource/'].forEach(pattern => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1432,9 +1432,6 @@ importers:
       eslint:
         specifier: ^8.28.0
         version: 8.28.0
-      eslint-formatter-codeframe:
-        specifier: ^7.32.1
-        version: 7.32.1
       husky:
         specifier: ^8.0.0
         version: 8.0.1
@@ -8445,12 +8442,6 @@ packages:
       '@ast-grep/napi-win32-arm64-msvc': 0.1.13
       '@ast-grep/napi-win32-ia32-msvc': 0.1.13
       '@ast-grep/napi-win32-x64-msvc': 0.1.13
-
-  /@babel/code-frame@7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
-    dependencies:
-      '@babel/highlight': 7.18.6
-    dev: false
 
   /@babel/code-frame@7.21.4:
     resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
@@ -20385,14 +20376,6 @@ packages:
       window-size: 0.3.0
       yargs: 16.2.0
     dev: true
-
-  /eslint-formatter-codeframe@7.32.1:
-    resolution: {integrity: sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      chalk: 4.1.2
-    dev: false
 
   /eslint-import-resolver-node@0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}

--- a/scripts/fast-lint.sh
+++ b/scripts/fast-lint.sh
@@ -16,5 +16,4 @@ env \
   TIMING=1 \
   npx eslint \
   --quiet \
-  --format codeframe \
   $(git diff --diff-filter=ACM ${TARGET_BRANCH}... --name-only | grep -E '\.(js|jsx|ts|tsx|mjs|mjsx|cjs|cjsx)$')


### PR DESCRIPTION
## Summary

Remove codeframe formatter, because:

- This module is not maintained, see: https://www.npmjs.com/package/eslint-formatter-codeframe
- ESLint may failed to resolve the module.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4d3ce0</samp>

This pull request removes the codeframe formatter for eslint from the `@modern-js/plugin-lint` package and updates the relevant files and scripts accordingly. This is a patch update that simplifies the linting output and reduces the package size.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4d3ce0</samp>

*  Remove codeframe formatter for eslint from `@modern-js/plugin-lint` package ([link](https://github.com/web-infra-dev/modern.js/pull/3903/files?diff=unified&w=0#diff-8459518f3fd3d1557ad6a04145e80d5daecffffdc7e80bd798b20eac4a9fb5fbR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3903/files?diff=unified&w=0#diff-f0410a76b9077653b85f45e8754d46a93f35e0c3b88ef644422b7702e90c3541L47), [link](https://github.com/web-infra-dev/modern.js/pull/3903/files?diff=unified&w=0#diff-1a450b544936d1c419f41ee7fad6853ca592ceb17dcd76ee19d73cec2137d8bcL30), [link](https://github.com/web-infra-dev/modern.js/pull/3903/files?diff=unified&w=0#diff-567654691ea4a510ca880f410076e1f80564018a05e72eceb3b78254fe97eb96L19))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
