### PR TITLE
fix: absoluteEntryDir should support directory entry & remove react-router-dom from plugin-data-loader

### DIFF
--- a/.changeset/silent-onions-bathe.md
+++ b/.changeset/silent-onions-bathe.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-data-loader': patch
+'@modern-js/app-tools': patch
+---
+
+fix: absoluteEntryDir should support directory entry
+fix: absoluteEntryDir 应该支持配置目录 entry，这里 document 会使用

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -65,7 +65,6 @@
     "@modern-js/utils": "workspace:*",
     "@remix-run/node": "^1.12.0",
     "path-to-regexp": "^6.2.0",
-    "react-router-dom": "^6.8.1",
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
@@ -87,12 +86,10 @@
     "webpack": "^5.82.1",
     "webpack-chain": "^6.5.1",
     "react": "^18",
-    "react-dom": "^18",
-    "react-router-dom": "^6.8.1"
+    "react-dom": "^18"
   },
   "peerDependencies": {
-    "react": ">=17.0.0",
-    "react-router-dom": "^6.8.1"
+    "react": ">=17.0.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cli/plugin-data-loader/src/cli/createRequest.ts
+++ b/packages/cli/plugin-data-loader/src/cli/createRequest.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable node/prefer-global/url */
 import { compile } from 'path-to-regexp';
-import { redirect } from 'react-router-dom';
+import { redirect } from '@modern-js/utils/runtime/router';
 import { type UNSAFE_DeferredData as DeferredData } from '@modern-js/utils/runtime/remix-router';
 import {
   LOADER_ID_PARAM,

--- a/packages/solutions/app-tools/src/analyze/getBundleEntry.ts
+++ b/packages/solutions/app-tools/src/analyze/getBundleEntry.ts
@@ -18,6 +18,12 @@ const ensureExtensions = (file: string) => {
   return file;
 };
 
+/**
+ *
+ * Lightweight method for whether it is a directory.
+ */
+const isDirectory = (file: string) => !path.extname(file);
+
 const ifAlreadyExists = (
   entrypoints: Entrypoint[],
   checked: Entrypoint,
@@ -48,9 +54,7 @@ export const getBundleEntry = (
   config: AppNormalizedConfig<'shared'>,
 ) => {
   const { appDirectory, packageName } = appContext;
-  const {
-    source: { disableDefaultEntries, entries, entriesDir },
-  } = config;
+  const { disableDefaultEntries, entries, entriesDir } = config.source;
 
   const defaults = disableDefaultEntries
     ? []
@@ -65,9 +69,11 @@ export const getBundleEntry = (
           ? {
               entryName: name,
               entry: ensureAbsolutePath(appDirectory, value),
-              absoluteEntryDir: path.dirname(
+              absoluteEntryDir: isDirectory(
                 ensureAbsolutePath(appDirectory, value),
-              ),
+              )
+                ? ensureAbsolutePath(appDirectory, value)
+                : path.dirname(ensureAbsolutePath(appDirectory, value)),
               isAutoMount: true,
               fileSystemRoutes: fs
                 .statSync(ensureAbsolutePath(appDirectory, value))
@@ -78,9 +84,11 @@ export const getBundleEntry = (
           : {
               entryName: name,
               entry: ensureAbsolutePath(appDirectory, value.entry),
-              absoluteEntryDir: path.dirname(
+              absoluteEntryDir: isDirectory(
                 ensureAbsolutePath(appDirectory, value.entry),
-              ),
+              )
+                ? ensureAbsolutePath(appDirectory, value.entry)
+                : path.dirname(ensureAbsolutePath(appDirectory, value.entry)),
               isAutoMount: !value.disableMount,
               customBootstrap:
                 value.customBootstrap &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1325,9 +1325,6 @@ importers:
       path-to-regexp:
         specifier: ^6.2.0
         version: 6.2.1
-      react-router-dom:
-        specifier: ^6.8.1
-        version: 6.11.2(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@modern-js/core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Here the document will use the absoluteEntryDir to determine document file path.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
