### PR TITLE
fix(builder): single-vendor chunkSplit not work as expected

### DIFF
--- a/.changeset/strange-bobcats-occur.md
+++ b/.changeset/strange-bobcats-occur.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder': patch
+---
+
+fix(builder): single-vendor chunkSplit not work as expected
+
+fix(builder): single-vendor 拆包规则未按照预期生效

--- a/packages/builder/builder-shared/src/constants.ts
+++ b/packages/builder/builder-shared/src/constants.ts
@@ -71,7 +71,7 @@ export const SASS_REGEX = /\.s(a|c)ss$/;
 export const STYLUS_REGEX = /\.styl$/;
 export const CSS_MODULES_REGEX = /\.module\.\w+$/i;
 export const GLOBAL_CSS_REGEX = /\.global\.\w+$/;
-export const NODE_MODULES_REGEX = /node_modules/;
+export const NODE_MODULES_REGEX = /[\\/]node_modules[\\/]/;
 export const MODULE_PATH_REGEX =
   /[\\/]node_modules[\\/](\.pnpm[\\/])?(?:(@[^[\\/]+)(?:[\\/]))?([^\\/]+)/;
 

--- a/packages/builder/builder/tests/plugins/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/builder/builder/tests/plugins/__snapshots__/splitChunks.test.ts.snap
@@ -84,7 +84,16 @@ exports[`plugins/splitChunks > should set single-vendor config 1`] = `
       "name": "builder-runtime",
     },
     "splitChunks": {
-      "cacheGroups": {},
+      "cacheGroups": {
+        "singleVendor": {
+          "chunks": "all",
+          "enforce": true,
+          "name": "vendor",
+          "priority": 0,
+          "reuseExistingChunk": true,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+        },
+      },
       "chunks": "all",
       "enforceSizeThreshold": 50000,
     },

--- a/tests/e2e/builder/cases/performance/basic/src/index.ts
+++ b/tests/e2e/builder/cases/performance/basic/src/index.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-dom';
+import ReactDOM from 'react-dom';
 import App from './App';
 
-render(React.createElement(App), document.getElementById('root'));
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/tests/e2e/builder/cases/performance/performance.test.ts
+++ b/tests/e2e/builder/cases/performance/performance.test.ts
@@ -75,3 +75,32 @@ allProviderTest('removeConsole', async () => {
   expect(jsFile.includes('test-console-warn')).toBeFalsy();
   expect(jsFile.includes('test-console-error')).toBeTruthy();
 });
+
+allProviderTest(
+  'should generate vendor chunk when chunkSplit is "single-vendor"',
+  async () => {
+    const builder = await build(
+      {
+        cwd: join(fixtures, 'basic'),
+        entry: {
+          main: join(fixtures, 'basic/src/index.ts'),
+        },
+      },
+      {
+        performance: {
+          chunkSplit: {
+            strategy: 'single-vendor',
+          },
+        },
+      },
+    );
+
+    const files = await builder.unwrapOutputJSON();
+
+    const [vendorFile] = Object.entries(files).find(
+      ([name, content]) => name.includes('vendor') && content.includes('React'),
+    )!;
+
+    expect(vendorFile).toBeTruthy();
+  },
+);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34bb8d3</samp>

This pull request fixes the single-vendor chunkSplit strategy for the `@modern-js/builder` package and adds a test case to verify its functionality. It also refactors some code to use a shared constant for the `node_modules` regex and to avoid a naming conflict in the test files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 34bb8d3</samp>

*  Add a changeset file to document the patch updates and the fix for the single-vendor chunkSplit strategy ([link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-79c4f7efc3803fe064b94eb5ba603d8f783e125382c0fdc112802b7e509661b9R1-R8))
*  Export the `NODE_MODULES_REGEX` constant from the `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-d75bc2bebe393676e9833866225d34ae065324dcbf284d725b6971c46a766bd3L74-R74))
*  Use the `NODE_MODULES_REGEX` constant in the `@modern-js/builder` package to split chunks by module and vendor name ([link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-acd8a3657576d12badbc5b7b055318732b09ef565ffcee6e27629005bf5f1951R3), [link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-acd8a3657576d12badbc5b7b055318732b09ef565ffcee6e27629005bf5f1951L166-R167))
*  Add a new parameter to the `singleVendor` function to allow user defined cache groups ([link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-acd8a3657576d12badbc5b7b055318732b09ef565ffcee6e27629005bf5f1951L218-R233))
*  Return the `singleVendorCacheGroup` object and merge it with the other cache groups in the `singleVendor` function ([link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-acd8a3657576d12badbc5b7b055318732b09ef565ffcee6e27629005bf5f1951R239-R240))
*  Replace the `render` function import with the `ReactDOM` namespace import in the `basic` test case to avoid a conflict ([link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-cf59a9adec3b0e6446b9b641a02b012301df33cfb3336a065a13bd132caa26eeL2-R5))
*  Add a new test case to check if the single-vendor chunkSplit strategy generates a vendor chunk that contains React ([link](https://github.com/web-infra-dev/modern.js/pull/3924/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aR78-R106))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
