### PR TITLE
test(module-doc): add basic test case for module doc

### DIFF
--- a/tests/integration/module-doc/tests/basic.test.ts
+++ b/tests/integration/module-doc/tests/basic.test.ts
@@ -1,0 +1,60 @@
+import { join } from 'path';
+import type { Page, Browser } from 'puppeteer';
+import puppeteer from 'puppeteer';
+import {
+  launchApp,
+  getPort,
+  killApp,
+  launchOptions,
+} from '../../../utils/modernTestUtils';
+
+describe('Check basic render in development', () => {
+  let app: any;
+  let page: Page;
+  let browser: Browser;
+  let appPort: number;
+  beforeAll(async () => {
+    const appDir = join(__dirname, '..');
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort);
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await killApp(app);
+    }
+    if (page) {
+      await page.close();
+    }
+    if (browser) {
+      browser.close();
+    }
+  });
+
+  it('Index page', async () => {
+    await page.goto(`http://localhost:${appPort}/en/`, {
+      waitUntil: ['networkidle0'],
+    });
+    const h1 = await page.$('h1');
+    const text = await page.evaluate(h1 => h1?.textContent, h1);
+    expect(text).toContain('Components Overview');
+    // expect the .header-anchor to be rendered and take the correct href
+    const headerAnchor = await page.$('.header-anchor');
+    const href = await page.evaluate(
+      headerAnchor => headerAnchor?.getAttribute('href'),
+      headerAnchor,
+    );
+    expect(href).toBe('#components-overview');
+  });
+
+  it('404 page', async () => {
+    await page.goto(`http://localhost:${appPort}/404`, {
+      waitUntil: ['networkidle0'],
+    });
+    // find the 404 text in the page
+    const text = await page.evaluate(() => document.body.textContent);
+    expect(text).toContain('404');
+  });
+});

--- a/tests/integration/module-doc/tsconfig.json
+++ b/tests/integration/module-doc/tsconfig.json
@@ -7,5 +7,5 @@
       "demo": ["."]
     }
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4526cbd</samp>

This pull request adds integration tests for the module-doc example app using puppeteer. It also updates the `tsconfig.json` file to include the `tests` folder.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4526cbd</samp>

*  Add a new test file `tests/basic.test.ts` to check the rendering of the module-doc example app in development mode ([link](https://github.com/web-infra-dev/modern.js/pull/3998/files?diff=unified&w=0#diff-9ed88e0bd742bf923b38e01ee5170f6bd2b9da828406c0d3bee1e69bb72e68d0R1-R60))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
