### PR TITLE
feat: add named exports for solution new command

### DIFF
--- a/.changeset/odd-flowers-thank.md
+++ b/.changeset/odd-flowers-thank.md
@@ -1,0 +1,12 @@
+---
+'@modern-js/dependence-generator': patch
+'@modern-js/router-v5-generator': patch
+'@modern-js/monorepo-generator': patch
+'@modern-js/bff-generator': patch
+'@modern-js/ssg-generator': patch
+'@modern-js/new-action': patch
+---
+
+feat: add named exports for solution new command
+
+feat: 为 solution new 命令添加 named 导出

--- a/packages/generator/generators/bff-generator/src/index.ts
+++ b/packages/generator/generators/bff-generator/src/index.ts
@@ -266,6 +266,7 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
         bffPluginName,
         pluginDependence,
         bffPluginDependence,
+        shouldUsePluginNameExport,
       } = context.config;
       console.info(
         chalk.green(`\n[INFO]`),
@@ -274,14 +275,28 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
         ':',
         '\n',
       );
-      console.info(
-        chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
-      );
-      console.info(
-        chalk.yellow.bold(
-          `import ${bffPluginName} from '${bffPluginDependence}';`,
-        ),
-      );
+      if (shouldUsePluginNameExport) {
+        console.info(
+          chalk.yellow.bold(
+            `import { ${pluginName} } from '${pluginDependence}';`,
+          ),
+        );
+        console.info(
+          chalk.yellow.bold(
+            `import { ${bffPluginName} } from '${bffPluginDependence}';`,
+          ),
+        );
+      } else {
+        console.info(
+          chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
+        );
+        console.info(
+          chalk.yellow.bold(
+            `import ${bffPluginName} from '${bffPluginDependence}';`,
+          ),
+        );
+      }
+
       if (isTS) {
         console.info(`
 export default defineConfig({

--- a/packages/generator/generators/dependence-generator/src/index.ts
+++ b/packages/generator/generators/dependence-generator/src/index.ts
@@ -95,7 +95,8 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
       const appDir = context.materials.default.basePath;
       const configFile = await getModernConfigFile(appDir);
       const isTS = configFile.endsWith('ts');
-      const { pluginName, pluginDependence } = context.config;
+      const { pluginName, pluginDependence, shouldUsePluginNameExport } =
+        context.config;
       console.info(
         chalk.green(`\n[INFO]`),
         `${i18n.t(localeKeys.success)}`,
@@ -103,9 +104,18 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
         ':',
         '\n',
       );
-      console.info(
-        chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
-      );
+      if (shouldUsePluginNameExport) {
+        console.info(
+          chalk.yellow.bold(
+            `import { ${pluginName} } from '${pluginDependence}';`,
+          ),
+        );
+      } else {
+        console.info(
+          chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
+        );
+      }
+
       if (isTS) {
         console.info(`
 export default defineConfig({

--- a/packages/generator/generators/monorepo-generator/templates/base-template/modern.config.js.handlebars
+++ b/packages/generator/generators/monorepo-generator/templates/base-template/modern.config.js.handlebars
@@ -1,5 +1,5 @@
-import MonorepoToolsPlugin from '@modern-js/monorepo-tools';
+import { monorepoTools } from '@modern-js/monorepo-tools';
 
 module.exports = {
-  plugins: [MonorepoToolsPlugin()],
+  plugins: [monorepoTools()],
 };

--- a/packages/generator/generators/router-v5-generator/src/index.ts
+++ b/packages/generator/generators/router-v5-generator/src/index.ts
@@ -86,7 +86,8 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
       const appDir = context.materials.default.basePath;
       const configFile = await getModernConfigFile(appDir);
       const isTS = configFile.endsWith('ts');
-      const { pluginName, pluginDependence } = context.config;
+      const { pluginName, pluginDependence, shouldUsePluginNameExport } =
+        context.config;
       console.info(
         chalk.green(`\n[INFO]`),
         `${i18n.t(localeKeys.success)}`,
@@ -94,9 +95,17 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
         ':',
         '\n',
       );
-      console.info(
-        chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
-      );
+      if (shouldUsePluginNameExport) {
+        console.info(
+          chalk.yellow.bold(
+            `import { ${pluginName} } from '${pluginDependence}';`,
+          ),
+        );
+      } else {
+        console.info(
+          chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
+        );
+      }
       if (isTS) {
         console.info(`
 export default defineConfig({

--- a/packages/generator/generators/ssg-generator/src/index.ts
+++ b/packages/generator/generators/ssg-generator/src/index.ts
@@ -58,7 +58,8 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
       const appDir = context.materials.default.basePath;
       const configFile = await getModernConfigFile(appDir);
       const isTS = configFile.endsWith('ts');
-      const { pluginName, pluginDependence } = context.config;
+      const { pluginName, pluginDependence, shouldUsePluginNameExport } =
+        context.config;
       console.info(
         chalk.green(`\n[INFO]`),
         `${i18n.t(localeKeys.success)}`,
@@ -66,9 +67,17 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
         ':',
         '\n',
       );
-      console.info(
-        chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
-      );
+      if (shouldUsePluginNameExport) {
+        console.info(
+          chalk.yellow.bold(
+            `import { ${pluginName} } from '${pluginDependence}';`,
+          ),
+        );
+      } else {
+        console.info(
+          chalk.yellow.bold(`import ${pluginName} from '${pluginDependence}';`),
+        );
+      }
       if (isTS) {
         console.info(`
 export default defineConfig({

--- a/packages/generator/new-action/src/module.ts
+++ b/packages/generator/new-action/src/module.ts
@@ -19,7 +19,12 @@ import {
   getPackageManager,
   getModernPluginVersion,
 } from '@modern-js/generator-utils';
-import { alreadyRepo, getGeneratorPath, hasEnabledFunction } from './utils';
+import {
+  alreadyRepo,
+  getGeneratorPath,
+  hasEnabledFunction,
+  usePluginNameExport,
+} from './utils';
 
 interface IModuleNewActionOption {
   locale?: string;
@@ -121,6 +126,12 @@ export const ModuleNewAction = async (options: IModuleNewActionOption) => {
     });
   };
 
+  const shouldUsePluginNameExport = await usePluginNameExport(Solution.Module, {
+    registry,
+    distTag,
+    cwd,
+  });
+
   const finalConfig = merge(
     UserConfig,
     ans,
@@ -144,6 +155,7 @@ export const ModuleNewAction = async (options: IModuleNewActionOption) => {
         : {},
       pluginName: ModuleNewActionPluginName[actionType]![action],
       pluginDependence: ModuleNewActionPluginDependence[actionType]![action],
+      shouldUsePluginNameExport,
     },
   );
 

--- a/packages/generator/new-action/src/mwa.ts
+++ b/packages/generator/new-action/src/mwa.ts
@@ -23,7 +23,12 @@ import {
   getModernPluginVersion,
   getPackageManager,
 } from '@modern-js/generator-utils';
-import { alreadyRepo, getGeneratorPath, hasEnabledFunction } from './utils';
+import {
+  alreadyRepo,
+  getGeneratorPath,
+  hasEnabledFunction,
+  usePluginNameExport,
+} from './utils';
 
 interface IMWANewActionOption {
   locale?: string;
@@ -128,6 +133,12 @@ export const MWANewAction = async (options: IMWANewActionOption) => {
     MWAActionFunctionsDependencies[action as ActionFunction] ||
     MWAActionRefactorDependencies[action as ActionRefactor];
 
+  const shouldUsePluginNameExport = await usePluginNameExport(Solution.MWA, {
+    registry,
+    distTag,
+    cwd,
+  });
+
   const finalConfig = merge(
     UserConfig,
     ans,
@@ -151,6 +162,7 @@ export const MWANewAction = async (options: IMWANewActionOption) => {
         MWAActionReactorAppendTypeContent[action as ActionRefactor],
       pluginName: MWANewActionPluginName[actionType][action],
       pluginDependence: MWANewActionPluginDependence[actionType][action],
+      shouldUsePluginNameExport,
     },
   );
 

--- a/packages/generator/new-action/src/utils/index.ts
+++ b/packages/generator/new-action/src/utils/index.ts
@@ -1,7 +1,12 @@
 import path from 'path';
-import { json5 } from '@modern-js/utils';
-import { ActionFunction, ActionRefactor } from '@modern-js/generator-common';
-import { fs } from '@modern-js/generator-utils';
+import { json5, semver } from '@modern-js/utils';
+import {
+  ActionFunction,
+  ActionRefactor,
+  Solution,
+  SolutionToolsMap,
+} from '@modern-js/generator-common';
+import { fs, getModernPluginVersion } from '@modern-js/generator-utils';
 
 export function alreadyRepo(cwd = process.cwd()) {
   try {
@@ -54,4 +59,19 @@ export function getGeneratorPath(generator: string, distTag: string) {
     return `${generator}@${distTag}`;
   }
   return generator;
+}
+
+export async function usePluginNameExport(
+  solution: Solution,
+  options: Record<string, string>,
+) {
+  const solutionVersion = await getModernPluginVersion(
+    solution,
+    SolutionToolsMap[Solution.MWA],
+    options,
+  );
+  if (semver.valid(solutionVersion) && semver.gte(solutionVersion, '2.0.0')) {
+    return semver.gt(solutionVersion, '2.24.0');
+  }
+  return true;
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a42c2e7</samp>

This pull request adds a new feature to the `generator` packages that allows users to customize the import style of the plugin dependencies in their solutions. It also updates the `new-action` package to support different import modes based on the solution version. Additionally, it modifies the `monorepo-generator` template to use named imports for the `monorepo-tools` plugin. These changes aim to improve the compatibility and readability of the generated code and the console output.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a42c2e7</samp>

*  Add a changeset file that describes the patch updates and the feature of named exports ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-9ee8095125d4bb237c1aadedec729379fb8eec4b0294846f78ca6b13cdd08165R1-R12))
*  Add a new parameter `shouldUsePluginNameExport` to the `writing` functions of the `bff-generator`, `dependence-generator`, `router-v5-generator`, and `ssg-generator` packages, which indicates whether to use named imports for the plugin dependencies ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-b7557b602c9d046acfc3749f08189f116d546e275ec368603467c405bf1c4206R269), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-72fff8e247dfd6c99b80937dc899b9bec20dbe5f5c6d8610aa9e52ea9406442cL98-R99), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-6c7940d1c85fd7805f0540221543095b6e0b1589704c1976c6aafd328d5cd74eL89-R90), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-d6c1fec3d66dafe73f9cb7da17827a43ce9906343be25f6ba2197f82cfdc0008L61-R62))
*  Modify the console outputs of the same packages to use either named imports or default imports based on the `shouldUsePluginNameExport` parameter ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-b7557b602c9d046acfc3749f08189f116d546e275ec368603467c405bf1c4206L277-R299), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-72fff8e247dfd6c99b80937dc899b9bec20dbe5f5c6d8610aa9e52ea9406442cL106-R118), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-6c7940d1c85fd7805f0540221543095b6e0b1589704c1976c6aafd328d5cd74eL97-R108), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-d6c1fec3d66dafe73f9cb7da17827a43ce9906343be25f6ba2197f82cfdc0008L69-R80))
*  Modify the template file of the `monorepo-generator` package to use named imports for the `monorepo-tools` plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-78094d781d1274acf67ee8f5d76374836101345c780999265b56cf89d9d5a561L1-R4))
*  Add a new import `usePluginNameExport` to the `module.ts` and `mwa.ts` files of the `new-action` package, which is a function that determines whether to use named imports based on the solution version ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-880dbe83176b62879be636bb02cab51bdb2465dfcd118ff2251e5f6c28fe8ef3L22-R27), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-0f049aa0fa7f021a4c01a8d8a92ec357b678f2172c87c987aa694489f061845dL26-R31))
*  Call the `usePluginNameExport` function with the solution and the options object to get the `shouldUsePluginNameExport` value for the `ModuleNewAction` and `MWANewAction` classes of the `new-action` package ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-880dbe83176b62879be636bb02cab51bdb2465dfcd118ff2251e5f6c28fe8ef3R129-R134), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-0f049aa0fa7f021a4c01a8d8a92ec357b678f2172c87c987aa694489f061845dR136-R141))
*  Pass the `shouldUsePluginNameExport` value to the `getGeneratorPath` function of the `new-action` package, which returns the path of the generator to run based on the solution and the plugin name export mode ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-880dbe83176b62879be636bb02cab51bdb2465dfcd118ff2251e5f6c28fe8ef3R158), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-0f049aa0fa7f021a4c01a8d8a92ec357b678f2172c87c987aa694489f061845dR165))
*  Add the `usePluginNameExport` function to the `utils/index.ts` file of the `new-action` package, which uses the `semver` module and the `getModernPluginVersion` function to compare the plugin version with the thresholds for named exports ([link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-bc2d45967c8faa8a61e60d8f11f9da9f9e3ddd35fd19cc69ae45c0f401378987L2-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4041/files?diff=unified&w=0#diff-bc2d45967c8faa8a61e60d8f11f9da9f9e3ddd35fd19cc69ae45c0f401378987R63-R77))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
