### PR TITLE
test(e2e): lock playwright version to compat Node 14

### DIFF
--- a/.changeset/brave-donuts-camp.md
+++ b/.changeset/brave-donuts-camp.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/e2e': patch
+---
+
+test(e2e): lock playwright version to compat Node 14
+
+test(e2e): 锁定 playwright 版本以兼容 Node 14

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@modern-js/utils": "workspace:*",
-    "@playwright/test": "^1.25.1",
+    "@playwright/test": "1.33.0",
     "connect": "^3.7.0",
-    "playwright": "^1.25.1",
+    "playwright": "1.33.0",
     "serve-static": "^1.14.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4932,14 +4932,14 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@playwright/test':
-        specifier: ^1.25.1
-        version: 1.25.1
+        specifier: 1.33.0
+        version: 1.33.0
       connect:
         specifier: ^3.7.0
         version: 3.7.0
       playwright:
-        specifier: ^1.25.1
-        version: 1.25.1
+        specifier: 1.33.0
+        version: 1.33.0
       serve-static:
         specifier: ^1.14.1
         version: 1.15.0
@@ -5826,6 +5826,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../../packages/toolkit/utils
+      '@playwright/test':
+        specifier: 1.33.0
+        version: 1.33.0
       '@types/lodash':
         specifier: ^4.14.195
         version: 4.14.195
@@ -5838,9 +5841,6 @@ importers:
       '@types/react-dom':
         specifier: ^18
         version: 18.0.6
-      playwright:
-        specifier: ^1.25.1
-        version: 1.25.1
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -12271,14 +12271,15 @@ packages:
       rimraf: 3.0.2
     dev: false
 
-  /@playwright/test@1.25.1:
-    resolution: {integrity: sha512-IJ4X0yOakXtwkhbnNzKkaIgXe6df7u3H3FnuhI9Jqh+CdO0e/lYQlDLYiyI9cnXK8E7UAppAWP+VqAv6VX7HQg==}
+  /@playwright/test@1.33.0:
+    resolution: {integrity: sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
       '@types/node': 18.11.17
-      playwright-core: 1.25.1
-    dev: false
+      playwright-core: 1.33.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0)(webpack@5.82.1):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
@@ -27039,18 +27040,19 @@ packages:
     dependencies:
       find-up: 3.0.0
 
-  /playwright-core@1.25.1:
-    resolution: {integrity: sha512-lSvPCmA2n7LawD2Hw7gSCLScZ+vYRkhU8xH0AapMyzwN+ojoDqhkH/KIEUxwNu2PjPoE/fcE0wLAksdOhJ2O5g==}
+  /playwright-core@1.33.0:
+    resolution: {integrity: sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==}
     engines: {node: '>=14'}
     hasBin: true
 
-  /playwright@1.25.1:
-    resolution: {integrity: sha512-kOlW7mllnQ70ALTwAor73q/FhdH9EEXLUqjdzqioYLcSVC4n4NBfDqeCikGuayFZrLECLkU6Hcbziy/szqTXSA==}
+  /playwright@1.33.0:
+    resolution: {integrity: sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==}
     engines: {node: '>=14'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      playwright-core: 1.25.1
+      playwright-core: 1.33.0
+    dev: false
 
   /pnp-webpack-plugin@1.6.4(typescript@5.0.4):
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -27,7 +27,7 @@
     "@types/lodash": "^4.14.195",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "playwright": "^1.25.1",
+    "@playwright/test": "1.33.0",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary

Node.js 14 is no longer supported in playwright v1.34.0.

https://github.com/microsoft/playwright/releases/tag/v1.34.0

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a9c005</samp>

This pull request updates the `@modern-js/e2e` package to use the latest version of `@playwright/test` and fixes the compatibility issue with Node 14. It also adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a9c005</samp>

*  Add changeset file to document patch update of `@modern-js/e2e` package ([link](https://github.com/web-infra-dev/modern.js/pull/3944/files?diff=unified&w=0#diff-b7afcbfc4717ffcbca6df05a44b7a80951979ac52aa67a00f41760d83eb4b4f5R1-R7))
*  Update `@playwright/test` and `playwright` dependencies to version 1.33.0 in `packages/toolkit/e2e/package.json` to lock playwright version for Node 14 compatibility ([link](https://github.com/web-infra-dev/modern.js/pull/3944/files?diff=unified&w=0#diff-31356500e2d759f2d711b16b39bf283c85dddbffd3f8fdba3f6efd00c176a505L39-R41))
*  Replace `playwright` with `@playwright/test` dependency in `tests/e2e/builder/package.json` to use official playwright test runner ([link](https://github.com/web-infra-dev/modern.js/pull/3944/files?diff=unified&w=0#diff-283456d349870a43f9269898463ae8e4041fd489a775c83b2aa27776d895b137L30-R30))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
