### PR TITLE
feat(module-tools): auto delete dist files by checking if outdir is root path

### DIFF
--- a/.changeset/swift-monkeys-repair.md
+++ b/.changeset/swift-monkeys-repair.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+feat: Auto delete build product by checking if outdir is project root path
+feat: 根据 outDir 是否是项目根目录决定是否自动删除产物目录

--- a/packages/solutions/module-tools/src/builder/clear.ts
+++ b/packages/solutions/module-tools/src/builder/clear.ts
@@ -8,8 +8,12 @@ export const clearDtsTemp = async () => {
 
 export const clearBuildConfigPaths = async (
   configs: BaseBuildConfig[],
-  noClear: boolean,
+  options?: {
+    noClear?: boolean;
+    projectAbsRootPath?: string;
+  },
 ) => {
+  const { noClear = false, projectAbsRootPath = process.cwd() } = options ?? {};
   const { fs } = await import('@modern-js/utils');
 
   if (noClear) {
@@ -17,6 +21,16 @@ export const clearBuildConfigPaths = async (
   }
 
   for (const config of configs) {
-    await fs.remove(config.outDir);
+    if (projectAbsRootPath === config.outDir) {
+      const { logger, chalk } = await import('@modern-js/utils');
+      const local = await import('../locale');
+      logger.warn(
+        chalk.bgYellowBright(
+          local.i18n.t(local.localeKeys.warns.clearRootPath),
+        ),
+      );
+    } else {
+      await fs.remove(config.outDir);
+    }
   }
 };

--- a/packages/solutions/module-tools/src/builder/index.ts
+++ b/packages/solutions/module-tools/src/builder/index.ts
@@ -28,7 +28,10 @@ export const run = async (
     const { default: pMap } = await import('../../compiled/p-map');
 
     const { clearBuildConfigPaths, clearDtsTemp } = await import('./clear');
-    await clearBuildConfigPaths(resolvedBuildConfig, !cmdOptions.clear);
+    await clearBuildConfigPaths(resolvedBuildConfig, {
+      noClear: !cmdOptions.clear,
+      projectAbsRootPath: context.appDirectory,
+    });
     await clearDtsTemp();
 
     if (cmdOptions.watch) {

--- a/packages/solutions/module-tools/src/locale/en.ts
+++ b/packages/solutions/module-tools/src/locale/en.ts
@@ -63,6 +63,6 @@ export const EN_LOCALE = {
         'With the `dts.abortOnError` configuration currently turned off, type errors do not cause build failures, but they do not guarantee proper type file output',
     },
     clearRootPath:
-      'It is detected that the outDir in the Edenx configuration is the same as the current project directory, and the current product directory will not be automatically deleted.',
+      'It is detected that the outDir in the configuration is the same as the current project directory, and the current product directory will not be automatically deleted.',
   },
 };

--- a/packages/solutions/module-tools/src/locale/en.ts
+++ b/packages/solutions/module-tools/src/locale/en.ts
@@ -62,5 +62,7 @@ export const EN_LOCALE = {
       abortOnError:
         'With the `dts.abortOnError` configuration currently turned off, type errors do not cause build failures, but they do not guarantee proper type file output',
     },
+    clearRootPath:
+      'It is detected that the outDir in the Edenx configuration is the same as the current project directory, and the current product directory will not be automatically deleted.',
   },
 };

--- a/packages/solutions/module-tools/src/locale/zh.ts
+++ b/packages/solutions/module-tools/src/locale/zh.ts
@@ -62,5 +62,7 @@ export const ZH_LOCALE = {
       abortOnError:
         '当前关闭了 `dts.abortOnError` 配置，类型错误不会导致构建失败，但无法保证类型文件正常输出',
     },
+    clearRootPath:
+      '检测到 Edenx 配置中 outDir 与当前项目目录相同，不会自动删除当前产物目录',
   },
 };

--- a/packages/solutions/module-tools/src/locale/zh.ts
+++ b/packages/solutions/module-tools/src/locale/zh.ts
@@ -63,6 +63,6 @@ export const ZH_LOCALE = {
         '当前关闭了 `dts.abortOnError` 配置，类型错误不会导致构建失败，但无法保证类型文件正常输出',
     },
     clearRootPath:
-      '检测到 Edenx 配置中 outDir 与当前项目目录相同，不会自动删除当前产物目录',
+      '检测到配置中 outDir 与当前项目目录相同，不会自动删除当前产物目录',
   },
 };


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5d629a</samp>

Added a `noClear` option to the module-tools builder to avoid deleting the project when using a flat output structure. Updated the locale modules to include warning messages for this option in English and Chinese.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5d629a</samp>

*  Add optional `options` parameter to `clearBuildConfigPaths` function to handle output directory being the same as project root directory ([link](https://github.com/web-infra-dev/modern.js/pull/4021/files?diff=unified&w=0#diff-20edc0d1347fe9a9ec86267371b7758bd0ae61f7420de1fec61116ed43c4da5dL11-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4021/files?diff=unified&w=0#diff-20edc0d1347fe9a9ec86267371b7758bd0ae61f7420de1fec61116ed43c4da5dL20-R34))
*  Pass `noClear` flag and `projectAbsRootPath` value from `cmdOptions` and `context` to `clearBuildConfigPaths` function in `run` function of `builder` module ([link](https://github.com/web-infra-dev/modern.js/pull/4021/files?diff=unified&w=0#diff-fa01db21d10eb93a5a98d6545fbe49c63eab71da53447ace99b81543097aa95aL31-R34))
*  Add `clearRootPath` property to `EN_LOCALE` and `ZH_LOCALE` objects in `locale` module to store warning message for output directory being the same as project root directory ([link](https://github.com/web-infra-dev/modern.js/pull/4021/files?diff=unified&w=0#diff-044266080bf8162ec64961353e7f64de96a77d536bc9b2aacda435ba28b0c55cR65-R66), [link](https://github.com/web-infra-dev/modern.js/pull/4021/files?diff=unified&w=0#diff-6f0fa3593edef4f07b0b158eda75b877e7307c02189b5681f15beef8195f02f2R65-R66))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
