### PR TITLE
feat: new and upgrade command support custom config file

### DIFF
--- a/.changeset/tough-houses-relax.md
+++ b/.changeset/tough-houses-relax.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/monorepo-tools': patch
+'@modern-js/module-tools': patch
+'@modern-js/app-tools': patch
+'@modern-js/core': patch
+---
+
+feat: new and upgrade command support custom config file
+
+feat: new 和 upgrade 命令支持自定义配置文件路径

--- a/packages/cli/core/src/runBin.ts
+++ b/packages/cli/core/src/runBin.ts
@@ -35,7 +35,7 @@ export const run = async (
 
   /**
    * Commands that support specify config files
-   * Some commands can't support this feature, such as `new`
+   * `new` command need to use `--config-file` params,because `--config` is already used
    */
   const SUPPORT_CONFIG_PARAM_COMMANDS = [
     'dev',
@@ -44,11 +44,20 @@ export const run = async (
     'start',
     'serve',
     'inspect',
+    'upgrade',
   ];
 
-  const customConfigFile = cliParams.config || cliParams.c;
+  let customConfigFile;
 
-  if (SUPPORT_CONFIG_PARAM_COMMANDS.includes(command) && customConfigFile) {
+  if (SUPPORT_CONFIG_PARAM_COMMANDS.includes(command)) {
+    customConfigFile = cliParams.config || cliParams.c;
+  }
+
+  if (command === 'new') {
+    customConfigFile = cliParams['config-file'];
+  }
+
+  if (customConfigFile) {
     runOptions.configFile = customConfigFile;
   }
 

--- a/packages/document/main-doc/docs/en/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/commands.mdx
@@ -17,7 +17,7 @@ Usage: modern dev [options]
 
 Options:
   -e --entry <entry>    compiler by entry
-  -c --config <config>  configuration file path, which can be a relative path or an absolute path
+  -c --config <config>  specify the configuration file, which can be a relative or absolute path
   -h, --help            show command help
   --analyze             analyze the bundle and view size of each module
   --web-only            only start web service
@@ -77,7 +77,7 @@ The `modern build` command will build a production-ready product in the `dist/` 
 Usage: modern build [options]
 
 Options:
-  -c --config <config>  configuration file path, which can be a relative path or an absolute path
+  -c --config <config>  specify the configuration file, which can be a relative or absolute path
   -h, --help            show command help
   --analyze             analyze the bundle and view size of each module
 ```
@@ -112,6 +112,7 @@ For example, add application entry, enable some optional features such as Tailwi
 Usage: modern new [options]
 
 Options:
+  --config-file <configFile>  specify the configuration file, which can be a relative or absolute path
   --lang <lang>          set the language (zh or en) for the new command.
   -d, --debug            using debug mode to log something (default: false)
   -c, --config <config>  set default generator config(json string)
@@ -161,7 +162,7 @@ Usually use the `modern serve` command to enable project run in the production e
 Usage: modern serve [options]
 
 Options:
-  -c --config <config>  configuration file path, which can be a relative path or an absolute path
+  -c --config <config>  specify the configuration file, which can be a relative or absolute path
   -h, --help            show command help
   --api-only            only run API service
 ```
@@ -184,6 +185,7 @@ Execute the command `npx modern upgrade` in the project, by default, dependencie
 Usage: modern upgrade [options]
 
 Options:
+  --config <config> specify the configuration file, which can be a relative or absolute path
   --registry <registry>  specify npm registry (default: "")
   -d,--debug             using debug mode to log something (default: false)
   --cwd <cwd>            app directory (default: "")
@@ -201,7 +203,7 @@ Options:
   --env <env>           view the configuration in the target environment (default: "development")
   --output <output>     Specify the path to output in the dist (default: "/")
   --verbose             Show the full function in the result
-  -c --config <config>  configuration file path, which can be a relative path or an absolute path
+  -c --config <config>  specify the configuration file, which can be a relative or absolute path
   -h, --help            show command help
 ```
 

--- a/packages/document/main-doc/docs/zh/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/commands.mdx
@@ -112,6 +112,7 @@ File sizes after production build:
 Usage: modern new [options]
 
 Options:
+  --config-file <configFile>  指定配置文件路径，可以为相对路径或绝对路径
   --lang <lang>          设置 new 命令执行语言(zh 或者 en)
   -d, --debug            开启 Debug 模式，打印调试日志信息 (default: false)
   -c, --config <config>  生成器运行默认配置(JSON 字符串)
@@ -184,6 +185,7 @@ export default defineConfig({
 Usage: modern upgrade [options]
 
 Options:
+  -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   --registry <registry>  定制 npm registry (default: "")
   -d,--debug             开启 Debug 模式，打印调试日志信息 (default: false)
   --cwd <cwd>            项目路径 (default: "")

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -220,6 +220,10 @@ export const appTools = (
           .command('new')
           .usage('[options]')
           .description(i18n.t(localeKeys.command.new.describe))
+          .option(
+            '--config-file <configFile>',
+            i18n.t(localeKeys.command.shared.config),
+          )
           .option('--lang <lang>', i18n.t(localeKeys.command.new.lang))
           .option(
             '-c, --config <config>',
@@ -256,7 +260,14 @@ export const appTools = (
             inspect(api, options);
           });
 
-        upgradeModel.defineCommand(program.command('upgrade'));
+        upgradeModel.defineCommand(
+          program
+            .command('upgrade')
+            .option(
+              '-c --config <config>',
+              i18n.t(localeKeys.command.shared.config),
+            ),
+        );
       },
 
       async prepare() {

--- a/packages/solutions/app-tools/src/locale/en.ts
+++ b/packages/solutions/app-tools/src/locale/en.ts
@@ -2,7 +2,8 @@ export const EN_LOCALE = {
   command: {
     shared: {
       analyze: 'analyze bundle size',
-      config: 'specify config file',
+      config:
+        'specify the configuration file, which can be a relative or absolute path',
       skipBuild: 'skip the build phase',
     },
     dev: {

--- a/packages/solutions/module-tools/src/command.ts
+++ b/packages/solutions/module-tools/src/command.ts
@@ -28,7 +28,7 @@ export const buildCommand = async (
     .option('--no-clear', local.i18n.t(local.localeKeys.command.build.noClear))
     .option(
       '-c --config <config>',
-      local.i18n.t(local.localeKeys.command.build.config),
+      local.i18n.t(local.localeKeys.command.shared.config),
     )
     .action(async (options: BuildCommandOptions) => {
       const { initModuleContext } = await import('./utils/context');
@@ -101,6 +101,10 @@ export const newCommand = async (program: Command) => {
     .command('new')
     .usage('[options]')
     .description(local.i18n.t(local.localeKeys.command.new.describe))
+    .option(
+      '--config-file <configFile>',
+      local.i18n.t(local.localeKeys.command.shared.config),
+    )
     .option('--lang <lang>', local.i18n.t(local.localeKeys.command.new.lang))
     .option(
       '-c, --config <config>',
@@ -129,6 +133,14 @@ export const newCommand = async (program: Command) => {
 };
 
 export const upgradeCommand = async (program: Command) => {
+  const local = await import('./locale');
   const { defineCommand } = await import('@modern-js/upgrade');
-  defineCommand(program.command('upgrade'));
+  defineCommand(
+    program
+      .command('upgrade')
+      .option(
+        '-c --config <config>',
+        local.i18n.t(local.localeKeys.command.shared.config),
+      ),
+  );
 };

--- a/packages/solutions/module-tools/src/locale/en.ts
+++ b/packages/solutions/module-tools/src/locale/en.ts
@@ -10,7 +10,8 @@ const noDevTools = `There are no DevTools available, you can learn about them an
 export const EN_LOCALE = {
   command: {
     shared: {
-      config: 'specify config file',
+      config:
+        'sspecify the configuration file, which can be a relative or absolute path',
     },
     build: {
       describe: 'build the module for production',

--- a/packages/solutions/module-tools/src/locale/en.ts
+++ b/packages/solutions/module-tools/src/locale/en.ts
@@ -9,6 +9,9 @@ const noDevTools = `There are no DevTools available, you can learn about them an
 
 export const EN_LOCALE = {
   command: {
+    shared: {
+      config: 'specify config file',
+    },
     build: {
       describe: 'build the module for production',
       watch: 'building module in watch mode',
@@ -19,7 +22,6 @@ export const EN_LOCALE = {
       noTsc: 'close tsc compiler to emit d.ts (Deprecated)',
       dts: 'Turn on dts generation and type checking',
       noClear: 'disable auto clear dist dir',
-      config: 'specify config file',
     },
     dev: {
       describe: 'run and debug the module',

--- a/packages/solutions/module-tools/src/locale/zh.ts
+++ b/packages/solutions/module-tools/src/locale/zh.ts
@@ -9,6 +9,9 @@ const noDevTools = `暂无可用的 DevTools，你可以通过以下选项以及
 
 export const ZH_LOCALE = {
   command: {
+    shared: {
+      config: '指定配置文件路径，可以为相对路径或绝对路径',
+    },
     build: {
       describe: '构建生产环境产物',
       watch: '使用 Watch 模式构建模块',
@@ -19,7 +22,6 @@ export const ZH_LOCALE = {
       noTsc: '关闭 tsc 编译（废弃）',
       dts: '开启 dts 文件的生成以及类型检查',
       noClear: '不清理产物目录',
-      config: '指定配置文件路径，可以为相对路径或绝对路径',
     },
     dev: {
       describe: '运行和调试模块',

--- a/packages/solutions/monorepo-tools/src/cli/new.ts
+++ b/packages/solutions/monorepo-tools/src/cli/new.ts
@@ -7,6 +7,10 @@ export const newCli = (program: Command, locale?: string) => {
     .command('new')
     .usage('[options]')
     .description(i18n.t(localeKeys.command.new.describe))
+    .option(
+      '--config-file <configFile>',
+      i18n.t(localeKeys.command.shared.config),
+    )
     .option('--lang <lang>', i18n.t(localeKeys.command.new.lang))
     .option('-c, --config <config>', i18n.t(localeKeys.command.new.config))
     .option(

--- a/packages/solutions/monorepo-tools/src/index.ts
+++ b/packages/solutions/monorepo-tools/src/index.ts
@@ -3,7 +3,7 @@ import { changesetPlugin } from '@modern-js/plugin-changeset';
 import { lintPlugin } from '@modern-js/plugin-lint';
 import { Import } from '@modern-js/utils';
 import { getLocaleLanguage } from '@modern-js/plugin-i18n/language-detector';
-import { i18n } from './locale';
+import { i18n, localeKeys } from './locale';
 import { newCli, deployCli, clearCli } from './cli';
 import { hooks } from './hooks';
 import { MonorepoTools } from './type';
@@ -34,7 +34,14 @@ export const monorepoTools = (): CliPlugin<MonorepoTools> => ({
         clearCli(program, api);
         deployCli(program, api);
         newCli(program, locale);
-        upgradeModel.defineCommand(program.command('upgrade'));
+        upgradeModel.defineCommand(
+          program
+            .command('upgrade')
+            .option(
+              '-c --config <config>',
+              i18n.t(localeKeys.command.shared.config),
+            ),
+        );
       },
     };
   },

--- a/packages/solutions/monorepo-tools/src/locale/en.ts
+++ b/packages/solutions/monorepo-tools/src/locale/en.ts
@@ -1,5 +1,8 @@
 export const EN_LOCALE = {
   command: {
+    shared: {
+      config: 'specify config file',
+    },
     new: {
       describe: 'generator runner for monorepo project',
       debug: 'using debug mode to log something',

--- a/packages/solutions/monorepo-tools/src/locale/en.ts
+++ b/packages/solutions/monorepo-tools/src/locale/en.ts
@@ -1,7 +1,8 @@
 export const EN_LOCALE = {
   command: {
     shared: {
-      config: 'specify config file',
+      config:
+        'specify the configuration file, which can be a relative or absolute path',
     },
     new: {
       describe: 'generator runner for monorepo project',

--- a/packages/solutions/monorepo-tools/src/locale/zh.ts
+++ b/packages/solutions/monorepo-tools/src/locale/zh.ts
@@ -1,5 +1,8 @@
 export const ZH_LOCALE = {
   command: {
+    shared: {
+      config: '指定配置文件路径，可以为相对路径或绝对路径',
+    },
     new: {
       describe: 'Monorepo 创建子项目',
       debug: '开启 Debug 模式，打印调试日志信息',


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ccae41</samp>

This pull request adds support for custom config files to the `new` and `upgrade` commands in the `cli`, `app-tools`, `module-tools`, and `monorepo-tools` packages. It also updates the locale files and the changeset file to reflect the new feature. This feature gives users more flexibility and control over their project configurations.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ccae41</samp>

*  Add support for custom config files for `new` and `upgrade` commands in `app-tools`, `module-tools`, and `monorepo-tools` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-708f11e9c968486e9f060c8770daebc0b169d7456638c02eb85d48f7f215b5c9L47-R60), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR223-R226), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebL259-R270), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-a20cb2b1c80dd3f40ea746005d954c2efbe9a0fd79c14d1a90f18a20c2765fa7R104-R107), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-a20cb2b1c80dd3f40ea746005d954c2efbe9a0fd79c14d1a90f18a20c2765fa7L132-R145), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-d39b26085a0d7d94cae3228dabd2751af173b1f4316b534608d1c2388f1e4966R10-R13), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-7c1160007e67e48b78d371458745e86d05546576d0b6d10b11352446e5a4dc19L37-R44))
*  Add `shared.config` locale key for the `-c` and `--config` options in `en.ts` and `zh.ts` files in `app-tools`, `module-tools`, and `monorepo-tools` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-044266080bf8162ec64961353e7f64de96a77d536bc9b2aacda435ba28b0c55cR12-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-6f0fa3593edef4f07b0b158eda75b877e7307c02189b5681f15beef8195f02f2R12-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-d7fbf5c14fef1b06aade81cac0f888aa3d39a6b64e66c5b866baa0c136a203c8R3-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-fe6ca53c740956c0c902bb8bf9ecc91ae11db3f65aaffbb16e5d09f7fd851af0R3-R5))
*  Update the comment and logic for the `SUPPORT_CONFIG_PARAM_COMMANDS` constant in `runBin.ts` file in `cli` package ([link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-708f11e9c968486e9f060c8770daebc0b169d7456638c02eb85d48f7f215b5c9L38-R38))
*  Update the description for the `-c` and `--config` options in `build` command in `module-tools` package to use the `shared.config` locale key ([link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-a20cb2b1c80dd3f40ea746005d954c2efbe9a0fd79c14d1a90f18a20c2765fa7L31-R31))
*  Remove the unused `build.config` locale key from `en.ts` and `zh.ts` files in `module-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-044266080bf8162ec64961353e7f64de96a77d536bc9b2aacda435ba28b0c55cL22), [link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-6f0fa3593edef4f07b0b158eda75b877e7307c02189b5681f15beef8195f02f2L22))
*  Add a changeset file that describes the changes and the version bump for the packages ([link](https://github.com/web-infra-dev/modern.js/pull/4056/files?diff=unified&w=0#diff-f041862e9b19eb29a97a3212b658825eaddf2d7d57e31b48e062e94fb94da6caR1-R10))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
