### PR TITLE
fix(builder): remove @modern-js/e2e from peerDependencies

### DIFF
--- a/.changeset/tame-hats-yell.md
+++ b/.changeset/tame-hats-yell.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): remove @modern-js/e2e from peerDependencies
+
+fix(builder): 移除 @modern-js/e2e peerDependencies

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -70,7 +70,6 @@
   },
   "devDependencies": {
     "@arco-design/web-react": "^2.46.0",
-    "@modern-js/e2e": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",
     "antd": "4",
@@ -78,14 +77,6 @@
     "typescript": "^5",
     "react": "^18",
     "react-dom": "^18"
-  },
-  "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.22.1"
-  },
-  "peerDependenciesMeta": {
-    "@modern-js/e2e": {
-      "optional": true
-    }
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -118,14 +118,6 @@
     "react": "^18",
     "react-dom": "^18"
   },
-  "peerDependencies": {
-    "@modern-js/e2e": "workspace:^2.22.1"
-  },
-  "peerDependenciesMeta": {
-    "@modern-js/e2e": {
-      "optional": true
-    }
-  },
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,9 +183,6 @@ importers:
       '@arco-design/web-react':
         specifier: ^2.46.0
         version: 2.46.1(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/e2e':
-        specifier: workspace:*
-        version: link:../../toolkit/e2e
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config


### PR DESCRIPTION
## Summary

Fix:

- https://github.com/web-infra-dev/modern.js/issues/3979

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6985e97</samp>

This pull request removes the optional `@modern-js/e2e` dependency from two packages in the `modern.js` framework: `@modern-js/builder-webpack-provider` and `@modern-js/builder-rspack-provider`. This simplifies the installation and usage of the packages and avoids unnecessary warnings.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6985e97</samp>

*  Remove `@modern-js/e2e` from peerDependencies of `@modern-js/builder-webpack-provider` and `@modern-js/builder-rspack-provider` packages ([link](https://github.com/web-infra-dev/modern.js/pull/3980/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L73), [link](https://github.com/web-infra-dev/modern.js/pull/3980/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L82-L89), [link](https://github.com/web-infra-dev/modern.js/pull/3980/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1L121-L128))
*  Add changeset file to document the patch-level fix and provide bilingual summary ([link](https://github.com/web-infra-dev/modern.js/pull/3980/files?diff=unified&w=0#diff-1752404a55a32562d11db6e6bab02431247edb344fb788ca4c7ab678b95b7febR1-R8))

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
