### PR TITLE
feat: add named exports for all solutions

### DIFF
--- a/.changeset/breezy-tigers-tell.md
+++ b/.changeset/breezy-tigers-tell.md
@@ -1,0 +1,15 @@
+---
+'@modern-js/generator-generator': patch
+'@modern-js/module-generator': patch
+'@modern-js/rspack-generator': patch
+'@modern-js/mwa-generator': patch
+'@modern-js/generator-plugin-plugin': patch
+'@modern-js/monorepo-tools': patch
+'@modern-js/module-tools': patch
+'@modern-js/app-tools': patch
+'@modern-js/doc-tools': patch
+---
+
+feat: add named exports for all solutions
+
+feat: 为各个 solutions 添加 named 导出

--- a/modern.config.js
+++ b/modern.config.js
@@ -4,7 +4,7 @@ const monorepoToolPath = path.resolve(
   __dirname,
   'packages/solutions/monorepo-tools/dist/cjs/index.js',
 );
-const monorepoTools = require(monorepoToolPath).default;
+const { monorepoTools } = require(monorepoToolPath);
 
 module.exports = {
   plugins: [monorepoTools()],

--- a/packages/document/builder-doc/docs/en/shared/enable-swc.md
+++ b/packages/document/builder-doc/docs/en/shared/enable-swc.md
@@ -8,7 +8,7 @@ First, you need to execute `pnpm run new` to enable the SWC compile:
 After the installation, please register the SWC plugin in the `modern.config.ts` file, then the SWC compilation and compression will be enabled.
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import swcPlugin from '@modern-js/plugin-swc';
 
 export default defineConfig({

--- a/packages/document/builder-doc/docs/zh/shared/enable-swc.md
+++ b/packages/document/builder-doc/docs/zh/shared/enable-swc.md
@@ -8,7 +8,7 @@
 执行完成后，你只需在 `modern.config.ts` 文件中注册 Modern.js 的 SWC 插件，即可启用 SWC 编译和压缩能力。
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import swcPlugin from '@modern-js/plugin-swc';
 
 export default defineConfig({

--- a/packages/document/builder-doc/modern.config.ts
+++ b/packages/document/builder-doc/modern.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import docTools, { defineConfig, Sidebar, NavItem } from '@modern-js/doc-tools';
+import { docTools, defineConfig, Sidebar, NavItem } from '@modern-js/doc-tools';
 
 function getI18nHelper(lang: 'zh' | 'en') {
   const cn = lang === 'zh';

--- a/packages/document/doc-tools-doc/docs/en/api/config/config-basic.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config/config-basic.mdx
@@ -8,7 +8,7 @@
 Deployment base path. For example, if you plan to deploy your site to `https://foo.github.io/bar/`, then you should set `base` to `"/bar/"`:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -26,7 +26,7 @@ export default defineConfig({
 Site title. This parameter will be used as the title of the HTML page. For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -44,7 +44,7 @@ export default defineConfig({
 Site description. This will be used as the description of the HTML page. For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -62,7 +62,7 @@ export default defineConfig({
 Site icon. This path will be used as the icon path for the HTML page. For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -82,7 +82,7 @@ The framework will find your icon in the `public` directory, of course you can a
 Site logo. This path will be used as the logo path in the upper left corner of the navbar. For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -97,7 +97,7 @@ The framework will find your icon in the `public` directory, you can also set it
 Of course you can set different logos for dark/light mode:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -118,7 +118,7 @@ export default defineConfig({
 Custom output directory for built sites. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -144,7 +144,7 @@ export interface Locale {
 I18n config of the site. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -179,7 +179,7 @@ Whether to enable the image zoom function. It is enabled by default, you can dis
 Example usage:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
@@ -48,7 +48,7 @@ Configure MDX-related compilation abilities.
 Configure the remark plugins. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -74,7 +74,7 @@ export default defineConfig({
 Configure the rehype plugin. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -101,7 +101,7 @@ export default defineConfig({
 Whether to check for dead links. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/api/config/config-theme.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config/config-theme.mdx
@@ -3,7 +3,7 @@
 Theme config is located under `themeConfig` in the `doc` param. For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -38,7 +38,7 @@ interface NavItem {
 For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -73,7 +73,7 @@ interface NavGroup {
 For example the following configuration:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -153,7 +153,7 @@ type SidebarItem =
 For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -209,7 +209,7 @@ export interface Footer {
 For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -233,7 +233,7 @@ Configure the title of the outline in the outline panel.
 For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -255,7 +255,7 @@ Whether to display the last update time, it is not displayed by default.
 For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -277,7 +277,7 @@ The text of the last update time.
 For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -297,7 +297,7 @@ export default defineConfig({
 The text of the previous page. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -318,7 +318,7 @@ You can add related links through the following config, such as `github` links, 
 Related links support three modes: `link mode` `text mode` `image mode`, for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -376,7 +376,7 @@ export type SocialLinkIcon =
 If you need to customize the icon, you can pass in an object with `svg attribute`, and the value of svg is the content of the custom icon, for example:
 
 ```js
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -404,7 +404,7 @@ export default defineConfig({
 Text for the next page. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -464,7 +464,7 @@ export interface LocaleConfig {
 Whether a Dark/Light mode toggle button appears. for example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/fragments/mdx-rs.mdx
+++ b/packages/document/doc-tools-doc/docs/en/fragments/mdx-rs.mdx
@@ -1,5 +1,5 @@
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/guide/advanced/extend-build.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/advanced/extend-build.mdx
@@ -7,7 +7,7 @@ Modern.js Doc builds documents based on the Rspack mode of [Modern.js Builder](h
 Modern.js Builder provides flexible build configurations, you can use [doc.builderConfig](/api/config/config-build.html#builderconfig) to customize these configurations. For example, change the output directory to `doc_dist`:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -42,7 +42,7 @@ The compilation of MDX in the framework is based on [unified](https://github.com
 :
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/guide/basic/global-styles.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/basic/global-styles.mdx
@@ -7,7 +7,7 @@ In some scenarios, you may need to add some global styles based on the theme UI.
 Add the following config to `modern.config.ts`:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/document/doc-tools-doc/docs/en/guide/default-theme/doc-page.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/default-theme/doc-page.mdx
@@ -19,7 +19,7 @@ In `modern.config.ts`, you can configure the content of the sidebar, for details
 With the `outlineTitle` config, you can set the title of the outline bar.
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({
@@ -37,7 +37,7 @@ export default defineConfig({
 With the `prevPageText` and `nextPageText` config, you can set the previous/next page text.
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/guide/default-theme/i18n.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/default-theme/i18n.mdx
@@ -60,7 +60,7 @@ These text data are used in both **config file** and **custom components**, whic
 In `modern.config.ts`, you can configure the default language of the document via `doc.lang`, as shown in the following example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -80,7 +80,7 @@ In `modern.config.ts`, you can configure `locales` data in two places:
 - `doc.themeConfig.locales`, used to configure the theme's `lang`, `outline title`, `previous page/next page text` and other information, mainly for theme-related config.
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -156,7 +156,7 @@ The answer is **no**. In the Modern.js Doc framework, you only need to write a c
 Let's configure the sidebar and navbar like this:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 // Utility function for getting type hints
 const getI18nKey = (key: keyof typeof import('./i18n.json')) => key;

--- a/packages/document/doc-tools-doc/docs/en/guide/default-theme/navbar.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/default-theme/navbar.mdx
@@ -7,7 +7,7 @@ The navbar is very important to a website. It allows users to quickly jump betwe
 You can add a custom navigation menu in `themeConfig.nav`, configured as an array, as follows:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -77,7 +77,7 @@ The meanings of the attributes are as follows:
 ### Example
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -114,7 +114,7 @@ export default defineConfig({
 By default, the navbar will have a toggle button for `Light/Dark` mode, you can disable it with the following config:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -131,7 +131,7 @@ export default defineConfig({
 Social Links to the Site. For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/guide/default-theme/overview-page.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/default-theme/overview-page.mdx
@@ -37,7 +37,7 @@ overview: true
 The structure of the overview page will be generated based on the config of the sidebar. For example, we add the following sidebar config:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/en/guide/start/getting-started.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/start/getting-started.mdx
@@ -73,7 +73,7 @@ Add the following script to `package.json`:
 Then initialize a configuration file `modern.config.ts`:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/document/doc-tools-doc/docs/en/guide/start/introduction.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/start/introduction.mdx
@@ -31,7 +31,7 @@ Built-in i18n support, supports multi-language switching, and supports multi-lan
 Based on [Shiki](https://github.com/shikijs/shiki) for compile-time code coloring, it supports multiple code language highlighting. For example:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/document/doc-tools-doc/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config/config-basic.mdx
@@ -8,7 +8,7 @@
 部署基准路径。比如，如果你计划将你的站点部署到 `https://foo.github.io/bar/`，那么你应该将 `base` 设置为 `"/bar/"`：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -26,7 +26,7 @@ export default defineConfig({
 站点标题。这个参数将被用作 HTML 页面的标题。例如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -44,7 +44,7 @@ export default defineConfig({
 站点描述。这将用作 HTML 页面的描述。例如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -62,7 +62,7 @@ export default defineConfig({
 站点图标。这个路径将用作 HTML 页面的图标路径。例如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -82,7 +82,7 @@ export default defineConfig({
 站点 logo。这个路径将用作导航栏左上角的 logo 路径。例如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -97,7 +97,7 @@ export default defineConfig({
 当然你可以针对浅色/暗黑模式设置不同的 logo：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -118,7 +118,7 @@ export default defineConfig({
 自定义构建站点的输出目录。比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -144,7 +144,7 @@ export interface Locale {
 站点的多语言配置。比如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -179,7 +179,7 @@ export default defineConfig({
 使用示例：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
@@ -48,7 +48,7 @@ DEBUG=builder modern dev
 配置 remark 插件。比如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -74,7 +74,7 @@ export default defineConfig({
 配置 rehype 插件。比如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -101,7 +101,7 @@ export default defineConfig({
 是否检查死链。比如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/api/config/config-theme.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config/config-theme.mdx
@@ -3,7 +3,7 @@
 主题配置位于 `doc` 配置中的 `themeConfig` 下。例如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -38,7 +38,7 @@ interface NavItem {
 比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -73,7 +73,7 @@ interface NavGroup {
 例如下面的配置:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -139,7 +139,7 @@ type SidebarItem =
 比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -195,7 +195,7 @@ export interface Footer {
 比如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -219,7 +219,7 @@ export default defineConfig({
 比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -241,7 +241,7 @@ export default defineConfig({
 比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -263,7 +263,7 @@ export default defineConfig({
 比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -283,7 +283,7 @@ export default defineConfig({
 上一页的文本。比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -304,7 +304,7 @@ export default defineConfig({
 相关链接支持三种模式：`链接模式link` `文本模式text` `图片模式img`，相关例子如下：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -362,7 +362,7 @@ export type SocialLinkIcon =
 如果需要自定义 icon，可以通过传入一个带有`svg属性`的对象，svg 的值为自定义图标内容即可，比如：
 
 ```js
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -390,7 +390,7 @@ export default defineConfig({
 下一页的文本。比如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -450,7 +450,7 @@ export interface LocaleConfig {
 是否出现暗黑模式/白天模式切换按钮。比如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/fragments/mdx-rs.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/fragments/mdx-rs.mdx
@@ -1,5 +1,5 @@
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/guide/advanced/extend-build.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/advanced/extend-build.mdx
@@ -7,7 +7,7 @@ Modern.js Doc 底层基于 [Modern.js Builder](https://modernjs.dev/builder/) �
 Modern.js Builder 提供了丰富的构建配置，你可以使用 [doc.builderConfig](/api/config/config-build.html#builderconfig) 来自定义这些配置项。比如，将产物目录修改为 `doc_dist`：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -41,7 +41,7 @@ export default defineConfig({
 在框架中 MDX 的编译基于 [unified](https://github.com/unifiedjs/unified) 完成，你可以通过 `markdown` 配置来添加相关的编译插件。比如
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/guide/basic/global-styles.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/basic/global-styles.mdx
@@ -7,7 +7,7 @@
 在 `modern.config.ts` 中添加以下配置：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/document/doc-tools-doc/docs/zh/guide/default-theme/doc-page.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/default-theme/doc-page.mdx
@@ -19,7 +19,7 @@ pageType: custom
 通过 `outlineTitle` 配置项，你可以设置大纲栏的标题。
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({
@@ -37,7 +37,7 @@ export default defineConfig({
 通过 `prevText` 和 `nextText` 配置项，你可以设置上一页/下一页的文本。
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/guide/default-theme/i18n.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/default-theme/i18n.mdx
@@ -60,7 +60,7 @@ export interface I18n {
 在 `modern.config.ts`中，你可以通过 `doc.lang` 配置文档的默认语言，如下例子所示:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -80,7 +80,7 @@ export default defineConfig({
 - `doc.themeConfig.locales`，用于配置主题的`语言`、`大纲栏标题`、`上一页/下一页文本`等信息，主要进行主题相关的配置。
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -157,7 +157,7 @@ docs
 我们来这样配置侧边栏和导航栏:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 // 工具函数，用于获取类型提示
 const getI18nKey = (key: keyof typeof import('./i18n.json')) => key;

--- a/packages/document/doc-tools-doc/docs/zh/guide/default-theme/navbar.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/default-theme/navbar.mdx
@@ -7,7 +7,7 @@
 你可以在 `themeConfig.nav` 中添加自定义的导航菜单，配置为一个数组，如下：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -77,7 +77,7 @@ export interface NavItemWithChildren {
 ### 示例
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -128,7 +128,7 @@ export default defineConfig({
 默认情况下导航栏会带上 `白天/夜间` 模式的切换按钮，你可以通过如下的配置禁用：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {
@@ -145,7 +145,7 @@ export default defineConfig({
 网站的社交链接。比如：
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/guide/default-theme/overview-page.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/default-theme/overview-page.mdx
@@ -37,7 +37,7 @@ overview: true
 配置预览页面的结构会基于 sidebar 的配置来生成，比如我们添加如下的 sidebar 配置:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   doc: {

--- a/packages/document/doc-tools-doc/docs/zh/guide/start/getting-started.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/start/getting-started.mdx
@@ -73,7 +73,7 @@ mkdir docs && echo '# Hello World' > docs/index.md
 然后初始化一个配置文件 `modern.config.ts`:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/document/doc-tools-doc/docs/zh/guide/start/introduction.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/start/introduction.mdx
@@ -31,7 +31,7 @@ Modern.js Doc 基于 [MDX](https://mdxjs.com/) 来进行 Markdown 语法的扩�
 基于 [Shiki](https://github.com/shikijs/shiki) 来进行编译时代码着色，支持多种代码语言高亮。如:
 
 ```ts title="modern.config.ts"
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 import path from 'path';
 
 export default defineConfig({

--- a/packages/document/doc-tools-doc/modern.config.ts
+++ b/packages/document/doc-tools-doc/modern.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 const isProd = () => process.env.NODE_ENV === 'production';
 

--- a/packages/document/main-doc/docs/en/components/enable-micro-frontend.mdx
+++ b/packages/document/main-doc/docs/en/components/enable-micro-frontend.mdx
@@ -1,5 +1,5 @@
 ```js title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/en/components/global-proxy-config.mdx
+++ b/packages/document/main-doc/docs/en/components/global-proxy-config.mdx
@@ -21,7 +21,7 @@ pnpm add @modern-js/plugin-proxy -D
 After the installation, please register the plugin in the `modern.config.ts` file:
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import proxyPlugin from '@modern-js/plugin-proxy';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/en/configure/app/auto-load-plugin.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/auto-load-plugin.mdx
@@ -14,7 +14,7 @@ Used to configure whether Modern.js enables auto-registration of plugins.
 By default, installing the plugin requires you to register the plugin manually in the `modern.config.ts`.
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import i18nPlugin from '@modern-js/plugin-i18n';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -43,7 +43,7 @@ $ pnpm run new
 After executing the command, enable the Rspack build in `modern.config.ts`:
 
 ```diff title=modern.config.ts
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 + export default defineConfig<'rspack'>({
   plugins: [

--- a/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
@@ -27,7 +27,7 @@ $ npx modern new
 After the execution is complete, you only need to register the Modern.js Storybook plugin in the `modern.config.ts` file to enable Storybook debugging capabilities.
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import storybookPlugin from '@modern-js/plugin-storybook';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/en/guides/topic-detail/micro-frontend/c02-development.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/micro-frontend/c02-development.mdx
@@ -150,7 +150,7 @@ After create sub-app. We execute `pnpm run new` to enable the `micro frontend` f
 Next, let's register the micro frontend plugin and modify `modern.config.ts` to add the configuration of the micro frontend sub-app `deploy.microFrontend`:
 
 ```js title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 
 export default defineConfig({
@@ -199,7 +199,7 @@ After create sub-app. We execute `pnpm run new` to enable the `micro frontend` f
 Next, let's register the micro frontend plugin and modify `modern.config.ts` to add the configuration of the micro frontend sub-app `deploy.microFrontend`:
 
 ```js title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c01-start.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c01-start.mdx
@@ -82,7 +82,7 @@ The page has no styles at the moment. The next chapter will expand on this secti
 Next, we modify the `modern.config.ts` in the project to enable the SSR capability:
 
 ```ts
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c03-css.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c03-css.mdx
@@ -121,7 +121,7 @@ Execute `pnpm run new` and select the following to start Tailwind CSS:
 Register the Tailwind plugin in `modern.config.ts`:
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c08-entries.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c08-entries.mdx
@@ -94,7 +94,7 @@ In the Modern.js configuration file, we can write our own code to control the co
 Now, modify the `modern.config.ts` to add something:
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/zh/components/enable-micro-frontend.mdx
+++ b/packages/document/main-doc/docs/zh/components/enable-micro-frontend.mdx
@@ -1,5 +1,5 @@
 ```js title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/zh/components/global-proxy-config.mdx
+++ b/packages/document/main-doc/docs/zh/components/global-proxy-config.mdx
@@ -21,7 +21,7 @@ pnpm add @modern-js/plugin-proxy -D
 安装完成后，在 `modern.config.ts` 文件中注册插件：
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import proxyPlugin from '@modern-js/plugin-proxy';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/zh/configure/app/auto-load-plugin.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/auto-load-plugin.mdx
@@ -14,7 +14,7 @@ sidebar_position: 11
 默认情况下，安装插件后，你需要在 `modern.config.ts` 文件中手动注册插件。
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import i18nPlugin from '@modern-js/plugin-i18n';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -44,7 +44,7 @@ $ pnpm run new
 执行以上命令后，在 `modern.config.ts` 中添加 Rspack 相关配置即可：
 
 ```diff title=modern.config.ts
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 + export default defineConfig<'rspack'>({
   plugins: [

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
@@ -27,7 +27,7 @@ $ npx modern new
 执行完成后，你只需在 `modern.config.ts` 文件中注册 Modern.js 的 Storybook 插件，即可启用 Storybook 调试能力。
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import storybookPlugin from '@modern-js/plugin-storybook';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
@@ -46,7 +46,7 @@ import DebugApp from "@site-docs/components/debug-app"
 可以通过该配置文件修改配置，覆盖 Modern.js 的默认行为。例如添加如下配置，开启 SSR：
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/micro-frontend/c02-development.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/micro-frontend/c02-development.mdx
@@ -151,7 +151,7 @@ npx @modern-js/create@latest
 接下来，让我们注册微前端插件并修改 `modern.config.ts`，添加微前端子应用的配置 `deploy.microFrontend`：
 
 ```js title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 
 export default defineConfig({
@@ -203,7 +203,7 @@ npx @modern-js/create@latest
 接下来，让我们注册微前端插件并修改 `modern.config.ts`，添加微前端子应用的配置 `deploy.microFrontend`：
 
 ```js title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c01-start.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c01-start.mdx
@@ -82,7 +82,7 @@ rm src/routes/index.css
 接下来，我们修改项目中的 `modern.config.ts`，开启 SSR 能力：
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c03-css.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c03-css.mdx
@@ -121,7 +121,7 @@ Modern.js 集成了主流、轻量、通用的 Utility Class 工具库 [Tailwind
 在 `modern.config.ts` 中注册 Tailwind 插件:
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c08-entries.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c08-entries.mdx
@@ -94,7 +94,7 @@ mv src/myapp src/contacts
 现在，修改 `modern.config.ts`，添加内容：
 
 ```ts title="modern.config.ts"
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/packages/document/main-doc/modern.config.ts
+++ b/packages/document/main-doc/modern.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import docTools, { defineConfig, type NavItem } from '@modern-js/doc-tools';
+import { docTools, defineConfig, type NavItem } from '@modern-js/doc-tools';
 import { pluginAutoSidebar } from '@modern-js/doc-plugin-auto-sidebar';
 
 const rootCategories = [

--- a/packages/document/module-doc/docs/en/guide/basic/before-getting-started.md
+++ b/packages/document/module-doc/docs/en/guide/basic/before-getting-started.md
@@ -167,7 +167,7 @@ The Module Tools configuration file - `modern.config.(j|t)s` - is provided in th
 By default, the contents of the generated configuration file are as follows.
 
 ```ts title="modern.config.ts"
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -178,7 +178,7 @@ export default defineConfig({
 **We recommend using the `defineConfig` function**, but it is not mandatory to use it. So you can also return an object directly in the config file: the
 
 ``` ts title="modern.config.ts"
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/en/guide/basic/modify-output-product.md
+++ b/packages/document/module-doc/docs/en/guide/basic/modify-output-product.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 When the `modern build` command is used in an initialized project, the products are generated according to the default configuration supported by Module Tools. The default supported configurations are specified as follows.
 
 ```ts title="modern.config.ts"
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -58,7 +58,7 @@ For example, if the output product is based on the preset string `"npm-library"`
 For example, to achieve the same effect as the preset string ``npm-library-es5"` using the form of a preset function, you can do the following.
 
 ```ts title="modern.config.ts"
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
@@ -22,7 +22,7 @@ When we want to test some modules, we can enable the test feature. When this fea
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import testPlugin from '@modern-js/plugin-testing';
 
 export default defineConfig({
@@ -41,7 +41,7 @@ The **Storybook feature** can be enabled when we want to debug a component or a 
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import storybookPlugin from '@modern-js/plugin-storybook';
 
 export default defineConfig({
@@ -71,7 +71,7 @@ For more information on how to use Tailwind CSS in your module projects, check o
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import tailwindPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({
@@ -94,7 +94,7 @@ Also, the Storybook debugging tool will determine if the project needs to use th
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import runtime from '@modern-js/runtime/cli';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/en/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/en/guide/intro/getting-started.md
@@ -54,7 +54,7 @@ npm install -D @modern-js/module-tools typescript
 Next, create the `modern.config.(t|j)s` file in the root of the project.
 
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
     plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.md
@@ -24,7 +24,7 @@ pnpm add @modern-js/plugin-module-babel -D
 You can install the plugin with the following command:
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({
@@ -42,7 +42,7 @@ See [babel options](https://babeljs.io/docs/options).
 Here is an example with `@babel/preset-env` configured
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-banner.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-banner.md
@@ -22,7 +22,7 @@ pnpm add @modern-js/plugin-module-banner -D
 You can install the plugin with the following command:
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
 
 export default defineConfig({
@@ -48,7 +48,7 @@ Note: CSS comments do not support the `//comment` syntax. Refer to [【CSS Comme
 
 ```ts
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 
 const copyRight = `/*

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-import.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-import.mdx
@@ -26,7 +26,7 @@ pnpm add @modern-js/plugin-module-import -D
 In Module Tools, you can register plugins in the following way:
 
 ```ts
-import moduleTools, { defineConfig  } from '@modern-js/module-tools';
+import { moduleTools, defineConfig  } from '@modern-js/module-tools';
 import { modulePluginImport } from '@modern-js/plugin-module-import';
 
 export default defineConfig({
@@ -64,7 +64,7 @@ The elements of the array are configuration objects for `babel-plugin-import`, w
 
 ```ts
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import moduleTools, { defineConfig  } from '@modern-js/module-tools';
+import { moduleTools, defineConfig  } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -110,7 +110,7 @@ Add the following configuration on the right-hand side:
 
 ```ts
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import moduleTools, { defineConfig  } from '@modern-js/module-tools';
+import { moduleTools, defineConfig  } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -159,7 +159,7 @@ The template used here is [handlebars](https://handlebarsjs.com). There are some
 
 ```ts focus=8:8
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import moduleTools, { defineConfig  } from '@modern-js/module-tools';
+import { moduleTools, defineConfig  } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-node-polyfill.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-node-polyfill.md
@@ -26,7 +26,7 @@ pnpm add @modern-js/plugin-module-node-polyfill -D
 In Module Tools, you can register plugins in the following way:
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -53,7 +53,7 @@ type NodePolyfillOptions = {
 Exclude the Node Polyfill to be injected.
 
 ``` ts focus=7:9
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -71,7 +71,7 @@ export default defineConfig({
 Override the built-in Node Polyfill.
 
 ``` ts focus=7:9
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
@@ -27,7 +27,7 @@ pnpm add @modern-js/plugin-module-polyfill -D
 In Module Tools, you can register plugins in the following way:
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({
@@ -55,7 +55,7 @@ See [Babel target](https://babeljs.io/docs/options#targets).
 This is a example.
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/guide/basic/before-getting-started.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/before-getting-started.md
@@ -167,7 +167,7 @@ npm install -g pnpm
 默认情况下，生成的配置文件的内容如下：
 
 ```ts title="modern.config.ts"
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -178,7 +178,7 @@ export default defineConfig({
 **我们推荐使用 `defineConfig` 函数**，不过并不强制使用它。因此你也可以在配置文件中直接返回一个对象：
 
 ```ts title="modern.config.ts"
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/zh/guide/basic/modify-output-product.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/modify-output-product.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 当在初始化的项目里使用 `modern build` 命令的时候，会根据 Module Tools 默认支持的配置生成相应的产物。默认支持的配置具体如下：
 
 ```ts title="modern.config.ts"
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -58,7 +58,7 @@ export default defineConfig({
 例如，如果使用预设函数的形式达到预设字符串 `"npm-library-es5"` 同样的效果，可以按照如下的方式：
 
 ```ts title="modern.config.ts"
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/zh/guide/basic/test-your-project.mdx
+++ b/packages/document/module-doc/docs/zh/guide/basic/test-your-project.mdx
@@ -11,7 +11,7 @@ sidebar_position: 6
 想要使用项目的测试功能，需要确保项目中包含依赖：`"@modern-js/plugin-testing"`，以及按照类似下面的内容进行配置：
 
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import testPlugin from '@modern-js/plugin-testing';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
@@ -21,7 +21,7 @@ sidebar_position: 4
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import testPlugin from '@modern-js/plugin-testing';
 
 export default defineConfig({
@@ -40,7 +40,7 @@ export default defineConfig({
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import storybookPlugin from '@modern-js/plugin-storybook';
 
 export default defineConfig({
@@ -68,7 +68,7 @@ export default defineConfig({
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import tailwindPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({
@@ -89,7 +89,7 @@ export default defineConfig({
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import runtime from '@modern-js/runtime/cli';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
@@ -51,7 +51,7 @@ npm install -D @modern-js/module-tools typescript
 接着在项目的根目录下创建 `modern.config.(t|j)s` 文件：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
@@ -24,7 +24,7 @@ pnpm add @modern-js/plugin-module-babel -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({
@@ -42,7 +42,7 @@ See [Babel options](https://babeljs.io/docs/options)
 下面是一个配置了`@babel/preset-env`的例子：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-banner.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-banner.md
@@ -22,7 +22,7 @@ pnpm add @modern-js/plugin-module-banner -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
 
 export default defineConfig({
@@ -48,7 +48,7 @@ export default defineConfig({
 
 ```ts
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 const copyRight = `/*
  © Copyright 2020 xxx.com or one of its affiliates.

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-import.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-import.mdx
@@ -27,7 +27,7 @@ pnpm add @modern-js/plugin-module-import -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginImport } from '@modern-js/plugin-module-import';
 
 export default defineConfig({
@@ -65,7 +65,7 @@ type Options = {
 
 ```ts
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -111,7 +111,7 @@ import { MyButton as Btn } from 'foo';
 
 ```ts
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -132,7 +132,7 @@ export default defineConfig({
 
 ```ts focus=8:8
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -162,7 +162,7 @@ import Btn from 'foo/es/MyButton';
 
 ```ts focus=8:8
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-node-polyfill.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-node-polyfill.md
@@ -26,7 +26,7 @@ pnpm add @modern-js/plugin-module-node-polyfill -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -53,7 +53,7 @@ type NodePolyfillOptions = {
 排除要注入的 Node Polyfill。
 
 ``` ts focus=7:9
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -71,7 +71,7 @@ export default defineConfig({
 覆盖内置的 Node Polyfill。
 
 ``` ts focus=7:9
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
@@ -27,7 +27,7 @@ pnpm add @modern-js/plugin-module-polyfill -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({
@@ -55,7 +55,7 @@ type options = {
 下面是一个例子：
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({

--- a/packages/document/module-doc/modern.config.ts
+++ b/packages/document/module-doc/modern.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import docTools, { defineConfig, NavItem } from '@modern-js/doc-tools';
+import { docTools, defineConfig, NavItem } from '@modern-js/doc-tools';
 import { remarkCodeHike } from '@code-hike/mdx';
 import { pluginAutoSidebar } from '@modern-js/doc-plugin-auto-sidebar';
 

--- a/packages/generator/generators/generator-generator/templates/js-template/modern.config.js.handlebars
+++ b/packages/generator/generators/generator-generator/templates/js-template/modern.config.js.handlebars
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 
 module.exports = {
   buildConfig: {

--- a/packages/generator/generators/generator-generator/templates/ts-template/modern.config.ts.handlebars
+++ b/packages/generator/generators/generator-generator/templates/ts-template/modern.config.ts.handlebars
@@ -1,4 +1,4 @@
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   buildConfig: {

--- a/packages/generator/generators/module-generator/templates/js-template/modern.config.js.handlebars
+++ b/packages/generator/generators/module-generator/templates/js-template/modern.config.js.handlebars
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/generator/generators/module-generator/templates/ts-template/modern.config.ts.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/modern.config.ts.handlebars
@@ -1,4 +1,4 @@
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/generator/generators/mwa-generator/templates/js-template/modern.config.js.handlebars
+++ b/packages/generator/generators/mwa-generator/templates/js-template/modern.config.js.handlebars
@@ -1,4 +1,4 @@
-import appTools from '@modern-js/app-tools';
+import { appTools } from '@modern-js/app-tools';
 
 // https://modernjs.dev/en/configure/app/usage
 module.exports = {

--- a/packages/generator/generators/mwa-generator/templates/ts-template/modern.config.ts.handlebars
+++ b/packages/generator/generators/mwa-generator/templates/ts-template/modern.config.ts.handlebars
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 // https://modernjs.dev/en/configure/app/usage
 export default defineConfig({

--- a/packages/generator/generators/rspack-generator/templates/modern.config.js.handlebars
+++ b/packages/generator/generators/rspack-generator/templates/modern.config.js.handlebars
@@ -1,4 +1,4 @@
-import appTools from '@modern-js/app-tools';
+import { appTools } from '@modern-js/app-tools';
 
 // https://modernjs.dev/en/configure/app/usage
 module.exports = {

--- a/packages/generator/generators/rspack-generator/templates/modern.config.ts.handlebars
+++ b/packages/generator/generators/rspack-generator/templates/modern.config.ts.handlebars
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 // https://modernjs.dev/en/configure/app/usage
 export default defineConfig<'rspack'>({

--- a/packages/generator/plugins/generator-plugin/templates/modern.config.js.handlebars
+++ b/packages/generator/plugins/generator-plugin/templates/modern.config.js.handlebars
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 
 module.exports = {
   buildConfig: {

--- a/packages/generator/plugins/generator-plugin/templates/modern.config.ts.handlebars
+++ b/packages/generator/plugins/generator-plugin/templates/modern.config.ts.handlebars
@@ -1,4 +1,4 @@
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   buildConfig: {

--- a/packages/module/plugin-module-babel/README.md
+++ b/packages/module/plugin-module-babel/README.md
@@ -7,7 +7,7 @@ You can add Babel compile by the plugin before module-tools internal building.
 ## Usage
 
 ```ts modern.config.ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 export default defineConfig({
   plugins: [

--- a/packages/module/plugin-module-banner/README.md
+++ b/packages/module/plugin-module-banner/README.md
@@ -5,7 +5,7 @@ The banner plugin of Modern.js Module Tools.
 ## Usage
 
 ```ts modern.config.ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
 
 export default defineConfig({

--- a/packages/module/plugin-module-node-polyfill/README.md
+++ b/packages/module/plugin-module-node-polyfill/README.md
@@ -5,7 +5,7 @@ The node polyfill plugin of Modern.js Module Tools.
 ## Usage
 
 ```js
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({

--- a/packages/module/plugin-module-polyfill/README.md
+++ b/packages/module/plugin-module-polyfill/README.md
@@ -9,7 +9,7 @@ A Library author don't want to "pollute" the global scope with the polyfills you
 ## Usage
 
 ```ts
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -117,7 +117,7 @@ export type AppToolsOptions = {
   bundler?: 'experimental-rspack' | 'webpack';
 };
 
-export default (
+export const appTools = (
   options: AppToolsOptions = {
     bundler: 'webpack',
   },
@@ -311,3 +311,5 @@ export default (
     };
   },
 });
+
+export default appTools;

--- a/packages/solutions/app-tools/tests/analyze/index.test.ts
+++ b/packages/solutions/app-tools/tests/analyze/index.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { manager, CliPlugin } from '@modern-js/core';
 import plugin from '../../src/analyze';
-import appToolsPlugin from '../../src';
+import { appTools } from '../../src';
 
 describe('analyze', () => {
   afterAll(() => {
@@ -31,7 +31,7 @@ describe('analyze', () => {
           mockContext.set(value);
         },
       })
-      .usePlugin(appToolsPlugin as CliPlugin)
+      .usePlugin(appTools as CliPlugin)
       .usePlugin(plugin as CliPlugin);
 
     const runner = await main.init();

--- a/packages/solutions/doc-tools/src/index.ts
+++ b/packages/solutions/doc-tools/src/index.ts
@@ -36,7 +36,7 @@ interface DocToolsOptions {
 
 const WATCH_FILE_TYPES = ['.md', '.mdx', '.tsx', '.jsx', '.ts', '.js', '.json'];
 
-export default (options: DocToolsOptions = {}): CliPlugin => ({
+export const docTools = (options: DocToolsOptions = {}): CliPlugin => ({
   name: '@modern-js/doc-tools',
   setup: async api => {
     const appContext = api.useAppContext();
@@ -159,5 +159,7 @@ export default (options: DocToolsOptions = {}): CliPlugin => ({
     };
   },
 });
+
+export default docTools;
 
 export { defineConfig } from './config/defineConfig';

--- a/packages/solutions/module-tools/src/cli.ts
+++ b/packages/solutions/module-tools/src/cli.ts
@@ -3,7 +3,7 @@ import type { ModuleTools } from './types';
 import { registerHook } from './hooks';
 import { getPlugins } from './plugins';
 
-export const cli = (): CliPlugin<ModuleTools> => ({
+export const moduleTools = (): CliPlugin<ModuleTools> => ({
   name: '@modern-js/module-tools',
   registerHook,
   usePlugins: getPlugins(process.argv.slice(2)[0]),
@@ -49,12 +49,12 @@ const setup: CliPlugin<ModuleTools>['setup'] = async api => {
     prepare,
     validateSchema,
     async commands({ program }) {
-      const { buildCommand, devCommand, newCommand, upgradCommand } =
+      const { buildCommand, devCommand, newCommand, upgradeCommand } =
         await import('./command');
       await buildCommand(program, api);
       await devCommand(program, api);
       await newCommand(program);
-      await upgradCommand(program);
+      await upgradeCommand(program);
     },
   };
 };

--- a/packages/solutions/module-tools/src/command.ts
+++ b/packages/solutions/module-tools/src/command.ts
@@ -128,7 +128,7 @@ export const newCommand = async (program: Command) => {
     });
 };
 
-export const upgradCommand = async (program: Command) => {
+export const upgradeCommand = async (program: Command) => {
   const { defineCommand } = await import('@modern-js/upgrade');
   defineCommand(program.command('upgrade'));
 };

--- a/packages/solutions/module-tools/src/index.ts
+++ b/packages/solutions/module-tools/src/index.ts
@@ -1,6 +1,7 @@
-import { cli } from './cli';
+import { moduleTools } from './cli';
 
 export { defineConfig, defineLegacyConfig } from './config/defineConfig';
 export { legacyPresets } from './constants/legacyBuildPresets';
 export * from './types';
-export default cli;
+export { moduleTools };
+export default moduleTools;

--- a/packages/solutions/module-tools/tests/index.test.ts
+++ b/packages/solutions/module-tools/tests/index.test.ts
@@ -1,4 +1,4 @@
-import moduleTools, { defineConfig, legacyPresets } from '../src';
+import { moduleTools, defineConfig, legacyPresets } from '../src';
 
 describe('index', () => {
   it('defineConfig', () => {

--- a/packages/solutions/monorepo-tools/src/index.ts
+++ b/packages/solutions/monorepo-tools/src/index.ts
@@ -15,7 +15,7 @@ const upgradeModel: typeof import('@modern-js/upgrade') = Import.lazy(
   require,
 );
 
-export default (): CliPlugin<MonorepoTools> => ({
+export const monorepoTools = (): CliPlugin<MonorepoTools> => ({
   name: '@modern-js/monorepo-tools',
   usePlugins: [changesetPlugin(), lintPlugin()],
   registerHook: hooks,
@@ -40,3 +40,5 @@ export default (): CliPlugin<MonorepoTools> => ({
   },
   post: ['@modern-js/plugin-changeset'],
 });
+
+export default monorepoTools;

--- a/tests/integration/alias-set/modern.config.ts
+++ b/tests/integration/alias-set/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   source: {

--- a/tests/integration/api-service-koa/modern.config.ts
+++ b/tests/integration/api-service-koa/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import bffPlugin from '@modern-js/plugin-bff';
 import testingPlugin from '@modern-js/plugin-testing';
 import koaPlugin from '@modern-js/plugin-koa';

--- a/tests/integration/app-document/modern.config.ts
+++ b/tests/integration/app-document/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import routerPlugin from '@modern-js/plugin-router-v5';
 
 export default defineConfig({

--- a/tests/integration/asset-prefix/fixtures/dev-asset-prefix/modern.config.ts
+++ b/tests/integration/asset-prefix/fixtures/dev-asset-prefix/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   dev: {

--- a/tests/integration/async-entry/modern.config.ts
+++ b/tests/integration/async-entry/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {

--- a/tests/integration/bff-express/modern.config.ts
+++ b/tests/integration/bff-express/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import bffPlugin from '@modern-js/plugin-bff';
 import expressPlugin from '@modern-js/plugin-express';
 

--- a/tests/integration/builder-plugins/fixtures/register-builder-plugins/modern.config.ts
+++ b/tests/integration/builder-plugins/fixtures/register-builder-plugins/modern.config.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import { fs } from '@modern-js/utils';
 
 const logs: string[] = [];

--- a/tests/integration/builder-rspack/modern.config.ts
+++ b/tests/integration/builder-rspack/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig<'rspack'>({
   plugins: [appTools({ bundler: 'experimental-rspack' })],

--- a/tests/integration/clean-dist-path/modern.config.ts
+++ b/tests/integration/clean-dist-path/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig<'rspack'>({
   output: {

--- a/tests/integration/copy-assets/fixtures/copy-public-html/modern.config.ts
+++ b/tests/integration/copy-assets/fixtures/copy-public-html/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 const BUNDLER = process.env.BUNDLER || 'webpack';
 

--- a/tests/integration/css/fixtures/antd-less-import/modern.config.ts
+++ b/tests/integration/css/fixtures/antd-less-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/bad-nested-npm-import/modern.config.ts
+++ b/tests/integration/css/fixtures/bad-nested-npm-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/bad-npm-import/modern.config.ts
+++ b/tests/integration/css/fixtures/bad-npm-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/base-import/modern.config.ts
+++ b/tests/integration/css/fixtures/base-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/disable-source-map/modern.config.ts
+++ b/tests/integration/css/fixtures/disable-source-map/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   output: {

--- a/tests/integration/css/fixtures/exclude-less/modern.config.ts
+++ b/tests/integration/css/fixtures/exclude-less/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/exclude-sass/modern.config.ts
+++ b/tests/integration/css/fixtures/exclude-sass/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   tools: {

--- a/tests/integration/css/fixtures/import-common-css/modern.config.ts
+++ b/tests/integration/css/fixtures/import-common-css/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/less-import/modern.config.ts
+++ b/tests/integration/css/fixtures/less-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/less-inline-js/modern.config.ts
+++ b/tests/integration/css/fixtures/less-inline-js/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/less-npm-import/modern.config.ts
+++ b/tests/integration/css/fixtures/less-npm-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/multi-css/modern.config.ts
+++ b/tests/integration/css/fixtures/multi-css/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/multi-less/modern.config.ts
+++ b/tests/integration/css/fixtures/multi-less/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/multi-sass/modern.config.ts
+++ b/tests/integration/css/fixtures/multi-sass/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/nested-npm-import/modern.config.ts
+++ b/tests/integration/css/fixtures/nested-npm-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/npm-import/modern.config.ts
+++ b/tests/integration/css/fixtures/npm-import/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/css/fixtures/tailwindcss-v2/modern.config.ts
+++ b/tests/integration/css/fixtures/tailwindcss-v2/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/tests/integration/css/fixtures/tailwindcss-v3/modern.config.ts
+++ b/tests/integration/css/fixtures/tailwindcss-v3/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/tests/integration/css/fixtures/twin.macro-v2/modern.config.ts
+++ b/tests/integration/css/fixtures/twin.macro-v2/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/tests/integration/css/fixtures/twin.macro-v3/modern.config.ts
+++ b/tests/integration/css/fixtures/twin.macro-v3/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import tailwindcssPlugin from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({

--- a/tests/integration/custom-render/modern.config.ts
+++ b/tests/integration/custom-render/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/custom-template/modern.config.ts
+++ b/tests/integration/custom-template/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   html: {

--- a/tests/integration/dev-server/modern.config.ts
+++ b/tests/integration/dev-server/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 const plugin = () => {
   return {

--- a/tests/integration/doc/fixtures/basic/modern.config.ts
+++ b/tests/integration/doc/fixtures/basic/modern.config.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   plugins: [docTools()],

--- a/tests/integration/doc/fixtures/i18n/modern.config.ts
+++ b/tests/integration/doc/fixtures/i18n/modern.config.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   plugins: [docTools()],

--- a/tests/integration/doc/fixtures/plugin/modern.config.ts
+++ b/tests/integration/doc/fixtures/plugin/modern.config.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 // import { pluginPreview } from '@modern-js/doc-plugin-preview';
 import { docPluginDemo } from './plugin';
 

--- a/tests/integration/doc/fixtures/production/modern.config.ts
+++ b/tests/integration/doc/fixtures/production/modern.config.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   plugins: [docTools()],

--- a/tests/integration/doc/fixtures/with-base/modern.config.ts
+++ b/tests/integration/doc/fixtures/with-base/modern.config.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import docTools, { defineConfig } from '@modern-js/doc-tools';
+import { docTools, defineConfig } from '@modern-js/doc-tools';
 
 export default defineConfig({
   plugins: [docTools()],

--- a/tests/integration/esbuild/fixtures/legacy-minify-js/modern.config.ts
+++ b/tests/integration/esbuild/fixtures/legacy-minify-js/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineLegacyConfig } from '@modern-js/app-tools';
+import { appTools, defineLegacyConfig } from '@modern-js/app-tools';
 
 export default defineLegacyConfig({
   tools: {

--- a/tests/integration/esbuild/fixtures/transform-and-minify/modern.config.ts
+++ b/tests/integration/esbuild/fixtures/transform-and-minify/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   tools: {

--- a/tests/integration/garfish/dashboard-router-v6/modern.config.js
+++ b/tests/integration/garfish/dashboard-router-v6/modern.config.js
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 // import routerPlugin from '@modern-js/runtime/dist/js/modern/router/cli';
 import garfishPlugin from '@modern-js/plugin-garfish';
 

--- a/tests/integration/garfish/dashboard/modern.config.js
+++ b/tests/integration/garfish/dashboard/modern.config.js
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 import routerPlugin from '@modern-js/plugin-router-v5';
 import { getPort } from '../../../utils/testCase';

--- a/tests/integration/garfish/main-router-v6/modern.config.js
+++ b/tests/integration/garfish/main-router-v6/modern.config.js
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 // import routerPlugin from '@modern-js/runtime/dist/js/modern/router/cli';
 import garfishPlugin from '@modern-js/plugin-garfish';
 

--- a/tests/integration/garfish/main-rspack/modern.config.js
+++ b/tests/integration/garfish/main-rspack/modern.config.js
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 import routerPlugin from '@modern-js/plugin-router-v5';
 

--- a/tests/integration/garfish/main/modern.config.js
+++ b/tests/integration/garfish/main/modern.config.js
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 import routerPlugin from '@modern-js/plugin-router-v5';
 

--- a/tests/integration/garfish/table/modern.config.js
+++ b/tests/integration/garfish/table/modern.config.js
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import garfishPlugin from '@modern-js/plugin-garfish';
 import routerPlugin from '@modern-js/plugin-router-v5';
 import { getPort } from '../../../utils/testCase';

--- a/tests/integration/load-config/fixtures/async-config-function/modern.config.ts
+++ b/tests/integration/load-config/fixtures/async-config-function/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig(async () => {
   return {

--- a/tests/integration/load-config/fixtures/basic-local-config/modern.config.ts
+++ b/tests/integration/load-config/fixtures/basic-local-config/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   output: {

--- a/tests/integration/load-config/fixtures/config-function-params/modern.config.ts
+++ b/tests/integration/load-config/fixtures/config-function-params/modern.config.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { writeFileSync } from 'fs';
-import appTools, {
+import {
+  appTools,
   AppTools,
   CliPlugin,
   defineConfig,

--- a/tests/integration/load-config/fixtures/local-config-function/modern.config.ts
+++ b/tests/integration/load-config/fixtures/local-config-function/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   output: {

--- a/tests/integration/main-entry-name/modern.config.ts
+++ b/tests/integration/main-entry-name/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   source: {

--- a/tests/integration/module-doc/modern.config.ts
+++ b/tests/integration/module-doc/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools, { defineConfig } from '@modern-js/module-tools';
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import docPlugin from '@modern-js/plugin-module-doc';
 
 export default defineConfig({

--- a/tests/integration/mwa-app/modern.config.ts
+++ b/tests/integration/mwa-app/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {

--- a/tests/integration/nonce/modern.config.ts
+++ b/tests/integration/nonce/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {

--- a/tests/integration/routes/modern.config.ts
+++ b/tests/integration/routes/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/runtime/fixtures/file-based-router/modern.config.ts
+++ b/tests/integration/runtime/fixtures/file-based-router/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import routerPlugin from '@modern-js/plugin-router-v5';
 
 export default defineConfig({

--- a/tests/integration/runtime/fixtures/use-loader/modern.config.ts
+++ b/tests/integration/runtime/fixtures/use-loader/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   server: {

--- a/tests/integration/select-entry/fixtures/select-mul-entry/modern.config.ts
+++ b/tests/integration/select-entry/fixtures/select-mul-entry/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/select-entry/fixtures/select-one-entry/modern.config.ts
+++ b/tests/integration/select-entry/fixtures/select-one-entry/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   plugins: [appTools()],

--- a/tests/integration/server-config/modern.config.ts
+++ b/tests/integration/server-config/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import plugin1 from './plugins/cliPlugin';
 
 export default defineConfig({

--- a/tests/integration/server-hook/middleware/modern.config.ts
+++ b/tests/integration/server-hook/middleware/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import serverPlugin from '@modern-js/plugin-server';
 
 export default defineConfig({

--- a/tests/integration/server-hook/request/modern.config.ts
+++ b/tests/integration/server-hook/request/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import serverPlugin from '@modern-js/plugin-server';
 
 export default defineConfig({

--- a/tests/integration/server-hook/response/modern.config.ts
+++ b/tests/integration/server-hook/response/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import serverPlugin from '@modern-js/plugin-server';
 
 export default defineConfig({

--- a/tests/integration/server-hook/router/modern.config.ts
+++ b/tests/integration/server-hook/router/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import serverPlugin from '@modern-js/plugin-server';
 
 export default defineConfig({

--- a/tests/integration/server-hook/template/modern.config.ts
+++ b/tests/integration/server-hook/template/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import serverPlugin from '@modern-js/plugin-server';
 
 export default defineConfig({

--- a/tests/integration/server-prod/modern.config.ts
+++ b/tests/integration/server-prod/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   output: {

--- a/tests/integration/ssg/fixtures/nested-routes/modern.config.ts
+++ b/tests/integration/ssg/fixtures/nested-routes/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import ssgPlugin from '@modern-js/plugin-ssg';
 
 export default defineConfig({

--- a/tests/integration/ssg/fixtures/simple/modern.config.ts
+++ b/tests/integration/ssg/fixtures/simple/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import ssgPlugin from '@modern-js/plugin-ssg';
 
 export default defineConfig({

--- a/tests/integration/ssg/fixtures/web-server/modern.config.ts
+++ b/tests/integration/ssg/fixtures/web-server/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import ssgPlugin from '@modern-js/plugin-ssg';
 import serverPlugin from '@modern-js/plugin-server';
 

--- a/tests/integration/ssr/fixtures/base-json/modern.config.ts
+++ b/tests/integration/ssr/fixtures/base-json/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 const bundler = process.env.BUNDLER;
 

--- a/tests/integration/ssr/fixtures/base/modern.config.ts
+++ b/tests/integration/ssr/fixtures/base/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 const bundler = process.env.BUNDLER;
 

--- a/tests/integration/ssr/fixtures/init/modern.config.ts
+++ b/tests/integration/ssr/fixtures/init/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 const bundler = process.env.BUNDLER;
 

--- a/tests/integration/ssr/fixtures/streaming/modern.config.ts
+++ b/tests/integration/ssr/fixtures/streaming/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 const bundler = process.env.BUNDLER;
 

--- a/tests/integration/swc/fixtures/minify-css/modern.config.ts
+++ b/tests/integration/swc/fixtures/minify-css/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import pluginSwc from '@modern-js/plugin-swc';
 
 export default defineConfig({

--- a/tests/integration/swc/fixtures/minify-js/modern.config.ts
+++ b/tests/integration/swc/fixtures/minify-js/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import pluginSwc from '@modern-js/plugin-swc';
 
 export default defineConfig({

--- a/tests/integration/swc/fixtures/transform-fail/modern.config.ts
+++ b/tests/integration/swc/fixtures/transform-fail/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import pluginSwc from '@modern-js/plugin-swc';
 
 export default defineConfig({

--- a/tests/integration/temp-dir/modern.config.ts
+++ b/tests/integration/temp-dir/modern.config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {},

--- a/tests/integration/worker/fixtures/worker-test/modern.config.ts
+++ b/tests/integration/worker/fixtures/worker-test/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import workPlugin from '@modern-js/plugin-worker';
 
 export default defineConfig({

--- a/tests/integration/write-to-dist/modern.config.ts
+++ b/tests/integration/write-to-dist/modern.config.ts
@@ -1,4 +1,4 @@
-import appTools, { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {


### PR DESCRIPTION
## Summary

Related issue: https://github.com/web-infra-dev/modern.js/issues/4032

```js
// before
import appTools from '@modern-js/app-tools';
import moduleTools from '@modern-js/module-tools';

// after
import { appTools } from '@modern-js/app-tools';
import { moduleTools } from '@modern-js/module-tools';
```

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8492f68</samp>

This pull request adds named exports for all solutions in the `doc-tools` package and updates the documentation files to use named imports instead of default imports. This is a new feature that allows users to import the solutions more conveniently and prevents import conflicts with other default exports. The pull request also adds a changeset file to document the changes and prepare for releasing new versions of the packages. The changes affect the `doc-tools` package and its documentation, as well as the configuration files for the modern.js framework and the `monorepoTools` and `appTools` solutions.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8492f68</samp>

*  Add a changeset file to document the changes and prepare for releasing new versions of the packages ([link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-58f0d2aa43ed96d7e232acae043ca2134e5db754e67206687b1f592fb8bd9689R1-R15))
*  Replace default imports with named imports for the `monorepoTools` solution in the `modern.config.js` file ([link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-2f0a0157734cf031c1271eab1696ac0f1ca712a36897d5d08de16a0068cd5aa6L7-R7))
*  Replace default imports with named imports for the `appTools` solution in the `enable-swc.md` files for both English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-3dfec0ed21c1ed6d1705043f2d58f06e8de7a29cd1d94ecb9b35931681e57aaaL11-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-d78a895600624de17c90ddea86757d287bc83615d1bb8652cdc9190b90129d5dL11-R11))
*  Replace default imports with named imports for the `docTools`, `defineConfig`, `Sidebar`, and `NavItem` modules in the `modern.config.ts` file for the doc-tools package ([link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-fc9e3b9be79489436a867bcdd7e7d56a5d8a90bd8c0390fdb2166410e494495fL2-R2))
*  Replace default imports with named imports for the `docTools` module in the `config-basic.mdx`, `config-build.mdx`, `config-theme.mdx`, `mdx-rs.mdx`, `extend-build.mdx`, `global-styles.mdx`, `doc-page.mdx`, `i18n.mdx`, `navbar.mdx`, `overview-page.mdx`, `getting-started.mdx`, and `introduction.mdx` files for both English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L11-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L29-R29), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L47-R47), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L65-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L85-R85), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L100-R100), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L121-R121), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L147-R147), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2L182-R182), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-bc40f81a971eaf041649c609ba3438007393fdfccc00b9eba5b432adcdd80c95L51-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-bc40f81a971eaf041649c609ba3438007393fdfccc00b9eba5b432adcdd80c95L77-R77), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-bc40f81a971eaf041649c609ba3438007393fdfccc00b9eba5b432adcdd80c95L104-R104), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL6-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL76-R76), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL156-R156), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL212-R212), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL236-R236), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL258-R258), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL280-R280), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL300-R300), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL321-R321), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL379-R379), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL407-R407), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5262769ad988460df334de11d90508bd265af35ce6661df8945ca5c0c5481bfaL467-R467), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-f250033012546955faa07a1ba9eadb723e5f49eb646e3c946685d9c4e12d3046L2-R2), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-8361ce1c4860d22d381c29f813aa4500e231a2b3dd516155017100bd541d2fcfL10-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-8361ce1c4860d22d381c29f813aa4500e231a2b3dd516155017100bd541d2fcfL45-R45), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-4b76dedd77fb7f2f52e729ab9f7b4989d2bdaf6073265ec14531fec476ac18e5L10-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-26c06ef5fd3cf4d3646d647d6497ae3b6916c7906601861d3bff787ece7b8b0bL22-R22), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-26c06ef5fd3cf4d3646d647d6497ae3b6916c7906601861d3bff787ece7b8b0bL40-R40), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5409d81800c1f353baac10d2b1bca8a28ae31eafd119f2862bdf611444fc2df1L63-R63), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5409d81800c1f353baac10d2b1bca8a28ae31eafd119f2862bdf611444fc2df1L83-R83), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5409d81800c1f353baac10d2b1bca8a28ae31eafd119f2862bdf611444fc2df1L159-R159), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-606aaa3f9c43b43e59cc32dc9e0374222442a2e7d1dfa25a044b56cfbbad9e8cL10-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-606aaa3f9c43b43e59cc32dc9e0374222442a2e7d1dfa25a044b56cfbbad9e8cL80-R80), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-606aaa3f9c43b43e59cc32dc9e0374222442a2e7d1dfa25a044b56cfbbad9e8cL117-R117), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-606aaa3f9c43b43e59cc32dc9e0374222442a2e7d1dfa25a044b56cfbbad9e8cL134-R134), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-a16872e3452796aede0f2fda35bbffb6d8795adbad1aef0b40909a1c02d7a513L40-R40), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-2640907b1ffa95630b5115e2ac2e4a2a0c6cd69c00531f57a8fe6542df504162L76-R76), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-0ae8a9c6d1ac266b32d26968062b0998a518daa6feed7d758ad75f3c2cc4c893L34-R34), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL11-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL29-R29), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL47-R47), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL65-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL85-R85), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL100-R100), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL121-R121), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL147-R147), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dL182-R182), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5bff610c93c6503d010f0dd3c8b5941a3c2fff2d14f0b925b640eb82d95da5b8L51-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5bff610c93c6503d010f0dd3c8b5941a3c2fff2d14f0b925b640eb82d95da5b8L77-R77), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-5bff610c93c6503d010f0dd3c8b5941a3c2fff2d14f0b925b640eb82d95da5b8L104-R104), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL6-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL76-R76), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL142-R142), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL198-R198), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL222-R222), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL244-R244), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL266-R266), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL286-R286), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL307-R307), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL365-R365), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL393-R393), [link](https://github.com/web-infra-dev/modern.js/pull/4033/files?diff=unified&w=0#diff-43b11005ca77011d45c4d7af1b1e6b3b311db750da7fc628428d6e9a0dcc4acfL453-R453))

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
