### PR TITLE
fix: the router-plugin should update source-map

### DIFF
--- a/.changeset/small-queens-remain.md
+++ b/.changeset/small-queens-remain.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: the router-plugin should update source-map
+fix: router-plugin 应该更新 sourcemap

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -18,12 +18,20 @@ type Compiler = webpack.Compiler | Rspack.Compiler;
 
 export class RouterPlugin {
   private isTargetNodeOrWebWorker(target: Compiler['options']['target']) {
-    return (
+    if (
       target === 'node' ||
-      (Array.isArray(target) && target.includes('node')) ||
+      (Array.isArray(target) && target.includes('node'))
+    ) {
+      return true;
+    }
+
+    if (
       target === 'webworker' ||
       (Array.isArray(target) && target.includes('webworker'))
-    );
+    ) {
+      return true;
+    }
+    return false;
   }
 
   apply(compiler: Compiler) {
@@ -183,6 +191,8 @@ export class RouterPlugin {
           })};
             })();
           `;
+
+          console.log('iiiiiiiii');
 
           const entrypointsArray = Array.from(
             compilation.entrypoints.entries() as IterableIterator<

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -192,8 +192,6 @@ export class RouterPlugin {
             })();
           `;
 
-          console.log('iiiiiiiii');
-
           const entrypointsArray = Array.from(
             compilation.entrypoints.entries() as IterableIterator<
               [string, unknown]

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -151,35 +151,22 @@ export class RouterPlugin {
             if (!asset) {
               continue;
             }
-            if (asset.sourceAndMap) {
-              const { source, map } = asset.sourceAndMap();
-              const newContent = `${injectedContent}${source.toString()}`;
-              const newSource = new SourceMapSource(
-                newContent,
-                file,
-                map,
-                source.toString(),
-                map,
-              );
+            const { source, map } = asset.sourceAndMap();
+            const newContent = `${injectedContent}${source.toString()}`;
+            const newSource = new SourceMapSource(
+              newContent,
+              file,
+              map,
+              source.toString(),
+              map,
+            );
 
-              compilation.updateAsset(
-                file,
-                newSource,
-                // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
-                undefined as any,
-              );
-            } else {
-              const newContent = `${injectedContent}${asset
-                .source()
-                .toString()}`;
-
-              compilation.updateAsset(
-                file,
-                new RawSource(newContent),
-                // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
-                undefined as any,
-              );
-            }
+            compilation.updateAsset(
+              file,
+              newSource,
+              // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
+              undefined as any,
+            );
           }
 
           if (prevManifestAsset) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f881cf6</samp>

This pull request fixes a bug in the `RouterPlugin` that prevented the source-map from updating correctly for the router assets. It also updates the `@modern-js/app-tools` package with a changeset file that documents the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f881cf6</samp>

* Fix the router-plugin to update the source-map for the generated assets ([link](https://github.com/web-infra-dev/modern.js/pull/4078/files?diff=unified&w=0#diff-6a80236b7a46854e8e9dc3e8b490bfc8bc2008b51b1bb371ebc75d7cfe2f3019R1-R6))
  * Replace the `RawSource` with the `SourceMapSource` to handle the assets that have source maps ([link](https://github.com/web-infra-dev/modern.js/pull/4078/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L37-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4078/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L158-R182))
  * Change the compilation stage to `PROCESS_ASSETS_STAGE_ADDITIONS` to run the plugin before the assets are emitted ([link](https://github.com/web-infra-dev/modern.js/pull/4078/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L37-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4078/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L55-R51))
  * Adjust the order of the injected content and the original source to avoid breaking the source map ([link](https://github.com/web-infra-dev/modern.js/pull/4078/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L158-R182))
* Remove an unused import of the `path` module from the `RouterPlugin.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4078/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
