### PR TITLE
fix: should not invoke onServerChange when `-server-loader.js` file change

### DIFF
--- a/.changeset/seven-spiders-sit.md
+++ b/.changeset/seven-spiders-sit.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server': patch
+---
+
+fix: should not invoke onServerChange when `-server-loader.js` file change
+fix: 不应该在 `-server-loader.js` 变化时触发 onServerChange

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -384,8 +384,10 @@ export class ModernDevServer extends ModernServer {
 
     // 监听文件变动，如果有变动则给 client，也就是 start 启动的插件发消息
     watcher.listen(defaultWatchedPaths, watchOptions, (filepath, event) => {
+      // Todo should delte this cache in onRepack
       if (filepath.includes('-server-loaders.js')) {
         delete require.cache[filepath];
+        return;
       } else {
         watcher.updateDepTree();
         watcher.cleanDepCache(filepath);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10158fd</samp>

This pull request fixes a bug in the `@modern-js/server` package that caused the `onServerChange` event to fire when the `-server-loader.js` file changed. It does so by adding a changeset file and modifying the `listen` method of the `ModernDevServer` class.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 10158fd</samp>

*  Add a changeset file to document the fixes for the `@modern-js/server` package ([link](https://github.com/web-infra-dev/modern.js/pull/4008/files?diff=unified&w=0#diff-7f5588c0232488984af440e7b2c66409f438f36b81e4b8e2aa97f96d3d475f1dR1-R6))
*  Prevent triggering the `onServerChange` event when the `-server-loader.js` file changes by returning early from the `listen` method of the `ModernDevServer` class ([link](https://github.com/web-infra-dev/modern.js/pull/4008/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aL387-R390))
*  Add a comment to suggest moving the cache deletion of the `-server-loader.js` file to the `onRepack` method in the future ([link](https://github.com/web-infra-dev/modern.js/pull/4008/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aL387-R390))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
