### PR TITLE
fix(app-tools): fix the sourcemap line number mapping offset

### DIFF
--- a/.changeset/thick-ghosts-tap.md
+++ b/.changeset/thick-ghosts-tap.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: fix the line number mapping offset between the sourcemap and the source code
+fix: 修复 sourcemap 到源代码行号映射偏移问题

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -155,7 +155,7 @@ export class RouterPlugin {
             if (!asset) {
               continue;
             }
-            const newContent = `${injectedContent}${asset.source().toString()}`;
+            const newContent = `${asset.source().toString()}${injectedContent}`;
             newAssetsMap.set(path.join(outputPath, file), newContent);
             compilation.updateAsset(
               file,


### PR DESCRIPTION
## Summary

The sourcemap and source code line numbers don't match up due to RouterPlugin injecting some runtime codes. Fix this issue by moving the injected codes to the end.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff32eea</samp>

This pull request fixes two bugs in the `@modern-js/app-tools` package related to sourcemap and router plugin. It adds a changeset file to document the patch updates and modifies the `RouterPlugin.ts` file to inject the router content at the end of the asset source.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff32eea</samp>

* Fix line number mapping offset between sourcemap and source code for `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4026/files?diff=unified&w=0#diff-c019ccacbdf7cac2d85fb99910ac56fce8aca5a6c99aa8a9b6b168168b0541e7R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4026/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L158-R158))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
