### PR TITLE
fix(builder): add attributes for inline runtime script

### DIFF
--- a/.changeset/shaggy-tools-add.md
+++ b/.changeset/shaggy-tools-add.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix: add attributes for inline runtime script
+fix: 为 inline runtime 脚本添加属性

--- a/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
@@ -90,9 +90,8 @@ export class InlineChunkHtmlPlugin {
     if (!(tag?.attributes.src && isString(tag.attributes.src))) {
       return tag;
     }
-    const scriptName = publicPath
-      ? tag.attributes.src.replace(publicPath, '')
-      : tag.attributes.src;
+    const { src, ...otherAttrs } = tag.attributes;
+    const scriptName = publicPath ? src.replace(publicPath, '') : src;
 
     if (!this.tests.some(test => test.exec(scriptName))) {
       return tag;
@@ -112,6 +111,9 @@ export class InlineChunkHtmlPlugin {
         publicPath,
         type: 'js',
       }),
+      attributes: {
+        ...otherAttrs,
+      },
       closeTag: true,
     };
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 224d747</samp>

Refactor `InlineChunkHtmlPlugin` to preserve script attributes and add changeset file for `@modern-js/builder-shared` package. This change improves the plugin functionality and prepares for publishing the updated package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 224d747</samp>

*  Add a changeset file for patch updates of `@modern-js/builder-shared` package with fix messages ([link](https://github.com/web-infra-dev/modern.js/pull/3987/files?diff=unified&w=0#diff-2390a29b78fce8544349f7885b7ca5db870af8e08d952e23c9965a84e987e293R1-R6))
*  Destructure `src` attribute from `tag.attributes` and assign the rest to `otherTags` in `InlineChunkHtmlPlugin` class ([link](https://github.com/web-infra-dev/modern.js/pull/3987/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL93-R94))
*  Include `otherTags` in the `attributes` of the new `script` tag created by `InlineChunkHtmlPlugin` to preserve original attributes ([link](https://github.com/web-infra-dev/modern.js/pull/3987/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aR114-R116))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
