### PR TITLE
docs: review runtime configuration

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/runtime/intro.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/runtime/intro.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Overview
 
-This section describes the configuration of the Runtime plugin.
+This section describes configuration of the Runtime plugin.
 
 ## Configuration
 
@@ -32,12 +32,33 @@ export default defineConfig({
 
 #### DefineConfig
 
-Configure use [`defineConfig`](/apis/app/runtime/app/define-config) API:
+Configure using [`defineConfig`](/apis/app/runtime/app/define-config) API:
 
 :::info
-When there is a function in the runtime configuration, it can only be configured in this way.
+When there is a function in the runtime configuration, it can only be configured this way.
 
 :::
+
+import { Tabs, Tab as TabItem } from "@theme";
+
+<Tabs>
+  <TabItem value="layout" label="Conventional Routing" default>
+
+```tsx title="src/routes/layout.tsx"
+import type { AppConfig } from '@modern-js/runtime';
+
+export const config = (): AppConfig => {
+  return {
+    router: {
+      supportHtml5History: false
+    }
+  }
+};
+```
+
+  </TabItem>
+
+  <TabItem value="app" label="Self-controlled Routing">
 
 ```ts title="src/App.tsx"
 import { defineConfig } from '@modern-js/runtime';
@@ -55,6 +76,9 @@ defineConfig(App, {
 export default App;
 ```
 
+  </TabItem>
+</Tabs>
+
 :::info
 Using runtime configuration, you can solve the problem that runtime plugin configuration needs to be at runtime to get specific content.
 
@@ -63,7 +87,7 @@ Runtime plugin runtime configuration and configuration directly in `modern.confi
 :::
 
 :::warning
-defineConfig can only define the specific configuration content of the Runtime plugin. To confirm whether to enable the plugin, it needs to be determined through the configuration in `modernConfig` in `package.json` or `modern.config.ts`.
+The `defineConfig` API only accepts the specific configuration of Runtime plugins. Enabling the plugin is determined through `modern.config.ts` configuration."
 
 :::
 

--- a/packages/document/main-doc/docs/en/configure/app/runtime/master-app.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/runtime/master-app.mdx
@@ -35,6 +35,6 @@ interface AppInfo {
 
 ### Other Config
 
-Under the `masterApp` configuration, developers can pass through the configuration items of Garfish.
+In the `masterApp` configuration, developers can pass through options supported by Garfish
 
 All supported configuration items [see here](https://garfishjs.org/api/run/#%E5%8F%82%E6%95%B0).

--- a/packages/document/main-doc/docs/en/configure/app/runtime/router.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/runtime/router.mdx
@@ -11,14 +11,14 @@ import RouterLegacyTip from "@site-docs-en/components/router-legacy-tip"
 - **Type:** `boolean | Object`
 - **Default:** `false`
 
-When `router` is enabled, routing management of conventional routes provided by Modern.js is supported. Based on [React Router 6](https://reactrouter.com/).
+When enabled, the router option provides routing management for Modern.js conventional routes. It is based on [React Router 6](https://reactrouter.com/).
 
 ## basename
 
 - **Type:** `string`
 - **Default:** ``
 
-The basename of the app for situations where you can't deploy to the root of the domain, but a sub directory.
+The basename option specifies the subpath where the app is deployed, for situations where it cannot be deployed to the root domain.
 
 ## supportHtml5History
 

--- a/packages/document/main-doc/docs/zh/configure/app/runtime/intro.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/runtime/intro.mdx
@@ -87,7 +87,7 @@ Runtime 插件运行时配置和直接在 `modern.config.ts` 中的配置默认�
 :::
 
 :::warning
-defineConfig 中只能定义 Runtime 插件的具体配置内容，确认是否开启插件还需要通过 `package.json` 中的 `modernConfig` 或者 `modern.config.ts` 中的配置决定。
+defineConfig 中只能定义 Runtime 插件的具体配置内容，确认是否开启插件还需要通过 `modern.config.ts` 中的配置决定。
 
 :::
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a334c95</samp>

Updated the documentation of the Runtime plugin configuration in both English and Chinese. Fixed grammar, terminology, and formatting issues. Reorganized the content to provide a better introduction and overview of the plugin features and APIs.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a334c95</samp>

*  Rename `master-app.mdx` and `router.mdx` to `intro.mdx` and move their content to the `runtime` directory ([link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-eb4b7471658c36879c3dcc1e148f1de0094e8288d55e754eda3fc8477e79bf3bL38-R38), [link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-04a2dc04ed07ed11cd0ee27134a8af55145a1227ddcc5f14d4dbfe84ebf21dc6L14-R14), [link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-04a2dc04ed07ed11cd0ee27134a8af55145a1227ddcc5f14d4dbfe84ebf21dc6L21-R21))
*  Remove the word "the" from the introduction sentence in `intro.mdx` ([link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-c5cb8399cafa3ec7a53bd29251ead77b6244d5c84d63e4643c99274639d55b64L8-R8))
*  Fix the grammar and add a tab component to show two ways of configuring the runtime plugin in `intro.mdx` ([link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-c5cb8399cafa3ec7a53bd29251ead77b6244d5c84d63e4643c99274639d55b64L35-R62), [link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-c5cb8399cafa3ec7a53bd29251ead77b6244d5c84d63e4643c99274639d55b64R79-R81))
*  Rephrase the warning message and remove the reference to `package.json` in `intro.mdx` ([link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-c5cb8399cafa3ec7a53bd29251ead77b6244d5c84d63e4643c99274639d55b64L66-R90), [link](https://github.com/web-infra-dev/modern.js/pull/3945/files?diff=unified&w=0#diff-195c3e6bda7d36282f0b392530c278fc2f52d5ed58938fd708ebb61dd95ceb23L90-R90))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
