### PR TITLE
fix: fix setAppContext

### DIFF
--- a/.changeset/friendly-shoes-flow.md
+++ b/.changeset/friendly-shoes-flow.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: merge with the latest context when calling `setAppContext`
+fix: 调用 `setAppContext` 时, 获取最新的 App Context 进行合并

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -73,7 +73,7 @@ export default ({
           debug(`server routes: %o`, routes);
 
           appContext = {
-            ...appContext,
+            ...api.useAppContext(),
             apiOnly,
             serverRoutes: routes,
           };
@@ -109,7 +109,7 @@ export default ({
         debug(`server routes: %o`, routes);
 
         appContext = {
-          ...appContext,
+          ...api.useAppContext(),
           entrypoints,
           serverRoutes: routes,
         };
@@ -155,7 +155,7 @@ export default ({
         }
 
         appContext = {
-          ...appContext,
+          ...api.useAppContext(),
           entrypoints,
           checkedEntries,
           apiOnly,
@@ -230,7 +230,7 @@ export default ({
           builder.addPlugins(resolvedConfig.builderPlugins);
 
           appContext = {
-            ...appContext,
+            ...api.useAppContext(),
             builder,
           };
           api.setAppContext(appContext);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 425bb9b</samp>

This pull request fixes a bug in the `app-tools` package that could cause app analysis or building to fail. It also updates the changeset file for the `@modern-js/app-tools` package with the fix messages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 425bb9b</samp>

*  Add changeset file for patch updates of `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4047/files?diff=unified&w=0#diff-7337ab40d32cbb1e909cd46896776845d253c5a664f7a91397c6920315f16be8R1-R6))
*  Fix `appContext` variable to merge with latest context from `api` object in `analyze` and `build` functions of `@modern-js/app-tools/src/analyze/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4047/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L76-R76), [link](https://github.com/web-infra-dev/modern.js/pull/4047/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L112-R112), [link](https://github.com/web-infra-dev/modern.js/pull/4047/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L158-R158), [link](https://github.com/web-infra-dev/modern.js/pull/4047/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L233-R233))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
