### PR TITLE
docs: fix duplicated menu position

### DIFF
--- a/packages/document/main-doc/docs/zh/guides/topic-detail/_category_.json
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "专题详解",
-  "position": 6,
+  "position": 8,
   "collapsed": false
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6e8233</samp>

Changed the sidebar order of the documentation website by modifying the `position` property of the `_category_` object in `packages/document/main-doc/docs/zh/guides/topic-detail/_category_.json`. This was done to improve the logical flow of the documentation content.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6e8233</samp>

* Change the position of the "专题详解" (Topic Detail) section in the sidebar from 6 to 8 ([link](https://github.com/web-infra-dev/modern.js/pull/3918/files?diff=unified&w=0#diff-54ec12d345a132767223de26d4ebcbad48cc0935eb2486c466dc9c30de8cd1daL3-R3))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
