### PR TITLE
fix(doc-plugin-preview): pure is not valid when preview mode is mobile

### DIFF
--- a/.changeset/angry-sheep-tease.md
+++ b/.changeset/angry-sheep-tease.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-plugin-preview': patch
+---
+
+fix: pure is not valid when preview mode is mobile
+fix: pure在移动端预览模式下不生效

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -53,6 +53,11 @@ export function pluginPreview(options?: Options): DocPlugin {
             visit(ast, 'code', (node: any) => {
               if (node.lang === 'jsx' || node.lang === 'tsx') {
                 const { value } = node;
+                const isPure = node?.meta?.includes('pure');
+                // not transform pure code
+                if (isPure) {
+                  return;
+                }
                 const { pageName } = routeMeta.find(
                   meta => meta.absolutePath === filepath,
                 )!;
@@ -127,6 +132,9 @@ export const pageType = "blank";
         // @ts-ignore
         rspack: {
           plugins: [demoRuntimeModule],
+          watchOptions: {
+            ignored: ['**/.modern-doc/virtual-demo/*.tsx'],
+          },
         },
         bundlerChain(chain) {
           chain.module


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0eb7ad2</samp>

This pull request fixes two bugs related to the `pure` meta tag for code blocks in the `@modern-js/doc-plugin-preview` package. It also improves the performance of the preview plugin by ignoring virtual demo files in the webpack watcher.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0eb7ad2</samp>

*  Respect `pure` meta tag for code blocks in preview plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3977/files?diff=unified&w=0#diff-0f7b4198a165bea1821ebd737b048240e4fdbbd50300913c6f29bf38ac99fe65R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/3977/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR56-R60))
* Improve dev server performance for preview plugin ([link](https://github.com/web-infra-dev/modern.js/pull/3977/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR135-R137))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
