### PR TITLE
fix(module-tools): close declarationMap when bundle dts

### DIFF
--- a/.changeset/thirty-cooks-sell.md
+++ b/.changeset/thirty-cooks-sell.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix: close declarationMap when bundle dts
+fix: 打包dts时关闭declarationMap

--- a/packages/solutions/module-tools/src/builder/dts/rollup.ts
+++ b/packages/solutions/module-tools/src/builder/dts/rollup.ts
@@ -81,7 +81,6 @@ export const runRollup = async (
       dtsPlugin({
         respectExternal,
         compilerOptions: {
-          declarationMap: false,
           skipLibCheck: true,
           // https://github.com/Swatinem/rollup-plugin-dts/issues/143,
           // but it will cause error when bundle ts which import another ts file.
@@ -89,6 +88,8 @@ export const runRollup = async (
           ...options,
           // https://github.com/Swatinem/rollup-plugin-dts/issues/127
           composite: false,
+          // https://github.com/Swatinem/rollup-plugin-dts/issues/113
+          declarationMap: false,
           // isAbsolute
           baseUrl,
           // Ensure ".d.ts" modules are generated


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c341efc</samp>

This pull request fixes a bug in TypeScript module bundling that caused incorrect declaration maps. It also updates the `@modern-js/module-tools` package version and changelog with a bilingual fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c341efc</samp>

* Add a changeset file for patching `@modern-js/module-tools` with a fix message ([link](https://github.com/web-infra-dev/modern.js/pull/4012/files?diff=unified&w=0#diff-975755579011a06510e12a2fb95ad65693597d7d51be587665593856ac179f35R1-R6))
* Fix an error when bundling declaration files for TypeScript modules by removing `declarationMap: false` from `rollup-plugin-dts` configuration ([link](https://github.com/web-infra-dev/modern.js/pull/4012/files?diff=unified&w=0#diff-1ccd8d9b8dd7ed45268001d4445d2d3550437eacd3173a47fecec5f5866727e1L84))
* Work around a bug in `rollup-plugin-dts` that prevents declaration map files from being closed by adding `declarationMap: false` to the output object ([link](https://github.com/web-infra-dev/modern.js/pull/4012/files?diff=unified&w=0#diff-1ccd8d9b8dd7ed45268001d4445d2d3550437eacd3173a47fecec5f5866727e1R91-R92))

## Related Issue

https://github.com/Swatinem/rollup-plugin-dts/issues/113

Closes #4009 
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
