### PR TITLE
fix(storybook): fix typescript v5 capability issue

### DIFF
--- a/.changeset/purple-dogs-know.md
+++ b/.changeset/purple-dogs-know.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-storybook': patch
+---
+
+fix(storybook): fix typescript v5 capability issue
+
+fix(storybook): 修复与 typescript v5 的兼容问题
+

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -60,12 +60,13 @@
     "@storybook/core": "6.5.12",
     "@storybook/manager-webpack5": "6.5.12",
     "@storybook/react": "6.5.12",
+    "@swc/helpers": "0.5.1",
     "esbuild": "0.15.7",
     "findup-sync": "^4.0.0",
     "fs-extra": "^10.0.0",
     "process.argv": "^0.6.0",
-    "tsconfig-paths-webpack-plugin": "4.0.0",
-    "@swc/helpers": "0.5.1"
+    "react-docgen-typescript-plugin": "1.0.5",
+    "tsconfig-paths-webpack-plugin": "4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/packages/cli/plugin-storybook/template/main.tmpl
+++ b/packages/cli/plugin-storybook/template/main.tmpl
@@ -43,6 +43,12 @@ module.exports = {
     },
     ...(userMainConfig.addons || []),
   ],
+  // Fix typescript v5 capability issue
+  // https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/78
+  // https://github.com/storybookjs/storybook/issues/21642
+  typescript: {
+    reactDocgen: 'react-docgen-typescript-plugin'
+  },
   webpackFinal: async (config, options) => {
     // change webpack config
     const { customFinalWebpack = () => config } = options;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1612,6 +1612,9 @@ importers:
       process.argv:
         specifier: ^0.6.0
         version: 0.6.0
+      react-docgen-typescript-plugin:
+        specifier: 1.0.5
+        version: 1.0.5(typescript@5.0.4)(webpack@5.82.1)
       tsconfig-paths-webpack-plugin:
         specifier: 4.0.0
         version: 4.0.0
@@ -29165,6 +29168,25 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.5
       react: 18.2.0
+
+  /react-docgen-typescript-plugin@1.0.5(typescript@5.0.4)(webpack@5.82.1):
+    resolution: {integrity: sha512-Ds6s2ioyIlH45XSfEVMNwRcDkzuff3xQCPxDFOzTc8GEshy+hksas8RYlmV4JEQREI+OGEGybhMCJk3vFbQZNQ==}
+    peerDependencies:
+      typescript: '>= 4.x'
+      webpack: '>= 4'
+    dependencies:
+      debug: 4.3.4(supports-color@8.1.1)
+      endent: 2.1.0
+      find-cache-dir: 3.3.2
+      flat-cache: 3.0.4
+      micromatch: 4.0.5
+      react-docgen-typescript: 2.2.2(typescript@5.0.4)
+      tslib: 2.4.0
+      typescript: 5.0.4
+      webpack: 5.82.1(esbuild@0.15.7)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /react-docgen-typescript@2.2.2(typescript@5.0.4):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}


### PR DESCRIPTION
## Summary

Fix the following error when using typescript v5 with storybook plugin:

```bash
70% sealing plugins DocGenPlugin error   TypeError: typescript_1.default.createIdentifier is not a function
```

Related issues:

- https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/78
- https://github.com/storybookjs/storybook/issues/21642

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cec5c47</samp>

This pull request updates the `@modern-js/plugin-storybook` package to support typescript v5 and enable typescript docgen for storybook. It adds a new dependency, a changeset file, and a template configuration file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cec5c47</samp>

*  Add changeset file for patch update of `@modern-js/plugin-storybook` ([link](https://github.com/web-infra-dev/modern.js/pull/4002/files?diff=unified&w=0#diff-dd42c9b896fab33d1824a3660aa90ca9548a852a6b3bdaa28a843a648294e9b2R1-R8))
*  Add `react-docgen-typescript-plugin` dependency to `@modern-js/plugin-storybook` ([link](https://github.com/web-infra-dev/modern.js/pull/4002/files?diff=unified&w=0#diff-4ba9c298e0c9aceb8c9f170f6ad80c539f36a3ceae0575c46dfc5976b735ace4L63-R69))
*  Configure storybook main template to use `react-docgen-typescript-plugin` and fix typescript v5 compatibility ([link](https://github.com/web-infra-dev/modern.js/pull/4002/files?diff=unified&w=0#diff-4319ef90392a4502f3e06a5ada67facceb796a2f758ae9f883d44f33c5b8a7bcR46-R51))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
