### PR TITLE
fix(doc-plugin-preview): add origin in iframe src

### DIFF
--- a/.changeset/rotten-coins-march.md
+++ b/.changeset/rotten-coins-march.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-plugin-preview': patch
+---
+
+fix: add origin in iframe src
+fix: 在iframe src添加origin前缀

--- a/packages/cli/doc-plugin-preview/src/components/container.tsx
+++ b/packages/cli/doc-plugin-preview/src/components/container.tsx
@@ -105,7 +105,10 @@ const Container: React.FC<ContainerProps> = props => {
             <div className="flex">
               <div className="preview-code">{children?.[0]}</div>
               <div className="preview-device">
-                <iframe src={url} className="preview-device-iframe"></iframe>
+                <iframe
+                  src={getPageUrl()}
+                  className="preview-device-iframe"
+                ></iframe>
                 {renderMobileOperations()}
               </div>
             </div>


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77f9559</samp>

This pull request fixes some rendering issues in the `@modern-js/doc-plugin-preview` package. It changes the `demo.tsx` and `container.tsx` files to normalize the demo id and add the origin prefix in the iframe src. It also adds two changeset files to document the fixes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77f9559</samp>

*  Add changeset files to document fixes for `@modern-js/doc-plugin-preview` package ([link](https://github.com/web-infra-dev/modern.js/pull/3917/files?diff=unified&w=0#diff-060693026f06a55d7d93cd4cf35500f06bef1910bc3e5f0a4bebcfadd3fb414eR1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3917/files?diff=unified&w=0#diff-a3f524b12dc8c4765bede60ee13a02edb0de38f42b663fbc59e259b9f6d2e2a2R1-R6))
*  Fix iframe src by adding origin prefix in `container.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/3917/files?diff=unified&w=0#diff-4ce052c16237a559236edd2e96fe732a7a5ed7768005c21223c5f6ac70ae0e87L108-R111))
*  Fix demo component rendering by normalizing id in `demo.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/3917/files?diff=unified&w=0#diff-201b40cc919014934752f2f9aebec76d4d130485b3d0b6071ae8db4c135e5110L10-R12), [link](https://github.com/web-infra-dev/modern.js/pull/3917/files?diff=unified&w=0#diff-201b40cc919014934752f2f9aebec76d4d130485b3d0b6071ae8db4c135e5110R20-R29))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
