### PR TITLE
docs: 修正文档中的`import { moduleTools, defineConfig } `导入错误

### DIFF
--- a/packages/document/module-doc/docs/en/guide/basic/before-getting-started.md
+++ b/packages/document/module-doc/docs/en/guide/basic/before-getting-started.md
@@ -167,7 +167,7 @@ The Module Tools configuration file - `modern.config.(j|t)s` - is provided in th
 By default, the contents of the generated configuration file are as follows.
 
 ```ts title="modern.config.ts"
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools,{  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -178,7 +178,7 @@ export default defineConfig({
 **We recommend using the `defineConfig` function**, but it is not mandatory to use it. So you can also return an object directly in the config file: the
 
 ``` ts title="modern.config.ts"
-import { moduleTools } from '@modern-js/module-tools';
+import  moduleTools  from '@modern-js/module-tools';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/en/guide/basic/modify-output-product.md
+++ b/packages/document/module-doc/docs/en/guide/basic/modify-output-product.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 When the `modern build` command is used in an initialized project, the products are generated according to the default configuration supported by Module Tools. The default supported configurations are specified as follows.
 
 ```ts title="modern.config.ts"
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -58,7 +58,7 @@ For example, if the output product is based on the preset string `"npm-library"`
 For example, to achieve the same effect as the preset string ``npm-library-es5"` using the form of a preset function, you can do the following.
 
 ```ts title="modern.config.ts"
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
@@ -22,7 +22,7 @@ When we want to test some modules, we can enable the test feature. When this fea
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { testingPlugin } from '@modern-js/plugin-testing';
 
 export default defineConfig({
@@ -41,7 +41,7 @@ The **Storybook feature** can be enabled when we want to debug a component or a 
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { storybookPlugin } from '@modern-js/plugin-storybook';
 
 export default defineConfig({
@@ -71,7 +71,7 @@ For more information on how to use Tailwind CSS in your module projects, check o
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { tailwindcssPlugin } from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({
@@ -94,7 +94,7 @@ Also, the Storybook debugging tool will determine if the project needs to use th
 :::tip
 After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import runtime from '@modern-js/runtime/cli';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/en/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/en/guide/intro/getting-started.md
@@ -54,7 +54,7 @@ npm install -D @modern-js/module-tools typescript
 Next, create the `modern.config.(t|j)s` file in the root of the project.
 
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
     plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.md
@@ -24,7 +24,7 @@ pnpm add @modern-js/plugin-module-babel -D
 You can install the plugin with the following command:
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({
@@ -42,7 +42,7 @@ See [babel options](https://babeljs.io/docs/options).
 Here is an example with `@babel/preset-env` configured
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-banner.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-banner.md
@@ -22,7 +22,7 @@ pnpm add @modern-js/plugin-module-banner -D
 You can install the plugin with the following command:
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
 
 export default defineConfig({
@@ -48,7 +48,7 @@ Note: CSS comments do not support the `//comment` syntax. Refer to [【CSS Comme
 
 ```ts
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 
 const copyRight = `/*

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-node-polyfill.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-node-polyfill.md
@@ -26,7 +26,7 @@ pnpm add @modern-js/plugin-module-node-polyfill -D
 In Module Tools, you can register plugins in the following way:
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -53,7 +53,7 @@ type NodePolyfillOptions = {
 Exclude the Node Polyfill to be injected.
 
 ``` ts focus=7:9
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -71,7 +71,7 @@ export default defineConfig({
 Override the built-in Node Polyfill.
 
 ``` ts focus=7:9
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.md
@@ -27,7 +27,7 @@ pnpm add @modern-js/plugin-module-polyfill -D
 In Module Tools, you can register plugins in the following way:
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({
@@ -55,7 +55,7 @@ See [Babel target](https://babeljs.io/docs/options#targets).
 This is a example.
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/guide/basic/before-getting-started.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/before-getting-started.md
@@ -167,7 +167,7 @@ npm install -g pnpm
 默认情况下，生成的配置文件的内容如下：
 
 ```ts title="modern.config.ts"
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/zh/guide/basic/modify-output-product.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/modify-output-product.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 当在初始化的项目里使用 `modern build` 命令的时候，会根据 Module Tools 默认支持的配置生成相应的产物。默认支持的配置具体如下：
 
 ```ts title="modern.config.ts"
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],
@@ -58,7 +58,7 @@ export default defineConfig({
 例如，如果使用预设函数的形式达到预设字符串 `"npm-library-es5"` 同样的效果，可以按照如下的方式：
 
 ```ts title="modern.config.ts"
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/zh/guide/basic/test-your-project.mdx
+++ b/packages/document/module-doc/docs/zh/guide/basic/test-your-project.mdx
@@ -11,7 +11,7 @@ sidebar_position: 6
 想要使用项目的测试功能，需要确保项目中包含依赖：`"@modern-js/plugin-testing"`，以及按照类似下面的内容进行配置：
 
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { testingPlugin } from '@modern-js/plugin-testing';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
@@ -21,7 +21,7 @@ sidebar_position: 4
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools,{ defineConfig } from '@modern-js/module-tools';
 import { testingPlugin } from '@modern-js/plugin-testing';
 
 export default defineConfig({
@@ -40,7 +40,7 @@ export default defineConfig({
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { storybookPlugin } from '@modern-js/plugin-storybook';
 
 export default defineConfig({
@@ -68,7 +68,7 @@ export default defineConfig({
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { tailwindcssPlugin } from '@modern-js/plugin-tailwindcss';
 
 export default defineConfig({
@@ -89,7 +89,7 @@ export default defineConfig({
 :::tip
 在成功开启后，会提示需要手动在配置中增加如下类似的代码。
 ``` ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import runtime from '@modern-js/runtime/cli';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
@@ -51,7 +51,7 @@ npm install -D @modern-js/module-tools typescript
 接着在项目的根目录下创建 `modern.config.(t|j)s` 文件：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.md
@@ -24,7 +24,7 @@ pnpm add @modern-js/plugin-module-babel -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({
@@ -42,7 +42,7 @@ See [Babel options](https://babeljs.io/docs/options)
 下面是一个配置了`@babel/preset-env`的例子：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-banner.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-banner.md
@@ -22,7 +22,7 @@ pnpm add @modern-js/plugin-module-banner -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
 
 export default defineConfig({
@@ -48,7 +48,7 @@ export default defineConfig({
 
 ```ts
 import { modulePluginBanner } from '@modern-js/plugin-module-banner';
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 const copyRight = `/*
  © Copyright 2020 xxx.com or one of its affiliates.

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-import.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-import.mdx
@@ -27,7 +27,7 @@ pnpm add @modern-js/plugin-module-import -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginImport } from '@modern-js/plugin-module-import';
 
 export default defineConfig({
@@ -65,7 +65,7 @@ type Options = {
 
 ```ts
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -111,7 +111,7 @@ import { MyButton as Btn } from 'foo';
 
 ```ts
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -132,7 +132,7 @@ export default defineConfig({
 
 ```ts focus=8:8
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [
@@ -162,7 +162,7 @@ import Btn from 'foo/es/MyButton';
 
 ```ts focus=8:8
 import { modulePluginImport } from '@modern-js/plugin-module-import';
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   plugins: [

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-node-polyfill.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-node-polyfill.md
@@ -26,7 +26,7 @@ pnpm add @modern-js/plugin-module-node-polyfill -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -53,7 +53,7 @@ type NodePolyfillOptions = {
 排除要注入的 Node Polyfill。
 
 ``` ts focus=7:9
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({
@@ -71,7 +71,7 @@ export default defineConfig({
 覆盖内置的 Node Polyfill。
 
 ``` ts focus=7:9
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginNodePolyfill } from '@modern-js/plugin-module-node-polyfill';
 
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.md
@@ -27,7 +27,7 @@ pnpm add @modern-js/plugin-module-polyfill -D
 在 Module Tools 中，你可以按照如下方式注册插件：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({
@@ -55,7 +55,7 @@ type options = {
 下面是一个例子：
 
 ```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import moduleTools, {  defineConfig } from '@modern-js/module-tools';
 import { modulePluginPolyfill } from '@modern-js/plugin-module-polyfill';
 
 export default defineConfig({


### PR DESCRIPTION
docs:  修正文档的`@modern-js/module-tools`导入错误 

```
// 原来是
import  {moduleTools, defineConfig } from "@modern-js/module-tools";
// 修正为：
import  moduleTools, { defineConfig } from "@modern-js/module-tools";

````


