### PR TITLE
fix(doc-core): encode filepath to be compatible with Windows

### DIFF
--- a/.changeset/kind-deers-refuse.md
+++ b/.changeset/kind-deers-refuse.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): encode filename to be compatible with Windows
+
+fix(doc-core): encode filename 以修复 Windows 兼容问题
+

--- a/packages/cli/doc-core/src/node/mdx/loader.ts
+++ b/packages/cli/doc-core/src/node/mdx/loader.ts
@@ -87,8 +87,13 @@ export default async function mdxLoader(
         checkLinks(links, filepath, docDirectory, routeService);
       }
     }
+
+    // encode filename to be compatible with Windows
+    const encodedFilepath = encodeURIComponent(filepath);
     const result = `globalThis.__RSPRESS_PAGE_META ||= {};
-globalThis.__RSPRESS_PAGE_META["${filepath}"] = ${JSON.stringify(pageMeta)};
+globalThis.__RSPRESS_PAGE_META["${encodeURIComponent(
+      encodedFilepath,
+    )}"] = ${JSON.stringify(pageMeta)};
 ${compileResult}`;
     callback(null, result);
   } catch (e) {

--- a/packages/cli/doc-core/src/runtime/App.tsx
+++ b/packages/cli/doc-core/src/runtime/App.tsx
@@ -37,9 +37,11 @@ export async function initPageData(routePath: string): Promise<PageData> {
 
     // FIXME: when sidebar item is configured as link string, the sidebar text won't updated when page title changed
     // Reason: The sidebar item text depends on pageData, which is not updated when page title changed, because the pageData is computed once when build
+
+    const encodedPagePath = encodeURIComponent(pagePath);
     const { toc, title, frontmatter } = (
       globalThis.__RSPRESS_PAGE_META as RspressPageMeta
-    )[pagePath];
+    )[encodedPagePath];
     return {
       siteData,
       page: {

--- a/tests/jest-ut.config.js
+++ b/tests/jest-ut.config.js
@@ -49,7 +49,6 @@ module.exports = {
     '<rootDir>/packages/toolkit/e2e/',
     '<rootDir>/packages/cli/doc-core/',
     '<rootDir>/packages/toolkit/remark-container',
-    '<rootDir>/packages/solutions/module-tools-v2/compiled/',
     '<rootDir>/packages/solutions/module-tools/compiled/',
     '<rootDir>/packages/toolkit/utils/compiled/',
   ],


### PR DESCRIPTION
## Summary

Fix the `Bad character escape sequence` error in Windows:

```bash
Compile Error:
error[jsx]: JSX parsing error
  ┌─ docs\en\apis\app\runtime\core\use-runtime-context.mdx:2:114
  │
2 │ globalThis.__RSPRESS_PAGE_META["C:\Users\Admin\modern.js\packages\document\main-doc\docs\en\apis\app\runtime\core\use-runtime-context.mdx"] = {"toc":[{"text":"Usage","id":"usage","depth":2},{"text":"Function Signature","id":"function-signature","depth":2},{"text":"Return Value","id":"return-value","depth":3},{"text":"Example","id":"example","depth":2}],"title":"useRuntimeContext","frontmatter":{"title":"useRuntimeContext"}};
  │                                                                                                                  ^^ Bad character escape sequence, expected 4 hex characters
```

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4497668</samp>

This pull request fixes a bug in the `doc-core` package that caused errors on Windows when using special characters in markdown file paths. It encodes the file paths in the `loader.ts` and `App.tsx` files, and adds a changeset file to document the patch version update. It also removes a redundant line from the `jest-ut.config.js` file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4497668</samp>

*  Fix doc-core package to encode filepaths for Windows compatibility ([link](https://github.com/web-infra-dev/modern.js/pull/4050/files?diff=unified&w=0#diff-a566ae5e894b282eb04e5dfac055648d9707f4e96293def12c6a32a1bbd40dccL90-R96), [link](https://github.com/web-infra-dev/modern.js/pull/4050/files?diff=unified&w=0#diff-83d3eef494f6dbc908a9da313a6e6d19e86beca442ab64fd4e72657f790c6f12L40-R44), [link](https://github.com/web-infra-dev/modern.js/pull/4050/files?diff=unified&w=0#diff-615222748837ee84c840ceb5d6d3ad8cad0c3242428021125f4d520a4210bf4cR1-R8))
* Remove unnecessary line from `jest-ut.config.js` to avoid warning when running tests ([link](https://github.com/web-infra-dev/modern.js/pull/4050/files?diff=unified&w=0#diff-93582d322926c96a6d34101b4c200bdde48d82a5af07be294c41bd757ccb53e4L52))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
