### PR TITLE
chore(builder): move more default config to shared package

### DIFF
--- a/.changeset/curvy-shoes-begin.md
+++ b/.changeset/curvy-shoes-begin.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+chore(builder): move more default config to shared package
+
+chore(builder): 移动更多默认 config 到 shared 包

--- a/packages/builder/builder-rspack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-rspack-provider/src/config/defaults.ts
@@ -13,19 +13,21 @@ import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = () =>
-  defineDefaultConfig({
-    dev: getDefaultDevConfig(),
-    html: getDefaultHtmlConfig(),
-    source: {
-      ...getDefaultSourceConfig(),
-      define: {},
-    },
-    output: getDefaultOutputConfig(),
-    tools: getDefaultToolsConfig(),
-    security: getDefaultSecurityConfig(),
-    performance: getDefaultPerformanceConfig(),
-  });
+export const createDefaultConfig = () => ({
+  dev: getDefaultDevConfig(),
+  html: getDefaultHtmlConfig(),
+  source: {
+    ...getDefaultSourceConfig(),
+    define: {},
+  },
+  output: getDefaultOutputConfig(),
+  tools: getDefaultToolsConfig(),
+  security: getDefaultSecurityConfig(),
+  performance: getDefaultPerformanceConfig(),
+});
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);
+  mergeBuilderConfig<BuilderConfig>(
+    defineDefaultConfig(createDefaultConfig()),
+    config,
+  );

--- a/packages/builder/builder-rspack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-rspack-provider/src/config/defaults.ts
@@ -13,7 +13,7 @@ import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = (): BuilderConfig =>
+export const createDefaultConfig = () =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),

--- a/packages/builder/builder-rspack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-rspack-provider/src/config/defaults.ts
@@ -9,11 +9,11 @@ import {
   getDefaultSecurityConfig,
   getDefaultPerformanceConfig,
 } from '@modern-js/builder-shared';
-import type { BuilderConfig, NormalizedConfig } from '../types';
+import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = (): NormalizedConfig =>
+export const createDefaultConfig = () =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),
@@ -28,7 +28,4 @@ export const createDefaultConfig = (): NormalizedConfig =>
   });
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(
-    createDefaultConfig() as BuilderConfig,
-    config,
-  );
+  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);

--- a/packages/builder/builder-rspack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-rspack-provider/src/config/defaults.ts
@@ -1,5 +1,4 @@
 import {
-  extendsType,
   mergeBuilderConfig,
   getDefaultDevConfig,
   getDefaultHtmlConfig,
@@ -11,9 +10,7 @@ import {
 } from '@modern-js/builder-shared';
 import type { BuilderConfig } from '../types';
 
-const defineDefaultConfig = extendsType<BuilderConfig>();
-
-export const createDefaultConfig = () => ({
+export const createDefaultConfig = (): BuilderConfig => ({
   dev: getDefaultDevConfig(),
   html: getDefaultHtmlConfig(),
   source: {
@@ -27,7 +24,4 @@ export const createDefaultConfig = () => ({
 });
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(
-    defineDefaultConfig(createDefaultConfig()),
-    config,
-  );
+  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);

--- a/packages/builder/builder-rspack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-rspack-provider/src/config/defaults.ts
@@ -13,7 +13,7 @@ import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = () =>
+export const createDefaultConfig = (): BuilderConfig =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),

--- a/packages/builder/builder-rspack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-rspack-provider/src/config/defaults.ts
@@ -2,41 +2,33 @@ import {
   extendsType,
   mergeBuilderConfig,
   getDefaultDevConfig,
-  getDefaultOutputConfig,
   getDefaultHtmlConfig,
+  getDefaultToolsConfig,
+  getDefaultOutputConfig,
   getDefaultSourceConfig,
+  getDefaultSecurityConfig,
+  getDefaultPerformanceConfig,
 } from '@modern-js/builder-shared';
-import type { BuilderConfig } from '../types';
+import type { BuilderConfig, NormalizedConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = () =>
+export const createDefaultConfig = (): NormalizedConfig =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),
     source: {
       ...getDefaultSourceConfig(),
-      alias: {},
       define: {},
     },
     output: getDefaultOutputConfig(),
-    tools: {},
-    security: {
-      checkSyntax: false,
-      nonce: '',
-      // sri: false
-    },
-    performance: {
-      // profile: false,
-      buildCache: true,
-      printFileSize: true,
-      removeConsole: false,
-      // removeMomentLocale: false,
-      chunkSplit: {
-        strategy: 'split-by-experience',
-      },
-    },
+    tools: getDefaultToolsConfig(),
+    security: getDefaultSecurityConfig(),
+    performance: getDefaultPerformanceConfig(),
   });
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);
+  mergeBuilderConfig<BuilderConfig>(
+    createDefaultConfig() as BuilderConfig,
+    config,
+  );

--- a/packages/builder/builder-rspack-provider/src/config/normalize.ts
+++ b/packages/builder/builder-rspack-provider/src/config/normalize.ts
@@ -5,9 +5,7 @@ import { createDefaultConfig } from './defaults';
 const defineNormalizedDefaultConfig = extendsType<NormalizedConfig>();
 
 const createNormalizedDefaultConfig = () =>
-  defineNormalizedDefaultConfig({
-    ...createDefaultConfig(),
-  });
+  defineNormalizedDefaultConfig(createDefaultConfig());
 
 /** #__PURE__
  * 1. May used by multiple plugins.

--- a/packages/builder/builder-rspack-provider/src/config/normalize.ts
+++ b/packages/builder/builder-rspack-provider/src/config/normalize.ts
@@ -1,11 +1,6 @@
-import { extendsType, mergeBuilderConfig } from '@modern-js/builder-shared';
+import { mergeBuilderConfig } from '@modern-js/builder-shared';
 import { BuilderConfig, NormalizedConfig } from '../types';
 import { createDefaultConfig } from './defaults';
-
-const defineNormalizedDefaultConfig = extendsType<NormalizedConfig>();
-
-const createNormalizedDefaultConfig = () =>
-  defineNormalizedDefaultConfig(createDefaultConfig());
 
 /** #__PURE__
  * 1. May used by multiple plugins.
@@ -14,6 +9,6 @@ const createNormalizedDefaultConfig = () =>
  */
 export const normalizeConfig = (config: BuilderConfig): NormalizedConfig =>
   mergeBuilderConfig<NormalizedConfig>(
-    createNormalizedDefaultConfig(),
+    createDefaultConfig() as NormalizedConfig,
     config as NormalizedConfig,
   );

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -19,14 +19,17 @@ import {
 import { generateMetaTags } from './generateMetaTags';
 import type {
   BuilderTarget,
+  BundlerChainRule,
   SharedHtmlConfig,
   InspectConfigOptions,
   CreateBuilderOptions,
   NormalizedSharedDevConfig,
+  NormalizedSharedHtmlConfig,
   NormalizedSharedOutputConfig,
   NormalizedSharedSourceConfig,
-  NormalizedSharedHtmlConfig,
-  BundlerChainRule,
+  NormalizedSharedSecurityConfig,
+  NormalizedSharedPerformanceConfig,
+  NormalizedSharedToolsConfig,
 } from './types';
 import { logger } from './logger';
 import { join } from 'path';
@@ -45,6 +48,7 @@ export const getDefaultDevConfig = (): NormalizedSharedDevConfig => ({
 });
 
 export const getDefaultSourceConfig = (): NormalizedSharedSourceConfig => ({
+  alias: {},
   preEntry: [],
   globalVars: {},
   compileJsDataURI: true,
@@ -57,6 +61,25 @@ export const getDefaultHtmlConfig = (): NormalizedSharedHtmlConfig => ({
   disableHtmlFolder: false,
   scriptLoading: 'defer',
 });
+
+export const getDefaultSecurityConfig = (): NormalizedSharedSecurityConfig => ({
+  nonce: '',
+  checkSyntax: false,
+});
+
+export const getDefaultToolsConfig = (): NormalizedSharedToolsConfig => ({
+  tsChecker: {},
+});
+
+export const getDefaultPerformanceConfig =
+  (): NormalizedSharedPerformanceConfig => ({
+    buildCache: true,
+    printFileSize: true,
+    removeConsole: false,
+    chunkSplit: {
+      strategy: 'split-by-experience',
+    },
+  });
 
 export const getDefaultOutputConfig = (): NormalizedSharedOutputConfig => ({
   distPath: {

--- a/packages/builder/builder-shared/src/types/config/source.ts
+++ b/packages/builder/builder-shared/src/types/config/source.ts
@@ -69,6 +69,7 @@ export type SharedTransformImport = {
 };
 
 export interface NormalizedSharedSourceConfig extends SharedSourceConfig {
+  alias: ChainedConfig<Alias>;
   preEntry: string[];
   globalVars: ChainedGlobalVars;
   compileJsDataURI: boolean;

--- a/packages/builder/builder-shared/src/types/config/tools.ts
+++ b/packages/builder/builder-shared/src/types/config/tools.ts
@@ -91,3 +91,7 @@ export interface SharedToolsConfig {
    */
   tsChecker?: ToolsTSCheckerConfig;
 }
+
+export interface NormalizedSharedToolsConfig extends SharedToolsConfig {
+  tsChecker: ToolsTSCheckerConfig;
+}

--- a/packages/builder/builder-shared/src/utils.ts
+++ b/packages/builder/builder-shared/src/utils.ts
@@ -11,11 +11,6 @@ import type {
 } from './types';
 import { join } from 'path';
 
-export const extendsType =
-  <T>() =>
-  <P extends T>(source: P): P =>
-    source;
-
 export const createVirtualModule = (content: string) =>
   `data:text/javascript,${content}`;
 

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -9,11 +9,11 @@ import {
   getDefaultPerformanceConfig,
   getDefaultToolsConfig,
 } from '@modern-js/builder-shared';
-import type { BuilderConfig, NormalizedConfig } from '../types';
+import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = (): NormalizedConfig =>
+export const createDefaultConfig = () =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),
@@ -44,7 +44,4 @@ export const createDefaultConfig = (): NormalizedConfig =>
   });
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(
-    createDefaultConfig() as BuilderConfig,
-    config,
-  );
+  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -13,7 +13,7 @@ import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = (): BuilderConfig =>
+export const createDefaultConfig = () =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -1,5 +1,4 @@
 import {
-  extendsType,
   mergeBuilderConfig,
   getDefaultDevConfig,
   getDefaultOutputConfig,
@@ -11,9 +10,7 @@ import {
 } from '@modern-js/builder-shared';
 import type { BuilderConfig } from '../types';
 
-const defineDefaultConfig = extendsType<BuilderConfig>();
-
-export const createDefaultConfig = () => ({
+export const createDefaultConfig = (): BuilderConfig => ({
   dev: getDefaultDevConfig(),
   html: getDefaultHtmlConfig(),
   tools: {
@@ -43,7 +40,4 @@ export const createDefaultConfig = () => ({
 });
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(
-    defineDefaultConfig(createDefaultConfig()),
-    config,
-  );
+  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -13,35 +13,37 @@ import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = () =>
-  defineDefaultConfig({
-    dev: getDefaultDevConfig(),
-    html: getDefaultHtmlConfig(),
-    tools: {
-      ...getDefaultToolsConfig(),
-      cssExtract: {
-        loaderOptions: {},
-        pluginOptions: {},
-      },
+export const createDefaultConfig = () => ({
+  dev: getDefaultDevConfig(),
+  html: getDefaultHtmlConfig(),
+  tools: {
+    ...getDefaultToolsConfig(),
+    cssExtract: {
+      loaderOptions: {},
+      pluginOptions: {},
     },
-    source: {
-      ...getDefaultSourceConfig(),
-      define: {},
-    },
-    output: getDefaultOutputConfig(),
-    security: {
-      ...getDefaultSecurityConfig(),
-      sri: false,
-    },
-    experiments: {
-      lazyCompilation: false,
-    },
-    performance: {
-      ...getDefaultPerformanceConfig(),
-      profile: false,
-      removeMomentLocale: false,
-    },
-  });
+  },
+  source: {
+    ...getDefaultSourceConfig(),
+    define: {},
+  },
+  output: getDefaultOutputConfig(),
+  security: {
+    ...getDefaultSecurityConfig(),
+    sri: false,
+  },
+  experiments: {
+    lazyCompilation: false,
+  },
+  performance: {
+    ...getDefaultPerformanceConfig(),
+    profile: false,
+    removeMomentLocale: false,
+  },
+});
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);
+  mergeBuilderConfig<BuilderConfig>(
+    defineDefaultConfig(createDefaultConfig()),
+    config,
+  );

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -13,7 +13,7 @@ import type { BuilderConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = () =>
+export const createDefaultConfig = (): BuilderConfig =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -5,43 +5,46 @@ import {
   getDefaultOutputConfig,
   getDefaultHtmlConfig,
   getDefaultSourceConfig,
+  getDefaultSecurityConfig,
+  getDefaultPerformanceConfig,
+  getDefaultToolsConfig,
 } from '@modern-js/builder-shared';
-import type { BuilderConfig } from '../types';
+import type { BuilderConfig, NormalizedConfig } from '../types';
 
 const defineDefaultConfig = extendsType<BuilderConfig>();
 
-export const createDefaultConfig = () =>
+export const createDefaultConfig = (): NormalizedConfig =>
   defineDefaultConfig({
     dev: getDefaultDevConfig(),
     html: getDefaultHtmlConfig(),
     tools: {
+      ...getDefaultToolsConfig(),
       cssExtract: {
         loaderOptions: {},
         pluginOptions: {},
       },
-      tsChecker: {},
     },
     source: {
       ...getDefaultSourceConfig(),
-      alias: {},
       define: {},
     },
     output: getDefaultOutputConfig(),
-    security: { sri: false, checkSyntax: false, nonce: '' },
+    security: {
+      ...getDefaultSecurityConfig(),
+      sri: false,
+    },
     experiments: {
       lazyCompilation: false,
     },
     performance: {
+      ...getDefaultPerformanceConfig(),
       profile: false,
-      buildCache: true,
-      printFileSize: true,
-      removeConsole: false,
       removeMomentLocale: false,
-      chunkSplit: {
-        strategy: 'split-by-experience',
-      },
     },
   });
 
 export const withDefaultConfig = (config: BuilderConfig) =>
-  mergeBuilderConfig<BuilderConfig>(createDefaultConfig(), config);
+  mergeBuilderConfig<BuilderConfig>(
+    createDefaultConfig() as BuilderConfig,
+    config,
+  );

--- a/packages/builder/builder-webpack-provider/src/config/normalize.ts
+++ b/packages/builder/builder-webpack-provider/src/config/normalize.ts
@@ -5,9 +5,7 @@ import { createDefaultConfig } from './defaults';
 const defineNormalizedDefaultConfig = extendsType<NormalizedConfig>();
 
 const createNormalizedDefaultConfig = () =>
-  defineNormalizedDefaultConfig({
-    ...createDefaultConfig(),
-  });
+  defineNormalizedDefaultConfig(createDefaultConfig());
 
 /** #__PURE__
  * 1. May used by multiple plugins.

--- a/packages/builder/builder-webpack-provider/src/config/normalize.ts
+++ b/packages/builder/builder-webpack-provider/src/config/normalize.ts
@@ -1,11 +1,6 @@
-import { extendsType, mergeBuilderConfig } from '@modern-js/builder-shared';
+import { mergeBuilderConfig } from '@modern-js/builder-shared';
 import { BuilderConfig, NormalizedConfig } from '../types';
 import { createDefaultConfig } from './defaults';
-
-const defineNormalizedDefaultConfig = extendsType<NormalizedConfig>();
-
-const createNormalizedDefaultConfig = () =>
-  defineNormalizedDefaultConfig(createDefaultConfig());
 
 /** #__PURE__
  * 1. May used by multiple plugins.
@@ -14,6 +9,6 @@ const createNormalizedDefaultConfig = () =>
  */
 export const normalizeConfig = (config: BuilderConfig): NormalizedConfig =>
   mergeBuilderConfig<NormalizedConfig>(
-    createNormalizedDefaultConfig(),
+    createDefaultConfig() as NormalizedConfig,
     config as NormalizedConfig,
   );

--- a/tests/e2e/builder/cases/cache/index.test.ts
+++ b/tests/e2e/builder/cases/cache/index.test.ts
@@ -7,6 +7,13 @@ import { fs } from '@modern-js/utils';
 webpackOnlyTest(
   'should save the buildDependencies to cache directory',
   async () => {
+    const configFile = path.resolve(
+      __dirname,
+      './node_modules/.cache/webpack/buildDependencies.json',
+    );
+
+    fs.removeSync(configFile);
+
     await build({
       cwd: __dirname,
       entry: { index: path.resolve(__dirname, './src/index.js') },
@@ -18,10 +25,6 @@ webpackOnlyTest(
       },
     });
 
-    const configFile = path.resolve(
-      __dirname,
-      './node_modules/.cache/webpack/buildDependencies.json',
-    );
     const buildDependencies = await fs.readJSON(configFile);
     expect(Object.keys(buildDependencies)).toEqual([
       'packageJson',

--- a/tests/e2e/builder/cases/cache/index.test.ts
+++ b/tests/e2e/builder/cases/cache/index.test.ts
@@ -7,18 +7,16 @@ import { fs } from '@modern-js/utils';
 webpackOnlyTest(
   'should save the buildDependencies to cache directory',
   async () => {
-    await build(
-      {
-        cwd: __dirname,
-        entry: { index: path.resolve(__dirname, './src/index.js') },
-        configPath: __dirname,
-      },
-      {
+    await build({
+      cwd: __dirname,
+      entry: { index: path.resolve(__dirname, './src/index.js') },
+      configPath: __dirname,
+      builderConfig: {
         performance: {
           buildCache: {},
         },
       },
-    );
+    });
 
     const configFile = path.resolve(
       __dirname,


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55cb801</samp>

This pull request refactors and improves the config creation and merging logic for different builders by using more shared functions and types from the `@modern-js/builder-shared` package. It also adds a new `tsChecker` option to the config and fixes a bug in the `build` function call in the e2e test. It updates the patch versions and changeset descriptions of the affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55cb801</samp>

*  Add a changeset file to indicate the patch versions and descriptions of the affected packages ([link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-aad6ce64d6db24821f2a00f612aea091041ebd8b6c414c9703d4e3de913a6b92R1-R9))
*  Import more default config functions from `@modern-js/builder-shared` to reduce duplication and simplify config creation and merging for `@modern-js/builder-webpack-provider` and `@modern-js/builder-rspack-provider` ([link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-2a9fd52b2595f20b19e244fb11c6592b69cf5bc92c8d5174a281034c988c5416L5-R16), [link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-509b786377fa5b943ac874136d340205543b916068fa1ac34947861673f54e27L8-R50))
*  Modify the `createDefaultConfig` function in `packages/builder/builder-rspack-provider/src/config/defaults.ts` to use the imported default config functions and return a `NormalizedConfig` type ([link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-2a9fd52b2595f20b19e244fb11c6592b69cf5bc92c8d5174a281034c988c5416L19-R34))
*  Add more type definitions and default config functions for the `security`, `performance`, and `tools` options in `@modern-js/builder-shared` to provide type safety and documentation for the common config options ([link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eL22-R32), [link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eR65-R83))
*  Add the `alias` option to the `getDefaultDevConfig` function in `@modern-js/builder-shared` to provide a default value for resolving modules with custom paths or names ([link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eR51))
*  Add the `tsChecker` option to the `NormalizedSharedToolsConfig` interface in `@modern-js/builder-shared` to define the type of the TypeScript type checking and linting tool ([link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-981f6d7d7f0b83caea36c977fe36969dbc79c9944f45839916eceb480931b59cR94-R97))
*  Fix a bug in the `tests/e2e/builder/cases/cache/index.test.ts` file that caused the `builderConfig` option to be ignored by the `build` function ([link](https://github.com/web-infra-dev/modern.js/pull/3949/files?diff=unified&w=0#diff-881278a7e406bc56da92613a6dfc45e7834997a14159afe9633dcaa4443097e5L10-R19))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
