### PR TITLE
docs: improve compatibility chapter

### DIFF
--- a/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
@@ -6,9 +6,9 @@ sidebar_position: 5
 
 ## Browserslist Configuration
 
-Modern.js supports setting the browserslist for your web applications. You can set the [Browserslist](https://browsersl.ist/) in the `.browserslistrc` file.
+Modern.js supports setting the browserslist for your web applications. You can set the value of [Browserslist](https://browsersl.ist/) in the `.browserslistrc` file.
 
-When you create a new Modern.js project, it includes a `.browserslistrc` configuration by default, which means that JavaScript code will be compiled to ES6.
+When you create a new Modern.js project, it will includes a `.browserslistrc` configuration by default, which means that the JavaScript code will be compiled to ES6.
 
 ```yaml title=".browserslistrc"
 chrome >= 51
@@ -22,32 +22,11 @@ ios_saf >= 10
 Please refer to [Modern.js Builder - Browserslist](https://modernjs.dev/builder/en/guide/advanced/browserslist) for more information.
 :::
 
-## Browserslist
-
-Modern.js supports the `browserslist` field in the `package.json` file, or a `.browserslistrc` file to specify the target browser range covered by the project.
-
-This value is used by ['@babel/preset-env'] (https://babeljs.io/docs/en/babel-preset-env) and ['autoprefixer'] (https://github.com/postcss/autoprefixer) to determine the JavaScript syntax features to be converted and the CSS browser prefix to be added.
-
-The default value in Modern.js as follow:
-
-```js
-['> 0.01%', 'not dead', 'not op_mini all'];
-```
-
-You can learn how to customize the browserslist [here](https://github.com/browserslist/browserslist).
-
-See Modern.js Builder docs to learn more [Browserslist](https://modernjs.dev/builder/en/guide/advanced/browserslist.html) info.
-
-:::note
-Modern.js also supports configuring [output.override Browserslist](/configure/app/output/override-browserslist) to override the default browserslist value.
-
-:::
-
 ## Polyfill
 
 ### Polyfill At Compile
 
-Modern.js inject the Polyfill code via [core-js] (https://github.com/zloirock/core-js) at compile time by default.
+Modern.js defaults to importing corresponding polyfill code through [core-js] (https://github.com/zloirock/core-js) during compilation.
 
 By default, the required Polyfill code will be introduced according to the settings of the Browserslist, so there is no need to worry about the Polyfill problem of the project source code and third-party dependencies, but because it contains some Polyfill code that is not used, the final bundle size may be increased.
 

--- a/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
@@ -26,7 +26,7 @@ Please refer to [Modern.js Builder - Browserslist](https://modernjs.dev/builder/
 
 ### Polyfill At Compile
 
-Modern.js defaults to importing corresponding polyfill code through [core-js] (https://github.com/zloirock/core-js) during compilation.
+Modern.js defaults to importing corresponding polyfill code from [core-js] (https://github.com/zloirock/core-js) during compilation.
 
 By default, the required Polyfill code will be introduced according to the settings of the Browserslist, so there is no need to worry about the Polyfill problem of the project source code and third-party dependencies, but because it contains some Polyfill code that is not used, the final bundle size may be increased.
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 415cd66</samp>

This pull request enhances the compatibility guide for `modern.js` by correcting and simplifying the documentation and the `.browserslistrc` file example.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 415cd66</samp>

*  Clarify and fix the documentation about Browserslist and Polyfill in `compatibility.mdx` ([link](https://github.com/web-infra-dev/modern.js/pull/3928/files?diff=unified&w=0#diff-7f31c05c259853063fea86db5178890ae9ccb82ccc9f512c297b0e63a26c5193L9-R11), [link](https://github.com/web-infra-dev/modern.js/pull/3928/files?diff=unified&w=0#diff-7f31c05c259853063fea86db5178890ae9ccb82ccc9f512c297b0e63a26c5193L25-R29))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
