### PR TITLE
fix(rspack-provider): remove useless todo for rspack

### DIFF
--- a/packages/builder/builder-shared/src/types/bundlerConfig.ts
+++ b/packages/builder/builder-shared/src/types/bundlerConfig.ts
@@ -54,6 +54,7 @@ type RspackOutput = {
   cssFilename?: string;
   cssChunkFilename?: string;
   library?: string;
+  crossOriginLoading?: false | 'anonymous' | 'use-credentials';
 };
 
 // fork from the @rspack/core

--- a/packages/builder/builder/src/plugins/html.ts
+++ b/packages/builder/builder/src/plugins/html.ts
@@ -236,8 +236,6 @@ export const builderPluginHtml = (): DefaultBuilderPlugin => ({
                 { crossOrigin: formattedCrossorigin, HtmlPlugin },
               ]);
 
-            // todo: not support in rspack
-            // @ts-expect-error
             chain.output.crossOriginLoading(formattedCrossorigin);
           }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53bca5b</samp>

This pull request adds support for the `crossOriginLoading` option in rspack, which allows controlling the cross-origin behavior of the script tags generated by the html plugin. It also removes some unnecessary code in the webpack html plugin that was related to the same option.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53bca5b</samp>

* Add `crossOriginLoading` property to `RspackOutput` type to support cross-origin requests for rspack bundler ([link](https://github.com/web-infra-dev/modern.js/pull/4018/files?diff=unified&w=0#diff-7c4255fe8725aa72645e91fca27ec3e6257351046a3c8d55201ddc01c92c793eR57))
* Remove unnecessary comment and TypeScript directive in `builderPluginHtml` function for webpack bundler, since `crossOriginLoading` is now supported by rspack types ([link](https://github.com/web-infra-dev/modern.js/pull/4018/files?diff=unified&w=0#diff-725166494340b3f29f8de572a5031618f0f3a96e01ff75c4a05f5dfdf22fa0afL239-L240))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
