### PR TITLE
test(e2e): improve builder test stability

### DIFF
--- a/packages/builder/builder-shared/src/prodServer.ts
+++ b/packages/builder/builder-shared/src/prodServer.ts
@@ -56,7 +56,7 @@ export async function startProdServer(
 
   const { getPort, DEFAULT_DEV_HOST } = await import('@modern-js/utils');
 
-  const port = await getPort(DEFAULT_PORT);
+  const port = await getPort(builderConfig.dev?.port || DEFAULT_PORT);
   const server = await prodServer({
     pwd: context.rootPath,
     config: getServerOptions(builderConfig),

--- a/tests/e2e/builder/cases/cache/index.test.ts
+++ b/tests/e2e/builder/cases/cache/index.test.ts
@@ -1,8 +1,8 @@
 import path from 'path';
-import { fs } from '@modern-js/utils';
 import { expect } from '@modern-js/e2e/playwright';
 import { webpackOnlyTest } from '@scripts/helper';
 import { build } from '@scripts/shared';
+import { fs } from '@modern-js/utils';
 
 webpackOnlyTest(
   'should save the buildDependencies to cache directory',

--- a/tests/e2e/builder/cases/check-syntax/index.test.ts
+++ b/tests/e2e/builder/cases/check-syntax/index.test.ts
@@ -1,9 +1,8 @@
 import path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
-import { allProviderTest } from '@scripts/helper';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
 
-allProviderTest('should throw error when exist syntax errors', async () => {
+test('should throw error when exist syntax errors', async () => {
   await expect(
     build(
       {

--- a/tests/e2e/builder/cases/html/app-icon/index.test.ts
+++ b/tests/e2e/builder/cases/html/app-icon/index.test.ts
@@ -27,8 +27,6 @@ test('should emit app icon to dist path', async () => {
 });
 
 test('should apply asset prefix to app icon URL', async () => {
-  process.env.NODE_ENV = 'production';
-
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },

--- a/tests/e2e/builder/cases/html/html.test.ts
+++ b/tests/e2e/builder/cases/html/html.test.ts
@@ -2,7 +2,6 @@ import { join } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { fs } from '@modern-js/utils';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
@@ -24,7 +23,7 @@ test.describe('html configure multi', () => {
     });
   });
 
-  allProviderTest('mountId', async ({ page }) => {
+  test('mountId', async ({ page }) => {
     await page.goto(getHrefByEntryName('main', builder.port));
 
     await expect(
@@ -32,13 +31,13 @@ test.describe('html configure multi', () => {
     ).resolves.toBe('Hello Builder!');
   });
 
-  allProviderTest('title default', async ({ page }) => {
+  test('title default', async ({ page }) => {
     await page.goto(getHrefByEntryName('main', builder.port));
 
     await expect(page.evaluate(`document.title`)).resolves.toBe('');
   });
 
-  allProviderTest('inject default (head)', async () => {
+  test('inject default (head)', async () => {
     const pagePath = join(builder.distPath, 'html/main/index.html');
     const content = await fs.readFile(pagePath, 'utf-8');
 
@@ -87,7 +86,7 @@ test.describe('html element set', () => {
     );
   });
 
-  allProviderTest('appicon', async () => {
+  test('appicon', async () => {
     const [, iconRelativePath] =
       /<link.*rel="apple-touch-icon".*href="(.*?)">/.exec(mainContent) || [];
 
@@ -102,7 +101,7 @@ test.describe('html element set', () => {
     ).toBeTruthy();
   });
 
-  allProviderTest('favicon', async () => {
+  test('favicon', async () => {
     const [, iconRelativePath] =
       /<link.*rel="icon".*href="(.*?)">/.exec(mainContent) || [];
 
@@ -115,7 +114,7 @@ test.describe('html element set', () => {
     expect(/<link.*rel="icon".*href="(.*?)">/.test(fooContent)).toBeTruthy();
   });
 
-  allProviderTest('custom inject', async () => {
+  test('custom inject', async () => {
     expect(
       /<head>[\s\S]*<script[\s\S]*>[\s\S]*<\/head>/.test(mainContent),
     ).toBeFalsy();
@@ -124,7 +123,7 @@ test.describe('html element set', () => {
     ).toBeTruthy();
   });
 
-  allProviderTest('custom meta', async () => {
+  test('custom meta', async () => {
     expect(
       /<meta name="description" content="a description of the page">/.test(
         mainContent,
@@ -132,7 +131,7 @@ test.describe('html element set', () => {
     ).toBeTruthy();
   });
 
-  allProviderTest('custom crossorigin', async () => {
+  test('custom crossorigin', async () => {
     const allScripts = /(<script [\s\S]*?>)/g.exec(mainContent);
 
     expect(
@@ -141,7 +140,7 @@ test.describe('html element set', () => {
   });
 });
 
-allProviderTest('custom title', async ({ page }) => {
+test('custom title', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'template'),
     entry: {
@@ -160,7 +159,7 @@ allProviderTest('custom title', async ({ page }) => {
   await expect(page.evaluate(`document.title`)).resolves.toBe('custom title');
 });
 
-allProviderTest('template & templateParameters', async ({ page }) => {
+test('template & templateParameters', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'template'),
     entry: {
@@ -193,95 +192,89 @@ allProviderTest('template & templateParameters', async ({ page }) => {
   await expect(page.evaluate(`window.foo`)).resolves.toBe('bar');
 });
 
-allProviderTest(
-  'templateByEntries & templateParametersByEntries',
-  async ({ page }) => {
-    const buildOpts = {
-      cwd: join(fixtures, 'template'),
-      entry: {
-        main: join(fixtures, 'template/src/index.ts'),
-        foo: join(fixtures, 'template/src/index.ts'),
-        bar: join(fixtures, 'template/src/index.ts'),
-      },
-    };
+test('templateByEntries & templateParametersByEntries', async ({ page }) => {
+  const buildOpts = {
+    cwd: join(fixtures, 'template'),
+    entry: {
+      main: join(fixtures, 'template/src/index.ts'),
+      foo: join(fixtures, 'template/src/index.ts'),
+      bar: join(fixtures, 'template/src/index.ts'),
+    },
+  };
 
-    const builder = await build(buildOpts, {
-      html: {
-        templateByEntries: {
-          foo: './static/foo.html',
-          bar: './static/bar.html',
+  const builder = await build(buildOpts, {
+    html: {
+      templateByEntries: {
+        foo: './static/foo.html',
+        bar: './static/bar.html',
+      },
+      templateParametersByEntries: {
+        foo: {
+          type: 'foo',
         },
-        templateParametersByEntries: {
-          foo: {
-            type: 'foo',
-          },
-          bar: {
-            type: 'bar',
-          },
+        bar: {
+          type: 'bar',
         },
       },
-    });
+    },
+  });
 
-    await page.goto(getHrefByEntryName('foo', builder.port));
+  await page.goto(getHrefByEntryName('foo', builder.port));
 
-    await expect(
-      page.evaluate(`document.getElementById('test-template').innerHTML`),
-    ).resolves.toBe('foo');
+  await expect(
+    page.evaluate(`document.getElementById('test-template').innerHTML`),
+  ).resolves.toBe('foo');
 
-    await expect(page.evaluate(`window.type`)).resolves.toBe('foo');
+  await expect(page.evaluate(`window.type`)).resolves.toBe('foo');
 
-    await page.goto(getHrefByEntryName('bar', builder.port));
+  await page.goto(getHrefByEntryName('bar', builder.port));
 
-    await expect(
-      page.evaluate(`document.getElementById('test-template').innerHTML`),
-    ).resolves.toBe('bar');
+  await expect(
+    page.evaluate(`document.getElementById('test-template').innerHTML`),
+  ).resolves.toBe('bar');
 
-    await expect(page.evaluate(`window.type`)).resolves.toBe('bar');
-  },
-);
+  await expect(page.evaluate(`window.type`)).resolves.toBe('bar');
+});
 
-allProviderTest(
-  'title & titleByEntries & templateByEntries',
-  async ({ page }) => {
-    const buildOpts = {
-      cwd: join(fixtures, 'template'),
-      entry: {
-        main: join(fixtures, 'template/src/index.ts'),
-        foo: join(fixtures, 'template/src/index.ts'),
-        bar: join(fixtures, 'template/src/index.ts'),
+test('title & titleByEntries & templateByEntries', async ({ page }) => {
+  const buildOpts = {
+    cwd: join(fixtures, 'template'),
+    entry: {
+      main: join(fixtures, 'template/src/index.ts'),
+      foo: join(fixtures, 'template/src/index.ts'),
+      bar: join(fixtures, 'template/src/index.ts'),
+    },
+  };
+
+  // priority: template title > titleByEntries > title
+  const builder = await build(buildOpts, {
+    html: {
+      title: 'custom title',
+      titleByEntries: {
+        foo: 'Tiktok',
       },
-    };
-
-    // priority: template title > titleByEntries > title
-    const builder = await build(buildOpts, {
-      html: {
-        title: 'custom title',
-        titleByEntries: {
-          foo: 'Tiktok',
-        },
-        templateByEntries: {
-          bar: './static/index.html',
-        },
-        templateParameters: {
-          foo: 'bar',
-        },
+      templateByEntries: {
+        bar: './static/index.html',
       },
-    });
+      templateParameters: {
+        foo: 'bar',
+      },
+    },
+  });
 
-    await page.goto(getHrefByEntryName('main', builder.port));
-    await expect(page.evaluate(`document.title`)).resolves.toBe('custom title');
+  await page.goto(getHrefByEntryName('main', builder.port));
+  await expect(page.evaluate(`document.title`)).resolves.toBe('custom title');
 
-    await page.goto(getHrefByEntryName('foo', builder.port));
-    await expect(page.evaluate(`document.title`)).resolves.toBe('Tiktok');
+  await page.goto(getHrefByEntryName('foo', builder.port));
+  await expect(page.evaluate(`document.title`)).resolves.toBe('Tiktok');
 
-    await page.goto(getHrefByEntryName('bar', builder.port));
-    await expect(page.evaluate(`document.title`)).resolves.toBe(
-      'custom template',
-    );
-  },
-);
+  await page.goto(getHrefByEntryName('bar', builder.port));
+  await expect(page.evaluate(`document.title`)).resolves.toBe(
+    'custom template',
+  );
+});
 
-allProviderTest('disableHtmlFolder', async ({ page }) => {
+test('disableHtmlFolder', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'template'),
     entry: {
@@ -302,7 +295,7 @@ allProviderTest('disableHtmlFolder', async ({ page }) => {
   expect(fs.existsSync(pagePath)).toBeTruthy();
 });
 
-allProviderTest('tools.htmlPlugin', async ({ page }) => {
+test('tools.htmlPlugin', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'template'),
     entry: {

--- a/tests/e2e/builder/cases/legalComments/index.test.ts
+++ b/tests/e2e/builder/cases/legalComments/index.test.ts
@@ -1,11 +1,11 @@
 import { join } from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest, webpackOnlyTest } from '@scripts/helper';
+import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
-allProviderTest('legalComments linked (default)', async ({ page }) => {
+test('legalComments linked (default)', async ({ page }) => {
   const buildOpts = {
     cwd: fixtures,
     entry: {
@@ -51,7 +51,7 @@ allProviderTest('legalComments linked (default)', async ({ page }) => {
   builder.close();
 });
 
-allProviderTest('legalComments none', async ({ page }) => {
+test('legalComments none', async ({ page }) => {
   const buildOpts = {
     cwd: fixtures,
     entry: {

--- a/tests/e2e/builder/cases/manifest/index.test.ts
+++ b/tests/e2e/builder/cases/manifest/index.test.ts
@@ -1,11 +1,10 @@
 import { join } from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
-allProviderTest('enableAssetManifest', async () => {
+test('enableAssetManifest', async () => {
   const buildOpts = {
     cwd: fixtures,
     entry: {

--- a/tests/e2e/builder/cases/node-polyfill/index.test.ts
+++ b/tests/e2e/builder/cases/node-polyfill/index.test.ts
@@ -1,29 +1,27 @@
 import path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
-import { allProviderTest } from '@scripts/helper';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
 import { builderPluginNodePolyfill } from '@modern-js/builder-plugin-node-polyfill';
 
-allProviderTest(
-  'should add node-polyfill when add node-polyfill plugin',
-  async ({ page }) => {
-    const builder = await build({
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-      plugins: [builderPluginNodePolyfill()],
-    });
-    await page.goto(getHrefByEntryName('index', builder.port));
+test('should add node-polyfill when add node-polyfill plugin', async ({
+  page,
+}) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    plugins: [builderPluginNodePolyfill()],
+  });
+  await page.goto(getHrefByEntryName('index', builder.port));
 
-    await expect(
-      page.evaluate(`document.getElementById('test').innerHTML`),
-    ).resolves.toBe('Hello Builder!');
+  await expect(
+    page.evaluate(`document.getElementById('test').innerHTML`),
+  ).resolves.toBe('Hello Builder!');
 
-    await expect(
-      page.evaluate(`document.getElementById('test-buffer').innerHTML`),
-    ).resolves.toBe('120120120120');
+  await expect(
+    page.evaluate(`document.getElementById('test-buffer').innerHTML`),
+  ).resolves.toBe('120120120120');
 
-    await expect(
-      page.evaluate(`document.getElementById('test-querystring').innerHTML`),
-    ).resolves.toBe('foo=bar');
-  },
-);
+  await expect(
+    page.evaluate(`document.getElementById('test-querystring').innerHTML`),
+  ).resolves.toBe('foo=bar');
+});

--- a/tests/e2e/builder/cases/output/assets.test.ts
+++ b/tests/e2e/builder/cases/output/assets.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
@@ -59,7 +58,7 @@ const cases = [
 ];
 
 cases.forEach(_case => {
-  allProviderTest(_case.name, async ({ page }) => {
+  test(_case.name, async ({ page }) => {
     const buildOpts = {
       cwd: _case.cwd,
       entry: {

--- a/tests/e2e/builder/cases/output/externals/tests/index.test.ts
+++ b/tests/e2e/builder/cases/output/externals/tests/index.test.ts
@@ -1,11 +1,10 @@
 import { join, resolve } from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = resolve(__dirname, '../');
 
-allProviderTest('externals', async ({ page }) => {
+test('externals', async ({ page }) => {
   const buildOpts = {
     cwd: fixtures,
     entry: {
@@ -42,30 +41,26 @@ allProviderTest('externals', async ({ page }) => {
   builder.close();
 });
 
-allProviderTest(
-  'should not external dependencies when target is web worker',
-  async () => {
-    const builder = await build(
-      {
-        cwd: fixtures,
-        target: 'web-worker',
-        entry: { index: resolve(fixtures, './src/index.js') },
-      },
-      {
-        output: {
-          externals: {
-            react: 'MyReact',
-          },
+test('should not external dependencies when target is web worker', async () => {
+  const builder = await build(
+    {
+      cwd: fixtures,
+      target: 'web-worker',
+      entry: { index: resolve(fixtures, './src/index.js') },
+    },
+    {
+      output: {
+        externals: {
+          react: 'MyReact',
         },
       },
-      false,
-    );
-    const files = await builder.unwrapOutputJSON();
+    },
+    false,
+  );
+  const files = await builder.unwrapOutputJSON();
 
-    const content =
-      files[Object.keys(files).find(file => file.endsWith('.js'))!];
-    expect(content.includes('MyReact')).toBeFalsy();
+  const content = files[Object.keys(files).find(file => file.endsWith('.js'))!];
+  expect(content.includes('MyReact')).toBeFalsy();
 
-    builder.clean();
-  },
-);
+  builder.clean();
+});

--- a/tests/e2e/builder/cases/output/output.test.ts
+++ b/tests/e2e/builder/cases/output/output.test.ts
@@ -2,11 +2,11 @@ import { join, dirname } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { fs } from '@modern-js/utils';
 import { build } from '@scripts/shared';
-import { webpackOnlyTest, allProviderTest } from '@scripts/helper';
+import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
-allProviderTest.describe('output configure multi', () => {
+test.describe('output configure multi', () => {
   const distFilePath = join(fixtures, 'rem/dist-1/test.json');
 
   let builder: Awaited<ReturnType<typeof build>>;
@@ -60,7 +60,7 @@ allProviderTest.describe('output configure multi', () => {
   });
 });
 
-allProviderTest('cleanDistPath disable', async () => {
+test('cleanDistPath disable', async () => {
   const buildOpts = {
     cwd: join(fixtures, 'rem'),
     entry: {

--- a/tests/e2e/builder/cases/output/rem/tests/index.test.ts
+++ b/tests/e2e/builder/cases/output/rem/tests/index.test.ts
@@ -1,11 +1,10 @@
 import { join, resolve } from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = resolve(__dirname, '../');
 
-allProviderTest('rem default (disable)', async ({ page }) => {
+test('rem default (disable)', async ({ page }) => {
   const buildOpts = {
     cwd: fixtures,
     entry: {
@@ -33,7 +32,7 @@ allProviderTest('rem default (disable)', async ({ page }) => {
   builder.close();
 });
 
-allProviderTest('rem enable', async ({ page }) => {
+test('rem enable', async ({ page }) => {
   const buildOpts = {
     cwd: fixtures,
     entry: {
@@ -78,7 +77,7 @@ allProviderTest('rem enable', async ({ page }) => {
   builder.close();
 });
 
-allProviderTest('should inline runtime code to html by default', async () => {
+test('should inline runtime code to html by default', async () => {
   const builder = await build({
     cwd: fixtures,
     entry: { index: join(fixtures, 'src/index.ts') },
@@ -95,29 +94,26 @@ allProviderTest('should inline runtime code to html by default', async () => {
   expect(files[htmlFile!].includes('function setRootPixel')).toBeTruthy();
 });
 
-allProviderTest(
-  'should extract runtime code when inlineRuntime is false',
-  async () => {
-    const builder = await build({
-      cwd: fixtures,
-      entry: { index: join(fixtures, 'src/index.ts') },
-      builderConfig: {
-        output: {
-          convertToRem: {
-            inlineRuntime: false,
-          },
+test('should extract runtime code when inlineRuntime is false', async () => {
+  const builder = await build({
+    cwd: fixtures,
+    entry: { index: join(fixtures, 'src/index.ts') },
+    builderConfig: {
+      output: {
+        convertToRem: {
+          inlineRuntime: false,
         },
       },
-    });
-    const files = await builder.unwrapOutputJSON();
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
 
-    const htmlFile = Object.keys(files).find(file => file.endsWith('.html'));
-    const retryFile = Object.keys(files).find(
-      file => file.includes('/convert-rem') && file.endsWith('.js'),
-    );
+  const htmlFile = Object.keys(files).find(file => file.endsWith('.html'));
+  const retryFile = Object.keys(files).find(
+    file => file.includes('/convert-rem') && file.endsWith('.js'),
+  );
 
-    expect(htmlFile).toBeTruthy();
-    expect(retryFile).toBeTruthy();
-    expect(files[htmlFile!].includes('function setRootPixel')).toBeFalsy();
-  },
-);
+  expect(htmlFile).toBeTruthy();
+  expect(retryFile).toBeTruthy();
+  expect(files[htmlFile!].includes('function setRootPixel')).toBeFalsy();
+});

--- a/tests/e2e/builder/cases/performance/performance.test.ts
+++ b/tests/e2e/builder/cases/performance/performance.test.ts
@@ -1,11 +1,10 @@
 import { join, resolve } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
-allProviderTest.describe('performance configure multi', () => {
+test.describe('performance configure multi', () => {
   let files: Record<string, string>;
   const basicFixtures = resolve(__dirname, 'basic');
 
@@ -46,7 +45,7 @@ allProviderTest.describe('performance configure multi', () => {
   });
 });
 
-allProviderTest('removeConsole', async () => {
+test('removeConsole', async () => {
   const builder = await build(
     {
       cwd: join(fixtures, 'removeConsole'),
@@ -76,31 +75,28 @@ allProviderTest('removeConsole', async () => {
   expect(jsFile.includes('test-console-error')).toBeTruthy();
 });
 
-allProviderTest(
-  'should generate vendor chunk when chunkSplit is "single-vendor"',
-  async () => {
-    const builder = await build(
-      {
-        cwd: join(fixtures, 'basic'),
-        entry: {
-          main: join(fixtures, 'basic/src/index.ts'),
+test('should generate vendor chunk when chunkSplit is "single-vendor"', async () => {
+  const builder = await build(
+    {
+      cwd: join(fixtures, 'basic'),
+      entry: {
+        main: join(fixtures, 'basic/src/index.ts'),
+      },
+    },
+    {
+      performance: {
+        chunkSplit: {
+          strategy: 'single-vendor',
         },
       },
-      {
-        performance: {
-          chunkSplit: {
-            strategy: 'single-vendor',
-          },
-        },
-      },
-    );
+    },
+  );
 
-    const files = await builder.unwrapOutputJSON();
+  const files = await builder.unwrapOutputJSON();
 
-    const [vendorFile] = Object.entries(files).find(
-      ([name, content]) => name.includes('vendor') && content.includes('React'),
-    )!;
+  const [vendorFile] = Object.entries(files).find(
+    ([name, content]) => name.includes('vendor') && content.includes('React'),
+  )!;
 
-    expect(vendorFile).toBeTruthy();
-  },
-);
+  expect(vendorFile).toBeTruthy();
+});

--- a/tests/e2e/builder/cases/polyfill/index.test.ts
+++ b/tests/e2e/builder/cases/polyfill/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
-import { allProviderTest, webpackOnlyTest } from '@scripts/helper';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { webpackOnlyTest } from '@scripts/helper';
 import { build } from '@scripts/shared';
 
 const POLYFILL_RE = /\/lib-polyfill/;
@@ -20,21 +20,18 @@ const getPolyfillContent = (files: Record<string, string>) => {
   return content;
 };
 
-allProviderTest(
-  'should add polyfill when set polyfill entry (default)',
-  async () => {
-    const builder = await build({
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    });
-    const files = await builder.unwrapOutputJSON(false);
+test('should add polyfill when set polyfill entry (default)', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+  });
+  const files = await builder.unwrapOutputJSON(false);
 
-    const content = getPolyfillContent(files);
+  const content = getPolyfillContent(files);
 
-    // should polyfill all api
-    expect(content.includes('es.array.flat.js')).toBeTruthy();
-  },
-);
+  // should polyfill all api
+  expect(content.includes('es.array.flat.js')).toBeTruthy();
+});
 
 webpackOnlyTest('should add polyfill when set polyfill usage', async () => {
   const builder = await build(

--- a/tests/e2e/builder/cases/source/resolve-extension-prefix/tests/index.test.ts
+++ b/tests/e2e/builder/cases/source/resolve-extension-prefix/tests/index.test.ts
@@ -1,13 +1,12 @@
 import { join, resolve } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = resolve(__dirname, '../');
 
 test.setTimeout(120000);
 
-allProviderTest('resolve-extension-prefix', async ({ page }) => {
+test('resolve-extension-prefix', async ({ page }) => {
   const buildOpts = {
     cwd: fixtures,
     entry: {

--- a/tests/e2e/builder/cases/source/source.test.ts
+++ b/tests/e2e/builder/cases/source/source.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
@@ -27,12 +26,12 @@ test.describe('source configure multi', () => {
     );
   });
 
-  allProviderTest('alias', async ({ page }) => {
+  test('alias', async ({ page }) => {
     await page.goto(getHrefByEntryName('main', builder.port));
     await expect(page.innerHTML('#test')).resolves.toBe('Hello Builder! 1');
   });
 
-  allProviderTest('pre-entry', async ({ page }) => {
+  test('pre-entry', async ({ page }) => {
     await page.goto(getHrefByEntryName('main', builder.port));
     await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
 
@@ -72,7 +71,7 @@ test.skip('module-scopes', async ({ page }) => {
   });
 });
 
-allProviderTest('global-vars & tsConfigPath', async ({ page }) => {
+test('global-vars & tsConfigPath', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'global-vars'),
     entry: {
@@ -97,7 +96,7 @@ allProviderTest('global-vars & tsConfigPath', async ({ page }) => {
   ).resolves.toBe('alias work correctly');
 });
 
-allProviderTest('define', async ({ page }) => {
+test('define', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'global-vars'),
     entry: {

--- a/tests/e2e/builder/cases/stylus-rem/index.test.ts
+++ b/tests/e2e/builder/cases/stylus-rem/index.test.ts
@@ -1,11 +1,10 @@
 import path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
-import { allProviderTest } from '@scripts/helper';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
 
 import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';
 
-allProviderTest('should compile stylus and rem correctly', async () => {
+test('should compile stylus and rem correctly', async () => {
   const builder = await build(
     {
       cwd: __dirname,

--- a/tests/e2e/builder/cases/stylus/index.test.ts
+++ b/tests/e2e/builder/cases/stylus/index.test.ts
@@ -1,11 +1,10 @@
 import path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
-import { allProviderTest } from '@scripts/helper';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
 
 import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';
 
-allProviderTest('should compile stylus correctly', async () => {
+test('should compile stylus correctly', async () => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },

--- a/tests/e2e/builder/cases/svg/svg.test.ts
+++ b/tests/e2e/builder/cases/svg/svg.test.ts
@@ -1,11 +1,10 @@
 import { join } from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
-allProviderTest('svg (default)', async ({ page }) => {
+test('svg (default)', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'svg'),
     entry: {
@@ -39,7 +38,7 @@ allProviderTest('svg (default)', async ({ page }) => {
   builder.close();
 });
 
-allProviderTest('svg (defaultExport component)', async ({ page }) => {
+test('svg (defaultExport component)', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'svg-default-export-component'),
     entry: {
@@ -62,7 +61,7 @@ allProviderTest('svg (defaultExport component)', async ({ page }) => {
   builder.close();
 });
 
-allProviderTest('svg (url)', async ({ page }) => {
+test('svg (url)', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'svg-url'),
     entry: {
@@ -92,7 +91,7 @@ allProviderTest('svg (url)', async ({ page }) => {
 });
 
 // It's an old bug when use svgr in css and external react.
-allProviderTest('svg (external react)', async ({ page }) => {
+test('svg (external react)', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'svg-external-react'),
     entry: {
@@ -136,7 +135,7 @@ allProviderTest('svg (external react)', async ({ page }) => {
   builder.close();
 });
 
-allProviderTest('svg (disableSvgr)', async ({ page }) => {
+test('svg (disableSvgr)', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'svg-assets'),
     entry: {

--- a/tests/e2e/builder/cases/svg/svgo.test.ts
+++ b/tests/e2e/builder/cases/svg/svgo.test.ts
@@ -1,10 +1,9 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
-allProviderTest('should preserve viewBox after svgo minification', async () => {
+test('should preserve viewBox after svgo minification', async () => {
   const fixture = join(__dirname, 'svgo-minify-view-box');
   const buildOpts = {
     cwd: fixture,
@@ -26,7 +25,7 @@ allProviderTest('should preserve viewBox after svgo minification', async () => {
   ).toBeTruthy();
 });
 
-allProviderTest('should add id prefix after svgo minification', async () => {
+test('should add id prefix after svgo minification', async () => {
   const fixture = join(__dirname, 'svgo-minify-id-prefix');
   const buildOpts = {
     cwd: fixture,

--- a/tests/e2e/builder/cases/tools/pug/tests/index.test.ts
+++ b/tests/e2e/builder/cases/tools/pug/tests/index.test.ts
@@ -1,11 +1,10 @@
 import { join, resolve } from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { allProviderTest } from '@scripts/helper';
 
 const fixtures = resolve(__dirname, '../');
 
-allProviderTest('pug', async ({ page }) => {
+test('pug', async ({ page }) => {
   const buildOpts = {
     cwd: fixtures,
     entry: {

--- a/tests/e2e/builder/scripts/helper.ts
+++ b/tests/e2e/builder/scripts/helper.ts
@@ -19,4 +19,3 @@ export const getProviderTest = (supportType: string[] = ['webpack']) => {
 
 export const webpackOnlyTest = getProviderTest(['webpack']);
 export const rspackOnlyTest = getProviderTest(['rspack']);
-export const allProviderTest = getProviderTest(['webpack', 'rspack']);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f32f2b8</samp>

The pull request refactors and updates the end-to-end tests for the builder features to use the `test` function from `@modern-js/e2e/playwright` instead of the `allProviderTest` function from `@scripts/helper`. This change simplifies the test code, removes unused dependencies, and improves the test performance and readability. The pull request also allows the user to customize the port for the production server in the `builderConfig.dev?.port` option and uses the `fs` module from `@modern-js/utils` for file operations.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f32f2b8</samp>

*  Allow user to customize port for production server ([link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-0d5122eb52264ef7896104414bbfcfa6d81575de09f8a9e37d338caec9e179cfL59-R59))
*  Use `@modern-js/utils` module for file system operations ([link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-881278a7e406bc56da92613a6dfc45e7834997a14159afe9633dcaa4443097e5L2-R5))
*  Use `test` function from `@modern-js/e2e/playwright` as default test runner for e2e tests ([link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-cd7580de9aa167a62592927f8c3bc122ab4adb1a4066eb1cb795097f77f9d90bL2-R5), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-c7a23d71297b4fad65c8758a7aa98029882cd0b0edcf1a9ab259d4b5e50c942fL30-L31), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L5), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L27-R26), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L35-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L41-R40), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L90-R89), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L105-R104), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L118-R117), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L127-R126), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L135-R134), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L144-R143), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L163-R162), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L196-R277), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L305-R298), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L2-R8), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L54-R54), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-67656284a76afce561166a92ad5c40771ec12b6428c4ec0892d49645152973a3L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f369e1d76ef1b2397a81de2c6a68c07d45aa6750acadd6f7e9ecf31582d20866L2-R27), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-2b7cc46c5fc94a366bf61ed09507c3c29aef41d19dca15961f818445dab5efb7L2-R3), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-2b7cc46c5fc94a366bf61ed09507c3c29aef41d19dca15961f818445dab5efb7L62-R61), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L45-R66), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL63-R63), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L36-R35), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L81-R80), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L98-R119), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL49-R48), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL79-R102), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L2-R3), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L23-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-be856b4c7bb9c6d10f4a24f9c348c7e11b23c8f6d422f8384ea0c731684f4259L10-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L30-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L75-R74), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L100-R99), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-591477e469324bbaa7018d5b8f3fe975a75b8a57c4ff151968327b47fbba5319L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-aaa4cdfe2b0ac249d1bb564a120cae59987f3e716fb7ce9ddbcccc8705fe0a37L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-04cbb4565c29af15dbe98e62205440fc3813637f507b038f31e0d334de776438L42-R41), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-04cbb4565c29af15dbe98e62205440fc3813637f507b038f31e0d334de776438L65-R64), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-04cbb4565c29af15dbe98e62205440fc3813637f507b038f31e0d334de776438L95-R94), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-04cbb4565c29af15dbe98e62205440fc3813637f507b038f31e0d334de776438L139-R138), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f74ddb8d41dcf7a42f5fd6f46101fffd48f650757796d67b48d7d2b288b7df63L3-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f74ddb8d41dcf7a42f5fd6f46101fffd48f650757796d67b48d7d2b288b7df63L29-R28))
*  Use `test.describe` function from `@modern-js/e2e/playwright` as default test suite runner for e2e tests ([link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL5-R9))
*  Remove unused code and dependencies ([link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L5), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL4-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-be856b4c7bb9c6d10f4a24f9c348c7e11b23c8f6d422f8384ea0c731684f4259L4), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L4))
*  Test various features of the builder, such as html, output, performance, polyfill, svg, etc. ([link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L27-R26)-[link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L305-R298), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L54-R54), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-67656284a76afce561166a92ad5c40771ec12b6428c4ec0892d49645152973a3L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f369e1d76ef1b2397a81de2c6a68c07d45aa6750acadd6f7e9ecf31582d20866L2-R27), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-2b7cc46c5fc94a366bf61ed09507c3c29aef41d19dca15961f818445dab5efb7L62-R61), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L45-R66), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL63-R63), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L36-R35)-[link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L98-R119), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL49-R48)-[link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL79-R102), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L23-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-be856b4c7bb9c6d10f4a24f9c348c7e11b23c8f6d422f8384ea0c731684f4259L10-R9), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L30-R34)-[link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L100-R99), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-591477e469324bbaa7018d5b8f3fe975a75b8a57c4ff151968327b47fbba5319L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-aaa4cdfe2b0ac249d1bb564a120cae59987f3e716fb7ce9ddbcccc8705fe0a37L2-R7), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-04cbb4565c29af15dbe98e62205440fc3813637f507b038f31e0d334de776438L42-R41)-[link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-04cbb4565c29af15dbe98e62205440fc3813637f507b038f31e0d334de776438L139-R138), [link](https://github.com/web-infra-dev/modern.js/pull/3937/files?diff=unified&w=0#diff-f74ddb8d41dcf7a42f5fd6f46101fffd48f650757796d67b48d7d2b288b7df63L29-R28))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
