### PR TITLE
docs: add guide to debug babel config

### DIFF
--- a/packages/document/builder-doc/docs/en/config/source/compileJsDataURI.md
+++ b/packages/document/builder-doc/docs/en/config/source/compileJsDataURI.md
@@ -1,9 +1,9 @@
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to compile JavaScript code imported via Data URI.
+This option is used to control whether to compile JavaScript code inside data URIs.
 
-Such as:
+By default, Builder uses Babel or SWC to compile the code inside data URIs. For example, the following code:
 
 ```js
 import x from 'data:text/javascript,export default 1;';

--- a/packages/document/builder-doc/docs/en/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/en/config/tools/babel.md
@@ -3,19 +3,23 @@
 
 With `tools.babel` you can modify the options of [babel-loader](https://github.com/babel/babel-loader).
 
-:::warning
-When using Rspack as the bundler, using this configuration will slow down the build speed of Rspack. As Rspack uses SWC compilation by default, there will be additional compilation overhead when using the Babel.
-:::
+### Usage Scenarios
+
+Please note the limitations of `tools.babel` in the following usage scenarios:
+
+- Rspack scenario: When using Rspack as the bundler, using the `tools.babel` option will significantly slow down the Rspack's build speed. This is because Rspack defaults to using SWC for compilation, and configuring Babel will cause the code to be compiled twice, resulting in additional compilation overhead.
+- webpack + SWC scenario: When using webpack as the bundler, if you use Builder's SWC plugin for code compilation, the `tools.babel` option will not take effect.
 
 ### Function Type
 
-When `tools.babel`'s type is Function, the default babel config will be passed in as the first parameter, the config object can be modified directly, or a value can be returned as the final result. The second parameter provides some util functions that can be called directly:
+
+When `tools.babel` is of type `Function`, the default Babel configuration will be passed as the first parameter. You can directly modify the configuration object or return an object as the final `babel-loader` configuration.
 
 ```js
 export default {
   tools: {
     babel(config) {
-      // Add a babel plugin
+      // Add a Babel plugin
       // note: the plugin have been added to the default config to support antd load on demand
       config.plugins.push([
         'babel-plugin-import',
@@ -29,6 +33,8 @@ export default {
   },
 };
 ```
+
+The second parameter of the `tools.babel` function provides some more convenient utility functions. Please continue reading the documentation below.
 
 :::tip
 The above example is just for reference, usually you don't need to manually configure `babel-plugin-import`, because the Builder already provides a more general `source.transformImport` configuration.
@@ -217,3 +223,19 @@ export default {
   },
 };
 ```
+
+### Debugging Babel Configuration
+
+After modifying the `babel-loader` configuration through `tools.babel`, you can view the final generated configuration in [Builder debug mode](https://modernjs.dev/builder/en/guide/debug/debug-mode.html).
+
+First, enable debug mode by using the `DEBUG=builder` parameter:
+
+```bash
+# Debug development mode
+DEBUG=builder pnpm dev
+
+# Debug production mode
+DEBUG=builder pnpm build
+```
+
+Then open the generated `(webpack|rspack).config.web.js` file and search for the `babel-loader` keyword to see the complete `babel-loader` configuration.

--- a/packages/document/builder-doc/docs/en/guide/advanced/browser-compatibility.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/browser-compatibility.md
@@ -179,7 +179,7 @@ export default {
 
 ## Polyfill mode
 
-Builder compiles JavaScript code through babel or SWC, and injects polyfill libraries like [core-js](https://github.com/zloirock/core-js), [@babel/runtime](https://www.npmjs.com/package/@babel/runtime) and [@swc/helpers](https://www.npmjs.com/package/@swc/helpers).
+Builder compiles JavaScript code through Babel or SWC, and injects polyfill libraries like [core-js](https://github.com/zloirock/core-js), [@babel/runtime](https://www.npmjs.com/package/@babel/runtime) and [@swc/helpers](https://www.npmjs.com/package/@swc/helpers).
 
 In different usage scenarios, you may need different polyfill solutions. Builder provides [output.polyfill](/en/api/config-output.html#outputpolyfill) config to switch between different polyfill modes.
 

--- a/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -181,7 +181,7 @@ More information about Rspack, please refer to the [Rspack website](https://www.
 
 ### 4. Babel Configuration Migration
 
-By default, Rspack uses SWC for transpilation and compression. Therefore, when using Rspack for building, babel-loader is not loaded by default.
+By default, Rspack uses SWC for transpilation and compression. Therefore, when using Rspack as the bundler, `babel-loader` is not loaded by default.
 
 For most common Babel plugins, you can find corresponding alternatives in Rspack, and there are also corresponding compatible configuration options in Builder.
 
@@ -229,17 +229,17 @@ Usually, after enabling Rspack, there will be a 5 to 10 times improvement in com
 
 The following behaviors are currently known to slow down Rspack build performance to some extent:
 
-##### Using configuration options or plugins that rely on babel
+##### Using configuration options or plugins that rely on Babel
 
 When using Rspack to build, babel-loader is not enabled by default.
 
-However, when a project uses configuration options or plugins implemented with babel, an additional babel-loader will be added for file transpilation:
+However, when a project uses configuration options or plugins implemented with Babel, an additional babel-loader will be added for file transpilation:
 
-- Add the babel plugin via [tools.babel](/api/config-tools.html#toolsbabel)
+- Add the Babel plugin via [tools.babel](/api/config-tools.html#toolsbabel)
 - Use [Modern.js SSR feature](https://modernjs.dev/en/guides/advanced-features/ssr.html)
 - ...
 
-You can check whether the babel plugin exists in the final generated Rspack configuration by using [debug mode](/guide/debug/debug-mode.html).
+You can check whether the Babel plugin exists in the final generated Rspack configuration by using [debug mode](/guide/debug/debug-mode.html).
 
 ##### Enable TypeScript type checking
 

--- a/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
@@ -65,14 +65,14 @@ Solution:
 
 ### Find `exports is not defined` runtime error?
 
-If the compilation is succeed, but the `exports is not defined` error appears after opening the page, it is usually because a CommonJS module is compiled by babel.
+If the compilation is succeed, but the `exports is not defined` error appears after opening the page, it is usually because a CommonJS module is compiled by Babel.
 
-Under normal circumstances, Builder will not use babel to compile CommonJS modules. If the [source.include](/en/api/config-source.html#sourceinclude) configuration item is used in the project, or the [tools.babel](/en/api/config-tools.html#tools -babel) `addIncludes` method, some CommonJS modules may be added to the babel compilation.
+Under normal circumstances, Builder will not use Babel to compile CommonJS modules. If the [source.include](/en/api/config-source.html#sourceinclude) configuration item is used in the project, or the [tools.babel](/en/api/config-tools.html#tools-babel) `addIncludes` method, some CommonJS modules may be added to the Babel compilation.
 
 There are two workarounds for this problem:
 
-1. Avoid adding CommonJS modules to babel compilation.
-2. Set babel's `sourceType` configuration item to `unambiguous`, for example:
+1. Avoid adding CommonJS modules to Babel compilation.
+2. Set Babel's `sourceType` configuration item to `unambiguous`, for example:
 
 ```js
 export default {
@@ -84,13 +84,13 @@ export default {
 };
 ```
 
-Setting `sourceType` to `unambiguous` may have some other effects, please refer to [babel official documentation](https://babeljs.io/docs/en/options#sourcetype).
+Setting `sourceType` to `unambiguous` may have some other effects, please refer to [Babel official documentation](https://babeljs.io/docs/en/options#sourcetype).
 
 ---
 
 ### Compile error "Error: ES Modules may not assign module.exports or exports.\*, Use ESM export syntax"?
 
-If the following error occurs during compilation, it is usually because a CommonJS module is compiled with babel in the project, and the solution is same as the above `exports is not defined` problem.
+If the following error occurs during compilation, it is usually because a CommonJS module is compiled with Babel in the project, and the solution is same as the above `exports is not defined` problem.
 
 ```bash
 Error: ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: 581

--- a/packages/document/builder-doc/docs/en/guide/introduction.mdx
+++ b/packages/document/builder-doc/docs/en/guide/introduction.mdx
@@ -40,7 +40,7 @@ import Rspack from '@en/shared/rspack-tip.mdx';
 
 <Rspack />
 
-By default, Builder uses webpack 5 as the bundler. Although the compilation speed of webpack is not ideal, it is still the most mature and ecological bundler in the community. Based on webpack, Builder integrates [babel](https://github.com/babel/babel), [postcss](https://github.com/postcss/postcss), [terser](https://github.com/terser/terser) and other tools to transform or minify codes. Builder also supports replacing some compile tools with native tools to improve compilation speed, such as replacing babel/terser with [swc](https://github.com/swc-project/swc) or [esbuild](https://github.com/evanw/esbuild).
+By default, Builder uses webpack 5 as the bundler. Although the compilation speed of webpack is not ideal, it is still the most mature and ecological bundler in the community. Based on webpack, Builder integrates [Babel](https://github.com/babel/babel), [postcss](https://github.com/postcss/postcss), [terser](https://github.com/terser/terser) and other tools to transform or minify codes. Builder also supports replacing some compile tools with native tools to improve compilation speed, such as replacing babel/terser with [swc](https://github.com/swc-project/swc) or [esbuild](https://github.com/evanw/esbuild).
 
 If you have higher build performance requirements, you can easily switch to Rspack build mode, see [Using Rspack](/guide/advanced/rspack-start) for more information.
 

--- a/packages/document/builder-doc/docs/en/guide/introduction.mdx
+++ b/packages/document/builder-doc/docs/en/guide/introduction.mdx
@@ -40,7 +40,7 @@ import Rspack from '@en/shared/rspack-tip.mdx';
 
 <Rspack />
 
-By default, Builder uses webpack 5 as the bundler. Although the compilation speed of webpack is not ideal, it is still the most mature and ecological bundler in the community. Based on webpack, Builder integrates [Babel](https://github.com/babel/babel), [postcss](https://github.com/postcss/postcss), [terser](https://github.com/terser/terser) and other tools to transform or minify codes. Builder also supports replacing some compile tools with native tools to improve compilation speed, such as replacing babel/terser with [swc](https://github.com/swc-project/swc) or [esbuild](https://github.com/evanw/esbuild).
+By default, Builder uses webpack 5 as the bundler. Although the compilation speed of webpack is not ideal, it is still the most mature and ecological bundler in the community. Based on webpack, Builder integrates [Babel](https://github.com/babel/babel), [PostCSS](https://github.com/postcss/postcss), [terser](https://github.com/terser/terser) and other tools to transform or minify codes. Builder also supports replacing some compile tools with native tools to improve compilation speed, such as replacing babel/terser with [swc](https://github.com/swc-project/swc) or [esbuild](https://github.com/evanw/esbuild).
 
 If you have higher build performance requirements, you can easily switch to Rspack build mode, see [Using Rspack](/guide/advanced/rspack-start) for more information.
 

--- a/packages/document/builder-doc/docs/zh/config/source/compileJsDataURI.md
+++ b/packages/document/builder-doc/docs/zh/config/source/compileJsDataURI.md
@@ -1,9 +1,9 @@
 - **类型：** `boolean`
 - **默认值：** `true`
 
-对于使用 Data URI 引入的 JavaScript 代码，是否采用 babel 进行编译。
+该选项用于控制是否编译 data URI 中的 JavaScript 代码。
 
-比如以下代码：
+默认情况下，Builder 会使用 Babel 或 SWC 对 data URI 中的代码进行编译。比如以下代码：
 
 ```js
 import x from 'data:text/javascript,export default 1;';

--- a/packages/document/builder-doc/docs/zh/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/babel.md
@@ -3,13 +3,16 @@
 
 通过 `tools.babel` 可以修改 [babel-loader](https://github.com/babel/babel-loader) 的配置项。
 
-:::warning
-在使用 Rspack 作为打包工具时，使用该配置项将在一定程度上拖慢 Rspack 构建速度。因为 Rspack 默认使用的是 SWC 编译，配置 Babel 时会产生额外的编译开销。
-:::
+### 使用场景
+
+请留意 `tools.babel` 在以下使用场景中的局限性：
+
+- Rspack 场景：在使用 Rspack 作为打包工具时，使用 `tools.babel` 配置项将会明显拖慢 Rspack 构建速度。因为 Rspack 默认使用的是 SWC 编译，配置 Babel 会导致代码需要编译两次，产生额外的编译开销。
+- webpack + SWC 场景：在使用 webpack 作为打包工具时，如果你使用了 Builder 的 SWC 插件进行代码编译，那么 `tools.babel` 选项将不会生效。
 
 ### Function 类型
 
-当 `tools.babel` 为 Function 类型时，默认配置作为第一个参数传入，可以直接修改配置对象，也可以返回一个值作为最终结果，第二个参数提供了一些可以直接调用的工具函数：
+当 `tools.babel` 为 Function 类型时，默认 Babel 配置会作为第一个参数传入，你可以直接修改配置对象，也可以返回一个对象作为最终的 `babel-loader` 配置。
 
 ```js
 export default {
@@ -28,6 +31,8 @@ export default {
   },
 };
 ```
+
+`tools.babel` 函数的第二个参数提供了一些方便的工具函数，请继续阅读下方文档。
 
 :::tip
 以上示例仅作为参考，通常来说，你不需要手动配置 `babel-plugin-import`，因为 Builder 已经提供了更通用的 `source.transformImport` 配置。
@@ -216,3 +221,19 @@ export default {
   },
 };
 ```
+
+### 调试 Babel 配置
+
+当你通过 `tools.babel` 修改 `babel-loader` 配置后，可以在 [Builder 调试模式](https://modernjs.dev/builder/guide/debug/debug-mode.html) 下查看最终生成的配置。
+
+首先通过 `DEBUG=builder` 参数开启调试模式：
+
+```bash
+# 调试开发环境
+DEBUG=builder pnpm dev
+
+# 调试生产环境
+DEBUG=builder pnpm build
+```
+
+然后打开生成的 `(webpack|rspack).config.web.js`，搜索 `babel-loader` 关键词，即可看到完整的 `babel-loader` 配置内容。

--- a/packages/document/builder-doc/docs/zh/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/babel.md
@@ -7,7 +7,7 @@
 
 请留意 `tools.babel` 在以下使用场景中的局限性：
 
-- Rspack 场景：在使用 Rspack 作为打包工具时，使用 `tools.babel` 配置项将会明显拖慢 Rspack 构建速度。因为 Rspack 默认使用的是 SWC 编译，配置 Babel 会导致代码需要编译两次，产生额外的编译开销。
+- Rspack 场景：在使用 Rspack 作为打包工具时，使用 `tools.babel` 配置项将会明显拖慢 Rspack 构建速度。因为 Rspack 默认使用的是 SWC 编译，配置 Babel 会导致代码需要被编译两次，产生了额外的编译开销。
 - webpack + SWC 场景：在使用 webpack 作为打包工具时，如果你使用了 Builder 的 SWC 插件进行代码编译，那么 `tools.babel` 选项将不会生效。
 
 ### Function 类型

--- a/packages/document/builder-doc/docs/zh/guide/advanced/browser-compatibility.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/browser-compatibility.md
@@ -179,7 +179,7 @@ export default {
 
 ## Polyfill 方案
 
-Builder 底层通过 babel 或 SWC 编译 JavaScript 代码，并注入 [core-js](https://github.com/zloirock/core-js)、[@babel/runtime](https://www.npmjs.com/package/@babel/runtime)、[@swc/helpers](https://www.npmjs.com/package/@swc/helpers) 等 polyfill 库。
+Builder 底层通过 Babel 或 SWC 编译 JavaScript 代码，并注入 [core-js](https://github.com/zloirock/core-js)、[@babel/runtime](https://www.npmjs.com/package/@babel/runtime)、[@swc/helpers](https://www.npmjs.com/package/@swc/helpers) 等 polyfill 库。
 
 在不同的使用场景下，你可能会需要不同的 polyfill 方案。Builder 提供了 [output.polyfill](/api/config-output.html#outputpolyfill) 配置项来切换不同的 polyfill 方案。
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -197,7 +197,7 @@ Rspack 默认会使用 SWC 进行转译和压缩，因此，在启用 Rspack 构
 | @babel/plugin-react-transform-remove-prop-types | 暂无                                                                                         | 暂无                                                                                                                  |
 
 :::tip
-在使用 Rspack 构建时，仍然**支持通过 [tools.babel](/api/config-tools.html#toolsbabel) 配置 babel 插件**，但会产生额外的编译开销，在一定程度上拖慢 Rspack 构建速度。
+在使用 Rspack 构建时，仍然**支持通过 [tools.babel](/api/config-tools.html#toolsbabel) 配置 Babel 插件**，但会产生额外的编译开销，在一定程度上拖慢 Rspack 构建速度。
 :::
 
 ### 5. SWC 配置支持
@@ -228,15 +228,15 @@ Rspack 中已内置了一部分的 swc 配置支持，如 builtins.react 等，�
 
 目前已知以下行为会在一定程度上拖慢 Rspack 构建性能：
 
-##### 使用依赖 babel 实现的配置项或插件
+##### 使用依赖 Babel 实现的配置项或插件
 
-在使用 Rspack 构建时，Builder 默认不会启用 babel-loader。但当项目中使用到依赖 babel 实现的配置项或插件时，会额外添加 babel-loader 进行文件转译：
+在使用 Rspack 构建时，Builder 默认不会启用 `babel-loader`。但当项目中使用到依赖 Babel 实现的配置项或插件时，会额外添加 `babel-loader` 进行文件转译：
 
-- 通过 [tools.babel](/api/config-tools.html#toolsbabel) 添加 babel plugin
+- 通过 [tools.babel](/api/config-tools.html#toolsbabel) 添加 Babel plugin
 - 使用 [Modern.js SSR 功能](https://modernjs.dev/guides/advanced-features/ssr.html)
 - ...
 
-你可以通过开启[调试模式](/guide/debug/debug-mode.html) 来查看最终生成的 Rspack 配置中是否存在 babel 插件。
+你可以通过开启[调试模式](/guide/debug/debug-mode.html) 来查看最终生成的 Rspack 配置中是否存在 Babel 插件。
 
 ##### 开启 TypeScript 类型检查
 

--- a/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
@@ -65,14 +65,14 @@ You may need an additional loader to handle the result of these loaders.
 
 ### 打开页面后报错，提示 exports is not defined？
 
-如果编译正常，但是打开页面后出现 `exports is not defined` 报错，通常是因为在项目中使用 babel 编译了一个 CommonJS 模块，导致 babel 出现异常。
+如果编译正常，但是打开页面后出现 `exports is not defined` 报错，通常是因为在项目中使用 Babel 编译了一个 CommonJS 模块，导致 Babel 出现异常。
 
-在正常情况下，Builder 是不会使用 babel 来编译 CommonJS 模块的。如果项目中使用了 [source.include]() 配置项，或使用了 [tools.babel](/api/config-tools.html#toolsbabel) 的 `addIncludes` 方法，则可能会把一些 CommonJS 模块加入到 babel 编译中。
+在正常情况下，Builder 是不会使用 Babel 来编译 CommonJS 模块的。如果项目中使用了 [source.include]() 配置项，或使用了 [tools.babel](/api/config-tools.html#toolsbabel) 的 `addIncludes` 方法，则可能会把一些 CommonJS 模块加入到 Babel 编译中。
 
 该问题有两种解决方法：
 
-1. 避免将 CommonJS 模块加入到 babel 编译中。
-2. 将 babel 的 `sourceType` 配置项设置为 `unambiguous`，示例如下：
+1. 避免将 CommonJS 模块加入到 Babel 编译中。
+2. 将 Babel 的 `sourceType` 配置项设置为 `unambiguous`，示例如下：
 
 ```js
 export default {
@@ -84,13 +84,13 @@ export default {
 };
 ```
 
-将 `sourceType` 设置为 `unambiguous` 可能会产生一些其他影响，请参考 [babel 官方文档](https://babeljs.io/docs/en/options#sourcetype)。
+将 `sourceType` 设置为 `unambiguous` 可能会产生一些其他影响，请参考 [Babel 官方文档](https://babeljs.io/docs/en/options#sourcetype)。
 
 ---
 
 ### 编译时报错 "Error: ES Modules may not assign module.exports or exports.\*, Use ESM export syntax"？
 
-如果编译时出现以下报错，通常也是因为在项目中使用 babel 编译了一个 CommonJS 模块，解决方法与上述的 `exports is not defined` 问题一致。
+如果编译时出现以下报错，通常也是因为在项目中使用 Babel 编译了一个 CommonJS 模块，解决方法与上述的 `exports is not defined` 问题一致。
 
 ```bash
 Error: ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: 581

--- a/packages/document/builder-doc/docs/zh/guide/introduction.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/introduction.mdx
@@ -40,7 +40,7 @@ import Rspack from '@zh/shared/rspack-tip.mdx';
 
 <Rspack />
 
-默认情况下，Builder 使用 webpack 5 作为打包工具，尽管 webpack 的编译速度不是很理想，但它依然是社区中功能最完整、生态最丰富的打包工具。Builder 在 webpack 的基础上，集成了 [babel](https://github.com/babel/babel)、[postcss](https://github.com/postcss/postcss)、[terser](https://github.com/terser/terser) 等工具进行代码转义和压缩。Builder 也支持替换部分编译能力为原生工具来提升编译速度，比如将 babel/terser 替换为 [swc](https://github.com/swc-project/swc) 或 [esbuild](https://github.com/evanw/esbuild)。
+默认情况下，Builder 使用 webpack 5 作为打包工具，尽管 webpack 的编译速度不是很理想，但它依然是社区中功能最完整、生态最丰富的打包工具。Builder 在 webpack 的基础上，集成了 [Babel](https://github.com/babel/babel)、[postcss](https://github.com/postcss/postcss)、[terser](https://github.com/terser/terser) 等工具进行代码转义和压缩。Builder 也支持替换部分编译能力为原生工具来提升编译速度，比如将 Babel / terser 替换为 [swc](https://github.com/swc-project/swc) 或 [esbuild](https://github.com/evanw/esbuild)。
 
 如果你对构建性能有更极致的需求，可以一键切换到 Rspack 构建模式，请参考 [使用 Rspack](/guide/advanced/rspack-start) 来进行切换。
 

--- a/packages/document/builder-doc/docs/zh/guide/introduction.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/introduction.mdx
@@ -40,7 +40,7 @@ import Rspack from '@zh/shared/rspack-tip.mdx';
 
 <Rspack />
 
-默认情况下，Builder 使用 webpack 5 作为打包工具，尽管 webpack 的编译速度不是很理想，但它依然是社区中功能最完整、生态最丰富的打包工具。Builder 在 webpack 的基础上，集成了 [Babel](https://github.com/babel/babel)、[postcss](https://github.com/postcss/postcss)、[terser](https://github.com/terser/terser) 等工具进行代码转义和压缩。Builder 也支持替换部分编译能力为原生工具来提升编译速度，比如将 Babel / terser 替换为 [swc](https://github.com/swc-project/swc) 或 [esbuild](https://github.com/evanw/esbuild)。
+默认情况下，Builder 使用 webpack 5 作为打包工具，尽管 webpack 的编译速度不是很理想，但它依然是社区中功能最完整、生态最丰富的打包工具。Builder 在 webpack 的基础上，集成了 [Babel](https://github.com/babel/babel)、[PostCSS](https://github.com/postcss/postcss)、[terser](https://github.com/terser/terser) 等工具进行代码转义和压缩。Builder 也支持替换部分编译能力为原生工具来提升编译速度，比如将 Babel / terser 替换为 [swc](https://github.com/swc-project/swc) 或 [esbuild](https://github.com/evanw/esbuild)。
 
 如果你对构建性能有更极致的需求，可以一键切换到 Rspack 构建模式，请参考 [使用 Rspack](/guide/advanced/rspack-start) 来进行切换。
 

--- a/packages/document/main-doc/docs/en/configure/app/builder-plugins.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/builder-plugins.mdx
@@ -17,7 +17,7 @@ This option **is used to configure the Modern.js Builder plugins**. If you need 
 
 - Use [plugins](/configure/app/builder-plugins) to configure Modern.js framework plugins.
 - Use [tools.webpack](/configure/app/tools/webpack) or [tools.webpackChain](/configure/app/tools/webpack-chain) to configure webpack plugins.
-- Use [tools.babel](/configure/app/tools/babel) to configure babel plugins.
+- Use [tools.babel](/configure/app/tools/babel) to configure Babel plugins.
 
 ## When to use
 

--- a/packages/document/main-doc/docs/en/configure/app/plugins.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/plugins.mdx
@@ -17,7 +17,7 @@ This config **is used to configure the Modern.js framework plugin**. If you need
 
 - Use [builderPlugins](/configure/app/builder-plugins) to configure Modern.js Builder plugins.
 - Use [tools.webpack](/configure/app/tools/webpack) or [tools.webpackChain](/configure/app/tools/webpack-chain) to configure webpack plugins.
-- Use [tools.babel](/configure/app/tools/babel) to configure babel plugins.
+- Use [tools.babel](/configure/app/tools/babel) to configure Babel plugins.
 
 ## Plugin type
 

--- a/packages/document/module-doc/docs/en/api/config/build-config.md
+++ b/packages/document/module-doc/docs/en/api/config/build-config.md
@@ -685,7 +685,7 @@ export default {
 - plugins
 - processOptions
 
-See [postcss](https://github.com/postcss/postcss#options) for detailed configuration
+See [PostCSS](https://github.com/postcss/postcss#options) for detailed configuration
 
 ### inject
 

--- a/packages/document/module-doc/docs/en/guide/best-practices/components.mdx
+++ b/packages/document/module-doc/docs/en/guide/best-practices/components.mdx
@@ -204,7 +204,7 @@ The following capabilities are currently supported for developing styles.
 
 ### CSS/PostCSS
 
-The module project supports PostCSS and has the following built-in postcss plugins.
+The module project supports PostCSS and has the following built-in PostCSS plugins.
 
 - [flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes)
 - [custom-properties](https://github.com/postcss/postcss-custom-properties)

--- a/packages/document/module-doc/docs/en/plugins/official-list/overview.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/overview.md
@@ -6,4 +6,4 @@
 * [@modern-js/plugin-module-banner](./plugin-banner.md)：Add custom content, such as copyright information, to the top and bottom of each JS and CSS file.
 * [@modern-js/plugin-module-node-polyfill](./plugin-node-polyfill.mdx)： Inject Polyfills of Node core modules in the browser side.
 * [@modern-js/plugin-module-polyfill](./plugin-polyfill.md)：Inject polyfill for unsupported features used in your code.
-* [@modern-js/plugin-module-babel](./plugin-babel.md)：Use babel to transform your code.
+* [@modern-js/plugin-module-babel](./plugin-babel.md)：Use Babel to transform your code.

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
@@ -50,7 +50,7 @@ type options = {
 
 ### targets
 
-See [babel target](https://babeljs.io/docs/options#targets).
+See [Babel target](https://babeljs.io/docs/options#targets).
 
 This is a example.
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.md
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.md
@@ -742,7 +742,7 @@ export default defineConfig({
 - plugins
 - processOptions
 
-详细配置查看 [postcss](https://github.com/postcss/postcss#options)。
+详细配置查看 [PostCSS](https://github.com/postcss/postcss#options)。
 
 ### inject
 

--- a/packages/document/module-doc/docs/zh/guide/best-practices/components.mdx
+++ b/packages/document/module-doc/docs/zh/guide/best-practices/components.mdx
@@ -208,7 +208,7 @@ export default {
 
 ### CSS/PostCSS
 
-模块工程支持 PostCSS，并且内置了以下 postcss 插件：
+模块工程支持 PostCSS，并且内置了以下 PostCSS 插件：
 
 - [flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes)
 - [custom-properties](https://github.com/postcss/postcss-custom-properties)

--- a/packages/document/module-doc/docs/zh/plugins/official-list/overview.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/overview.md
@@ -6,4 +6,4 @@
 * [@modern-js/plugin-module-banner](./plugin-banner.md)：为每个 JS 和 CSS 文件的顶部和底部添加自定义内容，例如版权信息。
 * [@modern-js/plugin-module-node-polyfill](./plugin-node-polyfill.mdx)：会自动注入 Node 核心模块在浏览器端的 polyfills。
 * [@modern-js/plugin-module-polyfill](./plugin-polyfill.md)：为你的代码中使用到的不支持的功能注入 polyfill。
-* [@modern-js/plugin-module-babel](./plugin-babel.md)：使用 babel 转换你的代码。
+* [@modern-js/plugin-module-babel](./plugin-babel.md)：使用 Babel 转换你的代码。

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
@@ -37,7 +37,7 @@ export default defineConfig({
 
 ## 配置
 
-See [babel options](https://babeljs.io/docs/options)
+See [Babel options](https://babeljs.io/docs/options)
 
 下面是一个配置了`@babel/preset-env`的例子：
 

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
@@ -50,9 +50,9 @@ type options = {
 
 ### targets
 
-See [babel target](https://babeljs.io/docs/options#targets).
+参考 [Babel target](https://babeljs.io/docs/options#targets).
 
-This is a example.
+下面是一个例子：
 
 ```ts
 import moduleTools, { defineConfig } from '@modern-js/module-tools';

--- a/packages/module/plugin-module-babel/README.md
+++ b/packages/module/plugin-module-babel/README.md
@@ -1,8 +1,8 @@
 # @modern-js/plugin-module-babel
 
-The babel plugin of Modern.js Module Tools.
+The Babel plugin of Modern.js Module Tools.
 
-You can add babel compile by the plugin before module-tools internal building.
+You can add Babel compile by the plugin before module-tools internal building.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 201fc37</samp>

This pull request updates the documentation and the README file of the plugin-module-babel package to improve the consistency, clarity, and accuracy of the references to `Babel`. It also adds more details, examples, and debugging tips to the documentation of the `tools.babel` option in Rspack.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 201fc37</samp>

*  Update the description of the `compileJsDataURI` option to reflect that Builder can use either Babel or SWC to compile the code inside data URIs ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-06271bf9b564d26d4f620a6f1b5c524944546fdb6f1af5f8aecb9dd3aa10cab6L4-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-b8ad5d779e2516bc8eac896b2d1bc3b8154a98804477b5b6b38fa9f3ef7581faL4-R6))
*  Reorganize the documentation of the `tools.babel` option to add a new section on usage scenarios, which explains the performance impact and the limitation of using the option with Rspack, webpack, and SWC ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-e96809b29417d6281f84f3b6a2dd8674fb248b85f8ddffc46cb8355a18cff841L6-R22), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-c31daf59e1b7eb317897582e8443464d03d88a13bd5ecad2eaf44b84cf6a7d5cL6-R15))
*  Add a sentence to introduce the second parameter of the `tools.babel` function, which provides some utility functions ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-e96809b29417d6281f84f3b6a2dd8674fb248b85f8ddffc46cb8355a18cff841R37-R38), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-c31daf59e1b7eb317897582e8443464d03d88a13bd5ecad2eaf44b84cf6a7d5cR35-R36))
*  Add a new section on debugging Babel configuration, which explains how to use the debug mode to view the final generated `babel-loader` configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-e96809b29417d6281f84f3b6a2dd8674fb248b85f8ddffc46cb8355a18cff841R226-R241), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-c31daf59e1b7eb317897582e8443464d03d88a13bd5ecad2eaf44b84cf6a7d5cR224-R239))
*  Capitalize the word "Babel" for consistency and correctness in all occurrences in the documentation and the README file of the plugin-module-babel package ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-2062fcddc68dde248c4a6b98e8f0a9c68b10b05fdd000cb36598b2bdfb6335d2L182-R182), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L184-R184), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L232-R242), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-e973d8362ca617a8bab5334833fc15ebff93d5823ae87ab98597eb0a7935fe81L68-R75), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-e973d8362ca617a8bab5334833fc15ebff93d5823ae87ab98597eb0a7935fe81L87-R87), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-e973d8362ca617a8bab5334833fc15ebff93d5823ae87ab98597eb0a7935fe81L93-R93), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-057d05e7df4d1b4eb40d5856e3419a4f587f37ed8385fc5ccf1ab109cd520f69L43-R43), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-0e8c4bce4203c3b7c2f022e897d369f2790cfcdc5baa2bca9904242c15bf742bL182-R182), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L200-R200), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L231-R239), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-61e9b6308f8819db84914f183dd09d9d0a5995e2102aff1170697d54aa53c62bL68-R75), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-61e9b6308f8819db84914f183dd09d9d0a5995e2102aff1170697d54aa53c62bL87-R87), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-61e9b6308f8819db84914f183dd09d9d0a5995e2102aff1170697d54aa53c62bL93-R93), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-9f204318c3d73d22c4d3a6cf4f6085a3d83698917f6178bc57ca916754627dbbL43-R43), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-5120997e6263471b2090ab0c8b9f7ee8f172b5f38548ef3e4a119927d5596904L20-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-9851f36409b8723099852b05480d2dc800c7a5c9d04ade54a6edc7dfed691febL20-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-763c8398e48df7a8d71966585ff22e6d9699df62cc570728f5cccacfb2d09cb2L9-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-999e57e70d33d6d85988f13c3544961a8c0fb8328d1abdec2009a066de7e174aL53-R53), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-b2273ae139c48c3568d433561df7a8b7ce2289d980ca6a92aa0dad539e6c87f1L9-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-df490092786f10ce9c53f9e808c3361a6610a5d9e467bc81656989ad05f0afa5L40-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-f3289067f803f0fb66eda5447f70ef5a03ad417aefba72b1b2b3c10ebcf08948L53-R55), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-a4e09de14a816008489fd319fdcaa4bdd8ed8c7e4985ebb3b137dde1d8f1a065L3-R5))
*  Add the word "plugin" or "插件" after "Babel" for clarity in all occurrences in the documentation ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L232-R242), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L200-R200), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L231-R239))
*  Wrap the word "babel-loader" with backticks to indicate that it is a code term in all occurrences in the documentation ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L184-R184))
*  Add a slash between "Babel" and "terser" for readability in all occurrences in the documentation ([link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-057d05e7df4d1b4eb40d5856e3419a4f587f37ed8385fc5ccf1ab109cd520f69L43-R43), [link](https://github.com/web-infra-dev/modern.js/pull/3909/files?diff=unified&w=0#diff-9f204318c3d73d22c4d3a6cf4f6085a3d83698917f6178bc57ca916754627dbbL43-R43))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
