### PR TITLE
chore: simplify some ESLint rules

### DIFF
--- a/.changeset/thin-dancers-know.md
+++ b/.changeset/thin-dancers-know.md
@@ -1,0 +1,8 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+chore: simplify some eslint rules
+
+chore: 简化一些 eslint 规则
+

--- a/packages/builder/builder-cli/.eslintrc.js
+++ b/packages/builder/builder-cli/.eslintrc.js
@@ -7,6 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/naming-convention': 0,
   },
 };

--- a/packages/builder/builder-rspack-provider/.eslintrc.js
+++ b/packages/builder/builder-rspack-provider/.eslintrc.js
@@ -44,9 +44,6 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@babel/no-invalid-this': 0,
-    '@typescript-eslint/ban-ts-comment': 0,
-    'eslint-comments/no-unlimited-disable': 0,
   },
   overrides: [
     {

--- a/packages/builder/builder-rspack-provider/tests/core/validate.test.ts
+++ b/packages/builder/builder-rspack-provider/tests/core/validate.test.ts
@@ -66,7 +66,6 @@ describe('validateBuilderConfig', () => {
     await validateBuilderConfig(config);
     const endedAt = performance.now();
     const cost = endedAt - startedAt;
-    // eslint-disable-next-line no-console
     console.log(`config validator cost: ${cost.toFixed(2)}ms`);
     expect(cost).lessThan(100);
   });

--- a/packages/builder/builder-shared/.eslintrc.js
+++ b/packages/builder/builder-shared/.eslintrc.js
@@ -7,7 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/ban-ts-comment': 0,
-    'eslint-comments/no-unlimited-disable': 0,
   },
 };

--- a/packages/builder/builder-shared/scripts/postCompile.js
+++ b/packages/builder/builder-shared/scripts/postCompile.js
@@ -35,7 +35,6 @@ async function compileRetryRuntime() {
 async function compile() {
   const startTime = performance.now();
   await compileRetryRuntime();
-  // eslint-disable-next-line no-console
   console.log(
     `Compiled assets retry runtime code. Time cost: ${(
       performance.now() - startTime

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable max-lines */
 import {
   DEFAULT_PORT,

--- a/packages/builder/builder-shared/src/loaders/css-modules-typescript-loader.ts
+++ b/packages/builder/builder-shared/src/loaders/css-modules-typescript-loader.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable @babel/no-invalid-this */
 /**
  * The following code is modified based on
  * https://github.com/seek-oss/css-modules-typescript-loader

--- a/packages/builder/builder-shared/src/loaders/ignore-css-loader.ts
+++ b/packages/builder/builder-shared/src/loaders/ignore-css-loader.ts
@@ -1,7 +1,6 @@
 import type { LoaderContext } from 'webpack';
 
 export default function (this: LoaderContext<unknown>, source: string) {
-  // eslint-disable-next-line @babel/no-invalid-this
   this?.cacheable(true);
 
   // if the source code include '___CSS_LOADER_EXPORT___'

--- a/packages/builder/builder-shared/tests/plugins/AutoSetRootFontSizePlugin.test.ts
+++ b/packages/builder/builder-shared/tests/plugins/AutoSetRootFontSizePlugin.test.ts
@@ -80,7 +80,6 @@ describe('test runtime', () => {
     listenerCbs = [];
 
     ['document', 'window', 'location', 'screen'].forEach(key => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       delete global[key];
     });
@@ -91,7 +90,6 @@ describe('test runtime', () => {
     runRootPixelCode(code);
     expect(listenerCbs.length).toBe(1);
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     expect(window[DEFAULT_OPTIONS.rootFontSizeVariableName]).toBe(
       DEFAULT_OPTIONS.maxRootFontSize,

--- a/packages/builder/builder-webpack-provider/.eslintrc.js
+++ b/packages/builder/builder-webpack-provider/.eslintrc.js
@@ -49,9 +49,6 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@babel/no-invalid-this': 0,
-    '@typescript-eslint/ban-ts-comment': 0,
-    'eslint-comments/no-unlimited-disable': 0,
   },
   overrides: [
     {

--- a/packages/builder/builder-webpack-provider/src/stub/builder.ts
+++ b/packages/builder/builder-webpack-provider/src/stub/builder.ts
@@ -236,7 +236,6 @@ export async function createStubBuilder(options?: StubBuilderOptions) {
     ]);
     const { port } = await runStaticServer(context.distPath);
     if (options?.hangOn) {
-      // eslint-disable-next-line no-console
       console.log(
         `Successfully build, and hang on running server: http://localhost:${port}`,
       );

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
@@ -35,7 +35,6 @@ class Bus {
   constructor() {
     this.prevOutput = '';
     this.log = create(process.stdout);
-    // eslint-disable-next-line no-console
     console.Console = Console;
     this.restore = patchConsole((type, data) => {
       this.writeToStd(type, data);

--- a/packages/builder/builder-webpack-provider/tests/config/validate.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/config/validate.test.ts
@@ -70,7 +70,6 @@ describe('validateBuilderConfig', () => {
     await validateBuilderConfig(config);
     const endedAt = performance.now();
     const cost = endedAt - startedAt;
-    // eslint-disable-next-line no-console
     console.log(`config validator cost: ${cost.toFixed(2)}ms`);
     expect(cost).lessThan(100);
   });

--- a/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
+++ b/packages/builder/builder-webpack-provider/tests/webpackConfig.test.ts
@@ -219,7 +219,6 @@ describe('webpackConfig', () => {
     const config = await builder.unwrapWebpackConfig();
 
     const babelRules = config.module!.rules?.filter(item => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error item has use
       return item?.use?.[0].loader.includes('babel-loader');
     });
@@ -235,7 +234,6 @@ describe('webpackConfig', () => {
     const config = await builder.unwrapWebpackConfig();
 
     const babelRules = config.module!.rules?.filter(item => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error item has use
       return item?.use?.[0].loader.includes('babel-loader');
     });
@@ -256,7 +254,6 @@ describe('webpackConfig', () => {
     const config = await builder.unwrapWebpackConfig();
 
     const babelRules = config.module!.rules?.filter(item => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error item has use
       return item?.use?.[0].loader.includes('babel-loader');
     });

--- a/packages/builder/builder/.eslintrc.js
+++ b/packages/builder/builder/.eslintrc.js
@@ -7,7 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/ban-ts-comment': 0,
-    'eslint-comments/no-unlimited-disable': 0,
   },
 };

--- a/packages/builder/plugin-esbuild/.eslintrc.js
+++ b/packages/builder/plugin-esbuild/.eslintrc.js
@@ -1,45 +1,3 @@
-const devDependencyPaths = Object.keys(
-  require('./package.json').devDependencies,
-);
-
-const withAllowTypeImports = key => pkg => ({
-  [key]: pkg,
-  allowTypeImports: true,
-});
-
-/**
- * @refer https://eslint.org/docs/latest/rules/no-restricted-imports
- * @refer https://typescript-eslint.io/rules/no-restricted-imports
- */
-const restrictedImportInSource = {
-  paths: [
-    'webpack',
-    'lodash',
-    'ts-loader',
-    'typescript',
-    '@modern-js/utils',
-    ...devDependencyPaths,
-  ].map(withAllowTypeImports('name')),
-  patterns: [
-    'src/**/*',
-    '**/stub',
-    '**/stub/*',
-    '**/plugins/*',
-    '**/webpackPlugins/*',
-    '*-webpack-plugin',
-    [
-      '@modern-js/utils/*',
-      '!@modern-js/utils/chalk',
-      '!@modern-js/utils/lodash',
-      '!@modern-js/utils/chain-id',
-    ],
-  ].map(withAllowTypeImports('group')),
-};
-
-const restrictedImportInTypes = {
-  patterns: [{ group: '**', allowTypeImports: true }],
-};
-
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: ['@modern-js'],
@@ -49,32 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/ban-ts-comment': 0,
-    'eslint-comments/no-unlimited-disable': 0,
   },
-  overrides: [
-    {
-      files: ['./src/types/**/*.ts'],
-      rules: {
-        '@typescript-eslint/no-restricted-imports': [
-          'error',
-          restrictedImportInTypes,
-        ],
-      },
-    },
-    {
-      files: ['./src/**/*.{ts,js}'],
-      excludedFiles: [
-        './src/webpackPlugins/**/*',
-        '**/*.test.*',
-        './src/types/**/*',
-      ],
-      rules: {
-        '@typescript-eslint/no-restricted-imports': [
-          'error',
-          restrictedImportInSource,
-        ],
-      },
-    },
-  ],
 };

--- a/packages/builder/plugin-image-compress/.eslintrc.js
+++ b/packages/builder/plugin-image-compress/.eslintrc.js
@@ -7,6 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/naming-convention': 0,
   },
 };

--- a/packages/builder/plugin-node-polyfill/.eslintrc.js
+++ b/packages/builder/plugin-node-polyfill/.eslintrc.js
@@ -1,45 +1,3 @@
-const devDependencyPaths = Object.keys(
-  require('./package.json').devDependencies,
-);
-
-const withAllowTypeImports = key => pkg => ({
-  [key]: pkg,
-  allowTypeImports: true,
-});
-
-/**
- * @refer https://eslint.org/docs/latest/rules/no-restricted-imports
- * @refer https://typescript-eslint.io/rules/no-restricted-imports
- */
-const restrictedImportInSource = {
-  paths: [
-    'webpack',
-    'lodash',
-    'ts-loader',
-    'typescript',
-    '@modern-js/utils',
-    ...devDependencyPaths,
-  ].map(withAllowTypeImports('name')),
-  patterns: [
-    'src/**/*',
-    '**/stub',
-    '**/stub/*',
-    '**/plugins/*',
-    '**/webpackPlugins/*',
-    '*-webpack-plugin',
-    [
-      '@modern-js/utils/*',
-      '!@modern-js/utils/chalk',
-      '!@modern-js/utils/lodash',
-      '!@modern-js/utils/chain-id',
-    ],
-  ].map(withAllowTypeImports('group')),
-};
-
-const restrictedImportInTypes = {
-  patterns: [{ group: '**', allowTypeImports: true }],
-};
-
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: ['@modern-js'],
@@ -49,32 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/ban-ts-comment': 0,
-    'eslint-comments/no-unlimited-disable': 0,
   },
-  overrides: [
-    {
-      files: ['./src/types/**/*.ts'],
-      rules: {
-        '@typescript-eslint/no-restricted-imports': [
-          'error',
-          restrictedImportInTypes,
-        ],
-      },
-    },
-    {
-      files: ['./src/**/*.{ts,js}'],
-      excludedFiles: [
-        './src/webpackPlugins/**/*',
-        '**/*.test.*',
-        './src/types/**/*',
-      ],
-      rules: {
-        '@typescript-eslint/no-restricted-imports': [
-          'error',
-          restrictedImportInSource,
-        ],
-      },
-    },
-  ],
 };

--- a/packages/builder/plugin-stylus/.eslintrc.js
+++ b/packages/builder/plugin-stylus/.eslintrc.js
@@ -7,6 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/naming-convention': 0,
   },
 };

--- a/packages/builder/plugin-swc/src/plugin.ts
+++ b/packages/builder/plugin-swc/src/plugin.ts
@@ -151,7 +151,6 @@ export const builderPluginSwc = (
 
       if (checkUseMinify(pluginOptions, builderConfig, isProd)) {
         // Insert swc minify plugin
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error webpack-chain missing minimizers type
         const minimizersChain = chain.optimization.minimizers;
 

--- a/packages/builder/plugin-vue/.eslintrc.js
+++ b/packages/builder/plugin-vue/.eslintrc.js
@@ -7,6 +7,5 @@ module.exports = {
   },
   rules: {
     'import/order': 0,
-    '@typescript-eslint/naming-convention': 0,
   },
 };

--- a/packages/cli/core/tests/loadConfigs.test.ts
+++ b/packages/cli/core/tests/loadConfigs.test.ts
@@ -6,10 +6,9 @@ import {
 } from '../src/config/loadConfig';
 
 // globby needs setImmediate
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 global.setImmediate = setTimeout;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 // @ts-expect-error
 global.clearImmediate = clearTimeout;
 

--- a/packages/cli/doc-core/src/node/mdx/remarkPlugins/toc.ts
+++ b/packages/cli/doc-core/src/node/mdx/remarkPlugins/toc.ts
@@ -61,7 +61,6 @@ export const parseToc = (tree: Root) => {
 };
 
 export const remarkPluginToc: Plugin<[], Root> = function (this: Processor) {
-  // eslint-disable-next-line @babel/no-invalid-this
   const data = this.data() as {
     pageMeta: PageMeta;
   };

--- a/packages/cli/doc-core/src/node/serve.ts
+++ b/packages/cli/doc-core/src/node/serve.ts
@@ -40,7 +40,6 @@ export async function serve(options: ServeOptions) {
         if (err) {
           throw err;
         }
-        // eslint-disable-next-line no-console
         console.log(
           `Preview server running at http://${host}:${port}/${base}/\n`,
         );
@@ -52,7 +51,6 @@ export async function serve(options: ServeOptions) {
         if (err) {
           throw err;
         }
-        // eslint-disable-next-line no-console
         console.log(`Preview server running at http://${host}:${port}/\n`);
       });
   }

--- a/packages/cli/doc-core/src/node/utils/detectReactVersion.ts
+++ b/packages/cli/doc-core/src/node/utils/detectReactVersion.ts
@@ -39,7 +39,6 @@ export async function resolveReactAlias(reactVersion: number) {
       try {
         alias[lib] = await resolveDepPath(lib, basedir, {});
       } catch (e) {
-        // eslint-disable-next-line no-console
         console.log(`warning: ${lib} not found`);
       }
     }),

--- a/packages/cli/doc-core/src/runtime/App.tsx
+++ b/packages/cli/doc-core/src/runtime/App.tsx
@@ -85,7 +85,6 @@ export function App({ helmetContext }: { helmetContext?: object }) {
         const pageData = await initPageData(normalizeRoutePath(pathname));
         setPageData(pageData);
       } catch (e) {
-        // eslint-disable-next-line no-console
         console.log(e);
       }
     }

--- a/packages/cli/doc-core/src/theme-default/components/Search/logic/providers/LocalProvider.ts
+++ b/packages/cli/doc-core/src/theme-default/components/Search/logic/providers/LocalProvider.ts
@@ -28,7 +28,6 @@ export class LocalProvider implements Provider {
 
   async #getPages(lang: string): Promise<PageIndexInfo[]> {
     const result = await fetch(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error __ASSET_PREFIX__ is injected by webpack
       `${__ASSET_PREFIX__}/static/${SEARCH_INDEX_NAME}.${lang}.${searchIndexHash[lang]}.json`,
     );

--- a/packages/cli/plugin-bff/src/loader.ts
+++ b/packages/cli/plugin-bff/src/loader.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable @babel/no-invalid-this */
 import { generateClient, GenClientOptions } from '@modern-js/bff-core';
 import type { HttpMethodDecider } from '@modern-js/types';
 import type { LoaderContext } from 'webpack';

--- a/packages/cli/plugin-bff/tests/compiler.ts
+++ b/packages/cli/plugin-bff/tests/compiler.ts
@@ -4,10 +4,9 @@ import { createFsFromVolume, Volume } from 'memfs';
 import { APILoaderOptions } from '../src/loader';
 
 // globby needs setImmediate
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 global.setImmediate = setTimeout;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 // @ts-expect-error
 global.clearImmediate = clearTimeout;
 

--- a/packages/cli/plugin-data-loader/src/cli/createRequest.ts
+++ b/packages/cli/plugin-data-loader/src/cli/createRequest.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable node/prefer-global/url */
 // Todo move this file to `runtime/` dir
 import { compile } from 'path-to-regexp';

--- a/packages/cli/plugin-data-loader/src/cli/loader.ts
+++ b/packages/cli/plugin-data-loader/src/cli/loader.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable @babel/no-invalid-this */
 import type { LoaderContext } from 'webpack';
 import { generateClient } from './generateClient';
 

--- a/packages/cli/plugin-data-loader/tests/loader.test.ts
+++ b/packages/cli/plugin-data-loader/tests/loader.test.ts
@@ -3,7 +3,6 @@ import { fs } from '@modern-js/utils';
 import { compiler } from './compiler';
 
 // compiler needs setImmediate
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 global.setImmediate = setTimeout;
 

--- a/packages/cli/plugin-data-loader/tests/mockTsLoader.ts
+++ b/packages/cli/plugin-data-loader/tests/mockTsLoader.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable @babel/no-invalid-this */
 import type { LoaderContext } from 'webpack';
 
 export default async function loader(this: LoaderContext<void>) {

--- a/packages/cli/plugin-data-loader/tests/server.test.ts
+++ b/packages/cli/plugin-data-loader/tests/server.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable node/prefer-global/url */
 import { IncomingMessage, ServerResponse } from 'http';
 import qs from 'querystring';

--- a/packages/generator/generators/generator-generator/templates/js-template/src/index.js.handlebars
+++ b/packages/generator/generators/generator-generator/templates/js-template/src/index.js.handlebars
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable node/no-unsupported-features/es-syntax */
 import { AppAPI } from '@modern-js/codesmith-api-app';
 

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -74,8 +74,6 @@ module.exports = {
     'no-compare-neg-zero': 'error',
     // https://eslint.org/docs/rules/no-cond-assign
     'no-cond-assign': ['error', 'always'],
-    // https://eslint.org/docs/rules/no-console
-    'no-console': ['error', { allow: ['info', 'warn', 'error'] }],
     // https://eslint.org/docs/rules/no-constant-condition
     'no-constant-condition': ['error', { checkLoops: false }],
 
@@ -266,9 +264,6 @@ module.exports = {
     'no-implicit-globals': 'error',
     // https://eslint.org/docs/rules/no-implied-eval
     'no-implied-eval': 'error',
-    // https://eslint.org/docs/rules/no-invalid-this
-    'no-invalid-this': 'off',
-    '@babel/no-invalid-this': 'error',
     // https://eslint.org/docs/rules/no-iterator
     'no-iterator': 'error',
     // https://eslint.org/docs/rules/no-labels
@@ -1100,7 +1095,7 @@ module.exports = {
     // 'import/no-relative-parent-imports': 'error',
     // eslint-comments
     // https://github.com/mysticatea/eslint-plugin-eslint-comments/blob/HEAD/docs/rules/disable-enable-pair.md
-    'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: false }],
+    'eslint-comments/disable-enable-pair': 'off',
     // https://github.com/mysticatea/eslint-plugin-eslint-comments/blob/HEAD/docs/rules/no-duplicate-disable.md
     'eslint-comments/no-duplicate-disable': 'error',
 

--- a/packages/review/eslint-config-app/ts.js
+++ b/packages/review/eslint-config-app/ts.js
@@ -64,7 +64,7 @@ module.exports = {
         '@typescript-eslint/ban-ts-comment': [
           'error',
           {
-            'ts-expect-error': true,
+            'ts-expect-error': false,
             'ts-ignore': true,
             'ts-nocheck': true,
             'ts-check': false,

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/no-require-imports */
 import path from 'path';
 import React from 'react';

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
 

--- a/packages/runtime/plugin-runtime/tests/document/index.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/index.test.tsx
@@ -46,7 +46,6 @@ describe('plugin-document', () => {
 
   it('should runder the script by IIFE ', () => {
     const fn = () => {
-      // eslint-disable-next-line no-console
       console.log('===> script can use script');
     };
     const document = (

--- a/packages/runtime/plugin-testing/src/cli/bff/utils/index.ts
+++ b/packages/runtime/plugin-testing/src/cli/bff/utils/index.ts
@@ -17,7 +17,6 @@ export const isBFFProject = (pwd: string) => {
 
     return isMWA && isBFF;
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.log(chalk.red(error));
     return false;
   }

--- a/packages/runtime/plugin-testing/src/runtime-testing/bff.ts
+++ b/packages/runtime/plugin-testing/src/runtime-testing/bff.ts
@@ -1,4 +1,3 @@
-/* eslint-disable eslint-comments/disable-enable-pair */
 import type { SuperTest, Test } from 'supertest';
 import supertest from 'supertest';
 import { getApp } from '../cli/bff/app';

--- a/packages/server/plugin-express/src/utils.ts
+++ b/packages/server/plugin-express/src/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable consistent-return */
 import 'reflect-metadata';
 import {

--- a/packages/server/plugin-express/tests/common.ts
+++ b/packages/server/plugin-express/tests/common.ts
@@ -1,7 +1,6 @@
 // globby needs setImmediate
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 global.setImmediate = setTimeout;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 // @ts-expect-error
 global.clearImmediate = clearTimeout;

--- a/packages/server/plugin-express/tests/fixtures/function-mode/api/nest/user.ts
+++ b/packages/server/plugin-express/tests/fixtures/function-mode/api/nest/user.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable react-hooks/rules-of-hooks */
 import { match } from '@modern-js/bff-runtime';
 import { useContext } from '../../../../../src/context';
 

--- a/packages/server/plugin-express/tests/fixtures/lambda-mode/api/lambda/nest/user.ts
+++ b/packages/server/plugin-express/tests/fixtures/lambda-mode/api/lambda/nest/user.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable react-hooks/rules-of-hooks */
 import { match } from '@modern-js/bff-runtime';
 import { useContext } from '../../../../../../src/context';
 

--- a/packages/server/plugin-koa/tests/common.ts
+++ b/packages/server/plugin-koa/tests/common.ts
@@ -1,7 +1,6 @@
 // globby needs setImmediate
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 global.setImmediate = setTimeout;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 // @ts-expect-error
 global.clearImmediate = clearTimeout;

--- a/packages/server/prod-server/src/libs/logger.ts
+++ b/packages/server/prod-server/src/libs/logger.ts
@@ -89,7 +89,6 @@ class Logger {
 
   private _log(type: string, message?: LogMsg, ...args: string[]) {
     if (message === undefined || message === null) {
-      // eslint-disable-next-line no-console
       console.log();
       return;
     }
@@ -121,7 +120,7 @@ class Logger {
     }
 
     const log = label.length > 0 ? `${label} ${text}` : text;
-    // eslint-disable-next-line no-console
+
     console.log(log, ...args);
   }
 

--- a/packages/server/server/src/dev-tools/dev-middleware/hmr-client/index.ts
+++ b/packages/server/server/src/dev-tools/dev-middleware/hmr-client/index.ts
@@ -4,7 +4,6 @@
  *
  * Tips: this package will be bundled and running in the browser, do not import from the entry of @modern-js/utils.
  */
-/* eslint-disable no-console */
 import stripAnsi from '@modern-js/utils/strip-ansi';
 import { formatWebpackMessages } from '@modern-js/utils/universal/format-webpack';
 import type webpack from 'webpack';
@@ -218,5 +217,3 @@ function tryApplyUpdates() {
     );
   }
 }
-
-/* eslint-enable no-console */

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -140,7 +140,6 @@ export class ModernDevServer extends ModernServer {
 
     // compression should be the first middleware
     if (!isUseStreamingSSR(this.getRoutes()) && dev.compress) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error http-compression does not provide a type definition
       const { default: compression } = await import('http-compression');
       this.addHandler((ctx, next) => {
@@ -309,7 +308,7 @@ export class ModernDevServer extends ModernServer {
 
         // onApiChange 钩子被调用，且返回 true，则表示无需重新编译
         // onApiChange 的类型是 WaterFall,WaterFall 钩子的返回值类型目前有问题
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
         // @ts-expect-error
         if (success !== true) {
           await super.onServerChange({ filepath });

--- a/packages/server/server/tests/server.test.ts
+++ b/packages/server/server/tests/server.test.ts
@@ -220,7 +220,6 @@ describe('test dev server', () => {
         compiler: null as any,
       });
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       expect(devServer.server.watcher).toBeInstanceOf(Watcher);
       await devServer.close();

--- a/packages/server/utils/tests/fixtures/ts-example/api/map-alias.ts
+++ b/packages/server/utils/tests/fixtures/ts-example/api/map-alias.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 import core from '@modern-js/runtime';
 

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable max-lines */
 import path from 'path';
 import {

--- a/packages/solutions/app-tools/src/types/utils.ts
+++ b/packages/solutions/app-tools/src/types/utils.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/ban-types */
 export type UnwrapBuilderConfig<
   Config,

--- a/packages/solutions/app-tools/tests/analyze/templates.test.ts
+++ b/packages/solutions/app-tools/tests/analyze/templates.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { RouteLegacy } from '@modern-js/types/cli';
 import {

--- a/packages/solutions/app-tools/tests/routes/compiler.ts
+++ b/packages/solutions/app-tools/tests/routes/compiler.ts
@@ -1,7 +1,6 @@
 import webpack, { Configuration } from 'webpack';
 
 // compiler needs setImmediate
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 global.setImmediate = setTimeout;
 

--- a/packages/solutions/module-tools/scripts/debug-mode.js
+++ b/packages/solutions/module-tools/scripts/debug-mode.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /**
  * 修改 exports.* 配置
  * 将 export.'.': './src/index.ts' 转换为 export.'.': './dist/index.js'
@@ -47,5 +46,3 @@ if (operation === ON) {
   fs.copyFileSync(tempPkgPath, pkgPath);
   fs.removeSync(tempPkgPath);
 }
-
-/* eslint-enable no-console */

--- a/packages/solutions/module-tools/tests/utils.ts
+++ b/packages/solutions/module-tools/tests/utils.ts
@@ -47,10 +47,9 @@ export const runCli = async (options: {
 };
 
 export const initBeforeTest = () => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
   global.setImmediate = setTimeout;
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
   // @ts-expect-error
   global.clearImmediate = clearTimeout;
 

--- a/packages/solutions/monorepo-tools/tests/getProjects.test.ts
+++ b/packages/solutions/monorepo-tools/tests/getProjects.test.ts
@@ -7,10 +7,10 @@ import {
 const root = path.join(__dirname, './fixtures/mono-1');
 
 // globby needs setImmediate
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 // @ts-expect-error
 global.setImmediate = setTimeout;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
 // @ts-expect-error
 global.clearImmediate = clearTimeout;
 

--- a/packages/toolkit/plugin/src/manager/sync.ts
+++ b/packages/toolkit/plugin/src/manager/sync.ts
@@ -258,7 +258,7 @@ export const generateRunner = <Hooks extends Record<string, any>>(
           cloneShape[key].use(hooks[key]);
         }
       });
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
       // @ts-expect-error
       runner[key] = (input: any, options: any) =>
         (cloneShape[key] as any).run(input, { ...options });
@@ -304,7 +304,6 @@ export const cloneHooksMap = <Hooks>(record: Hooks): Hooks => {
   const result: Hooks = {} as any;
 
   for (const key in record) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     result[key] = cloneHook(record[key]);
   }

--- a/packages/toolkit/plugin/tests/async.test.ts
+++ b/packages/toolkit/plugin/tests/async.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable max-lines */
 import {
   createPipeline,
@@ -263,6 +262,7 @@ describe('async manager', () => {
     it('should throw error when attaching rival plugin', async () => {
       const manager = createAsyncManager();
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let count = 0;
       const plugin0 = manager.createPlugin(
         () => {
@@ -272,7 +272,6 @@ describe('async manager', () => {
       );
       const plugin1 = manager.createPlugin(
         () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           count += 1;
         },
         {
@@ -289,6 +288,7 @@ describe('async manager', () => {
     it('should not throw error without attaching rival plugin', async () => {
       const manager = createAsyncManager();
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let count = 0;
       const plugin0 = manager.createPlugin(
         () => {
@@ -298,7 +298,6 @@ describe('async manager', () => {
       );
       const plugin1 = manager.createPlugin(
         () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           count += 1;
         },
         {
@@ -331,6 +330,7 @@ describe('async manager', () => {
     it('should not throw error without attaching rival plugin', async () => {
       const manager = createAsyncManager();
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let count = 0;
       const plugin0 = manager.createPlugin(
         () => {
@@ -343,7 +343,6 @@ describe('async manager', () => {
       );
       const plugin1 = manager.createPlugin(
         () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           count += 1;
         },
         { name: 'plugin1' },

--- a/packages/toolkit/plugin/tests/pipeline.test.ts
+++ b/packages/toolkit/plugin/tests/pipeline.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable max-lines */
 import {
   createContext,

--- a/packages/toolkit/plugin/tests/sync.test.ts
+++ b/packages/toolkit/plugin/tests/sync.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable max-lines */
 import {
   createPipeline,
@@ -274,6 +273,7 @@ describe('sync manager', () => {
     it('should not throw error without attaching rival plugin', () => {
       const manager = createManager();
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let count = 0;
       const plugin0 = manager.createPlugin(
         () => {
@@ -283,7 +283,6 @@ describe('sync manager', () => {
       );
       const plugin1 = manager.createPlugin(
         () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           count += 1;
         },
         {
@@ -316,6 +315,7 @@ describe('sync manager', () => {
     it('should not throw error without attaching rival plugin', () => {
       const manager = createManager();
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       let count = 0;
       const plugin0 = manager.createPlugin(
         () => {
@@ -328,7 +328,6 @@ describe('sync manager', () => {
       );
       const plugin1 = manager.createPlugin(
         () => {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           count += 1;
         },
         { name: 'plugin1' },

--- a/packages/toolkit/remark-container/src/index.ts
+++ b/packages/toolkit/remark-container/src/index.ts
@@ -132,7 +132,6 @@ function transformer(tree: Root) {
       let title = parseTitle(rawTitle);
       // :::tip{title="xxx"}
       const titleExpressionNode =
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error mdxTextExpression is not defined in mdast
         node.children[1] && node.children[1].type === 'mdxTextExpression'
           ? node.children[1]
@@ -288,7 +287,6 @@ function transformer(tree: Root) {
       i++;
     }
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.log(e);
     throw e;
   }

--- a/packages/toolkit/utils/src/cli/logger.ts
+++ b/packages/toolkit/utils/src/cli/logger.ts
@@ -92,7 +92,6 @@ class Logger {
 
   private _log(type: string, message?: LogMsg, ...args: string[]) {
     if (message === undefined || message === null) {
-      // eslint-disable-next-line no-console
       console.log();
       return;
     }
@@ -125,7 +124,7 @@ class Logger {
     }
 
     const log = label.length > 0 ? `${label} ${text}` : text;
-    // eslint-disable-next-line no-console
+
     console.log(log, ...args);
   }
 

--- a/packages/toolkit/utils/tests/applyOptionsChain.test.ts
+++ b/packages/toolkit/utils/tests/applyOptionsChain.test.ts
@@ -89,9 +89,7 @@ describe('apply options chain', () => {
 
   test(`should log warning about function result`, () => {
     let outputs = '';
-    /* eslint-disable no-console */
     console.log = jest.fn(input => (outputs += input));
-    /* eslint-enable no-console */
     applyOptionsChain({ name: 'a' } as any, [() => 111]);
 
     expect(outputs).toContain(

--- a/packages/toolkit/utils/tests/logger.test.ts
+++ b/packages/toolkit/utils/tests/logger.test.ts
@@ -2,12 +2,10 @@ import { logger } from '../src';
 
 describe('logger', () => {
   test('should log', () => {
-    // eslint-disable-next-line no-console
     console.log = jest.fn();
 
     logger.log('this is a log message');
 
-    // eslint-disable-next-line no-console
     expect((console.log as jest.Mock).mock.calls[0][0]).toBe(
       'this is a log message',
     );
@@ -20,12 +18,10 @@ describe('logger', () => {
 
     logger.success('this is a success message');
 
-    // eslint-disable-next-line no-console
     expect(console.log as jest.Mock).toHaveBeenCalledTimes(5);
   });
 
   test('should create new logger', () => {
-    // eslint-disable-next-line no-console
     console.log = jest.fn();
 
     const customLogger = new logger.Logger({
@@ -45,10 +41,8 @@ describe('logger', () => {
     customLogger.custom('custom log');
 
     const reg = new RegExp(`custom.*custom log$`);
-    // eslint-disable-next-line no-console
     expect((console.log as jest.Mock).mock.calls[0][0]).toMatch(reg);
 
-    // eslint-disable-next-line no-console
     expect(console.log as jest.Mock).toHaveBeenCalledTimes(1);
   });
 });

--- a/scripts/check-changeset/.eslintrc.js
+++ b/scripts/check-changeset/.eslintrc.js
@@ -5,7 +5,4 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
-  rules: {
-    'no-console': 'off',
-  },
 };

--- a/scripts/codemod/src/check.ts
+++ b/scripts/codemod/src/check.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import fs from 'fs';
 import path from 'path';
@@ -71,4 +70,3 @@ function main() {
 main();
 
 /* eslint-enable @typescript-eslint/no-unused-vars */
-/* eslint-enable no-console */

--- a/scripts/codemod/src/main.ts
+++ b/scripts/codemod/src/main.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import fs from 'fs';
 import path from 'path';
@@ -356,4 +355,3 @@ function main() {
 main();
 
 /* eslint-enable @typescript-eslint/no-unused-vars */
-/* eslint-enable no-console */

--- a/scripts/lint-package-json/.eslintrc.js
+++ b/scripts/lint-package-json/.eslintrc.js
@@ -5,7 +5,4 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
-  rules: {
-    'no-console': 'off',
-  },
 };

--- a/scripts/prebundle/.eslintrc.js
+++ b/scripts/prebundle/.eslintrc.js
@@ -7,6 +7,5 @@ module.exports = {
   },
   rules: {
     'max-lines': 'off',
-    'no-console': 'off',
   },
 };

--- a/scripts/skipDocsChange.js
+++ b/scripts/skipDocsChange.js
@@ -44,9 +44,7 @@ async function main() {
   const args = process.argv.slice(process.argv.indexOf(__filename) + 1);
 
   if (args.length === 0) {
-    // eslint-disable-next-line no-console
     console.log(process.argv, args);
-    // eslint-disable-next-line no-console
     console.log('no script provided, exiting...');
   }
 
@@ -66,7 +64,6 @@ async function main() {
       cmd.on('error', err => reject(err));
     });
   } else {
-    // eslint-disable-next-line no-console
     console.log('docs only change');
   }
 }

--- a/scripts/update-codesmith/.eslintrc.js
+++ b/scripts/update-codesmith/.eslintrc.js
@@ -5,7 +5,4 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
-  rules: {
-    'no-console': 'off',
-  },
 };

--- a/scripts/vitest-config/src/utils.ts
+++ b/scripts/vitest-config/src/utils.ts
@@ -9,7 +9,6 @@ import {
 } from '@modern-js/utils';
 
 export const debug: typeof console.log = (...args) => {
-  // eslint-disable-next-line no-console
   process.env.DEBUG_MODERNJS_VITEST && console.log(...args);
 };
 

--- a/scripts/vitestRunAll.js
+++ b/scripts/vitestRunAll.js
@@ -18,7 +18,6 @@ const restArgv = process.argv.slice(2);
     .map(dir => `--filter "${dir}..."`)
     .join(' ');
   const buildCmd = `pnpm ${pnpmFilters} run build`;
-  // eslint-disable-next-line no-console
   console.log('>', buildCmd);
 
   try {

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -2,7 +2,4 @@
 module.exports = {
   root: true,
   extends: ['@modern-js/eslint-config/lite'],
-  rules: {
-    'no-console': 0,
-  },
 };

--- a/tests/cypress/e2e/1-garfish/dashboard.cy.js
+++ b/tests/cypress/e2e/1-garfish/dashboard.cy.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
 import { getPublicPath } from '../../../utils/testCase';

--- a/tests/cypress/e2e/1-garfish/nested.cy.js
+++ b/tests/cypress/e2e/1-garfish/nested.cy.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
 import { getPublicPath } from '../../../utils/testCase';

--- a/tests/cypress/e2e/1-garfish/whole-process-rspack.cy.js
+++ b/tests/cypress/e2e/1-garfish/whole-process-rspack.cy.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
 import { getPublicPath, getAppInfo } from '../../../utils/testCase';

--- a/tests/cypress/e2e/1-garfish/whole-process.cy.js
+++ b/tests/cypress/e2e/1-garfish/whole-process.cy.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 /// <reference types="cypress" />
 import { getPublicPath, getAppInfo } from '../../../utils/testCase';

--- a/tests/e2e/builder/cases/legalComments/src/index.jsx
+++ b/tests/e2e/builder/cases/legalComments/src/index.jsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/manifest/src/index.jsx
+++ b/tests/e2e/builder/cases/manifest/src/index.jsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/node-polyfill/src/index.js
+++ b/tests/e2e/builder/cases/node-polyfill/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/output/assets-inline/src/index.js
+++ b/tests/e2e/builder/cases/output/assets-inline/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/output/assets-no-inline/src/index.js
+++ b/tests/e2e/builder/cases/output/assets-no-inline/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/output/assets-url/src/index.js
+++ b/tests/e2e/builder/cases/output/assets-url/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/output/assets/src/index.js
+++ b/tests/e2e/builder/cases/output/assets/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/output/assets__inline/src/index.js
+++ b/tests/e2e/builder/cases/output/assets__inline/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/output/externals/src/index.js
+++ b/tests/e2e/builder/cases/output/externals/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/source/basic/src/index.js
+++ b/tests/e2e/builder/cases/source/basic/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/source/basic/src/pre.js
+++ b/tests/e2e/builder/cases/source/basic/src/pre.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 const testEl = document.createElement('div');
 testEl.id = 'test-el';

--- a/tests/e2e/builder/cases/source/module-scopes/src/index.js
+++ b/tests/e2e/builder/cases/source/module-scopes/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/source/resolve-extension-prefix/src/ex.js
+++ b/tests/e2e/builder/cases/source/resolve-extension-prefix/src/ex.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 const testEl = document.createElement('div');
 testEl.id = 'test-el';

--- a/tests/e2e/builder/cases/source/resolve-extension-prefix/src/ex.web.js
+++ b/tests/e2e/builder/cases/source/resolve-extension-prefix/src/ex.web.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 const testEl = document.createElement('div');
 testEl.id = 'test-el';

--- a/tests/e2e/builder/cases/source/resolve-extension-prefix/src/index.js
+++ b/tests/e2e/builder/cases/source/resolve-extension-prefix/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/svg/svg-assets/src/index.js
+++ b/tests/e2e/builder/cases/svg/svg-assets/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/svg/svg-default-export-component/src/index.js
+++ b/tests/e2e/builder/cases/svg/svg-default-export-component/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/svg/svg-external-react/src/index.js
+++ b/tests/e2e/builder/cases/svg/svg-external-react/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/svg/svg-url/src/index.js
+++ b/tests/e2e/builder/cases/svg/svg-url/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/e2e/builder/cases/svg/svg/src/index.js
+++ b/tests/e2e/builder/cases/svg/svg/src/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 import React from 'react';
 import { render } from 'react-dom';

--- a/tests/generator/utils/tools.ts
+++ b/tests/generator/utils/tools.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable consistent-return */
 import { fs, execa, semver } from '@modern-js/utils';
 

--- a/tests/integration/asset-prefix/test/index.test.ts
+++ b/tests/integration/asset-prefix/test/index.test.ts
@@ -50,7 +50,6 @@ describe('asset prefix', () => {
     await page.goto(`${expected}`);
 
     const assetPrefix = await page.evaluate(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       return window.__assetPrefix__;
     });


### PR DESCRIPTION
## Motivations

If the ESLInt rules are too restrictive, it can be detrimental to the developer experience, and will cause a lot of `eslint-disable` comments.

I consulted the ByteDance code style guide and simplified some ESLint rules to be consistent with it.

Main changes: https://github.com/web-infra-dev/modern.js/pull/4043/files#diff-aaca3b5dde0cf9edd549873e1239bcf625e4c9603b312c3cdb6ecafa9817bcc4L77

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32d9aa2</samp>

This pull request removes or simplifies some eslint rules and comments from various files and packages in the `web-infra-dev/modern.js` repository. This improves the code quality, consistency, and maintainability of the project. It also adds a changeset file for the `@modern-js-app/eslint-config` package to document the patch version update and the chore message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32d9aa2</samp>

*  Add a changeset file to document the patch version update and the chore message for the `@modern-js-app/eslint-config` package ([link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-045d8cdcca382d09cce8ba76dbd337225b5ecbebdae2c6c898eb5568cea6a3d1R1-R8))
*  Remove the `@typescript-eslint/naming-convention` rule from the `.eslintrc.js` files of the `builder-cli`, `plugin-image-compress`, and `plugin-stylus` packages, as it was too strict and caused many lint errors ([link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-034e808f8d31a7c2a68c9da890272eab7901084fdb2267db99fcd3c75620ae6bL10), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-87222088ba94e48d4bf1139187c76ccc699ac8519ea1af55b1f0e181b4233ea4L10), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-e1f1faf3577050e81e9e028dc8a1366c7c9d02404bc20048bb5636c9bf6b3275L10))
*  Remove the `@babel/no-invalid-this`, `@typescript-eslint/ban-ts-comment`, and `eslint-comments/no-unlimited-disable` rules from the `.eslintrc.js` files of the `builder-rspack-provider`, `builder-shared`, `builder-webpack-provider`, `builder`, `plugin-esbuild`, and `plugin-node-polyfill` packages, as they were either unnecessary or too restrictive for the codebase ([link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-0035cd7fd722627732c2143e3913fddcbc6355da73fa2707bbf06fd9e3f389ffL47-L49), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-fc3eb1a83176bb91d6aa34b031ade16c37d0621be1e83cacea56921e24d57ec0L10-L11), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-d192e6b3d1569b17538a8b99f9af77a3273c64c9cddc50aa8402d59538ea2247L52-L54), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-59e1725b60df8f3d6e842b66955743153a0a168f913d7616afba573ffb850ac0L10-L11), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-cee5bd74d15d4609dc5da419fc8c0f984e4c29a8fe32c47f094b47a320bcb3adL52-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-58562acc17e5cdc97cd784c8dbd93af8cbe429f16cee60bb6a10ef67f9641e25L52-R10))
*  Remove the `@typescript-eslint/no-restricted-imports` rule and the code that defines the variables for its configuration from the `.eslintrc.js` files of the `plugin-esbuild` and `plugin-node-polyfill` packages, as the rule was too complex and caused many lint errors ([link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-cee5bd74d15d4609dc5da419fc8c0f984e4c29a8fe32c47f094b47a320bcb3adL1-L42), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-58562acc17e5cdc97cd784c8dbd93af8cbe429f16cee60bb6a10ef67f9641e25L1-L42))
*  Remove the redundant or unnecessary `// eslint-disable-next-line` or `/* eslint-disable */` comments from various files in the `builder-rspack-provider`, `builder-shared`, `builder-webpack-provider`, and `builder` packages, as the rules they disabled were already removed or disabled in the `.eslintrc.js` files ([link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-b15d72a4de50f8ca02e55a48d429dafd6f0fc1d6e96bce5b11eb1af61e4b7c37L69), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-735f5b8be1cf83658252c024057a521e92d9409767efc389e22e778a57da4b87L38), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eL1), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-2390ff2afad68fb8240df46c80e1dbf21b3c8fc1bfe19cb630fa5f2bca47ee84L1-L2), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-d5eeee9df182fa5582509233f33512a7d6a602181bab44209684c227bf9cf7e6L4), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-d2a53f946e21d626ec879ec06d6e94dbda7bc3bfd6d62be0a2d4874446e39f7bL83), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-d2a53f946e21d626ec879ec06d6e94dbda7bc3bfd6d62be0a2d4874446e39f7bL94), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-ffa8726585780699082224a70f2287daadae58e4182b5b64e522a9960afc64bcL239), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-a4504fca2d9827cddacdfe648cc40efb71325090e54ac8ae7b02095de4d6a17dL38), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-2fcf85aa561e61fdd87d9f99861aa671483a4017e6205afc2693b31e794bf95eL73), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3L222), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3L238), [link](https://github.com/web-infra-dev/modern.js/pull/4043/files?diff=unified&w=0#diff-94bad7f67a9adfac79c653b8f93c38977b1ae06fa8cc2f3d601c84c85afa8cc3L259))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
