### PR TITLE
test(e2e): should close builder server after run tests

### DIFF
--- a/tests/e2e/builder/cases/babel/build.test.ts
+++ b/tests/e2e/builder/cases/babel/build.test.ts
@@ -3,22 +3,23 @@ import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
 
 test('babel', async ({ page }) => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: {
-        index: path.resolve(__dirname, './src/index.js'),
-      },
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
     },
-    {
+    runServer: true,
+    builderConfig: {
       tools: {
         babel(_, { addPlugins }) {
           addPlugins([require('./plugins/myBabelPlugin')]);
         },
       },
     },
-  );
+  });
 
   await page.goto(getHrefByEntryName('index', builder.port));
   expect(await page.evaluate('window.b')).toBe(10);
+
+  builder.close();
 });

--- a/tests/e2e/builder/cases/check-syntax/index.test.ts
+++ b/tests/e2e/builder/cases/check-syntax/index.test.ts
@@ -4,12 +4,10 @@ import { build } from '@scripts/shared';
 
 test('should throw error when exist syntax errors', async () => {
   await expect(
-    build(
-      {
-        cwd: __dirname,
-        entry: { index: path.resolve(__dirname, './src/index.js') },
-      },
-      {
+    build({
+      cwd: __dirname,
+      entry: { index: path.resolve(__dirname, './src/index.js') },
+      builderConfig: {
         source: {
           exclude: [path.resolve(__dirname, './src/test.js')],
         },
@@ -25,6 +23,6 @@ test('should throw error when exist syntax errors', async () => {
           },
         },
       },
-    ),
+    }),
   ).rejects.toThrowError('[Syntax Checker]');
 });

--- a/tests/e2e/builder/cases/css/css-modules-dom/tests/index.test.ts
+++ b/tests/e2e/builder/cases/css/css-modules-dom/tests/index.test.ts
@@ -9,22 +9,18 @@ const fixtures = resolve(__dirname, '../');
 webpackOnlyTest('enableCssModuleTSDeclaration', async () => {
   fs.removeSync(join(fixtures, 'src/App.module.less.d.ts'));
   fs.removeSync(join(fixtures, 'src/App.module.scss.d.ts'));
-  const buildOpts = {
+
+  await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.ts'),
     },
-  };
-
-  const builder = await build(
-    buildOpts,
-    {
+    builderConfig: {
       output: {
         enableCssModuleTSDeclaration: true,
       },
     },
-    false,
-  );
+  });
 
   expect(
     fs.existsSync(join(fixtures, 'src/App.module.less.d.ts')),
@@ -49,21 +45,19 @@ webpackOnlyTest('enableCssModuleTSDeclaration', async () => {
       })
       .includes(`'header': string;`),
   ).toBeTruthy();
-
-  builder.close();
 });
 
 webpackOnlyTest('disableCssExtract', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.ts'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    output: {
-      disableCssExtract: true,
+    runServer: true,
+    builderConfig: {
+      output: {
+        disableCssExtract: true,
+      },
     },
   });
 

--- a/tests/e2e/builder/cases/css/css-modules-ts-declaration/index.test.ts
+++ b/tests/e2e/builder/cases/css/css-modules-ts-declaration/index.test.ts
@@ -19,19 +19,16 @@ webpackOnlyTest(
     const testDir = join(fixtures, 'test-src-1');
     const clear = await generatorTempDir(testDir);
 
-    await build(
-      {
-        cwd: __dirname,
-        entry: { index: resolve(testDir, 'index.js') },
-      },
-      {
+    await build({
+      cwd: __dirname,
+      entry: { index: resolve(testDir, 'index.js') },
+      builderConfig: {
         output: {
           disableSourceMap: true,
           enableCssModuleTSDeclaration: true,
         },
       },
-      false,
-    );
+    });
 
     expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
     expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
@@ -54,12 +51,10 @@ webpackOnlyTest(
     const testDir = join(fixtures, 'test-src-2');
     const clear = await generatorTempDir(testDir);
 
-    await build(
-      {
-        cwd: __dirname,
-        entry: { index: resolve(testDir, 'index.js') },
-      },
-      {
+    await build({
+      cwd: __dirname,
+      entry: { index: resolve(testDir, 'index.js') },
+      builderConfig: {
         output: {
           disableSourceMap: true,
           enableCssModuleTSDeclaration: true,
@@ -74,8 +69,7 @@ webpackOnlyTest(
           },
         },
       },
-      false,
-    );
+    });
 
     expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
     expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeFalsy();
@@ -92,12 +86,10 @@ webpackOnlyTest(
     const testDir = join(fixtures, 'test-src-3');
     const clear = await generatorTempDir(testDir);
 
-    await build(
-      {
-        cwd: __dirname,
-        entry: { index: resolve(testDir, 'index.js') },
-      },
-      {
+    await build({
+      cwd: __dirname,
+      entry: { index: resolve(testDir, 'index.js') },
+      builderConfig: {
         output: {
           disableSourceMap: true,
           enableCssModuleTSDeclaration: true,
@@ -110,8 +102,7 @@ webpackOnlyTest(
           },
         },
       },
-      false,
-    );
+    });
 
     expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
     expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();

--- a/tests/e2e/builder/cases/dev/dev.test.ts
+++ b/tests/e2e/builder/cases/dev/dev.test.ts
@@ -8,19 +8,18 @@ const fixtures = __dirname;
 // hmr test will timeout in CI
 test.skip('default & hmr (default true)', async ({ page }) => {
   await fs.copy(join(fixtures, 'hmr/src'), join(fixtures, 'hmr/test-src'));
-  const buildOpts = {
+  const builder = await dev({
     cwd: join(fixtures, 'hmr'),
     entry: {
       main: join(fixtures, 'hmr', 'test-src/index.ts'),
     },
-  };
-
-  const builder = await dev(buildOpts, {
-    tools: {
-      devServer: {
-        client: {
-          host: '',
-          port: '',
+    builderConfig: {
+      tools: {
+        devServer: {
+          client: {
+            host: '',
+            port: '',
+          },
         },
       },
     },
@@ -83,21 +82,20 @@ test.skip('default & hmr (default true)', async ({ page }) => {
 });
 
 test.skip('dev.port & output.distPath', async ({ page }) => {
-  const buildOpts = {
+  const builder = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
       main: join(fixtures, 'basic', 'src/index.ts'),
     },
-  };
-
-  const builder = await dev(buildOpts, {
-    dev: {
-      port: 3000,
-    },
-    output: {
-      distPath: {
-        root: 'dist-1',
-        js: 'aa/js',
+    builderConfig: {
+      dev: {
+        port: 3000,
+      },
+      output: {
+        distPath: {
+          root: 'dist-1',
+          js: 'aa/js',
+        },
       },
     },
   });
@@ -126,28 +124,24 @@ test.skip('hmr should work when setting dev.port & serverOptions.dev.client', as
 }) => {
   await fs.copy(join(fixtures, 'hmr/src'), join(fixtures, 'hmr/test-src-1'));
   const cwd = join(fixtures, 'hmr');
-  const buildOpts = {
+  const builder = await dev({
     cwd,
     entry: {
       main: join(cwd, 'test-src-1/index.ts'),
     },
-  };
-
-  const builder = await dev(
-    buildOpts,
-    {
+    builderConfig: {
       dev: {
         port: 3001,
       },
     },
-    {
+    serverOptions: {
       dev: {
         client: {
           host: '',
         },
       },
     },
-  );
+  });
 
   await page.goto(getHrefByEntryName('main', builder.port));
   expect(builder.port).toBe(3001);
@@ -181,16 +175,15 @@ test.skip('hmr should work when setting dev.port & serverOptions.dev.client', as
 
 // need devcert
 test.skip('dev.https', async () => {
-  const buildOpts = {
+  const builder = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
       main: join(join(fixtures, 'basic'), 'src/index.ts'),
     },
-  };
-
-  const builder = await dev(buildOpts, {
-    dev: {
-      https: true,
+    builderConfig: {
+      dev: {
+        https: true,
+      },
     },
   });
 
@@ -201,31 +194,30 @@ test.skip('dev.https', async () => {
 
 // hmr will timeout in CI
 test.skip('tools.devServer', async ({ page }) => {
-  const buildOpts = {
-    cwd: join(fixtures, 'basic'),
-    entry: {
-      main: join(join(fixtures, 'basic'), 'src/index.ts'),
-    },
-  };
-
   let i = 0;
   let reloadFn: undefined | (() => void);
 
   // Only tested to see if it works, not all configurations.
-  const builder = await dev(buildOpts, {
-    tools: {
-      devServer: {
-        setupMiddlewares: [
-          (_middlewares, server) => {
-            reloadFn = () => server.sockWrite('content-changed');
-          },
-        ],
-        before: [
-          (req, res, next) => {
-            i++;
-            next();
-          },
-        ],
+  const builder = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(join(fixtures, 'basic'), 'src/index.ts'),
+    },
+    builderConfig: {
+      tools: {
+        devServer: {
+          setupMiddlewares: [
+            (_middlewares, server) => {
+              reloadFn = () => server.sockWrite('content-changed');
+            },
+          ],
+          before: [
+            (req, res, next) => {
+              i++;
+              next();
+            },
+          ],
+        },
       },
     },
   });

--- a/tests/e2e/builder/cases/dev/write-to-disk.test.ts
+++ b/tests/e2e/builder/cases/dev/write-to-disk.test.ts
@@ -5,19 +5,18 @@ import { dev, getHrefByEntryName } from '@scripts/shared';
 const fixtures = __dirname;
 
 test('writeToDisk default', async ({ page }) => {
-  const buildOpts = {
+  const builder = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
       main: join(fixtures, 'basic', 'src/index.ts'),
     },
-  };
-
-  const builder = await dev(buildOpts, {
-    tools: {
-      devServer: {
-        client: {
-          host: '',
-          port: '',
+    builderConfig: {
+      tools: {
+        devServer: {
+          client: {
+            host: '',
+            port: '',
+          },
         },
       },
     },
@@ -33,18 +32,17 @@ test('writeToDisk default', async ({ page }) => {
 });
 
 test('writeToDisk false', async ({ page }) => {
-  const buildOpts = {
+  const builder = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
       main: join(fixtures, 'basic', 'src/index.ts'),
     },
-  };
-
-  const builder = await dev(buildOpts, {
-    tools: {
-      devServer: {
-        devMiddleware: {
-          writeToDisk: false,
+    builderConfig: {
+      tools: {
+        devServer: {
+          devMiddleware: {
+            writeToDisk: false,
+          },
         },
       },
     },
@@ -60,18 +58,17 @@ test('writeToDisk false', async ({ page }) => {
 });
 
 test('writeToDisk true', async ({ page }) => {
-  const buildOpts = {
+  const builder = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
       main: join(fixtures, 'basic', 'src/index.ts'),
     },
-  };
-
-  const builder = await dev(buildOpts, {
-    tools: {
-      devServer: {
-        devMiddleware: {
-          writeToDisk: true,
+    builderConfig: {
+      tools: {
+        devServer: {
+          devMiddleware: {
+            writeToDisk: true,
+          },
         },
       },
     },

--- a/tests/e2e/builder/cases/html-tags/index.test.ts
+++ b/tests/e2e/builder/cases/html-tags/index.test.ts
@@ -6,12 +6,10 @@ const isHtmlMatch = (html: string, pattern: RegExp): boolean =>
   Boolean(html.match(pattern));
 
 test('should inject tags', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.ts') },
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.ts') },
+    builderConfig: {
       html: {
         tags: [
           { tag: 'script', attrs: { src: 'foo.js' } },
@@ -22,8 +20,7 @@ test('should inject tags', async () => {
         ],
       },
     },
-    false,
-  );
+  });
 
   const files = await builder.unwrapOutputJSON();
 

--- a/tests/e2e/builder/cases/html/favicon/index.test.ts
+++ b/tests/e2e/builder/cases/html/favicon/index.test.ts
@@ -3,18 +3,15 @@ import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
 
 test('should emit local favicon to dist path', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
       html: {
         favicon: './src/icon.png',
       },
     },
-    false,
-  );
+  });
   const files = await builder.unwrapOutputJSON();
 
   expect(
@@ -28,12 +25,10 @@ test('should emit local favicon to dist path', async () => {
 });
 
 test('should apply asset prefix to favicon URL', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
       html: {
         favicon: './src/icon.png',
       },
@@ -41,8 +36,7 @@ test('should apply asset prefix to favicon URL', async () => {
         assetPrefix: 'https://www.example.com',
       },
     },
-    false,
-  );
+  });
   const files = await builder.unwrapOutputJSON();
 
   const html =
@@ -54,18 +48,15 @@ test('should apply asset prefix to favicon URL', async () => {
 });
 
 test('should allow favicon to be a CDN URL', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
       html: {
         favicon: 'https://foo.com/icon.png',
       },
     },
-    false,
-  );
+  });
   const files = await builder.unwrapOutputJSON();
 
   const html =

--- a/tests/e2e/builder/cases/inline-chunk/index.test.ts
+++ b/tests/e2e/builder/cases/inline-chunk/index.test.ts
@@ -21,15 +21,14 @@ const toolsConfig = {
 };
 
 webpackOnlyTest('inline runtime chunk by default', async ({ page }) => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    runServer: true,
+    builderConfig: {
       tools: toolsConfig,
     },
-  );
+  });
 
   // test runtime
   await page.goto(getHrefByEntryName('index', builder.port));
@@ -59,24 +58,23 @@ webpackOnlyTest('inline runtime chunk by default', async ({ page }) => {
     files[path.resolve(__dirname, './dist/html/index/index.html')];
 
   expect(isRuntimeChunkInHtml(indexHtml)).toBeTruthy();
+
+  builder.close();
 });
 
 webpackOnlyTest(
   'inline runtime chunk by default with multiple entries',
   async () => {
-    const builder = await build(
-      {
-        cwd: __dirname,
-        entry: {
-          index: path.resolve(__dirname, './src/index.js'),
-          another: path.resolve(__dirname, './src/another.js'),
-        },
+    const builder = await build({
+      cwd: __dirname,
+      entry: {
+        index: path.resolve(__dirname, './src/index.js'),
+        another: path.resolve(__dirname, './src/another.js'),
       },
-      {
+      builderConfig: {
         tools: toolsConfig,
       },
-      false,
-    );
+    });
     const files = await builder.unwrapOutputJSON(false);
 
     // no builder-runtime file in output
@@ -101,21 +99,20 @@ webpackOnlyTest(
 webpackOnlyTest(
   'inline all scripts and emit all source maps',
   async ({ page }) => {
-    const builder = await build(
-      {
-        cwd: __dirname,
-        entry: {
-          index: path.resolve(__dirname, './src/index.js'),
-          another: path.resolve(__dirname, './src/another.js'),
-        },
+    const builder = await build({
+      cwd: __dirname,
+      entry: {
+        index: path.resolve(__dirname, './src/index.js'),
+        another: path.resolve(__dirname, './src/another.js'),
       },
-      {
+      runServer: true,
+      builderConfig: {
         output: {
           enableInlineScripts: true,
         },
         tools: toolsConfig,
       },
-    );
+    });
 
     await page.goto(getHrefByEntryName('index', builder.port));
 
@@ -136,25 +133,24 @@ webpackOnlyTest(
       Object.keys(files).filter(fileName => fileName.endsWith('.js.map'))
         .length,
     ).toEqual(4);
+
+    builder.close();
   },
 );
 
 webpackOnlyTest('using RegExp to inline scripts', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: {
-        index: path.resolve(__dirname, './src/index.js'),
-      },
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
     },
-    {
+    builderConfig: {
       output: {
         enableInlineScripts: /\/main\.\w+\.js$/,
       },
       tools: toolsConfig,
     },
-    false,
-  );
+  });
   const files = await builder.unwrapOutputJSON(false);
 
   // no main.js in output
@@ -171,21 +167,18 @@ webpackOnlyTest('using RegExp to inline scripts', async () => {
 });
 
 webpackOnlyTest('using RegExp to inline styles', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: {
-        index: path.resolve(__dirname, './src/index.js'),
-      },
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
     },
-    {
+    builderConfig: {
       output: {
         enableInlineStyles: /\/main\.\w+\.css$/,
       },
       tools: toolsConfig,
     },
-    false,
-  );
+  });
   const files = await builder.unwrapOutputJSON(false);
 
   // no main.css in output

--- a/tests/e2e/builder/cases/legalComments/index.test.ts
+++ b/tests/e2e/builder/cases/legalComments/index.test.ts
@@ -6,17 +6,17 @@ import { webpackOnlyTest } from '@scripts/helper';
 const fixtures = __dirname;
 
 test('legalComments linked (default)', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.jsx'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    performance: {
-      chunkSplit: {
-        strategy: 'all-in-one',
+    runServer: true,
+    builderConfig: {
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
       },
     },
   });
@@ -52,21 +52,21 @@ test('legalComments linked (default)', async ({ page }) => {
 });
 
 test('legalComments none', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.jsx'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    performance: {
-      chunkSplit: {
-        strategy: 'all-in-one',
+    runServer: true,
+    builderConfig: {
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
       },
-    },
-    output: {
-      legalComments: 'none',
+      output: {
+        legalComments: 'none',
+      },
     },
   });
 
@@ -95,21 +95,21 @@ test('legalComments none', async ({ page }) => {
 });
 
 webpackOnlyTest('legalComments inline', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.jsx'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    performance: {
-      chunkSplit: {
-        strategy: 'all-in-one',
+    runServer: true,
+    builderConfig: {
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
       },
-    },
-    output: {
-      legalComments: 'inline',
+      output: {
+        legalComments: 'inline',
+      },
     },
   });
 

--- a/tests/e2e/builder/cases/manifest/index.test.ts
+++ b/tests/e2e/builder/cases/manifest/index.test.ts
@@ -5,16 +5,12 @@ import { build } from '@scripts/shared';
 const fixtures = __dirname;
 
 test('enableAssetManifest', async () => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.jsx'),
     },
-  };
-
-  const builder = await build(
-    buildOpts,
-    {
+    builderConfig: {
       output: {
         enableAssetManifest: true,
         legalComments: 'none',
@@ -25,8 +21,7 @@ test('enableAssetManifest', async () => {
         },
       },
     },
-    false,
-  );
+  });
 
   const files = await builder.unwrapOutputJSON();
 

--- a/tests/e2e/builder/cases/node-polyfill/index.test.ts
+++ b/tests/e2e/builder/cases/node-polyfill/index.test.ts
@@ -10,6 +10,7 @@ test('should add node-polyfill when add node-polyfill plugin', async ({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
     plugins: [builderPluginNodePolyfill()],
+    runServer: true,
   });
   await page.goto(getHrefByEntryName('index', builder.port));
 
@@ -24,4 +25,6 @@ test('should add node-polyfill when add node-polyfill plugin', async ({
   await expect(
     page.evaluate(`document.getElementById('test-querystring').innerHTML`),
   ).resolves.toBe('foo=bar');
+
+  builder.close();
 });

--- a/tests/e2e/builder/cases/output/assets.test.ts
+++ b/tests/e2e/builder/cases/output/assets.test.ts
@@ -59,14 +59,14 @@ const cases = [
 
 cases.forEach(_case => {
   test(_case.name, async ({ page }) => {
-    const buildOpts = {
+    const builder = await build({
       cwd: _case.cwd,
       entry: {
         main: join(_case.cwd, 'src/index.js'),
       },
-    };
-
-    const builder = await build(buildOpts, _case.config || {});
+      runServer: true,
+      builderConfig: _case.config || {},
+    });
 
     await page.goto(getHrefByEntryName('main', builder.port));
 

--- a/tests/e2e/builder/cases/output/externals/tests/index.test.ts
+++ b/tests/e2e/builder/cases/output/externals/tests/index.test.ts
@@ -5,21 +5,21 @@ import { build, getHrefByEntryName } from '@scripts/shared';
 const fixtures = resolve(__dirname, '../');
 
 test('externals', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.js'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    output: {
-      externals: {
-        './aaa': 'aa',
+    runServer: true,
+    builderConfig: {
+      output: {
+        externals: {
+          './aaa': 'aa',
+        },
       },
-    },
-    source: {
-      preEntry: './src/ex.js',
+      source: {
+        preEntry: './src/ex.js',
+      },
     },
   });
 
@@ -42,21 +42,18 @@ test('externals', async ({ page }) => {
 });
 
 test('should not external dependencies when target is web worker', async () => {
-  const builder = await build(
-    {
-      cwd: fixtures,
-      target: 'web-worker',
-      entry: { index: resolve(fixtures, './src/index.js') },
-    },
-    {
+  const builder = await build({
+    cwd: fixtures,
+    target: 'web-worker',
+    entry: { index: resolve(fixtures, './src/index.js') },
+    builderConfig: {
       output: {
         externals: {
           react: 'MyReact',
         },
       },
     },
-    false,
-  );
+  });
   const files = await builder.unwrapOutputJSON();
 
   const content = files[Object.keys(files).find(file => file.endsWith('.js'))!];

--- a/tests/e2e/builder/cases/output/output.test.ts
+++ b/tests/e2e/builder/cases/output/output.test.ts
@@ -12,13 +12,6 @@ test.describe('output configure multi', () => {
   let builder: Awaited<ReturnType<typeof build>>;
 
   test.beforeAll(async () => {
-    const buildOpts = {
-      cwd: join(fixtures, 'rem'),
-      entry: {
-        main: join(fixtures, 'rem/src/index.ts'),
-      },
-    };
-
     await fs.mkdir(dirname(distFilePath), { recursive: true });
     await fs.writeFile(
       distFilePath,
@@ -27,13 +20,19 @@ test.describe('output configure multi', () => {
     }`,
     );
 
-    builder = await build(buildOpts, {
-      output: {
-        distPath: {
-          root: 'dist-1',
-          js: 'aa/js',
+    builder = await build({
+      cwd: join(fixtures, 'rem'),
+      entry: {
+        main: join(fixtures, 'rem/src/index.ts'),
+      },
+      builderConfig: {
+        output: {
+          distPath: {
+            root: 'dist-1',
+            js: 'aa/js',
+          },
+          copy: [{ from: './src/assets', to: '' }],
         },
-        copy: [{ from: './src/assets', to: '' }],
       },
     });
   });
@@ -61,13 +60,6 @@ test.describe('output configure multi', () => {
 });
 
 test('cleanDistPath disable', async () => {
-  const buildOpts = {
-    cwd: join(fixtures, 'rem'),
-    entry: {
-      main: join(fixtures, 'rem/src/index.ts'),
-    },
-  };
-
   const distFilePath = join(fixtures, 'rem/dist-2/test.json');
 
   await fs.mkdir(dirname(distFilePath), { recursive: true });
@@ -78,12 +70,18 @@ test('cleanDistPath disable', async () => {
   }`,
   );
 
-  const builder = await build(buildOpts, {
-    output: {
-      distPath: {
-        root: 'dist-2',
+  const builder = await build({
+    cwd: join(fixtures, 'rem'),
+    entry: {
+      main: join(fixtures, 'rem/src/index.ts'),
+    },
+    builderConfig: {
+      output: {
+        distPath: {
+          root: 'dist-2',
+        },
+        cleanDistPath: false,
       },
-      cleanDistPath: false,
     },
   });
 

--- a/tests/e2e/builder/cases/output/rem/tests/index.test.ts
+++ b/tests/e2e/builder/cases/output/rem/tests/index.test.ts
@@ -5,15 +5,12 @@ import { build, getHrefByEntryName } from '@scripts/shared';
 const fixtures = resolve(__dirname, '../');
 
 test('rem default (disable)', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.ts'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    output: {},
+    runServer: true,
   });
   await page.goto(getHrefByEntryName('main', builder.port));
 
@@ -33,17 +30,17 @@ test('rem default (disable)', async ({ page }) => {
 });
 
 test('rem enable', async ({ page }) => {
-  const buildOpts = {
+  // convert to rem
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.ts'),
     },
-  };
-
-  // convert to rem
-  const builder = await build(buildOpts, {
-    output: {
-      convertToRem: true,
+    runServer: true,
+    builderConfig: {
+      output: {
+        convertToRem: true,
+      },
     },
   });
 

--- a/tests/e2e/builder/cases/performance/performance.test.ts
+++ b/tests/e2e/builder/cases/performance/performance.test.ts
@@ -9,14 +9,12 @@ test.describe('performance configure multi', () => {
   const basicFixtures = resolve(__dirname, 'basic');
 
   test.beforeAll(async () => {
-    const builder = await build(
-      {
-        cwd: basicFixtures,
-        entry: {
-          main: join(basicFixtures, 'src/index.ts'),
-        },
+    const builder = await build({
+      cwd: basicFixtures,
+      entry: {
+        main: join(basicFixtures, 'src/index.ts'),
       },
-      {
+      builderConfig: {
         performance: {
           bundleAnalyze: {},
           chunkSplit: {
@@ -24,7 +22,7 @@ test.describe('performance configure multi', () => {
           },
         },
       },
-    );
+    });
 
     files = await builder.unwrapOutputJSON();
   });
@@ -46,14 +44,12 @@ test.describe('performance configure multi', () => {
 });
 
 test('removeConsole', async () => {
-  const builder = await build(
-    {
-      cwd: join(fixtures, 'removeConsole'),
-      entry: {
-        main: join(fixtures, 'removeConsole/src/index.js'),
-      },
+  const builder = await build({
+    cwd: join(fixtures, 'removeConsole'),
+    entry: {
+      main: join(fixtures, 'removeConsole/src/index.js'),
     },
-    {
+    builderConfig: {
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -61,7 +57,7 @@ test('removeConsole', async () => {
         removeConsole: ['log', 'warn'],
       },
     },
-  );
+  });
 
   const files = await builder.unwrapOutputJSON();
 
@@ -76,21 +72,19 @@ test('removeConsole', async () => {
 });
 
 test('should generate vendor chunk when chunkSplit is "single-vendor"', async () => {
-  const builder = await build(
-    {
-      cwd: join(fixtures, 'basic'),
-      entry: {
-        main: join(fixtures, 'basic/src/index.ts'),
-      },
+  const builder = await build({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic/src/index.ts'),
     },
-    {
+    builderConfig: {
       performance: {
         chunkSplit: {
           strategy: 'single-vendor',
         },
       },
     },
-  );
+  });
 
   const files = await builder.unwrapOutputJSON();
 

--- a/tests/e2e/builder/cases/polyfill/index.test.ts
+++ b/tests/e2e/builder/cases/polyfill/index.test.ts
@@ -21,17 +21,15 @@ const getPolyfillContent = (files: Record<string, string>) => {
 };
 
 test('should add polyfill when set polyfill entry (default)', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
       output: {
         polyfill: 'entry',
       },
     },
-  );
+  });
   const files = await builder.unwrapOutputJSON(false);
 
   const content = getPolyfillContent(files);
@@ -41,17 +39,15 @@ test('should add polyfill when set polyfill entry (default)', async () => {
 });
 
 webpackOnlyTest('should add polyfill when set polyfill usage', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
       output: {
         polyfill: 'usage',
       },
     },
-  );
+  });
   const files = await builder.unwrapOutputJSON(false);
 
   const content = getPolyfillContent(files);

--- a/tests/e2e/builder/cases/progress/index.test.ts
+++ b/tests/e2e/builder/cases/progress/index.test.ts
@@ -18,17 +18,15 @@ webpackOnlyTest('should emit progress log in non-TTY environment', async () => {
     successMsgs.push(message);
   };
 
-  await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-    },
-    {
+  await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
       dev: {
         progressBar: true,
       },
     },
-  );
+  });
 
   expect(
     infoMsgs.some(message => message.includes('[Client] compile progress')),

--- a/tests/e2e/builder/cases/serve/index.test.ts
+++ b/tests/e2e/builder/cases/serve/index.test.ts
@@ -5,14 +5,13 @@ import { build, getHrefByEntryName } from '@scripts/shared';
 
 test('should serve dist files correctly', async ({ page }) => {
   const cwd = join(__dirname, 'basic');
-  const buildOpts = {
+
+  const { instance } = await build({
     cwd,
     entry: {
       main: join(cwd, 'src/index.js'),
     },
-  };
-
-  const { instance } = await build(buildOpts, {}, false);
+  });
 
   const { port, server } = await instance.serve();
 

--- a/tests/e2e/builder/cases/source/plugin-import/index.test.ts
+++ b/tests/e2e/builder/cases/source/plugin-import/index.test.ts
@@ -15,15 +15,19 @@ webpackOnlyTest('should import with function customName', async () => {
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
   };
+
   {
-    const builder = await build(setupConfig, {
-      source: {
-        transformImport: [
-          {
-            libraryName: 'foo',
-            customName: (member: string) => `foo/lib/${member}`,
-          },
-        ],
+    const builder = await build({
+      ...setupConfig,
+      builderConfig: {
+        source: {
+          transformImport: [
+            {
+              libraryName: 'foo',
+              customName: (member: string) => `foo/lib/${member}`,
+            },
+          ],
+        },
       },
     });
     const files = await builder.unwrapOutputJSON(false);
@@ -31,9 +35,10 @@ webpackOnlyTest('should import with function customName', async () => {
     expect(files[entry]).toContain('transformImport test succeed');
   }
 
-  const builder = await build(
-    { ...setupConfig, plugins: [builderPluginSwc()] },
-    {
+  const builder = await build({
+    ...setupConfig,
+    plugins: [builderPluginSwc()],
+    builderConfig: {
       source: {
         transformImport: [
           {
@@ -49,7 +54,7 @@ webpackOnlyTest('should import with function customName', async () => {
         },
       },
     },
-  );
+  });
   const files = await builder.unwrapOutputJSON(false);
   const entry = findEntry(files);
   expect(files[entry]).toContain('transformImport test succeed');
@@ -58,22 +63,22 @@ webpackOnlyTest('should import with function customName', async () => {
 rspackOnlyTest('should import with template config', async () => {
   copyPkgToNodeModules();
 
-  const setupConfig = {
+  const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
-  };
-  const builder = await build(setupConfig, {
-    source: {
-      transformImport: [
-        {
-          libraryName: 'foo',
-          customName: 'foo/lib/{{ member }}',
+    builderConfig: {
+      source: {
+        transformImport: [
+          {
+            libraryName: 'foo',
+            customName: 'foo/lib/{{ member }}',
+          },
+        ],
+      },
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
         },
-      ],
-    },
-    performance: {
-      chunkSplit: {
-        strategy: 'all-in-one',
       },
     },
   });
@@ -90,15 +95,19 @@ webpackOnlyTest('should import with template config with SWC', async () => {
     entry: { index: path.resolve(__dirname, './src/index.js') },
     plugins: [builderPluginSwc()],
   };
+
   {
-    const builder = await build(setupConfig, {
-      source: {
-        transformImport: [
-          {
-            libraryName: 'foo',
-            customName: 'foo/lib/{{ member }}',
-          },
-        ],
+    const builder = await build({
+      ...setupConfig,
+      builderConfig: {
+        source: {
+          transformImport: [
+            {
+              libraryName: 'foo',
+              customName: 'foo/lib/{{ member }}',
+            },
+          ],
+        },
       },
     });
     const files = await builder.unwrapOutputJSON(false);
@@ -107,14 +116,17 @@ webpackOnlyTest('should import with template config with SWC', async () => {
   }
 
   {
-    const builder = await build(setupConfig, {
-      source: {
-        transformImport: [
-          {
-            libraryName: 'foo',
-            customName: member => `foo/lib/${member}`,
-          },
-        ],
+    const builder = await build({
+      ...setupConfig,
+      builderConfig: {
+        source: {
+          transformImport: [
+            {
+              libraryName: 'foo',
+              customName: member => `foo/lib/${member}`,
+            },
+          ],
+        },
       },
     });
     const files = await builder.unwrapOutputJSON(false);
@@ -183,27 +195,31 @@ function shareTest(
 
   // webpack
   webpackOnlyTest(`${msg}-webpack`, async () => {
-    const builder = await build(setupConfig, { ...config });
+    const builder = await build({
+      ...setupConfig,
+      builderConfig: { ...config },
+    });
     const files = await builder.unwrapOutputJSON(false);
     expect(files[findEntry(files)]).toContain('transformImport test succeed');
   });
 
   // webpack with swc
   webpackOnlyTest(`${msg}-webpack-swc`, async () => {
-    const builder = await build(
-      {
-        ...setupConfig,
-        plugins: [builderPluginSwc()],
-      },
-      { ...config },
-    );
+    const builder = await build({
+      ...setupConfig,
+      plugins: [builderPluginSwc()],
+      builderConfig: { ...config },
+    });
     const files = await builder.unwrapOutputJSON(false);
     expect(files[findEntry(files)]).toContain('transformImport test succeed');
   });
 
   // rspack
   rspackOnlyTest(`${msg}-rspack`, async () => {
-    const builder = await build(setupConfig, { ...config });
+    const builder = await build({
+      ...setupConfig,
+      builderConfig: { ...config },
+    });
     const files = await builder.unwrapOutputJSON(false);
     expect(files[findEntry(files)]).toContain('transformImport test succeed');
   });

--- a/tests/e2e/builder/cases/source/resolve-extension-prefix/tests/index.test.ts
+++ b/tests/e2e/builder/cases/source/resolve-extension-prefix/tests/index.test.ts
@@ -12,6 +12,7 @@ test('resolve-extension-prefix', async ({ page }) => {
     entry: {
       main: join(fixtures, 'src/index.js'),
     },
+    runServer: true,
   };
 
   // ex.js take effect when not set resolveExtensionPrefix
@@ -22,11 +23,15 @@ test('resolve-extension-prefix', async ({ page }) => {
   builder.close();
 
   // ex.web.js take effect when set resolveExtensionPrefix
-  builder = await build(buildOpts, {
-    source: {
-      resolveExtensionPrefix: '.web',
+  builder = await build({
+    ...buildOpts,
+    builderConfig: {
+      source: {
+        resolveExtensionPrefix: '.web',
+      },
     },
   });
+
   await page.goto(getHrefByEntryName('main', builder.port));
   await expect(page.innerHTML('#test-el')).resolves.toBe('web');
 

--- a/tests/e2e/builder/cases/stylus-rem/index.test.ts
+++ b/tests/e2e/builder/cases/stylus-rem/index.test.ts
@@ -5,18 +5,16 @@ import { build } from '@scripts/shared';
 import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';
 
 test('should compile stylus and rem correctly', async () => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-      plugins: [builderPluginStylus()],
-    },
-    {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    plugins: [builderPluginStylus()],
+    builderConfig: {
       output: {
         convertToRem: true,
       },
     },
-  );
+  });
   const files = await builder.unwrapOutputJSON();
 
   const content =

--- a/tests/e2e/builder/cases/svg/svg.test.ts
+++ b/tests/e2e/builder/cases/svg/svg.test.ts
@@ -5,14 +5,13 @@ import { build, getHrefByEntryName } from '@scripts/shared';
 const fixtures = __dirname;
 
 test('svg (default)', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: join(fixtures, 'svg'),
     entry: {
       main: join(fixtures, 'svg', 'src/index.js'),
     },
-  };
-
-  const builder = await build(buildOpts, {});
+    runServer: true,
+  });
 
   await page.goto(getHrefByEntryName('main', builder.port));
 
@@ -39,16 +38,16 @@ test('svg (default)', async ({ page }) => {
 });
 
 test('svg (defaultExport component)', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: join(fixtures, 'svg-default-export-component'),
     entry: {
       main: join(fixtures, 'svg-default-export-component', 'src/index.js'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    output: {
-      svgDefaultExport: 'component',
+    runServer: true,
+    builderConfig: {
+      output: {
+        svgDefaultExport: 'component',
+      },
     },
   });
 
@@ -62,14 +61,13 @@ test('svg (defaultExport component)', async ({ page }) => {
 });
 
 test('svg (url)', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: join(fixtures, 'svg-url'),
     entry: {
       main: join(fixtures, 'svg-url', 'src/index.js'),
     },
-  };
-
-  const builder = await build(buildOpts, {});
+    runServer: true,
+  });
 
   await page.goto(getHrefByEntryName('main', builder.port));
 
@@ -92,22 +90,22 @@ test('svg (url)', async ({ page }) => {
 
 // It's an old bug when use svgr in css and external react.
 test('svg (external react)', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: join(fixtures, 'svg-external-react'),
     entry: {
       main: join(fixtures, 'svg-external-react', 'src/index.js'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    output: {
-      externals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
+    runServer: true,
+    builderConfig: {
+      output: {
+        externals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
       },
-    },
-    html: {
-      template: './static/index.html',
+      html: {
+        template: './static/index.html',
+      },
     },
   });
 
@@ -136,16 +134,16 @@ test('svg (external react)', async ({ page }) => {
 });
 
 test('svg (disableSvgr)', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: join(fixtures, 'svg-assets'),
     entry: {
       main: join(fixtures, 'svg-assets', 'src/index.js'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    output: {
-      disableSvgr: true,
+    runServer: true,
+    builderConfig: {
+      output: {
+        disableSvgr: true,
+      },
     },
   });
 

--- a/tests/e2e/builder/cases/swc/index.test.ts
+++ b/tests/e2e/builder/cases/swc/index.test.ts
@@ -13,6 +13,7 @@ webpackOnlyTest('should run SWC compilation correctly', async ({ page }) => {
       index: path.resolve(__dirname, './src/main.ts'),
     },
     plugins: [builderPluginSwc()],
+    runServer: true,
   });
 
   await page.goto(getHrefByEntryName('index', builder.port));
@@ -22,23 +23,24 @@ webpackOnlyTest('should run SWC compilation correctly', async ({ page }) => {
     age: 10,
     school: 'yyy',
   });
+
+  builder.close();
 });
 
 webpackOnlyTest('should optimize lodash bundle size', async ({ page }) => {
-  const builder = await build(
-    {
-      cwd: __dirname,
-      entry: {
-        index: path.resolve(__dirname, './src/main.ts'),
-      },
-      plugins: [builderPluginSwc()],
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/main.ts'),
     },
-    {
+    plugins: [builderPluginSwc()],
+    runServer: true,
+    builderConfig: {
       output: {
         polyfill: 'entry',
       },
     },
-  );
+  });
 
   await page.goto(getHrefByEntryName('index', builder.port));
 
@@ -52,4 +54,6 @@ webpackOnlyTest('should optimize lodash bundle size', async ({ page }) => {
   const bundleSize = readFileSync(lodashBundle, 'utf-8').length / 1024;
 
   expect(bundleSize < 10).toBeTruthy();
+
+  builder.close();
 });

--- a/tests/e2e/builder/cases/tools.test.ts
+++ b/tests/e2e/builder/cases/tools.test.ts
@@ -6,18 +6,18 @@ import { webpackOnlyTest } from '../scripts/helper';
 const fixtures = __dirname;
 
 test('postcss plugins overwrite', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: join(fixtures, 'output/rem'),
     entry: {
       main: join(fixtures, 'output/rem/src/index.ts'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    tools: {
-      postcss: {
-        postcssOptions: {
-          plugins: [],
+    runServer: true,
+    builderConfig: {
+      tools: {
+        postcss: {
+          postcssOptions: {
+            plugins: [],
+          },
         },
       },
     },
@@ -28,24 +28,26 @@ test('postcss plugins overwrite', async ({ page }) => {
   await expect(
     page.evaluate(`document.getElementById('title').innerHTML`),
   ).resolves.toBe('title');
+
+  builder.close();
 });
 
 webpackOnlyTest('webpackChain plugin', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: join(fixtures, 'source/global-vars'),
     entry: {
       main: join(fixtures, 'source/global-vars/src/index.ts'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    tools: {
-      webpackChain: (chain, { webpack }) => {
-        chain.plugin('define').use(webpack.DefinePlugin, [
-          {
-            ENABLE_TEST: JSON.stringify(true),
-          },
-        ]);
+    runServer: true,
+    builderConfig: {
+      tools: {
+        webpackChain: (chain, { webpack }) => {
+          chain.plugin('define').use(webpack.DefinePlugin, [
+            {
+              ENABLE_TEST: JSON.stringify(true),
+            },
+          ]);
+        },
       },
     },
   });
@@ -54,4 +56,6 @@ webpackOnlyTest('webpackChain plugin', async ({ page }) => {
   await expect(
     page.evaluate(`document.getElementById('test-el').innerHTML`),
   ).resolves.toBe('aaaaa');
+
+  builder.close();
 });

--- a/tests/e2e/builder/cases/tools/pug/tests/index.test.ts
+++ b/tests/e2e/builder/cases/tools/pug/tests/index.test.ts
@@ -5,19 +5,19 @@ import { build, getHrefByEntryName } from '@scripts/shared';
 const fixtures = resolve(__dirname, '../');
 
 test('pug', async ({ page }) => {
-  const buildOpts = {
+  const builder = await build({
     cwd: fixtures,
     entry: {
       main: join(fixtures, 'src/index.ts'),
     },
-  };
-
-  const builder = await build(buildOpts, {
-    html: {
-      template: './static/index.pug',
-    },
-    tools: {
-      pug: true,
+    runServer: true,
+    builderConfig: {
+      html: {
+        template: './static/index.pug',
+      },
+      tools: {
+        pug: true,
+      },
     },
   });
 

--- a/tests/e2e/builder/scripts/shared.ts
+++ b/tests/e2e/builder/scripts/shared.ts
@@ -4,9 +4,7 @@ import fs from '@modern-js/utils/fs-extra';
 import type { CreateBuilderOptions } from '@modern-js/builder';
 import type { BuilderConfig } from '@modern-js/builder-webpack-provider';
 import type { BuilderConfig as RspackBuilderConfig } from '@modern-js/builder-rspack-provider';
-import { createStubBuilder } from '@modern-js/builder-webpack-provider/stub';
 import { StartDevServerOptions } from '@modern-js/builder-shared';
-import { getPort } from '@modern-js/utils';
 
 export const getHrefByEntryName = (entryName: string, port: number) => {
   const baseUrl = new URL(`http://localhost:${port}`);
@@ -59,11 +57,25 @@ export const createBuilder = async (
   return builder;
 };
 
-const updateConfigForTest = async (config: BuilderConfig) => {
+const portMap = new Map();
+
+function getRandomPort(defaultPort = Math.ceil(Math.random() * 10000) + 10000) {
+  let port = defaultPort;
+  while (true) {
+    if (!portMap.get(port)) {
+      portMap.set(port, 1);
+      return port;
+    } else {
+      port++;
+    }
+  }
+}
+
+const updateConfigForTest = (config: BuilderConfig) => {
   // make devPort random to avoid port conflict
   config.dev = {
     ...(config.dev || {}),
-    port: await getRandomPort(config.dev?.port),
+    port: getRandomPort(config.dev?.port),
   };
 
   config.dev!.progressBar = config.dev!.progressBar || false;
@@ -92,54 +104,45 @@ const updateConfigForTest = async (config: BuilderConfig) => {
   }
 };
 
-export async function dev(
-  builderOptions: CreateBuilderOptions,
-  config: BuilderConfig = {},
-  serverOptions?: StartDevServerOptions['serverOptions'],
-) {
+export async function dev({
+  serverOptions,
+  builderConfig = {},
+  ...options
+}: CreateBuilderOptions & {
+  builderConfig?: BuilderConfig;
+  serverOptions?: StartDevServerOptions['serverOptions'];
+}) {
   process.env.NODE_ENV = 'development';
 
-  await updateConfigForTest(config);
+  updateConfigForTest(builderConfig);
 
-  const builder = await createBuilder(builderOptions, config);
+  const builder = await createBuilder(options, builderConfig);
   return builder.startDevServer({
     printURLs: false,
     serverOptions,
   });
 }
 
-const portMap = new Map();
-
-async function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 10000) + 10000,
-) {
-  while (true) {
-    const port = await getPort(defaultPort);
-    if (!portMap.get(port)) {
-      portMap.set(port, 1);
-      return port;
-    }
-  }
-}
-
-export async function build(
-  builderOptions: CreateBuilderOptions & {
-    builderConfig?: BuilderConfig;
-    plugins?: any[];
-  },
-  config: BuilderConfig = builderOptions.builderConfig || {},
-  runServer = true,
-) {
+export async function build({
+  plugins,
+  runServer = false,
+  builderConfig = {},
+  ...options
+}: CreateBuilderOptions & {
+  plugins?: any[];
+  runServer?: boolean;
+  builderConfig?: BuilderConfig;
+}) {
   process.env.NODE_ENV = 'production';
 
-  await updateConfigForTest(config);
+  updateConfigForTest(builderConfig);
 
-  const builder = await createBuilder(builderOptions, config);
+  const builder = await createBuilder(options, builderConfig);
 
   builder.removePlugins(['builder-plugin-file-size']);
 
-  if (builderOptions.plugins) {
-    builder.addPlugins(builderOptions.plugins);
+  if (plugins) {
+    builder.addPlugins(plugins);
   }
 
   const [{ runStaticServer, globContentJSON }] = await Promise.all([
@@ -151,7 +154,7 @@ export async function build(
 
   const { port, close } = runServer
     ? await runStaticServer(distPath, {
-        port: config.dev!.port,
+        port: builderConfig.dev!.port,
       })
     : { port: 0, close: noop };
 
@@ -174,28 +177,4 @@ export async function build(
     providerType: process.env.PROVIDE_TYPE || 'webpack',
     instance: builder,
   };
-}
-
-export async function stubBuild(
-  builderOptions: CreateBuilderOptions,
-  config: BuilderConfig = {},
-) {
-  const tsConfigPath = join(builderOptions.cwd!, 'tsconfig.json');
-
-  // todo: not yet support switch to rspack-builder
-  const builder = await createStubBuilder({
-    cwd: builderOptions.cwd,
-    webpack: true,
-    plugins: 'default',
-    target: ['web'],
-    builderConfig: config,
-    entry: builderOptions.entry,
-    context: {
-      tsconfigPath: fs.existsSync(tsConfigPath) ? tsConfigPath : undefined,
-    } as any,
-  });
-
-  builder.removePlugins(['builder-plugin-file-size']);
-
-  return builder;
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b06cadb</samp>

Refactored the `build` and `dev` functions in various test cases to use a more consistent and flexible interface. The functions now take an object with a `builderConfig` property and a `runServer` option, and return a `builder` object with a `close` method and other helper methods. This simplifies the test code, enables server testing and cleanup, and aligns with the latest changes in the `builder` module. Skipped or moved some tests due to unresolved issues.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b06cadb</samp>

*  Refactor `build` and `dev` functions to accept a single object argument and return a promise that resolves to a `builder` object with a `close` method ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-103fbd5c6a99fb551540e16f4b616f7cb9ca77409394423f3efbc22d345b5f0cL6-R12),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-103fbd5c6a99fb551540e16f4b616f7cb9ca77409394423f3efbc22d345b5f0cL20-R24),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cd7580de9aa167a62592927f8c3bc122ab4adb1a4066eb1cb795097f77f9d90bL7-R10),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cd7580de9aa167a62592927f8c3bc122ab4adb1a4066eb1cb795097f77f9d90bL28-R26),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-4eebba9872af66a9de75ab6f95eab8622aac8944a2b0828717d4ddd69f3d01efL12-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-4eebba9872af66a9de75ab6f95eab8622aac8944a2b0828717d4ddd69f3d01efL52-R60),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L22-R25),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L33-R31),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L57-R57),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L77-R72),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L95-R92),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L113-R105),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-5b4d8e6137e95185e99c1133be6e5f6fba6da4977d5a9215edfdea25a6d36e4bL9-R12),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-5b4d8e6137e95185e99c1133be6e5f6fba6da4977d5a9215edfdea25a6d36e4bL25-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cc420e6e5cf66c85b6ceb47ec81b5d668c7514170da5dac23df8369737e037c9L6-R14),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cc420e6e5cf66c85b6ceb47ec81b5d668c7514170da5dac23df8369737e037c9L31-R31),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cc420e6e5cf66c85b6ceb47ec81b5d668c7514170da5dac23df8369737e037c9L44-R39),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cc420e6e5cf66c85b6ceb47ec81b5d668c7514170da5dac23df8369737e037c9L57-R59),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL24-R31),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caR61-R62),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL67-R77),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL104-R109),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL118-R115),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL139-R147),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL156-R153),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL174-R175),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL187-R181),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L9-R19),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L55-R70),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L98-R113),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-67656284a76afce561166a92ad5c40771ec12b6428c4ec0892d49645152973a3L8-R13),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-67656284a76afce561166a92ad5c40771ec12b6428c4ec0892d49645152973a3L28-R24),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f369e1d76ef1b2397a81de2c6a68c07d45aa6750acadd6f7e9ecf31582d20866R13),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f369e1d76ef1b2397a81de2c6a68c07d45aa6750acadd6f7e9ecf31582d20866R28-R29),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-2b7cc46c5fc94a366bf61ed09507c3c29aef41d19dca15961f818445dab5efb7L62-R70),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L8-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L45-R49),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L58-R56),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL15-L21),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL30-R35),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL64-L70),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL81-R84),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L8-R13),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L36-R43),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL12-R17),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL27-R25),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL49-R52),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL64-R60),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL79-R80),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL93-R87),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L24-R32),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L44-R50),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e1e5e5614e182e4b1f16ac75b98962a452e1179b9341ebc1c38ab952d888d029L21-R29))
* Move `tools` option to a nested `builderConfig` property to separate it from other options ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-103fbd5c6a99fb551540e16f4b616f7cb9ca77409394423f3efbc22d345b5f0cL6-R12),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L11-R22),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L129-R137),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L184-R186),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L204-R220),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e6a5f01409e817dd67749be5c3fa6703e74560b4c66283edaecae051147787e6L8-R19),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L296-R329),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL174-R175))
* Move `output` option to a nested `builderConfig` property to separate it from other options ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-4eebba9872af66a9de75ab6f95eab8622aac8944a2b0828717d4ddd69f3d01efL12-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L22-R25),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L57-R57),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L95-R92),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL24-R31),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL67-R77),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL104-R109),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL139-R147),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L9-R19),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L98-R113),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-67656284a76afce561166a92ad5c40771ec12b6428c4ec0892d49645152973a3L8-R13),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-2b7cc46c5fc94a366bf61ed09507c3c29aef41d19dca15961f818445dab5efb7L62-R70),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L8-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL30-R35),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL81-R84),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L8-R13),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L24-R32))
* Move `html` option to a nested `builderConfig` property to separate it from other options ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-5b4d8e6137e95185e99c1133be6e5f6fba6da4977d5a9215edfdea25a6d36e4bL9-R12),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cc420e6e5cf66c85b6ceb47ec81b5d668c7514170da5dac23df8369737e037c9L6-R14),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L12-R29),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L59-R63),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L144-R161),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L160-R184),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L193-R208),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L203-R228),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L237-R255),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L247-R275),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L275-R303))
* Move `source` option to a nested `builderConfig` property to separate it from other options ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cd7580de9aa167a62592927f8c3bc122ab4adb1a4066eb1cb795097f77f9d90bL7-R10))
* Move `dev` option to a nested `builderConfig` property to separate it from other options ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L184-R186),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e1e5e5614e182e4b1f16ac75b98962a452e1179b9341ebc1c38ab952d888d029L21-R29))
* Move `performance` option to a nested `builderConfig` property to separate it from other options ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL12-R17),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL49-R52),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL79-R80))
* Add `runServer` option to `build` and `dev` functions to start a server for the test ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-4eebba9872af66a9de75ab6f95eab8622aac8944a2b0828717d4ddd69f3d01efL12-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L11-R22),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L86-R99),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L129-R137),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L184-R186),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L204-R220),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e6a5f01409e817dd67749be5c3fa6703e74560b4c66283edaecae051147787e6L8-R19),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L12-R29),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L59-R63),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L144-R161),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L160-R184),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L193-R208),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L203-R228),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L237-R255),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L247-R275),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L275-R303),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL24-R31),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL67-R77),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL104-R109),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L9-R19),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L98-R113),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f369e1d76ef1b2397a81de2c6a68c07d45aa6750acadd6f7e9ecf31582d20866R13))
* Add `serverOptions` option to `dev` function to pass additional options to the server ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L129-R137))
* Add `close` method to `builder` object to stop the server and call it after the test assertion or in the `afterAll` hook ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-103fbd5c6a99fb551540e16f4b616f7cb9ca77409394423f3efbc22d345b5f0cL20-R24),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-4eebba9872af66a9de75ab6f95eab8622aac8944a2b0828717d4ddd69f3d01efL52-R60),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L150-R144),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L65-R79),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589R93-R96),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589R344-R345),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caR61-R62),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL118-R115),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL139-R147),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-309d7e4c4d0316eee46bb0102cfc07638d01c8b344b549b87f96082151703176L55-R70),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f369e1d76ef1b2397a81de2c6a68c07d45aa6750acadd6f7e9ecf31582d20866R28-R29),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-31a263ba6d47f853b597b1299bb6f75bb255e8f41b12c30a73f528aab7e7edc6L36-R43))
* Use `unwrapOutputJSON` method on the `builder` object instead of the `builder` function to get the output JSON ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cd7580de9aa167a62592927f8c3bc122ab4adb1a4066eb1cb795097f77f9d90bL28-R26),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L33-R31),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L77-R72),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L113-R105),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-5b4d8e6137e95185e99c1133be6e5f6fba6da4977d5a9215edfdea25a6d36e4bL25-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cc420e6e5cf66c85b6ceb47ec81b5d668c7514170da5dac23df8369737e037c9L31-R31),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cc420e6e5cf66c85b6ceb47ec81b5d668c7514170da5dac23df8369737e037c9L57-R59),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL156-R153),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL187-R181),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-67656284a76afce561166a92ad5c40771ec12b6428c4ec0892d49645152973a3L28-R24),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L45-R49),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-dc95e8111a5ee5a275f0d5eadf92d9520e0af81d142346ca6e1e93438cb7ad40L58-R56),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL30-R35),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL81-R84),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL27-R25),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL64-R60),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL93-R87),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-e6a56ef315e0230b0c5ebe91866ce96d0143fbafe4cf5653ee9f886d75505767L44-R50))
* Move `build` function from `tests/e2e/builder/cases/check-syntax/index.test.ts` and `tests/e2e/builder/cases/html/html.test.ts` to `tests/e2e/builder/cases/babel/build.test.ts` and reuse it in other test files ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-cd7580de9aa167a62592927f8c3bc122ab4adb1a4066eb1cb795097f77f9d90bL7-R10),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L59-R63))
* Skip tests that are not working or require devcert ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L11-R22),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L86-R99),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L129-R137),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L184-R186),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-d7cea4042a9f7fc9e8ac47d68f527eeac34f2271dfe31c6369410744712423b0L204-R220),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-1b9b47b2fef2a91f25f41be12e0f4cc9a03debc2c106c741420c246bdfd39589L296-R329))
* Use `webpackOnlyTest` function to skip tests for other bundlers ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-4eebba9872af66a9de75ab6f95eab8622aac8944a2b0828717d4ddd69f3d01efL52-R60))
* Remove `buildOpts` variable and pass the object directly to the `build` function ([link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-4eebba9872af66a9de75ab6f95eab8622aac8944a2b0828717d4ddd69f3d01efL12-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-2b7cc46c5fc94a366bf61ed09507c3c29aef41d19dca15961f818445dab5efb7L62-R70),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL15-L21),[link](https://github.com/web-infra-dev/modern.js/pull/3948/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL64-L70))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
