### PR TITLE
fix: keep original fileChange hook, but add private configuration

### DIFF
--- a/.changeset/beige-hats-impress.md
+++ b/.changeset/beige-hats-impress.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/core': patch
+---
+
+fix: keep original fileChange hook, but add private configuration
+fix: 保留原有的 fileChange 钩子功能，但新增 private 配置

--- a/packages/cli/core/src/types/hooks.ts
+++ b/packages/cli/core/src/types/hooks.ts
@@ -30,9 +30,17 @@ export type BaseHooks<
   validateSchema: ParallelWorkflow<void>;
   prepare: AsyncWorkflow<void, void>;
   afterPrepare: AsyncWorkflow<void, void>;
-  watchFiles: ParallelWorkflow<void>;
+  watchFiles: ParallelWorkflow<
+    void,
+    // If the "private" is true, it will not restart cli.
+    string[] | { files: string[]; isPrivate: boolean }
+  >;
   fileChange: AsyncWorkflow<
-    { filename: string; eventType: 'add' | 'change' | 'unlink' },
+    {
+      filename: string;
+      eventType: 'add' | 'change' | 'unlink';
+      isPrivate: boolean;
+    },
     void
   >;
   commands: AsyncWorkflow<{ program: Command }, void>;

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -238,7 +238,7 @@ export default ({
       },
 
       watchFiles() {
-        return pagesDir;
+        return { files: pagesDir, isPrivate: true };
       },
 
       resolvedConfig({ resolved }) {

--- a/packages/solutions/doc-tools/src/index.ts
+++ b/packages/solutions/doc-tools/src/index.ts
@@ -58,7 +58,9 @@ export const docTools = (options: DocToolsOptions = {}): CliPlugin => ({
           configFile: string;
         };
         // Concern: if the doc root is set by cli, we cannot get the root parms in `watchFiles` hook, so we can only get the root from config file.
-        return [configFile, config.doc?.root, '**/_meta.json'].filter(Boolean);
+        return [configFile, config.doc?.root, '**/_meta.json'].filter(
+          Boolean,
+        ) as string[];
       },
       async fileChange({ filename, eventType }) {
         const isConfigFile = configFiles.some(configFileName =>


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 829de1e</samp>

This pull request enhances the file watching functionality of the CLI and the appTools solution by introducing a `isPrivate` property to distinguish between private and public files. It also updates the type definitions, the file change handling logic, and the version and fix messages for the affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 829de1e</samp>

*  Add a markdown file to indicate the patch version updates and the fix messages for `@modern-js/app-tools` and `@modern-js/core` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4042/files?diff=unified&w=0#diff-9f47591291af693b51c1d7f88bcb548f6ebc82af641fc5bf6a2580c4d118b341R1-R7))
*  Allow the `watchFiles` hook to return either an array of strings or an object with `files` and `isPrivate` properties in `hooks.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4042/files?diff=unified&w=0#diff-8da1726a5da82e9c6dcf2604766e45cd2616c55121f32411e510fc6ba3e2d947L33-R43))
*  Handle the different types of return values from the `watchFiles` hook in `createFileWatcher.ts` by separating the files into `watched` and `privateWatched` arrays and passing the `isPrivate` property to the `fileChange` hook ([link](https://github.com/web-infra-dev/modern.js/pull/4042/files?diff=unified&w=0#diff-e3875c82e53153ef96549534812c256242de53dafb94b8c1c2c314c8197ebed7L23-R43), [link](https://github.com/web-infra-dev/modern.js/pull/4042/files?diff=unified&w=0#diff-e3875c82e53153ef96549534812c256242de53dafb94b8c1c2c314c8197ebed7L46-R94))
*  Return an object with `files` and `isPrivate` properties from the `watchFiles` hook in `analyze/index.ts` to prevent the files in the pages directory from triggering a restart ([link](https://github.com/web-infra-dev/modern.js/pull/4042/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L241-R241))
*  Remove the unused `watchedFiles` variable and the `isWatched` function from the `appTools` value in `index.ts` and use the `isPrivate` property from the `fileChange` hook argument instead ([link](https://github.com/web-infra-dev/modern.js/pull/4042/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL154-L160), [link](https://github.com/web-infra-dev/modern.js/pull/4042/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL283-R287))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
