### PR TITLE
chore: lock `zod-validation-error` to compatible with Node.js@14

### DIFF
--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -114,7 +114,7 @@
     "webpack": "^5.82.1",
     "webpack-sources": "^3.2.3",
     "zod": "^3.20.2",
-    "zod-validation-error": "~1.2.1"
+    "zod-validation-error": "1.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -114,7 +114,7 @@
     "webpack": "^5.82.1",
     "webpack-sources": "^3.2.3",
     "zod": "^3.20.2",
-    "zod-validation-error": "^0.3.0"
+    "zod-validation-error": "~1.2.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ importers:
         specifier: ^3.20.2
         version: 3.20.2
       zod-validation-error:
-        specifier: ^0.3.0
-        version: 0.3.0(zod@3.20.2)
+        specifier: ~1.2.1
+        version: 1.2.1(zod@3.20.2)
     devDependencies:
       '@babel/preset-env':
         specifier: ^7.21.5
@@ -34275,9 +34275,9 @@ packages:
       commander: 2.20.3
     dev: false
 
-  /zod-validation-error@0.3.0(zod@3.20.2):
-    resolution: {integrity: sha512-M0g8+1fgEgz6do82lA90v1IA4WXOK7TxAHqohAPktNJbTacl7tI74JS38AUWJPIJgDjUkhtEuLkUUFl3uhneyA==}
-    engines: {node: ^14.17 || >=16.0.0}
+  /zod-validation-error@1.2.1(zod@3.20.2):
+    resolution: {integrity: sha512-xsWqzuFukr0C56QSoDCOJPrFOGWSmktNbTSPxV2ntT2ikUf1dOqHuM0Nt8g28Up7Cz889NTX8rc4K8LN7vy0Vw==}
+    engines: {node: '>=16.0.0'}
     peerDependencies:
       zod: ^3.18.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ importers:
         specifier: ^3.20.2
         version: 3.20.2
       zod-validation-error:
-        specifier: ~1.2.1
-        version: 1.2.1(zod@3.20.2)
+        specifier: 1.2.0
+        version: 1.2.0(zod@3.20.2)
     devDependencies:
       '@babel/preset-env':
         specifier: ^7.21.5
@@ -34275,9 +34275,9 @@ packages:
       commander: 2.20.3
     dev: false
 
-  /zod-validation-error@1.2.1(zod@3.20.2):
-    resolution: {integrity: sha512-xsWqzuFukr0C56QSoDCOJPrFOGWSmktNbTSPxV2ntT2ikUf1dOqHuM0Nt8g28Up7Cz889NTX8rc4K8LN7vy0Vw==}
-    engines: {node: '>=16.0.0'}
+  /zod-validation-error@1.2.0(zod@3.20.2):
+    resolution: {integrity: sha512-laJkD/ugwEh8CpuH+xXv5L9Z+RLz3lH8alNxolfaHZJck611OJj97R4Rb+ZqA7WNly2kNtTo4QwjdjXw9scpiw==}
+    engines: {node: ^14.17 || >=16.0.0}
     peerDependencies:
       zod: ^3.18.0
     dependencies:


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f305f07</samp>

Updated `zod-validation-error` dependency to use tilde version range in `builder-shared` package. This prevents breaking changes from affecting the error formatting functionality.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f305f07</samp>

*  Restrict `zod-validation-error` dependency to patch updates only ([link](https://github.com/web-infra-dev/modern.js/pull/3932/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L117-R117)) to prevent breaking changes in error formatting

## Related Issue

- https://github.com/web-infra-dev/rspack/pull/3510

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
