### PR TITLE
feat: support skip build phase when run deploy command

### DIFF
--- a/.changeset/modern-frogs-camp.md
+++ b/.changeset/modern-frogs-camp.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat: support skip build phase when run deploy command
+feat: 支持在执行 deploy 命令时，跳过构建阶段

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -199,10 +199,17 @@ export const appTools = (
             '-c --config <config>',
             i18n.t(localeKeys.command.shared.config),
           )
+          .option(
+            '-s --skip-build',
+            i18n.t(localeKeys.command.shared.skipBuild),
+          )
           .description(i18n.t(localeKeys.command.deploy.describe))
           .action(async (options: DeployOptions) => {
-            const { build } = await import('./commands/build');
-            await build(api);
+            if (!options.skipBuild) {
+              const { build } = await import('./commands/build');
+              await build(api);
+            }
+
             const { deploy } = await import('./commands/deploy');
             await deploy(api, options);
             // eslint-disable-next-line no-process-exit

--- a/packages/solutions/app-tools/src/locale/en.ts
+++ b/packages/solutions/app-tools/src/locale/en.ts
@@ -3,6 +3,7 @@ export const EN_LOCALE = {
     shared: {
       analyze: 'analyze bundle size',
       config: 'specify config file',
+      skipBuild: 'skip the build phase',
     },
     dev: {
       describe: 'starting the dev server',

--- a/packages/solutions/app-tools/src/locale/zh.ts
+++ b/packages/solutions/app-tools/src/locale/zh.ts
@@ -3,6 +3,7 @@ export const ZH_LOCALE = {
     shared: {
       analyze: '分析构建产物体积，查看各个模块打包后的大小',
       config: '指定配置文件路径，可以为相对路径或绝对路径',
+      skipBuild: '跳过构建阶段',
     },
     dev: {
       describe: '启动开发服务器',

--- a/packages/solutions/app-tools/src/utils/types.ts
+++ b/packages/solutions/app-tools/src/utils/types.ts
@@ -12,6 +12,7 @@ export type BuildOptions = {
 
 export type DeployOptions = {
   config?: string;
+  skipBuild?: boolean;
 };
 
 export type StartOptions = {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f1e8e8</samp>

This pull request adds a new feature to the `@modern-js/app-tools` package that allows the user to skip the build phase when deploying the app. It also adds the English and Chinese translations for the new option `-s --skip-build` and updates the relevant files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f1e8e8</samp>

*  Add a new option `-s --skip-build` to the deploy command of the `@modern-js/app-tools` package to allow skipping the build phase when deploying the app ([link](https://github.com/web-infra-dev/modern.js/pull/4044/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL202-R212), [link](https://github.com/web-infra-dev/modern.js/pull/4044/files?diff=unified&w=0#diff-96bc59386bd0aecfd52724f9a2e14e502bacee107ca38fa72a9a834f5bcedbd8R6), [link](https://github.com/web-infra-dev/modern.js/pull/4044/files?diff=unified&w=0#diff-a86aec521f74ce94a132bf546f59fbf09b7e53c9948b84dbd8a633f2f1d7a1e5R6), [link](https://github.com/web-infra-dev/modern.js/pull/4044/files?diff=unified&w=0#diff-de395c261e5cce00659ac086d20be7f6bcdd5963ad92f78d1354abdaa492ea3fR15))
*  Document the new features in the changeset file `.changeset/modern-frogs-camp.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4044/files?diff=unified&w=0#diff-412571778b38f6c82c0c7daa2941e098487646b26e5d90cf109b7d8a0a9a244aR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
