### PR TITLE
fix(builder): incorrect importLoaders option for sass/less files

### DIFF
--- a/.changeset/metal-pens-decide.md
+++ b/.changeset/metal-pens-decide.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-plugin-stylus': patch
+---
+
+fix(builder): incorrect importLoaders option for sass/less files
+
+fix(builder): 修正 importLoaders 对于 sass/less 文件的值

--- a/packages/builder/builder-rspack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/css.ts
@@ -39,12 +39,17 @@ export const getCssnanoDefaultOptions = (): CssNanoOptions => ({
   ],
 });
 
-export async function applyBaseCSSRule(
-  rule: ReturnType<BundlerChain['module']['rule']>,
-  config: NormalizedConfig,
-  context: BuilderContext,
-  { target, isProd, isServer, isWebWorker, CHAIN_ID }: ModifyBundlerChainUtils,
-) {
+export async function applyBaseCSSRule({
+  rule,
+  config,
+  context,
+  utils: { target, isProd, isServer, isWebWorker, CHAIN_ID },
+}: {
+  rule: ReturnType<BundlerChain['module']['rule']>;
+  config: NormalizedConfig;
+  context: BuilderContext;
+  utils: ModifyBundlerChainUtils;
+}) {
   // 1. Check user config
   const enableExtractCSS = isUseCssExtract(config, target);
   const enableSourceMap = isUseCssSourceMap(config);
@@ -218,7 +223,12 @@ export const builderPluginCss = (): BuilderPlugin => {
         const rule = chain.module.rule(utils.CHAIN_ID.RULE.CSS);
         rule.test(CSS_REGEX).type('css');
 
-        await applyBaseCSSRule(rule, config, api.context, utils);
+        await applyBaseCSSRule({
+          rule,
+          utils,
+          config,
+          context: api.context,
+        });
       });
       api.modifyRspackConfig(
         async (rspackConfig, { isProd, isServer, isWebWorker }) => {

--- a/packages/builder/builder-rspack-provider/src/plugins/less.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/less.ts
@@ -18,7 +18,12 @@ export function builderPluginLess(): BuilderPlugin {
           .test(LESS_REGEX)
           .type('css');
 
-        await applyBaseCSSRule(rule, config, api.context, utils);
+        await applyBaseCSSRule({
+          rule,
+          utils,
+          config,
+          context: api.context,
+        });
 
         const { excludes, options } = await getLessLoaderOptions(
           config.tools.less,
@@ -29,7 +34,12 @@ export function builderPluginLess(): BuilderPlugin {
           rule.exclude.add(item);
         });
 
-        await applyBaseCSSRule(rule, config, api.context, utils);
+        await applyBaseCSSRule({
+          rule,
+          utils,
+          config,
+          context: api.context,
+        });
 
         rule
           .use(utils.CHAIN_ID.USE.LESS)

--- a/packages/builder/builder-rspack-provider/src/plugins/sass.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/sass.ts
@@ -32,7 +32,12 @@ export function builderPluginSass(): BuilderPlugin {
           rule.exclude.add(item);
         });
 
-        await applyBaseCSSRule(rule, config, api.context, utils);
+        await applyBaseCSSRule({
+          rule,
+          utils,
+          config,
+          context: api.context,
+        });
 
         rule
           .use(utils.CHAIN_ID.USE.SASS)

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -61,19 +61,19 @@ export const normalizeCssLoaderOptions = (
   return options;
 };
 
-export async function applyBaseCSSRule(
-  rule: BundlerChainRule,
-  config: NormalizedConfig,
-  context: BuilderContext,
-  {
-    target,
-    isProd,
-    isServer,
-    CHAIN_ID,
-    isWebWorker,
-    getCompiledPath,
-  }: ModifyChainUtils,
-) {
+export async function applyBaseCSSRule({
+  rule,
+  config,
+  context,
+  utils: { target, isProd, isServer, CHAIN_ID, isWebWorker, getCompiledPath },
+  importLoaders = 1,
+}: {
+  rule: BundlerChainRule;
+  config: NormalizedConfig;
+  context: BuilderContext;
+  utils: ModifyChainUtils;
+  importLoaders?: number;
+}) {
   const { applyOptionsChain } = await import('@modern-js/utils');
   const browserslist = await getBrowserslistWithDefault(
     context.rootPath,
@@ -172,7 +172,7 @@ export async function applyBaseCSSRule(
 
   const mergedCssLoaderOptions = applyOptionsChain<CSSLoaderOptions, null>(
     {
-      importLoaders: 1,
+      importLoaders,
       modules: {
         auto: getCssModulesAutoRule(
           cssModules,
@@ -258,7 +258,12 @@ export const builderPluginCss = (): BuilderPlugin => {
         const rule = chain.module.rule(utils.CHAIN_ID.RULE.CSS);
         const config = api.getNormalizedConfig();
         rule.test(CSS_REGEX);
-        await applyBaseCSSRule(rule, config, api.context, utils);
+        await applyBaseCSSRule({
+          rule,
+          utils,
+          config,
+          context: api.context,
+        });
       });
     },
   };

--- a/packages/builder/builder-webpack-provider/src/plugins/less.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/less.ts
@@ -30,7 +30,13 @@ export function builderPluginLess(): BuilderPlugin {
           rule.exclude.add(item);
         });
 
-        await applyBaseCSSRule(rule, config, api.context, utils);
+        await applyBaseCSSRule({
+          rule,
+          utils,
+          config,
+          context: api.context,
+          importLoaders: 2,
+        });
 
         rule
           .use(utils.CHAIN_ID.USE.LESS)

--- a/packages/builder/builder-webpack-provider/src/plugins/sass.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/sass.ts
@@ -30,7 +30,13 @@ export function builderPluginSass(): BuilderPlugin {
           rule.exclude.add(item);
         });
 
-        await applyBaseCSSRule(rule, config, api.context, utils);
+        await applyBaseCSSRule({
+          rule,
+          utils,
+          config,
+          context: api.context,
+          importLoaders: 2,
+        });
 
         rule
           .use(utils.CHAIN_ID.USE.SASS)

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -306,7 +306,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -369,7 +369,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -1216,7 +1216,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -1279,7 +1279,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -2140,7 +2140,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -2169,7 +2169,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -2914,7 +2914,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -2943,7 +2943,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
@@ -277,7 +277,7 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -349,7 +349,7 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -607,7 +607,7 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -679,7 +679,7 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
           {
             "loader": "<ROOT>/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",

--- a/packages/builder/plugin-stylus/src/index.ts
+++ b/packages/builder/plugin-stylus/src/index.ts
@@ -50,12 +50,23 @@ export function builderPluginStylus(
           const { applyBaseCSSRule } = await import(
             '@modern-js/builder-rspack-provider/plugins/css'
           );
-          await applyBaseCSSRule(rule, config as any, api.context, utils);
+          await applyBaseCSSRule({
+            rule,
+            config: config as any,
+            context: api.context,
+            utils,
+          });
         } else {
           const { applyBaseCSSRule } = await import(
             '@modern-js/builder-webpack-provider/plugins/css'
           );
-          await applyBaseCSSRule(rule, config, api.context, utils);
+          await applyBaseCSSRule({
+            rule,
+            config,
+            context: api.context,
+            utils,
+            importLoaders: 2,
+          });
         }
 
         rule

--- a/packages/builder/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -14,7 +14,7 @@ exports[`plugins/stylus > should add stylus loader config correctly 1`] = `
           {
             "loader": "<WORKSPACE>/packages/builder/builder-webpack-provider/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",
@@ -85,7 +85,7 @@ exports[`plugins/stylus > should allow to configure stylus options 1`] = `
           {
             "loader": "<WORKSPACE>/packages/builder/builder-webpack-provider/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportLocalsConvention": "camelCase",

--- a/packages/document/builder-doc/docs/en/config/tools/cssLoader.md
+++ b/packages/document/builder-doc/docs/en/config/tools/cssLoader.md
@@ -6,7 +6,6 @@ The config of [css-loader](https://github.com/webpack-contrib/css-loader) can be
 
 ```js
 {
-  importLoaders: 1,
   modules: {
     auto: true,
     exportLocalsConvention: 'camelCase',
@@ -17,6 +16,8 @@ The config of [css-loader](https://github.com/webpack-contrib/css-loader) can be
   },
   // CSS Source Map enabled by default in development environment
   sourceMap: isDev,
+  // importLoaders is `1` when compiling css files, and is `2` when compiling sass/less files
+  importLoaders: 1 || 2,
 }
 ```
 

--- a/packages/document/builder-doc/docs/zh/config/tools/cssLoader.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/cssLoader.md
@@ -5,7 +5,6 @@
 
 ```js
 {
-  importLoaders: 1,
   modules: {
     auto: true,
     exportLocalsConvention: 'camelCase',
@@ -16,6 +15,8 @@
   },
   // 默认在开发环境下启用 CSS 的 Source Map
   sourceMap: isDev,
+  // importLoaders 在编译 css 文件时为 `1`，在编译 sass/less 文件时为 `2`
+  importLoaders: 1 || 2,
 }
 ```
 

--- a/tests/e2e/builder/cases/css/import-loaders/index.test.ts
+++ b/tests/e2e/builder/cases/css/import-loaders/index.test.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import { expect } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import { webpackOnlyTest } from '../../../scripts/helper';
+
+webpackOnlyTest(
+  'should compile CSS modules which depends on importLoaders correctly',
+  async () => {
+    const builder = await build({
+      cwd: __dirname,
+      entry: { index: path.resolve(__dirname, './src/index.js') },
+      builderConfig: {
+        output: {
+          disableSourceMap: true,
+        },
+      },
+    });
+    const files = await builder.unwrapOutputJSON();
+
+    const content =
+      files[Object.keys(files).find(file => file.endsWith('.css'))!];
+
+    expect(content).toEqual(
+      '.yQ8Tl+.hello-class-foo{background-color:red}.TVH2T .hello-class-bar{background-color:blue}',
+    );
+  },
+);

--- a/tests/e2e/builder/cases/css/import-loaders/src/a.module.less
+++ b/tests/e2e/builder/cases/css/import-loaders/src/a.module.less
@@ -1,0 +1,2 @@
+@value class-foo from "./b.module.less";
+@value class-bar from "./b.module.less";

--- a/tests/e2e/builder/cases/css/import-loaders/src/b.module.less
+++ b/tests/e2e/builder/cases/css/import-loaders/src/b.module.less
@@ -1,0 +1,15 @@
+@prefix: hello;
+
+.class-foo {
+  & + :global(.@{prefix}-class-foo) {
+    background-color: red;
+  }
+}
+
+.class-bar {
+  :global {
+    .@{prefix}-class-bar {
+      background-color: blue;
+    }
+  }
+}

--- a/tests/e2e/builder/cases/css/import-loaders/src/index.js
+++ b/tests/e2e/builder/cases/css/import-loaders/src/index.js
@@ -1,0 +1,5 @@
+import a from './a.module.less';
+import b from './b.module.less';
+
+console.log(a);
+console.log(b);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5dff248</samp>

This pull request refactors the `applyBaseCSSRule` function and its usage across different packages and plugins, to simplify its interface and improve its flexibility. It also updates the documentation and adds a new test case for the `importLoaders` option of the `css-loader`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5dff248</samp>

*  Refactor `applyBaseCSSRule` function to use object parameter and add `importLoaders` option ([link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-cf2a0cdc15b2ccf34cfd27ba9028db6a8e4fcfa3fc988bf6d7a374d61a337b5fL42-R52), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-b9af00201a8872c1f27b2c30486af0079c52b2308b819a712c5433f964c6fc5bL64-R76), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-b9af00201a8872c1f27b2c30486af0079c52b2308b819a712c5433f964c6fc5bL175-R175))
*  Update calls to `applyBaseCSSRule` function in `css.ts`, `less.ts`, `sass.ts`, and `index.ts` files of various packages to match new signature and pass `importLoaders` value ([link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-cf2a0cdc15b2ccf34cfd27ba9028db6a8e4fcfa3fc988bf6d7a374d61a337b5fL221-R231), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-5e1c5402a3240dda006300b182128af8417e065ba4ed08e96cdd8c5b3b4045caL21-R26), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-5e1c5402a3240dda006300b182128af8417e065ba4ed08e96cdd8c5b3b4045caL32-R42), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-e26b6ac5407632d9ab7c3f2147ccf91d560e91bf412b31b9430823bfe207a6f2L35-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-b9af00201a8872c1f27b2c30486af0079c52b2308b819a712c5433f964c6fc5bL261-R266), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-eb03a9426c87359e15ec37c3b7142bb24cc4f960928092916bbba139a4f7a670L33-R39), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-9917a0079ac77e650ed304b6d446f4915be2ddd16053d25a4b73a6eac03b2d7bL33-R39), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-6b3d781c72e48d6da544ca91e2156610b231884f8b5535b4cb100b39d46a3247L53-R69))
*  Remove `importLoaders: 1` option from `cssLoader` configuration examples in English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-cdb4383db0a9920882052dbbeb8940b29467509bb1449a18eb4686aef93bb8d8L9), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-895a0a257e5ad7277d429adbad38e7a6e0ee924f49c89826e90b40ce5e5e19d1L8))
*  Add comment to `cssLoader` configuration examples in English and Chinese documentation explaining default and customizable `importLoaders` values ([link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-cdb4383db0a9920882052dbbeb8940b29467509bb1449a18eb4686aef93bb8d8R19-R20), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-895a0a257e5ad7277d429adbad38e7a6e0ee924f49c89826e90b40ce5e5e19d1R18-R19))
*  Add test case to verify `importLoaders` option works correctly for CSS modules in `builder-webpack-provider` ([link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-e949f6725fccb6f07f76908018691c9dcda53ad6010a72acb82795443653799aR1-R27), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-dcf6fb25c76fe99ad9d6998e8b20b97a540721346df30c38cc5a560358171017R1-R2), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-0c65fd3ced68cec97f0453878d15d8dcf509c649d9db4da8c36e13417f81416cR1-R15), [link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-1c3431e578320d7c6cccd56c909e81fd33dd38c65660eebeab7a10c9180fd08bR1-R5))
*  Add changeset file to describe affected packages and versions and summarize fix ([link](https://github.com/web-infra-dev/modern.js/pull/3922/files?diff=unified&w=0#diff-9668d650a8bb4ed4dec65f65ee0a3dbb5e1f64f81e0ffacbb37783d121e0d1dbR1-R9))

## Related Issue

- https://github.com/facebook/create-react-app/pull/8281

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
