### PR TITLE
docs: improve dev.proxy usage guide

### DIFF
--- a/packages/document/main-doc/docs/en/components/global-proxy-config.mdx
+++ b/packages/document/main-doc/docs/en/components/global-proxy-config.mdx
@@ -1,16 +1,37 @@
 - **Type:** `string | Object`
 - **Default:** `null`
 
-When this option is configured, the development environment will start a global proxy, similar to [Fiddler](https://www.telerik.com/fiddler), [Charles](https://www.charlesproxy.com/) and other web proxy debugging tools, which can be used to view, modify HTTP/HTTPS requests, responses, and can also be used as a proxy server.
+This option is used to configure a global proxy based on [whistle](https://wproxy.org/whistle/) in the development environment, which can be used to view and modify HTTP/HTTPS requests, responses, and can also be used as a proxy server.
 
-:::tip
-Using this option requires advance installation `@modern-js/plugin-proxy`.
+### Register Plugin
 
-:::
+Before using this option, you need to install and register the `@modern-js/plugin-proxy` plugin:
 
-### Object
+```bash
+# npm
+npm add @modern-js/plugin-proxy -D
 
-Using this option requires that the value of `Object` be installed in advance, the `key` of the object corresponds to the matching `pattern`, and the `value` of the object corresponds to the matching `target`.
+#yarn
+yarn add @modern-js/plugin-proxy -D
+
+#pnpm
+pnpm add @modern-js/plugin-proxy -D
+```
+
+After the installation, please register the plugin in the `modern.config.ts` file:
+
+```ts title="modern.config.ts"
+import appTools, { defineConfig } from '@modern-js/app-tools';
+import proxyPlugin from '@modern-js/plugin-proxy';
+
+export default defineConfig({
+  plugins: [appTools(), proxyPlugin()],
+});
+```
+
+### Object Type
+
+When the value of `dev.proxy` is object type, the `key` of the object corresponds to the matching `pattern`, and the `value` of the object corresponds to the matching `target`.
 
 Example:
 
@@ -26,9 +47,11 @@ export default defineConfig({
 });
 ```
 
-### String
+Please refer to [whistle - Matching Patterns](https://wproxy.org/whistle/pattern.html) for detailed usage.
 
-When the value is `string`, it can be used to specify a separate proxy file, for example:
+### String Type
+
+When the value of `dev.proxy` is string type, it can be used to specify a separate proxy file, for example:
 
 ```ts title="modern.config.ts"
 export default defineConfig({
@@ -47,10 +70,7 @@ module.exports = {
 };
 ```
 
-:::info
-Modern.js global proxy implementation is based on [whistle](https://wproxy.org/whistle/), for more matching patterns, please refer to: [Matching Patterns](https://wproxy.org/whistle/pattern.html)
-
-:::
+### Start Proxy
 
 Execute `dev`, when the prompt is as follows, the proxy server starts successfully:
 
@@ -68,7 +88,7 @@ Access the `localhost:8899` to view the Network and configure proxy rules on the
 
 ![proxy UI](https://lf3-static.bytednsdoc.com/obj/eden-cn/aphqeh7uhohpquloj/modern-js/docs/dev-proxy.png)
 
-:::caution Caution
+:::info
 The https agent automatically installs the certificate to obtain root privileges. Please enter the password as prompted. ** The password is only used when the certificate is trusted and will not be leaked or used for other links **.
 
 :::

--- a/packages/document/main-doc/docs/zh/components/global-proxy-config.mdx
+++ b/packages/document/main-doc/docs/zh/components/global-proxy-config.mdx
@@ -1,14 +1,37 @@
 - **类型：** `string | Object`
 - **默认值：** `null`
 
-配置该选项后，开发环境时会启动全局代理，类似 [Fiddler](https://www.telerik.com/fiddler), [Charles](https://www.charlesproxy.com/) 等 web 代理调试工具，可以用来查看、修改 HTTP/HTTPS 请求、响应、也可以用作代理服务器。
+该选项用于在开发环境下启用基于 [whistle](https://wproxy.org/whistle/) 的全局代理，可以用来查看、修改 HTTP/HTTPS 请求、响应、也可以用作代理服务器。
 
-:::tip 提示
-使用该选项需要提前安装 `@modern-js/plugin-proxy`。
+### 注册插件
 
-:::
+使用该选项前，你需要提前安装和注册 `@modern-js/plugin-proxy` 插件：
 
-值为 `Object` 时，对象的 `key` 对应匹配的 `pattern`，对象的 `value` 对应匹配的 `target`。
+```bash
+# npm
+npm add @modern-js/plugin-proxy -D
+
+# yarn
+yarn add @modern-js/plugin-proxy -D
+
+# pnpm
+pnpm add @modern-js/plugin-proxy -D
+```
+
+安装完成后，在 `modern.config.ts` 文件中注册插件：
+
+```ts title="modern.config.ts"
+import appTools, { defineConfig } from '@modern-js/app-tools';
+import proxyPlugin from '@modern-js/plugin-proxy';
+
+export default defineConfig({
+  plugins: [appTools(), proxyPlugin()],
+});
+```
+
+### Object 类型
+
+`dev.proxy` 的值为 `Object` 时，对象的 `key` 对应匹配的 `pattern`，对象的 `value` 对应匹配的 `target`。
 
 例如：
 
@@ -24,7 +47,11 @@ export default defineConfig({
 });
 ```
 
-值为 `string` 时， 可以用来指定单独的代理文件，例如：
+请参考 [whistle - 匹配模式](https://wproxy.org/whistle/pattern.html) 来了解详细用法。
+
+### String 类型
+
+`dev.proxy` 的值为 `string` 时， 可以用来指定单独的代理文件，例如：
 
 ```ts title="modern.config.ts"
 export default defineConfig({
@@ -43,10 +70,7 @@ module.exports = {
 };
 ```
 
-:::info
-Modern.js 全局代理实现底层基于 [whistle](https://wproxy.org/whistle/), 更多匹配模式请参考: [匹配模式](https://wproxy.org/whistle/pattern.html)
-
-:::
+### 启动代理
 
 执行 `dev`, 提示如下时，即代理服务器启动成功：
 
@@ -64,7 +88,7 @@ Modern.js 全局代理实现底层基于 [whistle](https://wproxy.org/whistle/),
 
 ![proxy ui 界面](https://lf3-static.bytednsdoc.com/obj/eden-cn/aphqeh7uhohpquloj/modern-js/docs/dev-proxy.png)
 
-:::caution 注意
+:::info
 https 代理自动安装证书需要获取 root 权限, 请根据提示输入密码即可。**密码仅在信任证书时使用，不会泄漏或者用于其他环节**。
 
 :::


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67b9a9f</samp>

Improved the documentation for the `global-proxy-config` component in both English and Chinese, explaining how to use the `dev.proxy` option with the `@modern-js/plugin-proxy` plugin and whistle.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67b9a9f</samp>

*  Update the description and usage of the `dev.proxy` option for global proxy configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-3de68618d44529a9ef86218895a6af5cfd034a8b3b15c7666951f36b207c6336L4-R35), [link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-f0bc59252bf9cb9f2c59c1639685f0adccfa96c404e0b162a6d3c2e70851950dL4-R35))
*  Harmonize the titles and references for the string and object type values of `dev.proxy` ([link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-3de68618d44529a9ef86218895a6af5cfd034a8b3b15c7666951f36b207c6336L29-R55), [link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-f0bc59252bf9cb9f2c59c1639685f0adccfa96c404e0b162a6d3c2e70851950dL27-R55))
*  Remove the redundant info tip and add the title for the section on starting the proxy ([link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-3de68618d44529a9ef86218895a6af5cfd034a8b3b15c7666951f36b207c6336L50-R74), [link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-f0bc59252bf9cb9f2c59c1639685f0adccfa96c404e0b162a6d3c2e70851950dL46-R74))
*  Change the caution tip to an info tip for the https agent certificate ([link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-3de68618d44529a9ef86218895a6af5cfd034a8b3b15c7666951f36b207c6336L71-R91), [link](https://github.com/web-infra-dev/modern.js/pull/3907/files?diff=unified&w=0#diff-f0bc59252bf9cb9f2c59c1639685f0adccfa96c404e0b162a6d3c2e70851950dL67-R91))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
