### PR TITLE
fix(doc-core): .md comment compile error

### DIFF
--- a/.changeset/fsg-jis-md.md
+++ b/.changeset/fsg-jis-md.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): .md comment compile error
+
+fix(doc-core): .md 文件中的注释导致编译报错

--- a/packages/cli/doc-core/src/node/mdx/options.ts
+++ b/packages/cli/doc-core/src/node/mdx/options.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import remarkGFM from 'remark-gfm';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutoLink from 'rehype-autolink-headings';
@@ -17,6 +18,7 @@ export async function createMDXOptions(
   config: UserConfig,
   checkDeadLinks: boolean,
   routeService: RouteService,
+  filepath: string,
 ): Promise<Options> {
   const {
     remarkPlugins: remarkPluginsFromConfig = [],
@@ -33,6 +35,7 @@ export async function createMDXOptions(
   return {
     providerImportSource: '@mdx-js/react',
     jsx: true,
+    format: path.extname(filepath).slice(1) as 'mdx' | 'md',
     remarkPlugins: [
       remarkPluginContainer,
       remarkGFM,


### PR DESCRIPTION
## Summary

1. fix the comment of `.md` file compile error

![CqmEGux1AB](https://github.com/web-infra-dev/modern.js/assets/39261479/a5f60428-3f26-44e3-8538-cf4ec35c7581)

2. catch the log in mdx compile process

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef14988</samp>

This pull request fixes a bug in the doc-core package that causes .md files with comments to fail to compile with the mdx-rs binding. It also adds support for distinguishing between mdx and md files based on their extensions and updates the changeset file accordingly. The changes affect the `options.ts`, `loader.ts`, and `.changeset/fsg-jis-md.md` files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef14988</samp>

*  Fix .md comment compile error for doc-core package ([link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-6df4a38ffba26d1f79ea3e65133f857cf890a47f966cec753f83e855b4c4bc2dR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-a566ae5e894b282eb04e5dfac055648d9707f4e96293def12c6a32a1bbd40dccL43-R89), [link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R1), [link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R21), [link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R38))
  * Add a changeset file to document the patch version update and the bug fix ([link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-6df4a38ffba26d1f79ea3e65133f857cf890a47f966cec753f83e855b4c4bc2dR1-R7))
  * Wrap the whole compile logic in a try-catch block in `loader.ts` to handle potential errors from the `compile` or `createMDXOptions` functions ([link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-a566ae5e894b282eb04e5dfac055648d9707f4e96293def12c6a32a1bbd40dccL43-R89))
  * Import the `path` module and add the `filepath` parameter to the `createMDXOptions` function in `options.ts` to pass the file path of the current mdx or md file to the mdx-rs binding ([link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R1), [link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R21))
  * Add the `format` option to the mdx-rs binding options in `options.ts` to specify the file extension of the current mdx or md file and handle different syntax rules ([link](https://github.com/web-infra-dev/modern.js/pull/4039/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R38))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
