### PR TITLE
test(builder): disable polyfill to make e2e tests faster

### DIFF
--- a/tests/e2e/builder/cases/inline-chunk/index.test.ts
+++ b/tests/e2e/builder/cases/inline-chunk/index.test.ts
@@ -135,7 +135,7 @@ webpackOnlyTest(
     expect(
       Object.keys(files).filter(fileName => fileName.endsWith('.js.map'))
         .length,
-    ).toEqual(5);
+    ).toEqual(4);
   },
 );
 
@@ -167,7 +167,7 @@ webpackOnlyTest('using RegExp to inline scripts', async () => {
   // all source maps in output
   expect(
     Object.keys(files).filter(fileName => fileName.endsWith('.js.map')).length,
-  ).toEqual(4);
+  ).toEqual(3);
 });
 
 webpackOnlyTest('using RegExp to inline styles', async () => {

--- a/tests/e2e/builder/cases/polyfill/index.test.ts
+++ b/tests/e2e/builder/cases/polyfill/index.test.ts
@@ -21,10 +21,17 @@ const getPolyfillContent = (files: Record<string, string>) => {
 };
 
 test('should add polyfill when set polyfill entry (default)', async () => {
-  const builder = await build({
-    cwd: __dirname,
-    entry: { index: path.resolve(__dirname, './src/index.js') },
-  });
+  const builder = await build(
+    {
+      cwd: __dirname,
+      entry: { index: path.resolve(__dirname, './src/index.js') },
+    },
+    {
+      output: {
+        polyfill: 'entry',
+      },
+    },
+  );
   const files = await builder.unwrapOutputJSON(false);
 
   const content = getPolyfillContent(files);

--- a/tests/e2e/builder/cases/swc/index.test.ts
+++ b/tests/e2e/builder/cases/swc/index.test.ts
@@ -25,13 +25,20 @@ webpackOnlyTest('should run SWC compilation correctly', async ({ page }) => {
 });
 
 webpackOnlyTest('should optimize lodash bundle size', async ({ page }) => {
-  const builder = await build({
-    cwd: __dirname,
-    entry: {
-      index: path.resolve(__dirname, './src/main.ts'),
+  const builder = await build(
+    {
+      cwd: __dirname,
+      entry: {
+        index: path.resolve(__dirname, './src/main.ts'),
+      },
+      plugins: [builderPluginSwc()],
     },
-    plugins: [builderPluginSwc()],
-  });
+    {
+      output: {
+        polyfill: 'entry',
+      },
+    },
+  );
 
   await page.goto(getHrefByEntryName('index', builder.port));
 

--- a/tests/e2e/builder/scripts/shared.ts
+++ b/tests/e2e/builder/scripts/shared.ts
@@ -75,10 +75,19 @@ const updateConfigForTest = async (config: BuilderConfig) => {
     };
   }
 
+  // disable ts checker to make the tests faster
   if (config.output?.disableTsChecker !== false) {
     config.output = {
       ...(config.output || {}),
       disableTsChecker: true,
+    };
+  }
+
+  // disable polyfill to make the tests faster
+  if (config.output?.polyfill === undefined) {
+    config.output = {
+      ...(config.output || {}),
+      polyfill: 'off',
     };
   }
 };


### PR DESCRIPTION
## Summary

The webpack test time can be reduced from 150s to 60s.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3447c11</samp>

Improved the consistency, accuracy, and performance of the e2e tests for the builder module. Modified the build options for the `inline-chunk` and `swc` test cases to use the `output.polyfill` entry option.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3447c11</samp>

*  Reduce the expected number of source map files for the inline-chunk test case ([link](https://github.com/web-infra-dev/modern.js/pull/3942/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL138-R138), [link](https://github.com/web-infra-dev/modern.js/pull/3942/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL170-R170))
*  Enable the output.polyfill option for the inline-chunk test case in `tests/e2e/builder/cases/inline-chunk/index.test.ts` and `tests/e2e/builder/cases/swc/index.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3942/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L24-R34), [link](https://github.com/web-infra-dev/modern.js/pull/3942/files?diff=unified&w=0#diff-e63741023e472646952a2e20a91e597cba1e69e737b14dca470c07a98acba456L28-R41))
*  Add a comment to explain why the ts checker plugin is disabled for the e2e tests in `tests/e2e/builder/scripts/shared.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3942/files?diff=unified&w=0#diff-c315a24d60f9b1bcc59f235721dec1646952bc77ef04ed3733a890ef6104525aR78))
*  Set the output.polyfill option to off by default for the e2e tests, unless specified in the test case, in `tests/e2e/builder/scripts/shared.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/3942/files?diff=unified&w=0#diff-c315a24d60f9b1bcc59f235721dec1646952bc77ef04ed3733a890ef6104525aR85-R92))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
