### PR TITLE
fix: ssr script、link should add some attrs, like ["defer", "crossorigin"]

### DIFF
--- a/.changeset/strange-walls-unite.md
+++ b/.changeset/strange-walls-unite.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(plugin-ssr): ssr script、link should add some attrs, like ["defer", "crossorigin"]
+fix(plugin-ssr): ssr script,link 标签应该添加像 ["defer", "crossorigin"] 属性

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -189,10 +189,15 @@ export default (): CliPlugin<AppTools> => ({
           const chunkLoadingGlobal = bundlerConfigs?.find(
             config => config.name === 'client',
           )?.output?.chunkLoadingGlobal;
+          const config = api.useResolvedConfigContext();
+          const { crossorigin, scriptLoading } = config.html;
+
           plugins.push({
             name: PLUGIN_IDENTIFIER,
             options: JSON.stringify({
               ...(ssrConfigMap.get(entrypoint.entryName) || {}),
+              crossorigin,
+              scriptLoading,
               chunkLoadingGlobal,
             }),
           });

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
@@ -35,18 +35,31 @@ export const toHtml: RenderHandler = (jsx, renderer, next) => {
 
   for (const v of chunks) {
     const fileType = extname(v.url!).slice(1);
+    const attributes: Record<string, any> = {};
+    const { crossorigin, scriptLoading = 'defer' } = config;
+    if (crossorigin && isCrossOrigin(v.url, host)) {
+      attributes.crossorigin = crossorigin === true ? 'anonymous' : crossorigin;
+    }
+
+    switch (scriptLoading) {
+      case 'defer':
+        attributes.defer = true;
+        break;
+      case 'module':
+        attributes.type = 'module';
+        break;
+      default:
+    }
 
     if (fileType === 'js') {
-      const attributes: Record<string, any> = { nonce };
-      const { crossorigin } = config;
-      if (crossorigin && isCrossOrigin(v.url, host)) {
-        attributes.crossorigin =
-          crossorigin === true ? 'anonymous' : crossorigin;
-      }
+      // `nonce` attrs just for script tag
+      attributes.nonce = nonce;
       const attrsStr = attributesToString(attributes);
       chunksMap[fileType] += `<script${attrsStr} src="${v.url}"></script>`;
     } else if (fileType === 'css') {
-      chunksMap[fileType] += `<link href="${v.url}" rel="stylesheet" />`;
+      chunksMap[
+        fileType
+      ] += `<link${attributes} href="${v.url}" rel="stylesheet" />`;
     }
   }
 

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
@@ -8,6 +8,7 @@ export { RuntimeContext, RenderLevel };
 
 export type SSRPluginConfig = {
   crossorigin?: boolean | 'anonymous' | 'use-credentials';
+  scriptLoading?: 'defer' | 'blocking' | 'module';
   chunkLoadingGlobal?: string;
 } & Exclude<ServerUserConfig['ssr'], boolean>;
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e016d8a</samp>

This pull request adds support for customizing the script loading mode and the crossorigin attribute for the SSR plugin. It updates the `SSRPluginConfig` type, the `toHtml` function, and the `cli/index.ts` file to use these options.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e016d8a</samp>

*  Pass `crossorigin` and `scriptLoading` options from config to SSR plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4000/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L192-R200))
*  Generate script tags with `crossorigin`, `scriptLoading` and `nonce` attributes based on config in `toHtml` function ([link](https://github.com/web-infra-dev/modern.js/pull/4000/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L38-R62))
*  Add `scriptLoading` type to `SSRPluginConfig` interface in `types.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4000/files?diff=unified&w=0#diff-7bb2b37d7c4c35db7a1d3fbfbd76ed3192cc5ca45a0a749df4661179ad395c32R11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
