### PR TITLE
fix(builder): support devMiddleware.writeToDisk in rspack

### DIFF
--- a/.changeset/dull-jars-tickle.md
+++ b/.changeset/dull-jars-tickle.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): support devMiddleware.writeToDisk in rspack and use webpack-dev-middleware instead of @rspack/dev-middleware
+
+fix(builder): 在 rspack 中支持 devMiddleware.writeToDisk 配置项，并使用webpack-dev-middleware 代替 @rspack/dev-middleware
+

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -59,7 +59,6 @@
     "@babel/preset-typescript": "^7.21.5",
     "@rspack/core": "0.2.1",
     "@rspack/dev-client": "0.2.1",
-    "@rspack/dev-middleware": "0.2.1",
     "@rspack/plugin-html": "0.2.1",
     "rspack-manifest-plugin": "5.0.0-alpha0",
     "caniuse-lite": "^1.0.30001489",

--- a/packages/builder/builder-rspack-provider/src/core/devMiddleware.ts
+++ b/packages/builder/builder-rspack-provider/src/core/devMiddleware.ts
@@ -1,4 +1,5 @@
-import inner from '@rspack/dev-middleware';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import webpackDevMiddleware from '@modern-js/utils/webpack-dev-middleware';
 import type { ModernDevServerOptions } from '@modern-js/server';
 import { setupServerHooks, isClientCompiler } from '@modern-js/builder-shared';
 
@@ -57,5 +58,5 @@ export const getDevMiddleware: (
   }
 
   // @ts-expect-error
-  return inner(compiler, restOptions);
+  return webpackDevMiddleware(compiler, restOptions);
 };

--- a/packages/builder/builder-rspack-provider/src/plugins/transition.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/transition.ts
@@ -6,23 +6,7 @@ import type { BuilderPlugin } from '../types';
 export const builderPluginTransition = (): BuilderPlugin => ({
   name: 'builder-plugin-transition',
 
-  setup(api) {
-    api.modifyBuilderConfig(async (config, { mergeBuilderConfig }) => {
-      const { fs } = await import('@modern-js/utils');
-
-      // Align with webpack. Some configurations are not currently supported in Rspack, but will be in the future.
-      process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
-
-      return mergeBuilderConfig(config, {
-        tools: {
-          devServer: {
-            devMiddleware: {
-              // not support set writeToDisk true or function, so use outputFileSystem instead.
-              outputFileSystem: fs,
-            },
-          },
-        },
-      });
-    });
+  setup() {
+    process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
   },
 });

--- a/packages/document/builder-doc/docs/en/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/en/config/tools/devServer.md
@@ -140,8 +140,6 @@ export default {
 }
 ```
 
-- **Bundler:** `only support webpack`
-
 The config of devMiddleware. Current options is the subset of [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware).
 
 #### headers

--- a/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -117,7 +117,6 @@ Unsupported configurations and capabilities include:
 - [tools.terser](/api/config-tools.html#toolsterser)
 - [tools.cssExtract](/api/config-tools.html#toolscssextract)
 - [tools.cssLoader](/api/config-tools.html#toolscssloader)
-- [tools.devServer.devMiddleware](/api/config-tools.html#devmiddleware) ([track issue](https://github.com/web-infra-dev/rspack/issues/2391))
 - [tools.inspector](/api/config-tools.html#toolsinspector)
 - [tools.minifyCss](/api/config-tools.html#toolsminifycss)
 - [tools.styleLoader](/api/config-tools.html#toolsstyleloader)

--- a/packages/document/builder-doc/docs/zh/config/tools/devServer.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/devServer.md
@@ -140,8 +140,6 @@ export default {
 }
 ```
 
-- **打包工具：** `仅支持 webpack`
-
 devMiddleware 配置项。当前配置是 [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) 配置项的子集.
 
 #### headers

--- a/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -118,7 +118,6 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 - [tools.terser](/api/config-tools.html#toolsterser)
 - [tools.cssExtract](/api/config-tools.html#toolscssextract)
 - [tools.cssLoader](/api/config-tools.html#toolscssloader)
-- [tools.devServer.devMiddleware](/api/config-tools.html#devmiddleware) ([issue 追踪](https://github.com/web-infra-dev/rspack/issues/2391))
 - [tools.inspector](/api/config-tools.html#toolsinspector)
 - [tools.minifyCss](/api/config-tools.html#toolsminifycss)
 - [tools.styleLoader](/api/config-tools.html#toolsstyleloader)

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -80,7 +80,6 @@ For example, if you are using pnpm, you can update the Rspack version with `over
     "overrides": {
       "@rspack/core": "nightly",
       "@rspack/dev-client": "nightly",
-      "@rspack/dev-middleware": "nightly",
       "@rspack/plugin-html": "nightly"
     }
   }

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -81,7 +81,6 @@ import appTools, { defineConfig } from '@modern-js/app-tools';
     "overrides": {
       "@rspack/core": "nightly",
       "@rspack/dev-client": "nightly",
-      "@rspack/dev-middleware": "nightly",
       "@rspack/plugin-html": "nightly"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,9 +155,6 @@ importers:
       '@rspack/dev-client':
         specifier: 0.2.1
         version: 0.2.1(react-refresh@0.14.0)(webpack@5.82.1)
-      '@rspack/dev-middleware':
-        specifier: 0.2.1
-        version: 0.2.1(webpack@5.82.1)
       '@rspack/plugin-html':
         specifier: 0.2.1
         version: 0.2.1(@rspack/core@0.2.1)
@@ -12758,21 +12755,6 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /@rspack/dev-middleware@0.2.1(webpack@5.82.1):
-    resolution: {integrity: sha512-K42kkXsfi7xQGCm19VczAGGX/CYk2JZcNDdLjSeIppejPXDn/3GVHijG+fbqa/eyPEvzWy10cZ7+bDmoW5rCmQ==}
-    dependencies:
-      '@rspack/core': 0.2.1(webpack@5.82.1)
-      webpack-dev-middleware: 6.0.2(webpack@5.82.1)
-    transitivePeerDependencies:
-      - '@types/webpack'
-      - sockjs-client
-      - type-fest
-      - webpack
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: false
-
   /@rspack/plugin-html@0.2.1(@rspack/core@0.2.1):
     resolution: {integrity: sha512-Qn3tUJrG8WmNmCBKzwFxCBk96teQ/g9wzNytMucgC35efSCfgFW5PvtSk+vlIztccLmbBMngl2+qoBUU2+UUUA==}
     peerDependencies:
@@ -17876,6 +17858,7 @@ packages:
 
   /colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+    dev: true
 
   /colors@1.1.2:
     resolution: {integrity: sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==}
@@ -33444,23 +33427,6 @@ packages:
       schema-utils: 4.0.0
       webpack: 5.82.1(esbuild@0.15.7)
     dev: true
-
-  /webpack-dev-middleware@6.0.2(webpack@5.82.1):
-    resolution: {integrity: sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-    dependencies:
-      colorette: 2.0.19
-      memfs: 3.5.1
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.0.0
-      webpack: 5.82.1(esbuild@0.15.7)
-    dev: false
 
   /webpack-filter-warnings-plugin@1.2.1(webpack@4.46.0):
     resolution: {integrity: sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==}

--- a/tests/e2e/builder/cases/dev/write-to-disk.test.ts
+++ b/tests/e2e/builder/cases/dev/write-to-disk.test.ts
@@ -1,0 +1,87 @@
+import { join } from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { dev, getHrefByEntryName } from '@scripts/shared';
+
+const fixtures = __dirname;
+
+test('writeToDisk default', async ({ page }) => {
+  const buildOpts = {
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+  };
+
+  const builder = await dev(buildOpts, {
+    tools: {
+      devServer: {
+        client: {
+          host: '',
+          port: '',
+        },
+      },
+    },
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.getElementById('test').innerHTML`),
+  ).resolves.toBe('Hello Builder!');
+
+  await builder.server.close();
+});
+
+test('writeToDisk false', async ({ page }) => {
+  const buildOpts = {
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+  };
+
+  const builder = await dev(buildOpts, {
+    tools: {
+      devServer: {
+        devMiddleware: {
+          writeToDisk: false,
+        },
+      },
+    },
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.getElementById('test').innerHTML`),
+  ).resolves.toBe('Hello Builder!');
+
+  await builder.server.close();
+});
+
+test('writeToDisk true', async ({ page }) => {
+  const buildOpts = {
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+  };
+
+  const builder = await dev(buildOpts, {
+    tools: {
+      devServer: {
+        devMiddleware: {
+          writeToDisk: true,
+        },
+      },
+    },
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.getElementById('test').innerHTML`),
+  ).resolves.toBe('Hello Builder!');
+
+  await builder.server.close();
+});


### PR DESCRIPTION
## Summary

Related PR: ​https://github.com/web-infra-dev/rspack/pull/3478

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e28d3cf</samp>

This pull request fixes the issue of supporting the `devMiddleware` option in rspack by updating the `@modern-js/builder-rspack-provider` package to use `webpack-dev-middleware` instead of `@rspack/dev-middleware`. It also updates the documentation and the tests to reflect this change.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e28d3cf</samp>

*  Add a changeset file to document the patch version update and the fix message for the `@modern-js/builder-rspack-provider` package ([link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-15d1f1b35c258fbe455bff0e40ace302d13d48b48d80bf578b991323cdbfd0c1R1-R8))
*  Replace `@rspack/dev-middleware` with `webpack-dev-middleware` in the `@modern-js/builder-rspack-provider` package to support the `devMiddleware.writeToDisk` option in rspack ([link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L62), [link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-d57f288b87d58ab3b17edaab449d0f99658ed2d73a65f477e96afef577e6d3e3L1-R2), [link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-d57f288b87d58ab3b17edaab449d0f99658ed2d73a65f477e96afef577e6d3e3L60-R61))
*  Simplify the `builderPluginTransition` function in the `transition.ts` file of the `@modern-js/builder-rspack-provider` package to remove unnecessary modifications to the builder config ([link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-cc53bd04dfb62d632e0a49d06097f9e2b503952a211577329836c880af324411L9-R10))
*  Remove the lines that state that the `devMiddleware` option only supports webpack from the builder documentation in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-0a714ddc474c7a425c13ae672e264ac547893c9283cc43e155d06d121f6329beL143-L144), [link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-69d3b93a9b57afe8f5e9d592ac1aac80306d6ba8399f930dffd1c3aa7aa6f606L143-L144))
*  Remove the links to the issue tracking the support of the `devMiddleware` option in rspack from the builder documentation in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L120), [link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L121))
*  Remove the dependency on `@rspack/dev-middleware` from the `package.json` file of the main documentation in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-eda7074c67ef707f70206cf9404950df1e4b9de3c8b7831a6c951b38af9403ceL83), [link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-6b5d7dabc07cedb68247471404a2ee5ea2426fb560961f24781a4ab144909737L84))
*  Add a new test file `write-to-disk.test.ts` to the e2e test cases for the builder that check the behavior of the `devMiddleware.writeToDisk` option in different scenarios ([link](https://github.com/web-infra-dev/modern.js/pull/3908/files?diff=unified&w=0#diff-e6a5f01409e817dd67749be5c3fa6703e74560b4c66283edaecae051147787e6R1-R87))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
