### PR TITLE
chore: export @remix-run/router cjs instead of react-router-dom

### DIFF
--- a/.changeset/tender-forks-grow.md
+++ b/.changeset/tender-forks-grow.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-data-loader': patch
+'@modern-js/utils': patch
+---
+
+fix: export `@remix-run/router` cjs instead of `react-router-dom`
+fix: 暴露 `@remix-run/router` 的 cjs 导出代替 `react-router-dom`

--- a/packages/cli/plugin-data-loader/src/cli/createRequest.ts
+++ b/packages/cli/plugin-data-loader/src/cli/createRequest.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable node/prefer-global/url */
+// Todo move this file to `runtime/` dir
 import { compile } from 'path-to-regexp';
 import { redirect } from '@modern-js/utils/runtime/router';
 import { type UNSAFE_DeferredData as DeferredData } from '@modern-js/utils/runtime/remix-router';

--- a/packages/cli/plugin-data-loader/src/server/index.ts
+++ b/packages/cli/plugin-data-loader/src/server/index.ts
@@ -17,6 +17,7 @@ export default (): ServerPlugin => ({
       distDir: string;
     }) {
       return async (context: ServerContext) => {
+        // Todo remove matchEntry, bundle follow logic to server-loader
         const entry = matchEntry(context.path, serverRoutes);
         if (!entry) {
           return;

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -36,11 +36,11 @@
     },
     "./runtime/router": {
       "jsnext:source": "./src/runtime/router.ts",
-      "require": "./dist/cjs/runtime/router.js",
       "default": "./dist/esm/runtime/router.js"
     },
     "./runtime/remix-router": {
       "jsnext:source": "./src/runtime/remixRouter.ts",
+      "require": "./dist/cjs/runtime/remixRouter.js",
       "default": "./dist/esm/runtime/remixRouter.js"
     },
     "./runtime/nested-routes": {
@@ -58,7 +58,6 @@
     },
     "./runtime-node/router": {
       "jsnext:source": "./src/runtime-node/router.ts",
-      "require": "./dist/cjs/runtime-node/router.js",
       "default": "./dist/esm/runtime-node/router.js"
     },
     "./universal/constants": {
@@ -118,11 +117,11 @@
       },
       "./runtime/router": {
         "types": "./dist/types/runtime/router.d.ts",
-        "require": "./dist/cjs/runtime/router.js",
         "default": "./dist/esm/runtime/router.js"
       },
       "./runtime/remix-router": {
         "types": "./dist/types/runtime/remixRouter.d.ts",
+        "require": "./dist/cjs/runtime/remixRouter.js",
         "default": "./dist/esm/runtime/remixRouter.js"
       },
       "./runtime/nested-routes": {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 555c7f4</samp>

This pull request fixes the cjs export of `@remix-run/router` for node environments in two packages, and adds some todo comments to refactor the data loading logic in the cli and server packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 555c7f4</samp>

*  Patch two packages to export `@remix-run/router` cjs instead of `react-router-dom` for node environments ([link](https://github.com/web-infra-dev/modern.js/pull/4011/files?diff=unified&w=0#diff-36a27083fe9fa9f69363c85f2cbbf4c31d046f01ccdd26b87ffd73b30874ba68R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4011/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L39-R43), [link](https://github.com/web-infra-dev/modern.js/pull/4011/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L61))
*  Add todo comments to move `createRequest.ts` to `runtime/` directory and remove `matchEntry` and `bundle` logic from server data loader ([link](https://github.com/web-infra-dev/modern.js/pull/4011/files?diff=unified&w=0#diff-11d382118af0b9e02cea623de0313c26c484e99b59379f3dca8d29f2fba68855R3), [link](https://github.com/web-infra-dev/modern.js/pull/4011/files?diff=unified&w=0#diff-504cf21b8c63c862a0a8998c8e641022dccf66f79cdaa21c6b61398159c01289R20))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
