### PR TITLE
docs(builder): update rspack unsupported configurations

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -54,7 +54,7 @@ Unsupported configurations and capabilities include:
 
 - [source.include](/api/config-source.html#sourceinclude) ([track issue](https://github.com/web-infra-dev/rspack/issues/3067))
 - [source.exclude](/api/config-source.html#sourceexclude) ([track issue](https://github.com/web-infra-dev/rspack/issues/3067))
-- [source.moduleScopes](/api/config-source.html#sourcemodulescopes)
+- [source.moduleScopes](/api/config-source.html#sourcemodulescopes) ([track issue](https://github.com/web-infra-dev/rspack/issues/3548))
 
 #### Html Config
 
@@ -103,7 +103,6 @@ Unsupported configurations and capabilities include:
 Unsupported configurations and capabilities include:
 
 - [performance.profile](/api/config-performance.html#performanceprofile)
-- [performance.removeMomentLocale](/api/config-performance.html#performanceremovemomentlocale)
 - [performance.buildCache](/api/config-performance.html#performancebuildcache)
 - [performance.chunkSplit (split-by-module)](/api/config-performance.html#performancechunksplit)
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -55,7 +55,7 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 
 - [source.include](/api/config-source.html#sourceinclude) ([issue 追踪](https://github.com/web-infra-dev/rspack/issues/3067))
 - [source.exclude](/api/config-source.html#sourceexclude) ([issue 追踪](https://github.com/web-infra-dev/rspack/issues/3067))
-- [source.moduleScopes](/api/config-source.html#sourcemodulescopes)
+- [source.moduleScopes](/api/config-source.html#sourcemodulescopes) ([issue 追踪](https://github.com/web-infra-dev/rspack/issues/3548))
 
 #### Html Config
 
@@ -104,7 +104,6 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 不支持的配置项及能力包括：
 
 - [performance.profile](/api/config-performance.html#performanceprofile)
-- [performance.removeMomentLocale](/api/config-performance.html#performanceremovemomentlocale)
 - [performance.buildCache](/api/config-performance.html#performancebuildcache)
 - [performance.chunkSplit (split-by-module)](/api/config-performance.html#performancechunksplit)
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed43380</samp>

This pull request updates the documentation of `rspack-start` in both English and Chinese to match the current version of `rspack`. It removes outdated information and adds references to relevant issues.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed43380</samp>

*  Add link to issue for `source.moduleScopes` option in rspack-start guide ([link](https://github.com/web-infra-dev/modern.js/pull/4006/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L57-R57), [link](https://github.com/web-infra-dev/modern.js/pull/4006/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L58-R58))
*  Remove mention of deprecated `performance.removeMomentLocale` option in rspack-start guide ([link](https://github.com/web-infra-dev/modern.js/pull/4006/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L106), [link](https://github.com/web-infra-dev/modern.js/pull/4006/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L107))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
