### PR TITLE
test: fix integration test to compat Node 18

### DIFF
--- a/tests/integration/api-service-koa/test/index.test.ts
+++ b/tests/integration/api-service-koa/test/index.test.ts
@@ -1,3 +1,4 @@
+import dns from 'node:dns';
 import path from 'path';
 import {
   getPort,
@@ -8,6 +9,7 @@ import {
 } from '../../../utils/modernTestUtils';
 import 'isomorphic-fetch';
 
+dns.setDefaultResultOrder('ipv4first');
 describe('api-service in dev', () => {
   let port = 8080;
   const prefix = '/api';

--- a/tests/integration/bff-express/test/index.test.ts
+++ b/tests/integration/bff-express/test/index.test.ts
@@ -1,3 +1,4 @@
+import dns from 'node:dns';
 import path from 'path';
 import { Page } from 'puppeteer';
 import {
@@ -10,6 +11,7 @@ import {
 } from '../../../utils/modernTestUtils';
 import 'isomorphic-fetch';
 
+dns.setDefaultResultOrder('ipv4first');
 describe('bff express in dev', () => {
   let port = 8080;
   const SSR_PAGE = 'ssr';

--- a/tests/integration/doc/fixtures/i18n/package.json
+++ b/tests/integration/doc/fixtures/i18n/package.json
@@ -2,6 +2,9 @@
   "name": "i18n-doc",
   "version": "1.0.0",
   "private": true,
+  "scripts": {
+    "dev": "modern dev"
+  },
   "dependencies": {
     "@modern-js/doc-tools": "workspace:*"
   },

--- a/tests/integration/doc/test/i18n.test.ts
+++ b/tests/integration/doc/test/i18n.test.ts
@@ -1,10 +1,10 @@
 import path, { join } from 'path';
-import { Page } from 'puppeteer';
+import puppeteer, { Page, Browser } from 'puppeteer';
 import {
   launchApp,
   getPort,
   killApp,
-  openPage,
+  launchOptions,
 } from '../../../utils/modernTestUtils';
 
 const fixtureDir = path.resolve(__dirname, '../fixtures');
@@ -12,22 +12,31 @@ const fixtureDir = path.resolve(__dirname, '../fixtures');
 describe('I18n doc render', () => {
   let app: any;
   let appPort: number;
+  let page: Page;
+  let browser: Browser;
 
   beforeAll(async () => {
     const appDir = join(fixtureDir, 'i18n');
     appPort = await getPort();
     app = await launchApp(appDir, appPort);
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
   });
 
   afterAll(async () => {
     if (app) {
       await killApp(app);
     }
+    if (page) {
+      await page.close();
+    }
+    if (browser) {
+      browser.close();
+    }
   });
 
   // check the language switch button
   it('Language switch button', async () => {
-    const page: Page = await openPage();
     await page.goto(`http://localhost:${appPort}/en/`, {
       waitUntil: ['networkidle0'],
     });
@@ -50,12 +59,10 @@ describe('I18n doc render', () => {
     const title = await page.$('h1');
     const titleText = await page.evaluate(title => title?.textContent, title);
     await expect(titleText).toContain('首页');
-    await page.close();
   });
 
   it('Add language prefix in route automatically', async () => {
     // Chinese
-    const page: Page = await openPage();
     await page.goto(`http://localhost:${appPort}`, {
       waitUntil: ['networkidle0'],
     });
@@ -77,11 +84,9 @@ describe('I18n doc render', () => {
     // get the href
     href = await page.evaluate(link => link?.getAttribute('href'), link);
     expect(href).toBe('/en/guide/quick-start.html');
-    await page.close();
   });
 
   it('Should render sidebar correctly', async () => {
-    const page: Page = await openPage();
     await page.goto(`http://localhost:${appPort}/guide/quick-start`, {
       waitUntil: ['networkidle0'],
     });
@@ -90,18 +95,15 @@ describe('I18n doc render', () => {
       '.modern-sidebar .modern-scrollbar > nav > section',
     );
     expect(sidebar?.length).toBe(1);
-    await page.close();
     // get the section
   });
 
   it('Should not render appearance switch button', async () => {
-    const page: Page = await openPage();
     await page.goto(`http://localhost:${appPort}/guide/quick-start`, {
       waitUntil: ['networkidle0'],
     });
     // take the appearance switch button
     const button = await page.$('.modern-nav-appearance');
     expect(button).toBeFalsy();
-    await page.close();
   });
 });

--- a/tests/integration/doc/test/plugin.test.ts
+++ b/tests/integration/doc/test/plugin.test.ts
@@ -1,10 +1,10 @@
 import path, { join } from 'path';
-import { Page } from 'puppeteer';
+import puppeteer, { Page, Browser } from 'puppeteer';
 import {
   launchApp,
   getPort,
   killApp,
-  openPage,
+  launchOptions,
 } from '../../../utils/modernTestUtils';
 
 const fixtureDir = path.resolve(__dirname, '../fixtures');
@@ -13,18 +13,25 @@ describe('I18n doc render', () => {
   let app: any;
   let appPort: number;
   let page: Page;
+  let browser: Browser;
 
   beforeAll(async () => {
     const appDir = join(fixtureDir, 'plugin');
     appPort = await getPort();
     app = await launchApp(appDir, appPort);
-    page = await openPage();
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
   });
 
   afterAll(async () => {
     if (app) {
       await killApp(app);
+    }
+    if (page) {
       await page.close();
+    }
+    if (browser) {
+      browser.close();
     }
   });
 

--- a/tests/integration/doc/test/production.test.ts
+++ b/tests/integration/doc/test/production.test.ts
@@ -1,11 +1,11 @@
 import path, { join } from 'path';
-import { Page } from 'puppeteer';
+import puppeteer, { Browser, Page } from 'puppeteer';
 import {
   getPort,
   killApp,
   modernBuild,
   modernServe,
-  openPage,
+  launchOptions,
 } from '../../../utils/modernTestUtils';
 
 const fixtureDir = path.resolve(__dirname, '../fixtures');
@@ -15,17 +15,24 @@ describe('Check production build', () => {
   let appDir: string;
   let appPort: number;
   let page: Page;
+  let browser: Browser;
   beforeAll(async () => {
     appDir = join(fixtureDir, 'production');
     await modernBuild(appDir);
     app = await modernServe(appDir, (appPort = await getPort()), {
       cwd: appDir,
     });
-    page = await openPage();
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
   });
   afterAll(async () => {
     await killApp(app);
-    await page.close();
+    if (page) {
+      await page.close();
+    }
+    if (browser) {
+      browser.close();
+    }
   });
   it('check whether the page can be interacted', async () => {
     await page.goto(`http://localhost:${appPort}`, {

--- a/tests/integration/doc/test/with-base.test.ts
+++ b/tests/integration/doc/test/with-base.test.ts
@@ -1,10 +1,10 @@
 import path, { join } from 'path';
-import type { Page } from 'puppeteer';
+import puppeteer, { Browser, Page } from 'puppeteer';
 import {
   launchApp,
   getPort,
   killApp,
-  openPage,
+  launchOptions,
 } from '../../../utils/modernTestUtils';
 
 const fixtureDir = path.resolve(__dirname, '../fixtures');
@@ -12,21 +12,30 @@ const fixtureDir = path.resolve(__dirname, '../fixtures');
 describe('Check functions when base path exists', () => {
   let app: any;
   let appPort: number;
+  let page: Page;
+  let browser: Browser;
 
   beforeAll(async () => {
     const appDir = join(fixtureDir, 'with-base');
     appPort = await getPort();
     app = await launchApp(appDir, appPort);
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
   });
 
   afterAll(async () => {
     if (app) {
       await killApp(app);
     }
+    if (page) {
+      await page.close();
+    }
+    if (browser) {
+      browser.close();
+    }
   });
 
   it('Should render sidebar correctly', async () => {
-    const page: Page = await openPage();
     await page.goto(`http://localhost:${appPort}/base/en/guide/quick-start`, {
       waitUntil: ['networkidle0'],
     });
@@ -35,12 +44,10 @@ describe('Check functions when base path exists', () => {
       '.modern-sidebar .modern-scrollbar > nav > section',
     );
     expect(sidebar?.length).toBe(1);
-    await page.close();
     // get the section
   });
 
   it('Should goto correct link', async () => {
-    const page: Page = await openPage();
     await page.goto(`http://localhost:${appPort}/base/en/guide/quick-start`, {
       waitUntil: ['networkidle0'],
     });

--- a/tests/integration/esbuild/test/index.test.ts
+++ b/tests/integration/esbuild/test/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { readdirSync, readFileSync } from 'fs';
+import { readdirSync, readFileSync, rmdirSync, existsSync } from 'fs';
 import { modernBuild } from '../../../utils/modernTestUtils';
 
 const fixtures = path.resolve(__dirname, '../fixtures');
@@ -12,7 +12,9 @@ const getJsFiles = (appDir: string) =>
 describe('esbuild', () => {
   it(`should emitted script files correctly when using esbuild transform`, async () => {
     const appDir = path.resolve(fixtures, 'transform-and-minify');
-
+    if (existsSync(path.join(appDir, 'dist'))) {
+      rmdirSync(path.join(appDir, 'dist'), { recursive: true });
+    }
     await modernBuild(appDir);
 
     const files = getJsFiles(appDir);
@@ -26,7 +28,9 @@ describe('esbuild', () => {
 
   it(`should emitted script files correctly when using legacy esbuild minify`, async () => {
     const appDir = path.resolve(fixtures, 'legacy-minify-js');
-
+    if (existsSync(path.join(appDir, 'dist'))) {
+      rmdirSync(path.join(appDir, 'dist'), { recursive: true });
+    }
     await modernBuild(appDir);
 
     const files = getJsFiles(appDir);

--- a/tests/integration/routes/tests/index.test.ts
+++ b/tests/integration/routes/tests/index.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import path from 'path';
+import puppeteer, { Browser } from 'puppeteer';
 import { fs, ROUTE_MANIFEST_FILE } from '@modern-js/utils';
 import { ROUTE_MANIFEST } from '@modern-js/utils/universal/constants';
 import type {
@@ -12,7 +13,7 @@ import {
   getPort,
   modernBuild,
   modernServe,
-  openPage,
+  launchOptions,
 } from '../../../utils/modernTestUtils';
 
 // declare const browser: Browser;
@@ -373,10 +374,8 @@ const supportLoaderForSSRAndCSR = async (
   await page.goto(`http://localhost:${appPort}/three`, {
     waitUntil: ['domcontentloaded'],
   });
-  await Promise.all([
-    page.click('.user-btn'),
-    page.waitForSelector('.user-layout'),
-  ]);
+  await page.click('.user-btn');
+  await page.waitForSelector('.user-layout');
   const userLayout = await page.$(`.user-layout`);
   const text = await page.evaluate(el => {
     return el?.textContent;
@@ -421,10 +420,8 @@ const supportRedirectForCSR = async (
   await page.goto(`http://localhost:${appPort}/three/user`, {
     waitUntil: ['networkidle0'],
   });
-  await Promise.all([
-    page.click('.redirect-btn'),
-    page.waitForSelector('.user-profile'),
-  ]);
+  await page.click('.redirect-btn');
+  await page.waitForSelector('.user-profile');
   const rootElm = await page.$('.user-profile');
   const text = await page.evaluate(el => el?.textContent, rootElm);
   expect(text?.includes('profile page')).toBeTruthy();
@@ -464,11 +461,13 @@ describe('dev', () => {
   let app: unknown;
   let appPort: number;
   let page: Page;
+  let browser: Browser;
   const errors: string[] = [];
   beforeAll(async () => {
     appPort = await getPort();
     app = await launchApp(appDir, appPort, {}, {});
-    page = await openPage();
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
     page.on('pageerror', error => {
       errors.push(error.message);
     });
@@ -556,6 +555,7 @@ describe('build', () => {
   let appPort: number;
   let app: unknown;
   let page: Page;
+  let browser: Browser;
   const errors: string[] = [];
 
   beforeAll(async () => {
@@ -564,7 +564,8 @@ describe('build', () => {
     app = await modernServe(appDir, appPort, {
       cwd: appDir,
     });
-    page = await openPage();
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
     page.on('pageerror', error => {
       errors.push(error.message);
     });

--- a/tests/integration/server-config/tests/index.test.ts
+++ b/tests/integration/server-config/tests/index.test.ts
@@ -1,3 +1,4 @@
+import dns from 'node:dns';
 import path from 'path';
 import { fs } from '@modern-js/utils';
 import {
@@ -9,6 +10,7 @@ import {
 } from '../../../utils/modernTestUtils';
 import 'isomorphic-fetch';
 
+dns.setDefaultResultOrder('ipv4first');
 const supportServerConfig = async ({
   host,
   port,

--- a/tests/integration/ssr/test/base.test.js
+++ b/tests/integration/ssr/test/base.test.js
@@ -1,3 +1,4 @@
+const dns = require('node:dns');
 const { join } = require('path');
 const path = require('path');
 const puppeteer = require('puppeteer');
@@ -9,6 +10,7 @@ const {
   launchOptions,
 } = require('../../../utils/modernTestUtils');
 
+dns.setDefaultResultOrder('ipv4first');
 const fixtureDir = path.resolve(__dirname, '../fixtures');
 
 async function basicUsage(page, appPort) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a89467</samp>

This pull request fixes some flaky integration tests by using the `dns` module to prefer IPv4 addresses, refactors the test code to use a single `Browser` instance and the `launchOptions` object from `puppeteer` and `modernTestUtils` modules, and updates some test fixtures and options to improve the performance and consistency of the tests.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a89467</samp>

*  Set the default result order for DNS queries to prefer IPv4 addresses over IPv6 addresses in the test files to fix some flaky tests that fail due to IPv6 issues on GitHub Actions ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-52cb06856043efce44ffd1b4425c5d7783319be368ee904f635922b5f032d5a9R1),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-52cb06856043efce44ffd1b4425c5d7783319be368ee904f635922b5f032d5a9R12),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-fe967846c00b4eaf07193e2163ee84b265f1adf07997a8844f3abf747b99ef8eR1),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-fe967846c00b4eaf07193e2163ee84b265f1adf07997a8844f3abf747b99ef8eR14),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-0f06ac70f03e0413c7a6cd8f380f3b1ae98a3cfbfd4222e83418af5727744fbbR1),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-0f06ac70f03e0413c7a6cd8f380f3b1ae98a3cfbfd4222e83418af5727744fbbR13),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-1a2c1cf226f106f06ed79b504ed0226786716fdb346e9d9b34ec2c632034ea70R1),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-1a2c1cf226f106f06ed79b504ed0226786716fdb346e9d9b34ec2c632034ea70R13))
*  Add a `dev` script to the `package.json` file in the `tests/integration/doc/fixtures/i18n` folder to enable running the `modern dev` command in the `i18n` fixture ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-ec98ff0918e5f573d829dfac941fe52355b0d3e281178994548c497712308f39R5-R7))
*  Refactor the test code in the `tests/integration/doc/test` folder to use a `Browser` instance and the `launchOptions` object to launch and control the `Page` instances for testing, and to ensure proper cleanup of the resources in the `afterAll` hook ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL2-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL14-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL26-R38),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL43-R54),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL54-R63),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL65-R72),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL88),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L2-R7),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416R15-R16),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416R22-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L26-R39),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L53-R65),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L80-R89),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L93-R101),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L105),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-cb8e6d622338763ba786e87532551f9bff97d1833be775c2339501c9a5f3c85dL2-R7),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-cb8e6d622338763ba786e87532551f9bff97d1833be775c2339501c9a5f3c85dR16),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-cb8e6d622338763ba786e87532551f9bff97d1833be775c2339501c9a5f3c85dL21-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-cb8e6d622338763ba786e87532551f9bff97d1833be775c2339501c9a5f3c85dL27-R35),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-7fa6f5476dbc3d4904e129b11d725c01ddb8239177ff34531feca798f096137bL2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-7fa6f5476dbc3d4904e129b11d725c01ddb8239177ff34531feca798f096137bL8-R8),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-7fa6f5476dbc3d4904e129b11d725c01ddb8239177ff34531feca798f096137bR18),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-7fa6f5476dbc3d4904e129b11d725c01ddb8239177ff34531feca798f096137bL24-R35),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6228585c88f107bf0c9ca812f7c644b9b3482e973722b0ff537c4f3e7f8e044dL2-R7),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6228585c88f107bf0c9ca812f7c644b9b3482e973722b0ff537c4f3e7f8e044dR15-R16),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6228585c88f107bf0c9ca812f7c644b9b3482e973722b0ff537c4f3e7f8e044dR22-R23),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6228585c88f107bf0c9ca812f7c644b9b3482e973722b0ff537c4f3e7f8e044dL26-R38),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6228585c88f107bf0c9ca812f7c644b9b3482e973722b0ff537c4f3e7f8e044dL38-R50))
*  Remove the `openPage` function call and use the `page` variable instead to navigate to the pages in the test cases in the `tests/integration/doc/test` folder, and to avoid unnecessary page creation ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL54-R63),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL65-R72),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L53-R65),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L80-R89),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L93-R101),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6228585c88f107bf0c9ca812f7c644b9b3482e973722b0ff537c4f3e7f8e044dL38-R50))
*  Remove the `page.close()` statement from the test cases in the `tests/integration/doc/test` folder that share the same `page` instance in the `describe` block, and to avoid closing the `page` instance that is used by other tests ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6cbe46b40abeccec9f67ad5277bb9270dbacd9d9503cbba8a44e219b3ba1ff5cL88),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-6706996d81b7bcd238985f11b2ceb1bda88416abdf1d3895d177c662fd426416L105))
*  Use the `fs` module to remove the `dist` folder before running the `modernBuild` function in the test cases in the `tests/integration/esbuild/test/index.test.ts` file, to ensure a clean build environment ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-4b3f7f9d3e8bbe15a7eabc7de8ccb68d6f3dd0c01c75e1f9d6618cf32ec51559L2-R2),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-4b3f7f9d3e8bbe15a7eabc7de8ccb68d6f3dd0c01c75e1f9d6618cf32ec51559L15-R17),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-4b3f7f9d3e8bbe15a7eabc7de8ccb68d6f3dd0c01c75e1f9d6618cf32ec51559L29-R33))
*  Refactor the test code in the `tests/integration/routes/tests/index.test.ts` file to use a `Browser` instance instead of a `Page` instance for each test case, to improve the performance and stability of the tests, and to use the `launchOptions` object to configure the `puppeteer` launch options ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444R3),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L15-R16),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L376-R378),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L424-R424),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L467-R470),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444R558),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L567-R568))
*  Remove the `Promise.all` call and use the `await` keyword instead to wait for the `page.click` and `page.waitForSelector` actions to complete in the `supportLoaderForSSRAndCSR` and `supportRedirectForCSR` functions in the `tests/integration/routes/tests/index.test.ts` file, to simplify the code and avoid potential race conditions or errors when using `Promise.all` with `puppeteer` actions ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L376-R378),[link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L424-R424))
*  Increase the timeout limit for the `should support ssr and csr` test in the `tests/integration/runtime/test/index.test.js` file, as it may take longer than the default 5 seconds to complete ([link](https://github.com/web-infra-dev/modern.js/pull/3957/files?diff=unified&w=0#diff-be23084cf036055b1f6cdea83c183eb7d5c7bae7e0b7ff0ee58150db386cd810R135))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
