### PR TITLE
WIP feat: support for fallback SSR using request header fields

### DIFF
--- a/.changeset/shy-elephants-walk.md
+++ b/.changeset/shy-elephants-walk.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/prod-server': patch
+'@modern-js/utils': patch
+---
+
+feat: support for fallback SSR using request header fields
+feat: 支持通过请求头字段来降级 SSR

--- a/packages/server/prod-server/src/libs/render/index.ts
+++ b/packages/server/prod-server/src/libs/render/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { mime } from '@modern-js/utils';
+import { cutNameByHyphen, mime } from '@modern-js/utils';
 import type { ModernServerContext } from '@modern-js/types';
 import { RenderResult, ServerHookRunner } from '../../type';
 import { ModernRoute } from '../route';
@@ -14,11 +14,13 @@ export const createRenderHandler = ({
   staticGenerate,
   forceCSR,
   nonce,
+  metaName = 'modern-js',
 }: {
   distDir: string;
   staticGenerate: boolean;
   forceCSR?: boolean;
   nonce?: string;
+  metaName?: string;
 }) =>
   async function render({
     ctx,
@@ -48,7 +50,10 @@ export const createRenderHandler = ({
     }
 
     // handles ssr first
-    const useCSR = forceCSR && ctx.query.csr;
+    const useCSR =
+      forceCSR &&
+      (ctx.query.csr ||
+        ctx.headers[`x-${cutNameByHyphen(metaName)}-ssr-fallback`]);
     if (route.isSSR && !useCSR) {
       try {
         const result = await ssr.render(

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -113,6 +113,8 @@ export class ModernServer implements ModernServerInterface {
 
   private readonly staticGenerate: boolean;
 
+  private readonly metaName?: string;
+
   constructor({
     pwd,
     config,
@@ -122,6 +124,7 @@ export class ModernServer implements ModernServerInterface {
     metrics,
     runMode,
     proxyTarget,
+    appContext,
   }: ModernServerOptions) {
     require('ignore-styles');
 
@@ -137,6 +140,7 @@ export class ModernServer implements ModernServerInterface {
     this.proxyTarget = proxyTarget;
     this.staticGenerate = staticGenerate || false;
     this.runMode = runMode || RUN_MODE.FULL;
+    this.metaName = appContext?.metaName;
     // process.env.BUILD_TYPE = `${this.staticGenerate ? 'ssg' : 'ssr'}`;
   }
 
@@ -144,7 +148,7 @@ export class ModernServer implements ModernServerInterface {
   public async onInit(runner: ServerHookRunner, app: Server) {
     this.runner = runner;
 
-    const { distDir, staticGenerate, conf } = this;
+    const { distDir, staticGenerate, conf, metaName } = this;
 
     this.initReader();
 
@@ -179,6 +183,7 @@ export class ModernServer implements ModernServerInterface {
       staticGenerate,
       forceCSR,
       nonce: conf.security?.nonce,
+      metaName,
     });
 
     await this.setupBeforeProdMiddleware();

--- a/packages/server/prod-server/src/type.ts
+++ b/packages/server/prod-server/src/type.ts
@@ -38,6 +38,7 @@ export type ModernServerOptions = {
     sharedDirectory: string;
     apiDirectory: string;
     lambdaDirectory: string;
+    metaName: string;
   };
   serverConfigFile?: string;
   proxyTarget?: any;

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -27,8 +27,14 @@ export const dev = async (
   normalizedConfig = { ...normalizedConfig, cliOptions: options };
   ResolvedConfigContext.set(normalizedConfig);
 
-  const { appDirectory, distDirectory, port, apiOnly, serverConfigFile } =
-    appContext;
+  const {
+    appDirectory,
+    distDirectory,
+    port,
+    apiOnly,
+    serverConfigFile,
+    metaName,
+  } = appContext;
 
   await buildServerConfig({
     appDirectory,
@@ -60,6 +66,7 @@ export const dev = async (
       ...normalizedConfig.tools?.devServer,
     },
     appContext: {
+      metaName,
       appDirectory: appContext.appDirectory,
       sharedDirectory: appContext.sharedDirectory,
       apiDirectory: appContext.apiDirectory,

--- a/packages/solutions/app-tools/src/commands/serve.ts
+++ b/packages/solutions/app-tools/src/commands/serve.ts
@@ -11,7 +11,7 @@ export const start = async (api: PluginAPI<AppTools<'shared'>>) => {
   const userConfig = api.useResolvedConfigContext();
   const hookRunners = api.useHookRunners();
 
-  const { appDirectory, port, serverConfigFile } = appContext;
+  const { appDirectory, port, serverConfigFile, metaName } = appContext;
 
   logger.log(chalk.cyan(`Starting the modern server...`));
   const apiOnly = await isApiOnly(
@@ -32,6 +32,7 @@ export const start = async (api: PluginAPI<AppTools<'shared'>>) => {
       },
     },
     appContext: {
+      metaName,
       sharedDirectory: getTargetDir(
         appContext.sharedDirectory,
         appContext.appDirectory,

--- a/packages/solutions/app-tools/src/utils/env.ts
+++ b/packages/solutions/app-tools/src/utils/env.ts
@@ -1,8 +1,9 @@
+import { cutNameByHyphen } from '@modern-js/utils';
 import type { IAppContext } from '../types';
 
 export function getAutoInjectEnv(appContext: IAppContext) {
   const { metaName } = appContext;
-  const prefix = `${metaName.split(/[-_]/)[0]}_`.toUpperCase();
+  const prefix = `${cutNameByHyphen(metaName)}_`.toUpperCase();
   const envReg = new RegExp(`^${prefix}`);
   return Object.keys(process.env).reduce((prev, key) => {
     const value = process.env[key];

--- a/packages/toolkit/utils/src/cli/path.ts
+++ b/packages/toolkit/utils/src/cli/path.ts
@@ -77,3 +77,7 @@ export const removeTailSlash = (s: string): string => s.replace(/\/+$/, '');
 
 export const removeSlash = (s: string): string =>
   removeLeadingSlash(removeTailSlash(s));
+
+export const cutNameByHyphen = (s: string) => {
+  return s.split(/[-_]/)[0];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7862,6 +7862,34 @@ importers:
         specifier: ^5
         version: 5.0.4
 
+  tests/integration/ssr/fixtures/fallback:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^18.0.1
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.0.1
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/tsconfig':
+        specifier: workspace:*
+        version: link:../../../../../packages/review/tsconfig
+      '@types/react':
+        specifier: ^18
+        version: 18.0.21
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.0.6
+      typescript:
+        specifier: ^5
+        version: 5.0.4
+
   tests/integration/ssr/fixtures/init:
     dependencies:
       '@modern-js/app-tools':

--- a/tests/integration/ssr/fixtures/fallback/modern.config.ts
+++ b/tests/integration/ssr/fixtures/fallback/modern.config.ts
@@ -1,0 +1,24 @@
+import { appTools, defineConfig } from '@modern-js/app-tools';
+
+const bundler = process.env.BUNDLER;
+
+export default defineConfig({
+  runtime: {
+    router: true,
+  },
+  server: {
+    ssr: {
+      forceCSR: true,
+    },
+  },
+  tools: {
+    webpack(config) {
+      config.output!.chunkLoadingGlobal = 'hello xxx';
+    },
+  },
+  plugins: [
+    appTools({
+      bundler: bundler === 'rspack' ? 'experimental-rspack' : 'webpack',
+    }),
+  ],
+});

--- a/tests/integration/ssr/fixtures/fallback/package.json
+++ b/tests/integration/ssr/fixtures/fallback/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ssr-base-fallback-test",
+  "version": "2.9.0",
+  "private": true,
+  "scripts": {
+    "dev": "modern dev"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18.0.1",
+    "react-dom": "^18.0.1"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/tsconfig": "workspace:*",
+    "typescript": "^5",
+    "@types/react": "^18",
+    "@types/react-dom": "^18"
+  }
+}

--- a/tests/integration/ssr/fixtures/fallback/src/modern-app-env.d.ts
+++ b/tests/integration/ssr/fixtures/fallback/src/modern-app-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@modern-js/runtime/types' />
+/// <reference types='@modern-js/runtime/types/router' />

--- a/tests/integration/ssr/fixtures/fallback/src/routes/layout.tsx
+++ b/tests/integration/ssr/fixtures/fallback/src/routes/layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from '@modern-js/runtime/router';
+
+export default function Layout() {
+  return (
+    <div>
+      Root layout
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/ssr/fixtures/fallback/src/routes/page.tsx
+++ b/tests/integration/ssr/fixtures/fallback/src/routes/page.tsx
@@ -1,0 +1,3 @@
+export default function Layout() {
+  return <div>page</div>;
+}

--- a/tests/integration/ssr/fixtures/fallback/tsconfig.json
+++ b/tests/integration/ssr/fixtures/fallback/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ],
+      "@shared/*": [
+        "./shared/*"
+      ],
+      "@api/*": [
+        "./api/*"
+      ]
+    }
+  },
+  "include": [
+    "src",
+    "shared",
+    "config",
+    "modern.config.ts",
+    "api"
+  ]
+}

--- a/tests/integration/ssr/test/base-fallback.test.js
+++ b/tests/integration/ssr/test/base-fallback.test.js
@@ -1,0 +1,86 @@
+const dns = require('node:dns');
+const { join } = require('path');
+const path = require('path');
+const puppeteer = require('puppeteer');
+const {
+  launchApp,
+  getPort,
+  killApp,
+  launchOptions,
+} = require('../../../utils/modernTestUtils');
+
+dns.setDefaultResultOrder('ipv4first');
+const fixtureDir = path.resolve(__dirname, '../fixtures');
+
+async function basicUsage(page, appPort) {
+  await page.setExtraHTTPHeaders({
+    'x-modern-js-ssr-fallback': '1',
+  });
+  const response = await page.goto(`http://localhost:${appPort}`, {
+    waitUntil: ['networkidle0'],
+  });
+  const text = await response.text();
+  expect(text).toMatch('<!--<?- html ?>-->');
+}
+
+describe('Traditional SSR', () => {
+  let app,
+    appPort,
+    /** @type {puppeteer.Page} */
+    page,
+    /** @type {puppeteer.Browser} */
+    browser;
+
+  beforeAll(async () => {
+    const appDir = join(fixtureDir, 'fallback');
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort);
+
+    browser = await puppeteer.launch(launchOptions);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    if (browser) {
+      browser.close();
+    }
+    if (app) {
+      await killApp(app);
+    }
+  });
+
+  it(`basic usage`, async () => {
+    await basicUsage(page, appPort);
+  });
+});
+
+describe('Traditional SSR with rspack', () => {
+  let app,
+    appPort,
+    /** @type {puppeteer.Page} */
+    page,
+    /** @type {puppeteer.Browser} */
+    browser;
+
+  beforeAll(async () => {
+    const appDir = join(fixtureDir, 'fallback');
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort, {}, { BUNDLER: 'rspack' });
+
+    browser = await puppeteer.launch(launchOptions);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    if (browser) {
+      browser.close();
+    }
+    if (app) {
+      await killApp(app);
+    }
+  });
+
+  it(`basic usage`, async () => {
+    await basicUsage(page, appPort);
+  });
+});


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 855da0b</samp>

This pull request adds a `metaName` option to the `@modern-js/prod-server` and `@modern-js/app-tools` packages, which allows customizing the SSR behavior and environment variables based on the project name. It also adds a utility function `cutNameByHyphen` to the `@modern-js/utils` package, which is used to generate header and variable names from the `metaName` option. Additionally, it adds a test fixture and integration tests for the SSR fallback feature of the modern server, using both webpack and rspack bundlers.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 855da0b</samp>

*  Add a `.changeset` file to document the changes in the pull request ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-2411294ce9a16f482e9f83e5d148061c70e714a5e340d3d112f82d022b890e04R1-R8))
*  Add a `metaName` option to the `createRenderHandler` function and the `RenderOptions` type to customize the SSR fallback header and the auto-injected environment variables based on the project name ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bR17),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bR23),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bL51-R56))
*  Add a `metaName` property to the `ModernServer` class and the `ModernServerOptions` type to pass the `metaName` option to the `render` function and the `getAutoInjectEnv` function ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bR116-R117),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bR127),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bR143),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL147-R151),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bR186),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-43eeb40674837c6fea50840b269fbf2cc78be93bb1445caed035d0897ce76f47R41))
*  Add a `metaName` property to the `appContext` object in the `dev.ts` and `serve.ts` files, and generate it by calling the `cutNameByHyphen` function with the `name` property of the `package.json` file ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-c5e04e972eb500f233ab890a23fb40f4f77c017c51676f25562d1f37b356564aL30-R37),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-c5e04e972eb500f233ab890a23fb40f4f77c017c51676f25562d1f37b356564aR69),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-dfb668e02ff0e10c6c5eac1774fc425572c888c7bc40da98458b6c95bea01521L14-R14),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-dfb668e02ff0e10c6c5eac1774fc425572c888c7bc40da98458b6c95bea01521R35))
*  Replace the `metaName.split(/[-_]/)[0]` expression with the `cutNameByHyphen` function call in the `getAutoInjectEnv` function in the `env.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-9f7daa840e950d7e12ca3d4fa2b0060e4edde0e098ea00cb190534c3a227079aL1-R6))
*  Add the `cutNameByHyphen` function to the `path.ts` file to extract the first part of a string that is separated by hyphens or underscores ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-f981da3eb5ebbaa20f23267609c16cd3b593daec343fe1ccdca2e918ee42bf09R80-R83))
*  Add a `fallback` test fixture to the `tests/integration/ssr/fixtures` directory to test the SSR fallback feature of the modern server, and customize the webpack output chunk loading global name to `hello xxx` ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-f76798186dd32f029e7514997ce2192fcdec0cf2fd36ba4a104dc829bfa8a3b2R1-R24),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-d62e581d7fdabc11efc5764e75adae93fee901b4690ab53df969344d7e32a404R1-R23),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-ee005cf07edbc2ac8110f2daf4ebb64442aae5eb6b5df9c3487cf17edc5d2c02R1-R10),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-a4d8519c8aa0b246a50fa5fd7362b8a456c53aef59dc539b5a7b9d0b5c315ff1R1-R3),[link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-8184c07adcb6bd6f5d2cc9077738165778063339ed41cb2d254850a183cf50a3L1-R25))
*  Add a `base-fallback.test.js` file to the `tests/integration/ssr/test` directory to test the SSR fallback feature with both webpack and rspack bundlers, using the `puppeteer` library and the `fallback` test fixture ([link](https://github.com/web-infra-dev/modern.js/pull/4053/files?diff=unified&w=0#diff-d5bd76108a70acb8b5cca036d57cf2d5e7915a9eabcf4ec2ee4ab571acf1d476R1-R86))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
