### PR TITLE
docs: deploy configuration

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/deploy/microFrontend.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/deploy/microFrontend.mdx
@@ -15,10 +15,10 @@ interface MicroFrontend {
 }
 ```
 
-Developers can use the `deploy.microFrontend` to configure micro-frontend sub-application information.
+Developers can configure micro-frontend sub-application information using the `deploy.microFrontend` object.
 
 :::caution
-Enable the "Micro Frontend" features through `pnpm run new` first.
+To enable the "Micro Frontend" features, run `pnpm run new` first.
 
 :::
 
@@ -41,13 +41,13 @@ export default defineConfig({
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to enable the html entry, the default is `true`, the sub-application is built into the `HTML` mode, Garfish supports the `html` entry, you can turn on the open option, experience the corresponding features, and directly point the sub-application entry to the HTML entry when it is the HTML entry. Just point to the html of the sub-application
+Specifies whether to enable the HTML entry. By default, it is set to `true`, which means the sub-application is built in `HTML` mode. Garfish supports the `html` entry, so you can enable this option to experience the corresponding features. When using the HTML entry, simply point the sub-application entry to the HTML file.
 
-Set it to `false` to indicate that the sub-application is built as `js`. After the sub-application is built as `js`, it cannot run independently. When it is a `JS` entry, point the entry file of the sub-application to the `JS` of the sub-application.
+Set it to `false` to indicate that the sub-application is built as `js`. After building the sub-application as `js`, it cannot run independently. When using the `JS` entry, point the entry file of the sub-application to the `JS` file of the sub-application.
 
 ### externalBasicLibrary
 
 - **Type:** `boolean`
 - **Default:** `false`
 
-Whether the `external` base library, when set to `true`, the current child application will be `external`: `react`, `react-dom`, Modern.js main application will automatically `setExternal` these two base libraries, if other types of frameworks Please add `react`, `react-dom` dependencies through `Garfish.setExternal`.
+Specifies whether to use the external base library. When set to `true`, the current child application will be externalized for `react` and `react-dom`. The main application of Modern.js will automatically `setExternal` these two base libraries. If you are using other frameworks, please add `react` and `react-dom` dependencies through `Garfish.setExternal`.


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b617cbe</samp>

This pull request improves the documentation for the `deploy.microFrontend` configuration option in the `modern.js` package. It clarifies how to use the option to deploy micro-frontends with different strategies and frameworks.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b617cbe</samp>

* Improve the documentation of the `deploy.microFrontend` object in `packages/document/main-doc/docs/en/configure/app/deploy/microFrontend.mdx` by:
  - Rewriting the sentence that introduces the object for clarity and grammar ([link](https://github.com/web-infra-dev/modern.js/pull/4001/files?diff=unified&w=0#diff-fcbb764afe1f922a70bae273c5b9050c048f5a88072f8d25be2688e883c28729L18-R21))
  - Refactoring the paragraph that explains the `htmlEntry` option for readability and structure ([link](https://github.com/web-infra-dev/modern.js/pull/4001/files?diff=unified&w=0#diff-fcbb764afe1f922a70bae273c5b9050c048f5a88072f8d25be2688e883c28729L44-R46))
  - Simplifying the sentence that describes the `externalBasicLibrary` option for conciseness and consistency ([link](https://github.com/web-infra-dev/modern.js/pull/4001/files?diff=unified&w=0#diff-fcbb764afe1f922a70bae273c5b9050c048f5a88072f8d25be2688e883c28729L53-R53))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
