### PR TITLE
feat(plugin-vue): support Vue 3 JSX compilation

### DIFF
--- a/.changeset/kind-ears-act.md
+++ b/.changeset/kind-ears-act.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-vue': patch
+---
+
+feat(plugin-vue): support Vue 3 JSX compilation
+
+feat(plugin-vue): 支持编译 Vue 3 JSX

--- a/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -31,6 +31,254 @@ exports[`plugins/vue > should add vue-loader and VueLoaderPlugin correctly 1`] =
 }
 `;
 
+exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "test": /\\\\\\.vue\\$/,
+        "use": [
+          {
+            "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/vue-loader/dist/index.js",
+            "options": {
+              "compilerOptions": {
+                "preserveWhitespace": false,
+              },
+              "experimentalInlineMatchResource": false,
+            },
+          },
+        ],
+      },
+      {
+        "include": [
+          {
+            "and": [
+              "<ROOT>",
+              {
+                "not": /node_modules/,
+              },
+            ],
+          },
+        ],
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+                  {},
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+                  {
+                    "legacy": true,
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "helpers": false,
+                    "regenerator": true,
+                    "useESModules": true,
+                    "version": "7.21.5",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                  "styled-components",
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
+                  {
+                    "transformOn": false,
+                  },
+                ],
+              ],
+              "presets": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": false,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.30",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": false,
+                    "shippedProposals": false,
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "mimetype": {
+          "or": [
+            "text/javascript",
+            "application/javascript",
+          ],
+        },
+        "use": [
+          {
+            "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+                  {},
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+                  {
+                    "legacy": true,
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "helpers": false,
+                    "regenerator": true,
+                    "useESModules": true,
+                    "version": "7.21.5",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                  "styled-components",
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
+                  {
+                    "transformOn": false,
+                  },
+                ],
+              ],
+              "presets": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": false,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.30",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": false,
+                    "shippedProposals": false,
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "plugins": [
+    Plugin {},
+  ],
+  "resolve": {
+    "extensions": [
+      ".vue",
+    ],
+  },
+}
+`;
+
 exports[`plugins/vue > should allow to configure vueLoader options 1`] = `
 {
   "module": {
@@ -46,6 +294,250 @@ exports[`plugins/vue > should allow to configure vueLoader options 1`] = `
               },
               "experimentalInlineMatchResource": false,
               "hotReload": false,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "plugins": [
+    Plugin {},
+  ],
+  "resolve": {
+    "extensions": [
+      ".vue",
+    ],
+  },
+}
+`;
+
+exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "test": /\\\\\\.vue\\$/,
+        "use": [
+          {
+            "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/vue-loader/dist/index.js",
+            "options": {
+              "compilerOptions": {
+                "preserveWhitespace": false,
+              },
+              "experimentalInlineMatchResource": false,
+            },
+          },
+        ],
+      },
+      {
+        "include": [
+          {
+            "and": [
+              "<ROOT>",
+              {
+                "not": /node_modules/,
+              },
+            ],
+          },
+        ],
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+                  {},
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+                  {
+                    "legacy": true,
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "helpers": false,
+                    "regenerator": true,
+                    "useESModules": true,
+                    "version": "7.21.5",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                  "styled-components",
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
+                  {},
+                ],
+              ],
+              "presets": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": false,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.30",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": false,
+                    "shippedProposals": false,
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "mimetype": {
+          "or": [
+            "text/javascript",
+            "application/javascript",
+          ],
+        },
+        "use": [
+          {
+            "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
+                  {},
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-decorators/index.js",
+                  {
+                    "legacy": true,
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "helpers": false,
+                    "regenerator": true,
+                    "useESModules": true,
+                    "version": "7.21.5",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-export-default-from/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-pipeline-operator/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/@babel/plugin-proposal-partial-application/index.js",
+                ],
+                [
+                  "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-styled-components/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                  "styled-components",
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
+                  {},
+                ],
+              ],
+              "presets": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": false,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.30",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": false,
+                    "shippedProposals": false,
+                    "targets": [
+                      "> 0.01%",
+                      "not dead",
+                      "not op_mini all",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+              ],
             },
           },
         ],

--- a/packages/builder/plugin-vue/tests/index.test.ts
+++ b/packages/builder/plugin-vue/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { createStubBuilder } from '@modern-js/builder-webpack-provider/stub';
+import { builderPluginBabel } from '@modern-js/builder-webpack-provider/plugins/babel';
 import { builderPluginVue } from '../src';
 
 describe('plugins/vue', () => {
@@ -20,6 +21,31 @@ describe('plugins/vue', () => {
             hotReload: false,
           },
         }),
+      ],
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should apply jsx babel plugin correctly', async () => {
+    const builder = await createStubBuilder({
+      plugins: [builderPluginVue(), builderPluginBabel()],
+    });
+    const config = await builder.unwrapWebpackConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should allow to configure jsx babel plugin options', async () => {
+    const builder = await createStubBuilder({
+      plugins: [
+        builderPluginVue({
+          vueJsxOptions: {
+            transformOn: false,
+          },
+        }),
+        builderPluginBabel(),
       ],
     });
     const config = await builder.unwrapWebpackConfig();

--- a/packages/document/builder-doc/docs/en/plugins/plugin-vue.mdx
+++ b/packages/document/builder-doc/docs/en/plugins/plugin-vue.mdx
@@ -58,3 +58,36 @@ builderPluginVue({
   },
 });
 ```
+
+### vueJsxOptions
+
+- **Type:**
+
+```ts
+type VueJSXPluginOptions = {
+  /** transform `on: { click: xx }` to `onClick: xxx` */
+  transformOn?: boolean;
+  /** enable optimization or not. */
+  optimize?: boolean;
+  /** merge static and dynamic class / style attributes / onXXX handlers */
+  mergeProps?: boolean;
+  /** configuring custom elements */
+  isCustomElement?: (tag: string) => boolean;
+  /** enable object slots syntax */
+  enableObjectSlots?: boolean;
+  /** Replace the function used when compiling JSX expressions */
+  pragma?: string;
+};
+```
+
+- **Default:** `{}`
+
+Options passed to `@vue/babel-plugin-jsx`, please refer to the [@vue/babel-plugin-jsx documentation](https://github.com/vuejs/babel-plugin-jsx) for specific usage.
+
+```ts
+builderPluginVue({
+  vueJsxOptions: {
+    transformOn: true,
+  },
+});
+```

--- a/packages/document/builder-doc/docs/zh/plugins/plugin-vue.mdx
+++ b/packages/document/builder-doc/docs/zh/plugins/plugin-vue.mdx
@@ -58,3 +58,36 @@ builderPluginVue({
   },
 });
 ```
+
+### vueJsxOptions
+
+- **类型：**
+
+```ts
+type VueJSXPluginOptions = {
+  /** 将 `on: { click: xx }` 转换为 `onClick: xxx` */
+  transformOn?: boolean;
+  /** 是否启用优化。 */
+  optimize?: boolean;
+  /** 合并静态和动态 class / style 属性 / onXXX 事件处理函数 */
+  mergeProps?: boolean;
+  /** 配置自定义元素 */
+  isCustomElement?: (tag: string) => boolean;
+  /** 启用对象插槽语法 */
+  enableObjectSlots?: boolean;
+  /** 替换用于编译 JSX 表达式的函数 */
+  pragma?: string;
+};
+```
+
+- **默认值：** `{}`
+
+传递给 `@vue/babel-plugin-jsx` 的选项，请查阅 [@vue/babel-plugin-jsx 文档](https://github.com/vuejs/babel-plugin-jsx) 来了解具体用法。
+
+```ts
+builderPluginVue({
+  vueJsxOptions: {
+    transformOn: true,
+  },
+});
+```

--- a/tests/e2e/builder/cases/vue/index.test.ts
+++ b/tests/e2e/builder/cases/vue/index.test.ts
@@ -25,3 +25,24 @@ test('should build basic Vue sfc correctly', async ({ page }) => {
 
   builder.close();
 });
+
+test('should build basic Vue jsx correctly', async ({ page }) => {
+  const root = join(__dirname, 'jsx-basic');
+
+  const builder = await build({
+    cwd: root,
+    entry: {
+      main: join(root, 'src/index.js'),
+    },
+    runServer: true,
+    plugins: [builderPluginVue()],
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.querySelector('#button1').innerHTML`),
+  ).resolves.toBe('A: 0');
+
+  builder.close();
+});

--- a/tests/e2e/builder/cases/vue/jsx-basic/src/A.jsx
+++ b/tests/e2e/builder/cases/vue/jsx-basic/src/A.jsx
@@ -1,0 +1,14 @@
+import { ref, defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'Test',
+
+  setup() {
+    const count = ref(0);
+    return () => (
+      <button id="button1" onClick={() => count.value++}>
+        A: {count.value}
+      </button>
+    );
+  },
+});

--- a/tests/e2e/builder/cases/vue/jsx-basic/src/index.js
+++ b/tests/e2e/builder/cases/vue/jsx-basic/src/index.js
@@ -1,0 +1,6 @@
+import { createApp } from 'vue';
+import A from './A';
+
+console.log(A);
+
+createApp(A).mount('#root');


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5e4d6d</samp>

This pull request adds support for Vue 3 JSX compilation using the `@vue/babel-plugin-jsx` package to the `@modern-js/builder-plugin-vue` package. It updates the plugin function, the interface, the tests, the changeset, and the documentation files to reflect the new feature. It also adds a new end-to-end test case with a basic Vue JSX component.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5e4d6d</samp>

*  Add Vue 3 JSX compilation feature to `@modern-js/builder-plugin-vue` package ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-19cb836d9134a664c3cd2aae991664845206971d9ebf35599ecda9e18a9c6476R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368L6-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368L26-R43), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-b2b9e1eadea0ec5fec9c34cc91d803b4792b54bc650ca787eb69d06f095d5da1R61-R93), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-1f3846f5f50449a656aab3a19dba5a68e3ffca5ae3d77b7386e05b919b868262R61-R93), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R28-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-f3c1df6efa0819e57ad44ec6ee6a4ead955a5694b6f9bba0f13d57c47f8d09b0R1-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-e99684f6b485d05c4910f394dbfd0f6438f558cc92632f8c5279a5faf26d098dR1-R6))
  *  Add changeset file to document patch version update and feature introduction ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-19cb836d9134a664c3cd2aae991664845206971d9ebf35599ecda9e18a9c6476R1-R7))
  *  Add `vueJsxOptions` property to `PluginVueOptions` interface to pass options to `@vue/babel-plugin-jsx` package ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368L6-R14))
  *  Merge custom configuration with existing configuration using `mergeBuilderConfig` helper function ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368L26-R43))
    *  Set `disableSvgr` property to `true` in `output` object to avoid SVG React component transformation ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368L26-R43))
    *  Add `@vue/babel-plugin-jsx` plugin with `options.vueJsxOptions` to `babel` tool in `tools` object to enable Vue 3 JSX compilation ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368L26-R43))
  *  Remove optional chaining operator from `options.vueLoaderOptions` property when merging with `vueLoaderOptions` object ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368L42-R57))
  *  Add documentation for `vueJsxOptions` property in English and Chinese files ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-b2b9e1eadea0ec5fec9c34cc91d803b4792b54bc650ca787eb69d06f095d5da1R61-R93), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-1f3846f5f50449a656aab3a19dba5a68e3ffca5ae3d77b7386e05b919b868262R61-R93))
  *  Add end-to-end test case for basic Vue JSX component using `builderPluginVue` function ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R28-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-f3c1df6efa0819e57ad44ec6ee6a4ead955a5694b6f9bba0f13d57c47f8d09b0R1-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-e99684f6b485d05c4910f394dbfd0f6438f558cc92632f8c5279a5faf26d098dR1-R6))
    *  Add `A.jsx` file with Vue JSX component definition ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-f3c1df6efa0819e57ad44ec6ee6a4ead955a5694b6f9bba0f13d57c47f8d09b0R1-R14))
    *  Add `index.js` file with entry point for Vue app instance ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-e99684f6b485d05c4910f394dbfd0f6438f558cc92632f8c5279a5faf26d098dR1-R6))
    *  Use `build`, `getHrefByEntryName`, and `page` helper functions to create builder instance, get URL, and interact with browser ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R28-R48))
    *  Expect button element with id of `button1` to have correct innerHTML value ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R28-R48))
    *  Close builder instance after test ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R28-R48))
*  Add unit test cases for `@vue/babel-plugin-jsx` plugin application and configuration ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR3), [link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR30-R54))
  *  Import `builderPluginBabel` function from `@modern-js/builder-webpack-provider/plugins/babel` package ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR3))
  *  Check that `@vue/babel-plugin-jsx` plugin is applied correctly with default options ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR30-R54))
  *  Check that `@vue/babel-plugin-jsx` plugin options can be configured through `vueJsxOptions` property ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR30-R54))
  *  Use `createStubBuilder`, `unwrapWebpackConfig`, and `toMatchSnapshot` helper functions to create mock builder instance, get webpack config, and compare with snapshot ([link](https://github.com/web-infra-dev/modern.js/pull/4013/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR30-R54))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
