### PR TITLE
docs(app-tools): add using-storybook guide

### DIFF
--- a/packages/document/main-doc/docs/en/apis/app/hooks/config/storybook.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/hooks/config/storybook.mdx
@@ -2,6 +2,7 @@
 title: storybook/
 sidebar_position: 7
 ---
+
 # storybook/
 
 Modern.js supports debugging using Storybook. When configuring Storybook, you need to configure it in the `config/storybook` directory of the project.
@@ -12,3 +13,26 @@ Please refer to [Storybook Configuration](https://storybook.js.org/docs/react/co
 Enabling the Visual Testing (Storybook) mode function requires running the new command to enable it under the project first.
 
 :::
+
+#### Example
+
+For the webpack configuration of the Storybook Manager app section, you can configure it by adding the `./config/storybook/main.js` file to configure it.
+
+```js
+// ./config/storybook/main.js
+
+module.exports = {
+  // it controls the Storybook manager app
+  managerWebpack: async (config, options) => {
+    // update config here
+    return config;
+  },
+};
+```
+
+### Limitation
+
+There are some limitations when using the `config/storybook` directory for configuration:
+
+- The location where the Story file is stored cannot be modified, that is, the `stories` configuration cannot be modified in the `main.js` file.
+- It is not supported to modify Webpack and Babel related configurations in `main.js`, related requirements can be passed through [`tools.webpack`](/configure/app/tools/webpack.html) /[`tools.babel`](/configure/app/tools/babel.html) modify.

--- a/packages/document/main-doc/docs/en/apis/app/hooks/src/stories.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/hooks/src/stories.mdx
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 Application project Storybook files.
 
-You can create files in the `*.stories.[tj]sx` format in the project source code directory `src/` as Storybook files.
+You can create files in the `*.stories.(js|jsx|ts|tsx|mdx)` format in the project source code directory `src/` as Storybook files.
 
 Run the `npm run dev story` command in the project to use these files to debug relevant content in Storybook.
 

--- a/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
@@ -1,0 +1,44 @@
+---
+sidebar_position: 20
+---
+
+# Using Storybook
+
+[Storybook](https://storybook.js.org/) is a tool dedicated to component debugging, providing around component development.
+
+- Develop UIs that are more durable
+- Test UIs with less effort and no flakes
+- Document UI for your team to reuse
+- Share how the UI actually works
+- Automate UI workflows
+
+## Enable Storybook debugging
+
+The Modern.js framework integrates the Builder's Node Polyfill plugin by default.
+
+If you want to debug the component, you can enable Storybook debugging through `pnpm run new`.
+
+```bash
+$ npx modern new
+? Please select the operation you want: Enable features
+? Please select the feature name: Enable Visual Testing (Storybook)
+```
+
+After the execution is complete, you only need to register the Modern.js Storybook plugin in the `modern.config.ts` file to enable Storybook debugging capabilities.
+
+```ts title="modern.config.ts"
+import appTools, { defineConfig } from '@modern-js/app-tools';
+import storybookPlugin from '@modern-js/plugin-storybook';
+
+export default defineConfig({
+  plugins: [appTools(), storybookPlugin()],
+});
+```
+
+## Debugging code
+
+Modern.js recognizes files in the format of [\*.stories.\[tj\]sx](/apis/app/hooks/src/stories.html) under the project source code directory (src/) by default as Storybook debugging files.
+
+## Configure Storybook
+
+In Modern.js, Storybook configuration files can be added to the [`config/storybook`](/apis/app/hooks/config/storybook.html) directory of the project.

--- a/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
@@ -37,7 +37,7 @@ export default defineConfig({
 
 ## Debugging code
 
-Modern.js recognizes files in the format of [\*.stories.\[tj\]sx](/apis/app/hooks/src/stories.html) under the project source code directory (src/) by default as Storybook debugging files.
+Modern.js recognizes files in the format of [\*.stories.(js|jsx|ts|tsx|mdx)](/apis/app/hooks/src/stories.html) under the project source code directory (src/) by default as Storybook debugging files.
 
 ## Configure Storybook
 

--- a/packages/document/main-doc/docs/zh/apis/app/hooks/config/storybook.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/hooks/config/storybook.mdx
@@ -2,6 +2,7 @@
 title: storybook/
 sidebar_position: 7
 ---
+
 # storybook/
 
 Modern.js 支持使用 Storybook 进行调试，当需要对 Storybook 进行配置时，需要在项目 config/storybook 目录进行配置。
@@ -12,3 +13,26 @@ Storybook 配置请查看：[Storybook 配置](https://storybook.js.org/docs/rea
 使用 Storybook 进行调试需要提前在项目下执行 new 命令启用「Visual Testing (Storybook)」模式功能。
 
 :::
+
+### 示例
+
+对于 Storybook Manager app 部分的 webpack 配置，可以通过增加 `./config/storybook/main.js` 文件进行配置。
+
+```js
+// ./config/storybook/main.js
+
+module.exports = {
+  // it controls the Storybook manager app
+  managerWebpack: async (config, options) => {
+    // update config here
+    return config;
+  },
+};
+```
+
+### 限制
+
+在使用 config/storybook 目录进行配置时，存在以下限制：
+
+- 不能修改 Story 文件存放的位置，即无法在 `main.js` 文件里修改 `stories` 配置。
+- 不支持在 `main.js` 中修改 Webpack 和 Babel 相关配置，相关需求可通过 [`tools.webpack`](/configure/app/tools/webpack.html) / [`tools.babel`](/configure/app/tools/babel.html) 修改。

--- a/packages/document/main-doc/docs/zh/apis/app/hooks/src/stories.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/hooks/src/stories.mdx
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 应用项目 Storybook 调试文件。
 
-可以在项目源码目录 `src/` 下创建 `*.stories.[tj]sx` 格式的文件作为 Storybook 的调试文件。
+可以在项目源码目录 `src/` 下创建 `*.stories.(js|jsx|ts|tsx|mdx)` 格式的文件作为 Storybook 的调试文件。
 
 在项目下执行 `npm run dev story` 命令，支持使用这些文件在 Storybook 中对相关内容进行调试。
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
@@ -37,7 +37,7 @@ export default defineConfig({
 
 ## 调试代码
 
-Modern.js 默认识别项目源码目录 src/ 下 [\*.stories.\[tj\]sx](/apis/app/hooks/src/stories.html) 格式的文件作为 Storybook 的调试文件。
+Modern.js 默认识别项目源码目录 src/ 下 [\*.stories.(js|jsx|ts|tsx|mdx)](/apis/app/hooks/src/stories.html) 格式的文件作为 Storybook 的调试文件。
 
 ## 配置 Storybook
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
@@ -1,0 +1,44 @@
+---
+sidebar_position: 20
+---
+
+# 使用 Storybook
+
+[Storybook](https://storybook.js.org/) 是一个专门用于组件调试的工具，它围绕着组件开发提供了：
+
+- 丰富多样的调试能力
+- 可与一些测试工具结合使用
+- 可重复使用的文档内容
+- 可分享能力
+- 工作流程自动化
+
+## 开启 Storybook 调试
+
+EdenX 默认集成了 Storybook 的调试能力。
+
+当我们想要对组件进行调试的时候，可以通过 `pnpm run new` 启用 Storybook 调试功能。
+
+```bash
+$ npx modern new
+? 请选择你想要的操作 启用可选功能
+? 请选择功能名称 启用「Visual Testing (Storybook)」模式
+```
+
+执行完成后，你只需在 `modern.config.ts` 文件中注册 Modern.js 的 Storybook 插件，即可启用 Storybook 调试能力。
+
+```ts title="modern.config.ts"
+import appTools, { defineConfig } from '@modern-js/app-tools';
+import storybookPlugin from '@modern-js/plugin-storybook';
+
+export default defineConfig({
+  plugins: [appTools(), storybookPlugin()],
+});
+```
+
+## 调试代码
+
+Modern.js 默认识别项目源码目录 src/ 下 [\*.stories.\[tj\]sx](/apis/app/hooks/src/stories.html) 格式的文件作为 Storybook 的调试文件。
+
+## 配置 Storybook
+
+在 Modern.js 中，可以在项目的 [`config/storybook`](/apis/app/hooks/config/storybook.html) 目录下增加 Storybook 配置文件。


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fce6020</samp>

This pull request adds and updates documentation for the Storybook integration feature of Modern.js. It adds a new guide section `using-storybook.mdx` in both English and Chinese, and updates the app API reference for the `config` hook with examples and limitations for the `storybook` option. It also fixes some minor typos and formatting issues.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fce6020</samp>

*  Add new files `using-storybook.mdx` to the English and Chinese versions of the `advanced-features` guide section of the documentation, introducing the Storybook tool and how to enable, debug, and configure it with Modern.js ([link](https://github.com/web-infra-dev/modern.js/pull/3990/files?diff=unified&w=0#diff-035db2ac24c8b7d4a7e94f94ac046804a4786d5688eadb9b3538920ab557c8a3R1-R44), [link](https://github.com/web-infra-dev/modern.js/pull/3990/files?diff=unified&w=0#diff-a47ea9bca5870e6377cdd9e866aa7f90e8069297b59d3c83ef3d12b87cbfe7f6R1-R44))
*  Add examples and limitation sections to the English and Chinese versions of the `storybook.mdx` file under the `config` hook section of the app API documentation, providing more details on how to use the `managerWebpack` option in the `main.js` file to configure the Storybook manager app, and what restrictions apply when using the `config/storybook` directory for configuration ([link](https://github.com/web-infra-dev/modern.js/pull/3990/files?diff=unified&w=0#diff-02f3a80980d5499681c6bb41f362a46a743c29a6a4e2c4b7823d3097c3748515R16-R38), [link](https://github.com/web-infra-dev/modern.js/pull/3990/files?diff=unified&w=0#diff-3c876652895e5d3691356c75e478835b26d97accc4744c554db088e14a5b1327R16-R38))
*  Remove empty code blocks from the English and Chinese versions of the `storybook.mdx` file under the `config` hook section of the app API documentation, as they are likely mistakes or placeholders for future content ([link](https://github.com/web-infra-dev/modern.js/pull/3990/files?diff=unified&w=0#diff-02f3a80980d5499681c6bb41f362a46a743c29a6a4e2c4b7823d3097c3748515R5), [link](https://github.com/web-infra-dev/modern.js/pull/3990/files?diff=unified&w=0#diff-3c876652895e5d3691356c75e478835b26d97accc4744c554db088e14a5b1327R5))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
