### PR TITLE
test(builder): add more e2e cases for Vue 3 sfc

### DIFF
--- a/tests/e2e/builder/cases/vue/index.test.ts
+++ b/tests/e2e/builder/cases/vue/index.test.ts
@@ -46,3 +46,74 @@ test('should build basic Vue jsx correctly', async ({ page }) => {
 
   builder.close();
 });
+
+test('should build Vue sfc with lang="ts" correctly', async ({ page }) => {
+  const root = join(__dirname, 'sfc-lang-ts');
+
+  const builder = await build({
+    cwd: root,
+    entry: {
+      main: join(root, 'src/index.js'),
+    },
+    runServer: true,
+    plugins: [builderPluginVue()],
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.querySelector('#button').innerHTML`),
+  ).resolves.toBe('count: 0 foo: bar');
+
+  builder.close();
+});
+
+test('should build Vue sfc with lang="jsx" correctly', async ({ page }) => {
+  const root = join(__dirname, 'sfc-lang-jsx');
+
+  const builder = await build({
+    cwd: root,
+    entry: {
+      main: join(root, 'src/index.js'),
+    },
+    runServer: true,
+    plugins: [builderPluginVue()],
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.querySelector('#button').innerHTML`),
+  ).resolves.toBe('0');
+
+  await expect(
+    page.evaluate(`document.querySelector('#foo').innerHTML`),
+  ).resolves.toBe('Foo');
+
+  builder.close();
+});
+
+test('should build Vue sfc with lang="tsx" correctly', async ({ page }) => {
+  const root = join(__dirname, 'sfc-lang-tsx');
+
+  const builder = await build({
+    cwd: root,
+    entry: {
+      main: join(root, 'src/index.js'),
+    },
+    runServer: true,
+    plugins: [builderPluginVue()],
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.querySelector('#button').innerHTML`),
+  ).resolves.toBe('0');
+
+  await expect(
+    page.evaluate(`document.querySelector('#foo').innerHTML`),
+  ).resolves.toBe('Foo');
+
+  builder.close();
+});

--- a/tests/e2e/builder/cases/vue/sfc-lang-jsx/src/App.vue
+++ b/tests/e2e/builder/cases/vue/sfc-lang-jsx/src/App.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <button id="button" @click="count++">{{ count }}</button>
+    <Foo />
+  </div>
+</template>
+
+<script setup lang="jsx">
+import { ref } from 'vue';
+
+const Foo = () => {
+  return <div id="foo">Foo</div>;
+};
+
+const count = ref(0);
+</script>

--- a/tests/e2e/builder/cases/vue/sfc-lang-jsx/src/index.js
+++ b/tests/e2e/builder/cases/vue/sfc-lang-jsx/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#root');

--- a/tests/e2e/builder/cases/vue/sfc-lang-ts/src/App.vue
+++ b/tests/e2e/builder/cases/vue/sfc-lang-ts/src/App.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <button id="button" @click="count++">count: {{ count }} foo: {{ props.foo }}</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const props = defineProps<{
+  foo: string
+}>()
+
+const count = ref<number>(0);
+</script>

--- a/tests/e2e/builder/cases/vue/sfc-lang-ts/src/index.js
+++ b/tests/e2e/builder/cases/vue/sfc-lang-ts/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App, { foo: 'bar' }).mount('#root');

--- a/tests/e2e/builder/cases/vue/sfc-lang-tsx/src/App.vue
+++ b/tests/e2e/builder/cases/vue/sfc-lang-tsx/src/App.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <button id="button" @click="count++">{{ count }}</button>
+    <Foo />
+  </div>
+</template>
+
+<script setup lang="tsx">
+import { VNode, ref } from 'vue';
+
+const Foo = (): VNode => {
+  return <div id="foo">Foo</div>;
+};
+
+const count = ref<number>(0);
+</script>

--- a/tests/e2e/builder/cases/vue/sfc-lang-tsx/src/index.js
+++ b/tests/e2e/builder/cases/vue/sfc-lang-tsx/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#root');


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a826d6f</samp>

Added new e2e test cases for the builder plugin for Vue sfc with different script languages. The test cases cover `ts`, `jsx` and `tsx` as the `lang` attribute values in the `script setup` blocks. The test cases use the `@modern-js/e2e-test` package to build and verify the output of the components. The test cases are located in the `tests/e2e/builder/cases/vue` folder.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a826d6f</samp>

*  Add three test cases for Vue sfc with different script languages ([link](https://github.com/web-infra-dev/modern.js/pull/4072/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R49-R119))
* Use the `build`, `expect` and `getHrefByEntryName` functions from the `@modern-js/e2e-test` package to create and verify the builder instances ([link](https://github.com/web-infra-dev/modern.js/pull/4072/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R49-R119))
* Close the builder instances after each test ([link](https://github.com/web-infra-dev/modern.js/pull/4072/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R49-R119))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
