### PR TITLE
fix(doc-core): lark icon type

### DIFF
--- a/.changeset/nasty-peaches-ring.md
+++ b/.changeset/nasty-peaches-ring.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): lark icon type
+
+fix(doc-core): lark 图标类型缺失

--- a/packages/cli/doc-core/src/shared/types/defaultTheme.ts
+++ b/packages/cli/doc-core/src/shared/types/defaultTheme.ts
@@ -186,6 +186,7 @@ export interface SocialLink {
 }
 
 export type SocialLinkIcon =
+  | 'lark'
   | 'discord'
   | 'facebook'
   | 'github'


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcfd703</samp>

This pull request adds support for the lark social link in the default theme of the `@modern-js/doc-core` package. It updates the `SocialLink` interface in `defaultTheme.ts` and adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcfd703</samp>

* Add `lark` option to `SocialLink` interface in `defaultTheme.ts` to enable lark social link in site configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3962/files?diff=unified&w=0#diff-b84833b1604fed5e609c7b8e25cd29620b04432b07c39fdec2bb8e6cc5a5fc2dR189))
* Add changeset file to document patch update for `@modern-js/doc-core` package and fix missing icon type for lark social link in default theme ([link](https://github.com/web-infra-dev/modern.js/pull/3962/files?diff=unified&w=0#diff-adf6f835c205ef39eb3a5b03550f3d12262487fb8ad5a5ca89be3cc65d5a08a6R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
