### PR TITLE
feat(doc-core): support markdown global components

### DIFF
--- a/.changeset/swift-otters-hear.md
+++ b/.changeset/swift-otters-hear.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-core': minor
+---
+
+feat: support markdown global components
+feat: 支持在markdown作用域下注册全局组件

--- a/packages/cli/doc-core/src/node/mdx/options.ts
+++ b/packages/cli/doc-core/src/node/mdx/options.ts
@@ -12,6 +12,7 @@ import { remarkPluginToc } from './remarkPlugins/toc';
 import { rehypePluginCodeMeta } from './rehypePlugins/codeMeta';
 import { remarkPluginNormalizeLink } from './remarkPlugins/normalizeLink';
 import { remarkCheckDeadLinks } from './remarkPlugins/checkDeadLink';
+import { remarkBuiltin } from './remarkPlugins/builtin';
 
 export async function createMDXOptions(
   docDirectory: string,
@@ -23,6 +24,7 @@ export async function createMDXOptions(
   const {
     remarkPlugins: remarkPluginsFromConfig = [],
     rehypePlugins: rehypePluginsFromConfig = [],
+    globalComponents: globalComponentsFromConfig = [],
   } = config.doc?.markdown || {};
   const docPlugins = config.doc?.plugins || [];
   const remarkPluginsFromPlugins = docPlugins.flatMap(
@@ -31,6 +33,10 @@ export async function createMDXOptions(
   const rehypePluginsFromPlugins = docPlugins.flatMap(
     plugin => plugin.markdown?.rehypePlugins || [],
   ) as PluggableList;
+  const globalComponents = [
+    ...docPlugins.flatMap(plugin => plugin.markdown?.globalComponents || []),
+    ...globalComponentsFromConfig,
+  ];
   const defaultLang = config.doc?.lang || '';
   return {
     providerImportSource: '@mdx-js/react',
@@ -54,6 +60,12 @@ export async function createMDXOptions(
           root: docDirectory,
           base: config.doc?.base || '',
           routeService,
+        },
+      ],
+      globalComponents.length && [
+        remarkBuiltin,
+        {
+          globalComponents,
         },
       ],
       ...remarkPluginsFromConfig,

--- a/packages/cli/doc-core/src/node/mdx/remarkPlugins/builtin.ts
+++ b/packages/cli/doc-core/src/node/mdx/remarkPlugins/builtin.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import type { Plugin } from 'unified';
+import type { Root } from 'mdast';
+import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
+import { getASTNodeImport } from '@/node/utils/getASTNodeImport';
+
+/**
+ * A remark plugin to import all builtin components.
+ * @param options configure the global components.
+ * @returns A unified transformer.
+ */
+export const remarkBuiltin: Plugin<[{ globalComponents: string[] }], Root> = ({
+  globalComponents,
+}) => {
+  return tree => {
+    const demos: MdxjsEsm[] = globalComponents.map(componentPath => {
+      const filename = path.parse(componentPath).name;
+      const componentName = filename[0].toUpperCase() + filename.slice(1);
+      return getASTNodeImport(componentName, componentPath);
+    });
+
+    tree.children.unshift(...demos);
+  };
+};

--- a/packages/cli/doc-core/src/node/mdx/remarkPlugins/normalizeLink.ts
+++ b/packages/cli/doc-core/src/node/mdx/remarkPlugins/normalizeLink.ts
@@ -11,41 +11,12 @@ import {
   isExternalUrl,
 } from '@/shared/utils';
 import { PUBLIC_DIR } from '@/node/constants';
+import { getASTNodeImport } from '@/node/utils/getASTNodeImport';
 
 interface LinkNode {
   type: string;
   url?: string;
 }
-
-// Construct import statement for AST
-// Such as: import image1 from './test.png'
-const getASTNodeImport = (name: string, from: string) =>
-  ({
-    type: 'mdxjsEsm',
-    value: `import ${name} from "${from}"`,
-    data: {
-      estree: {
-        type: 'Program',
-        sourceType: 'module',
-        body: [
-          {
-            type: 'ImportDeclaration',
-            specifiers: [
-              {
-                type: 'ImportDefaultSpecifier',
-                local: { type: 'Identifier', name },
-              },
-            ],
-            source: {
-              type: 'Literal',
-              value: from,
-              raw: `"${from}"`,
-            },
-          },
-        ],
-      },
-    },
-  } as MdxjsEsm);
 
 export function extractLangFromFilePath(filePath: string) {
   const [lang] = filePath.split(path.sep);

--- a/packages/cli/doc-core/src/node/utils/getASTNodeImport.ts
+++ b/packages/cli/doc-core/src/node/utils/getASTNodeImport.ts
@@ -1,0 +1,31 @@
+import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
+
+// Construct import statement for AST
+// Such as: import image1 from './test.png'
+export const getASTNodeImport = (name: string, from: string) =>
+  ({
+    type: 'mdxjsEsm',
+    value: `import ${name} from "${from}"`,
+    data: {
+      estree: {
+        type: 'Program',
+        sourceType: 'module',
+        body: [
+          {
+            type: 'ImportDeclaration',
+            specifiers: [
+              {
+                type: 'ImportDefaultSpecifier',
+                local: { type: 'Identifier', name },
+              },
+            ],
+            source: {
+              type: 'Literal',
+              value: from,
+              raw: `"${from}"`,
+            },
+          },
+        ],
+      },
+    },
+  } as MdxjsEsm);

--- a/packages/cli/doc-core/src/shared/types/Plugin.ts
+++ b/packages/cli/doc-core/src/shared/types/Plugin.ts
@@ -28,6 +28,7 @@ export interface DocPlugin {
   markdown?: {
     remarkPlugins?: PluggableList;
     rehypePlugins?: PluggableList;
+    globalComponents?: string[];
   };
   /**
    * Builder config.

--- a/packages/cli/doc-core/src/shared/types/index.ts
+++ b/packages/cli/doc-core/src/shared/types/index.ts
@@ -284,6 +284,7 @@ export interface MarkdownOptions {
   checkDeadLinks?: boolean;
   experimentalMdxRs?: boolean;
   showLineNumbers?: boolean;
+  globalComponents?: string[];
 }
 
 export interface UserConfig {

--- a/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
@@ -130,3 +130,10 @@ import MdxRs from '../../fragments/mdx-rs';
 - Type: `boolean`
 
 Whether to display the line number of the code block. Defaults to `false`.
+
+
+### markdown.globalComponents
+
+- Type: `string[]`
+
+Register component to the global scope, which will make it automatically available in every MDX file, without any import statements.

--- a/packages/document/doc-tools-doc/docs/en/plugin/system/plugin-api.mdx
+++ b/packages/document/doc-tools-doc/docs/en/plugin/system/plugin-api.mdx
@@ -186,7 +186,7 @@ When the `beforeBuild` hook is executed, the `config` plugins of all plugins hav
 
 - **Type**：`{ remarkPlugins?: Plugin[]; rehypePlugins?: Plugin[] }`
 
-It is used to extend the compilation ability of Markdown/MDX. If you want to add custom remark/rehype plug-ins, you can use `markdown.remarkPlugins/markdown.rehypePlugins` to achieve:
+It is used to extend the compilation ability of Markdown/MDX. If you want to add custom remark/rehype plugins or MDX globalComponents, you can use `markdown` options to achieve:
 
 ```tsx title="plugin.ts"
 import { DocPlugin } from '@modern-js/doc-tools';
@@ -200,6 +200,9 @@ export function pluginForDoc(): DocPlugin {
       ],
       rehypePlugins: [
         // Add custom rehype plugin
+      ],
+      globalComponents: [
+        // Register global components for MDX
       ],
     },
   };

--- a/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
@@ -130,3 +130,10 @@ import MdxRs from '../../fragments/mdx-rs';
 - Type: `boolean`
 
 是否显示代码块的行号。默认为 `false`。
+
+
+### markdown.globalComponents
+
+- Type: `string[]`
+
+注册全局组件，无需通过导入声明，就允许在每个 MDX 文件中使用

--- a/packages/document/doc-tools-doc/docs/zh/plugin/system/plugin-api.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/plugin/system/plugin-api.mdx
@@ -189,9 +189,9 @@ export function pluginForDoc(): DocPlugin {
 
 ### markdown
 
-- **类型**：`{ remarkPlugins?: Plugin[]; rehypePlugins?: Plugin[] }`
+- **类型**：`{ remarkPlugins?: Plugin[]; rehypePlugins?: Plugin[]; globalComponents?: string[] }`
 
-用于扩展 Markdown/MDX 的编译能力，如果你想要添加自定义的 remark/rehype 插件，可以通过 `markdown.remarkPlugins/markdown.rehypePlugins` 来实现：
+用于扩展 Markdown/MDX 的编译能力，如果你想要添加自定义的 remark/rehype 插件以及 MDX 里的全局组件，可以通过 `markdown` 配置来实现：
 
 ```tsx title="plugin.ts"
 import { DocPlugin } from '@modern-js/doc-tools';
@@ -207,6 +207,9 @@ export function pluginForDoc(): DocPlugin {
       ],
       rehypePlugins: [
         // 添加自定义的 rehype 插件
+      ],
+      globalComponents: [
+        // 为 MDX 注册全局组件
       ],
     },
   };


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afc05b9</samp>

This pull request adds a new feature to the `@modern-js/doc-core` package, which allows doc plugins to register global components that can be used in markdown files. It implements a new remark plugin `remarkBuiltin` that inserts import statements for the global components, and adds new options and types to support this feature. It also refactors some existing code and adds a changeset file to document the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at afc05b9</samp>

*  Add `remarkBuiltin` plugin to import global components in markdown AST ([link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R15),[link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R65-R70),[link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-78474fc4dd391b52c3146588775740509b240d1ff6160dd586516f7a652d5773R1-R24))
*  Add `globalComponents` parameter and property to specify paths to global components ([link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R27),[link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-7d6d0deef427fad42c67bae3777f043e19a53ff6255620c16420bf57597864e1R36-R39),[link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-fcbad2de417f238c600c4131d79ef12dd4ddb45908a4f0097639791f7b4b27a5R31),[link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-3b9ef78ff832598dcdf880304579f2f3fc95e1dc287ff5a94f1d0e04b162927eR287))
*  Add `getASTNodeImport` utility function to create import statements for AST nodes ([link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-611f4838e8482ebb8b0d41980dcd03bba2178cc1231c787382bc3fa459dae9f5R14),[link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-4566742424408602aa69ddb9f45c0d096da02883bc5ed181f9bbbb98d3d81134R1-R31))
*  Remove redundant `getASTNodeImport` function from `normalizeLink` plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-611f4838e8482ebb8b0d41980dcd03bba2178cc1231c787382bc3fa459dae9f5L20-L49))
*  Add changeset file to document features and bump minor version of `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4051/files?diff=unified&w=0#diff-7ba0a57fea1b49f222053215234daf50fb6e6f27f7d130de9d423af0b3c12ee3R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
