### PR TITLE
fix(testing): jest unexpected token error for @modern-js/runtime

### DIFF
--- a/.changeset/orange-horses-wonder.md
+++ b/.changeset/orange-horses-wonder.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-testing': patch
+---
+
+fix: jest unexpected token error for @modern-js/runtime
+fix: 修复 Jest 对于 @modern-js/runtime 出现 unexpected token 的错误

--- a/packages/runtime/plugin-testing/src/cli/index.ts
+++ b/packages/runtime/plugin-testing/src/cli/index.ts
@@ -26,6 +26,26 @@ export const mergeUserJestConfig = (testUtils: TestConfigOperator) => {
   }
 };
 
+export const getJestTransformEsModulesRegStr = () => {
+  const esmModulesInPnpm = [
+    '@modern-js\\+runtime@',
+    '@modern-js\\+plugin@',
+    // @modern-js-reduck+store, @modern-js-reduck+effects and so on
+    '@modern-js-reduck',
+    '@babel\\+runtime@',
+  ];
+  // yarn or npm
+  const esmModules = [
+    '@modern-js/runtime',
+    '@modern-js/plugin',
+    '@modern-js-reduck',
+    '@babel/runtime',
+  ];
+  return `node_modules/(?!(\\.pnpm/(${esmModulesInPnpm.join(
+    '|',
+  )}))|(${esmModules.join('|')}))`;
+};
+
 export const testingPlugin = (): CliPlugin<{
   hooks: Hooks;
   userConfig: UserConfig;
@@ -128,6 +148,7 @@ export const testingPlugin = (): CliPlugin<{
               `<rootDir>/src/**/*.test.[jt]s?(x)`,
               `<rootDir>/tests/**/*.test.[jt]s?(x)`,
             ],
+            transformIgnorePatterns: [getJestTransformEsModulesRegStr()],
           });
 
           mergeUserJestConfig(utils);

--- a/packages/runtime/plugin-testing/tests/jestTransformEsModueRegExpStr.test.ts
+++ b/packages/runtime/plugin-testing/tests/jestTransformEsModueRegExpStr.test.ts
@@ -1,0 +1,25 @@
+import { getJestTransformEsModulesRegStr } from '../src/cli';
+
+describe('Jest transform esModules RegExp String ', () => {
+  const r = new RegExp(getJestTransformEsModulesRegStr());
+  it('In pnpm project', () => {
+    expect(r.test('node_modules/.pnpm/@modern-js+runtime@0.0.0')).toBeFalsy();
+    expect(r.test('node_modules/.pnpm/@modern-js+plugin@0.0.0')).toBeFalsy();
+    expect(
+      r.test('node_modules/.pnpm/@modern-js-reduck+store@0.0.0'),
+    ).toBeFalsy();
+    expect(
+      r.test('node_modules/.pnpm/@modern-js-reduck+plugin-effects@0.0.0'),
+    ).toBeFalsy();
+    expect(r.test('node_modules/apnpm/@modern-js+runtime@0.0.0')).toBeTruthy();
+    expect(r.test('node_modules/.pnpm/webpack')).toBeTruthy();
+  });
+
+  it('In npm or yarn@1 project', () => {
+    expect(r.test('node_modules/@modern-js/runtime')).toBeFalsy();
+    expect(r.test('node_modules/@modern-js/plugin')).toBeFalsy();
+    expect(r.test('node_modules/@modern-js-reduck/store')).toBeFalsy();
+    expect(r.test('node_modules/@modern-js-reduck/plugin-effects')).toBeFalsy();
+    expect(r.test('node_modules/webpack')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a165586</samp>

This pull request fixes a jest error for `@modern-js/runtime` by adding a `transformIgnorePatterns` option to the `@modern-js/plugin-testing` package. It also updates the changeset file for the patch release of the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a165586</samp>

*  Add a changeset file to document the patch updates for the `@modern-js/plugin-testing` package (.changeset/orange-horses-wonder.md)
*  Add a `transformIgnorePatterns` option to the `testingPlugin` function to exclude the `@modern-js/runtime` package from being transformed by jest ([link](https://github.com/web-infra-dev/modern.js/pull/4070/files?diff=unified&w=0#diff-03280beb0bbf5eaa5166abe24f86095e69cd4bbb15fbf4cdbd29f294b8a060aeR131-R133))

## Related Issue

<!--- Provide link of related issues -->
#3889

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
