### PR TITLE
fix(doc-core): checkDeadLink failed in windows

### DIFF
--- a/.changeset/small-pets-clap.md
+++ b/.changeset/small-pets-clap.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): checkDeadLink failed in windows
+
+fix(doc-core): 死链检测在 windows 下失败

--- a/packages/cli/doc-core/src/node/mdx/loader.ts
+++ b/packages/cli/doc-core/src/node/mdx/loader.ts
@@ -89,10 +89,9 @@ export default async function mdxLoader(
     }
 
     // encode filename to be compatible with Windows
-    const encodedFilepath = encodeURIComponent(filepath);
     const result = `globalThis.__RSPRESS_PAGE_META ||= {};
 globalThis.__RSPRESS_PAGE_META["${encodeURIComponent(
-      encodedFilepath,
+      filepath,
     )}"] = ${JSON.stringify(pageMeta)};
 ${compileResult}`;
     callback(null, result);

--- a/packages/cli/doc-core/src/node/mdx/remarkPlugins/checkDeadLink.ts
+++ b/packages/cli/doc-core/src/node/mdx/remarkPlugins/checkDeadLink.ts
@@ -25,6 +25,7 @@ export function checkLinks(
   const errorInfos: string[] = [];
   links
     .filter(link => !IGNORE_REGEXP.test(link))
+    .map(link => link.replace(/\\/g, '/'))
     .forEach(link => {
       const relativePath = path.relative(root, filepath);
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 572cd52</samp>

This pull request fixes a bug in the `doc-core` package that caused incorrect page meta data and link checking on Windows systems. It also adds a changeset file to document the patch version update and the bilingual description of the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 572cd52</samp>

* Fix a bug in `doc-core` package that caused double encoding or decoding of MDX filepaths on Windows ([link](https://github.com/web-infra-dev/modern.js/pull/4054/files?diff=unified&w=0#diff-a566ae5e894b282eb04e5dfac055648d9707f4e96293def12c6a32a1bbd40dccL92-R94), [link](https://github.com/web-infra-dev/modern.js/pull/4054/files?diff=unified&w=0#diff-39ab36d9281cd24cd56337fa820c2f67a0a64d31b29d1c5a3e15bf2c86a6540bR28))
* Add a changeset file to document the patch version update and the bug fix for `doc-core` package in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4054/files?diff=unified&w=0#diff-0c579cf2a0a8f4d228be4608be95606a2459bc9a4e6d507222dc35dcac65cea2R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
