### PR TITLE
docs(doc-tools): fix global style doc

### DIFF
--- a/packages/document/doc-tools-doc/docs/en/guide/basic/global-styles.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/basic/global-styles.mdx
@@ -12,7 +12,7 @@ import path from 'path';
 
 export default defineConfig({
   doc: {
-    globalStyles: [path.join(__dirname, 'styles/index.css')],
+    globalStyles: path.join(__dirname, 'styles/index.css'),
   },
   plugins: [docTools()],
 });

--- a/packages/document/doc-tools-doc/docs/zh/guide/basic/global-styles.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/basic/global-styles.mdx
@@ -12,7 +12,7 @@ import path from 'path';
 
 export default defineConfig({
   doc: {
-    globalStyles: [path.join(__dirname, 'styles/index.css')],
+    globalStyles: path.join(__dirname, 'styles/index.css'),
   },
   plugins: [docTools()],
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88bb8df</samp>

Simplified the `globalStyles` option in the doc config to accept a single string instead of an array of strings, and updated the documentation in both English and Chinese to reflect this change. This change aligns with the new API of the docTools plugin.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88bb8df</samp>

*  Simplify the `globalStyles` option in the doc config to accept a single string instead of an array of strings, to match the updated API of the docTools plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3963/files?diff=unified&w=0#diff-4b76dedd77fb7f2f52e729ab9f7b4989d2bdaf6073265ec14531fec476ac18e5L15-R15), [link](https://github.com/web-infra-dev/modern.js/pull/3963/files?diff=unified&w=0#diff-d7da843db289d9d463cb6663f6802a8aa1105dab91a9fd1f188bf4197f3547a9L15-R15))
* Update the English and Chinese versions of the documentation for the `globalStyles` option in the files `global-styles.mdx` ([link](https://github.com/web-infra-dev/modern.js/pull/3963/files?diff=unified&w=0#diff-4b76dedd77fb7f2f52e729ab9f7b4989d2bdaf6073265ec14531fec476ac18e5L15-R15), [link](https://github.com/web-infra-dev/modern.js/pull/3963/files?diff=unified&w=0#diff-d7da843db289d9d463cb6663f6802a8aa1105dab91a9fd1f188bf4197f3547a9L15-R15))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
