### PR TITLE
chore: remove changeset zh summary check

### DIFF
--- a/scripts/check-changeset/src/index.ts
+++ b/scripts/check-changeset/src/index.ts
@@ -17,7 +17,7 @@ type NewChangeset = Changeset & {
 
 function checkChangeset(packages: Package[], changesets: NewChangeset[]) {
   for (const changeset of changesets) {
-    const { id, releases, summary } = changeset;
+    const { id, releases } = changeset;
     releases.forEach(release => {
       if (release.type === 'major') {
         throw Error(
@@ -28,11 +28,6 @@ function checkChangeset(packages: Package[], changesets: NewChangeset[]) {
         throw Error(`package ${release.name} is not found in ${id}.md file`);
       }
     });
-    if (summary.split('\n').filter(v => v).length < 2) {
-      throw Error(
-        `Changeset '${id}' should container English and Chinese info`,
-      );
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 285b4a6</samp>

Simplified the `check-changeset` script by removing unused code related to the old changeset format.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 285b4a6</samp>

* Remove summary check from changeset validation ([link](https://github.com/web-infra-dev/modern.js/pull/3911/files?diff=unified&w=0#diff-c42fc6c7648f3f80e2b76b3f7d59c107130732fb0cd715339b7c58d36db1089bL20-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3911/files?diff=unified&w=0#diff-c42fc6c7648f3f80e2b76b3f7d59c107130732fb0cd715339b7c58d36db1089bL31-L35))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
