### PR TITLE
feat(module-doc): support external demo

### DIFF
--- a/.changeset/itchy-news-drive.md
+++ b/.changeset/itchy-news-drive.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-plugin-preview': patch
+---
+
+feat(module-doc): support external demo
+
+feat(module-doc): 支持外部 demo

--- a/packages/cli/doc-plugin-preview/src/codeToDemo.ts
+++ b/packages/cli/doc-plugin-preview/src/codeToDemo.ts
@@ -9,6 +9,46 @@ import { injectDemoBlockImport, toValidVarName } from './utils';
 import { demoBlockComponentPath } from './constant';
 import { demoRoutes } from '.';
 
+const getExternalDemoContent = (tempVar: string) => ({
+  type: 'mdxJsxFlowElement',
+  name: 'pre',
+  children: [
+    {
+      type: 'mdxJsxFlowElement',
+      name: 'code',
+      attributes: [
+        {
+          type: 'mdxJsxAttribute',
+          name: 'className',
+          value: 'language-tsx',
+        },
+        {
+          type: 'mdxJsxAttribute',
+          name: 'children',
+          value: {
+            type: 'mdxJsxExpressionAttribute',
+            value: tempVar,
+            data: {
+              estree: {
+                type: 'Program',
+                body: [
+                  {
+                    type: 'ExpressionStatement',
+                    expression: {
+                      type: 'Identifier',
+                      name: tempVar,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  ],
+});
+
 /**
  * remark plugin to transform code to demo
  */
@@ -16,9 +56,99 @@ export const remarkCodeToDemo: Plugin<
   [{ isMobile: boolean; getRouteMeta: () => RouteMeta[] }],
   Root
 > = ({ isMobile, getRouteMeta }) => {
+  const routeMeta = getRouteMeta();
+
   return (tree, vfile) => {
     const demos: MdxjsEsm[] = [];
     let index = 1;
+    const route = routeMeta.find(meta => meta.absolutePath === vfile.path);
+    if (!route) {
+      return;
+    }
+    const { pageName } = route;
+
+    function constructDemoNode(
+      demoId: string,
+      demoPath: string,
+      currentNode: any,
+      isMobileMode: boolean,
+      // Only for external demo
+      externalDemoIndex?: number,
+    ) {
+      const demoRoute = `/~demo/${demoId}`;
+      if (isMobileMode) {
+        // only add demoRoutes in mobile mode
+        demoRoutes.push({
+          path: demoRoute,
+        });
+      } else {
+        demos.push(getASTNodeImport(`Demo${demoId}`, demoPath));
+      }
+      const tempVar = `externalDemoContent${externalDemoIndex}`;
+
+      if (externalDemoIndex !== undefined) {
+        demos.push(getASTNodeImport(tempVar, `${demoPath}?raw`));
+      }
+      Object.assign(currentNode, {
+        type: 'mdxJsxFlowElement',
+        name: 'Container',
+        attributes: [
+          {
+            type: 'mdxJsxAttribute',
+            name: 'isMobile',
+            value: isMobileMode,
+          },
+          {
+            type: 'mdxJsxAttribute',
+            name: 'url',
+            value: demoRoute,
+          },
+          {
+            type: 'mdxJsxAttribute',
+            name: 'isExternal',
+            value: externalDemoIndex !== undefined,
+          },
+        ],
+        children: [
+          externalDemoIndex === undefined
+            ? {
+                ...currentNode,
+                hasVisited: true,
+              }
+            : getExternalDemoContent(tempVar),
+          isMobileMode
+            ? {
+                type: 'mdxJsxFlowElement',
+                name: null,
+              }
+            : {
+                type: 'mdxJsxFlowElement',
+                name: `Demo${demoId}`,
+              },
+        ],
+      });
+    }
+    let externalDemoIndex = 0;
+    // 1. External demo , use <code src="xxx" /> to declare demo
+    tree.children.forEach((node: any) => {
+      if (node.type === 'mdxJsxFlowElement' && node.name === 'code') {
+        const src = node.attributes.find(
+          (attr: { name: string; value: string }) => attr.name === 'src',
+        )?.value;
+        const isMobileMode =
+          node.attributes.find(
+            (attr: { name: string; value: boolean }) =>
+              attr.name === 'isMobile',
+          )?.value ?? isMobile;
+        if (!src) {
+          return;
+        }
+        const id = `${toValidVarName(pageName)}_${index++}`;
+        constructDemoNode(id, src, node, isMobileMode, externalDemoIndex++);
+      }
+    });
+
+    // 2. Internal demo, use ```j/tsx to declare demo
     visit(tree, 'code', node => {
       // hasVisited is a custom property
       if ('hasVisited' in node) {
@@ -40,17 +170,13 @@ export const remarkCodeToDemo: Plugin<
           node?.meta?.includes('mobile') ||
           (!node?.meta?.includes('web') && isMobile);
 
-        const routeMeta = getRouteMeta();
-        const { pageName } = routeMeta.find(
-          meta => meta.absolutePath === vfile.path,
-        )!;
-        const id = `${toValidVarName(pageName)}_${index++}`;
         const demoDir = join(
           process.cwd(),
           'node_modules',
           '.modern-doc',
           `virtual-demo`,
         );
+        const id = `${toValidVarName(pageName)}_${index++}`;
         const virtualModulePath = join(demoDir, `${id}.tsx`);
         fs.ensureDirSync(join(demoDir));
         // Only when the content of the file changes, the file will be written
@@ -61,49 +187,7 @@ export const remarkCodeToDemo: Plugin<
             fs.writeFileSync(virtualModulePath, value);
           }
         }
-        demos.push(getASTNodeImport(`Demo${id}`, virtualModulePath));
-        const demoRoute = `/~demo/${id}`;
-
-        if (isMobileMode) {
-          // only add demoRoutes in mobile mode
-          demoRoutes.push({
-            path: demoRoute,
-          });
-        } else {
-          demos.push(getASTNodeImport(`Demo${id}`, virtualModulePath));
-        }
-        Object.assign(node, {
-          type: 'mdxJsxFlowElement',
-          name: 'Container',
-          attributes: [
-            {
-              type: 'mdxJsxAttribute',
-              name: 'isMobile',
-              value: isMobileMode,
-            },
-            {
-              type: 'mdxJsxAttribute',
-              name: 'url',
-              value: demoRoute,
-            },
-          ],
-          children: [
-            {
-              // if lang not change, this node will be visited again and again
-              ...node,
-              hasVisited: true,
-            },
-            isMobileMode
-              ? {
-                  type: 'mdxJsxFlowElement',
-                  name: null,
-                }
-              : {
-                  type: 'mdxJsxFlowElement',
-                  name: `Demo${id}`,
-                },
-          ],
-        });
+        constructDemoNode(id, virtualModulePath, node, isMobileMode);
       }
     });
     tree.children.unshift(...demos);

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -48,6 +48,49 @@ export function pluginPreview(options?: Options): DocPlugin {
             const source = await fs.readFile(filepath, 'utf-8');
             const ast = processor.parse(source);
             let index = 1;
+            const { pageName } = routeMeta.find(
+              meta => meta.absolutePath === filepath,
+            )!;
+
+            const registerDemo = (
+              demoId: string,
+              demoPath: string,
+              isMobileMode: boolean,
+            ) => {
+              if (isMobileMode) {
+                // only add demoMeta in mobile mode
+                demoMeta[filepath] = demoMeta[filepath] ?? [];
+                const isExist = demoMeta[filepath].find(
+                  item => item.id === demoId,
+                );
+                if (!isExist) {
+                  demoMeta[filepath].push({
+                    id: demoId,
+                    virtualModulePath: demoPath,
+                  });
+                }
+              }
+            };
+
+            visit(ast, 'mdxJsxFlowElement', (node: any) => {
+              if (node.name === 'code') {
+                const src = node.attributes.find(
+                  (attr: { name: string; value: string }) =>
+                    attr.name === 'src',
+                )?.value;
+                const isMobileMode =
+                  node.attributes.find(
+                    (attr: { name: string; value: boolean }) =>
+                      attr.name === 'isMobile',
+                  )?.value ?? isMobile;
+                if (!src) {
+                  return;
+                }
+                const id = `${toValidVarName(pageName)}_${index++}`;
+                registerDemo(id, src, isMobileMode);
+              }
+            });
+
             visit(ast, 'code', (node: any) => {
               if (node.lang === 'jsx' || node.lang === 'tsx') {
                 const { value } = node;
@@ -76,20 +119,7 @@ export function pluginPreview(options?: Options): DocPlugin {
                 );
 
                 const virtualModulePath = join(demoDir, `${id}.tsx`);
-
-                if (isMobileMode) {
-                  // only add demoMeta in mobile mode
-                  demoMeta[filepath] = demoMeta[filepath] ?? [];
-                  const isExist = demoMeta[filepath].find(
-                    item => item.id === id,
-                  );
-                  if (!isExist) {
-                    demoMeta[filepath].push({
-                      id,
-                      virtualModulePath,
-                    });
-                  }
-                }
+                registerDemo(id, virtualModulePath, isMobileMode);
 
                 fs.ensureDirSync(join(demoDir));
                 fs.writeFileSync(
@@ -147,6 +177,9 @@ import Demo from '${demoComponentPath}'
         },
         bundlerChain(chain) {
           chain.module
+            .rule('Raw')
+            .resourceQuery(/raw/)
+            .type('asset/source')
             .rule('MDX')
             .oneOf('MDXMeta')
             .before('MDXCompile')

--- a/packages/cli/doc-plugin-preview/static/global-components/Container.tsx
+++ b/packages/cli/doc-plugin-preview/static/global-components/Container.tsx
@@ -30,6 +30,7 @@ type ContainerProps = {
 
 const Container: React.FC<ContainerProps> = props => {
   const { children, isMobile, url } = props;
+
   const [showCode, setShowCode] = useState(false);
   const lang = useLang() || Object.keys(locales)[0];
   const dark = useDark();
@@ -41,6 +42,7 @@ const Container: React.FC<ContainerProps> = props => {
     // Do nothing in ssr
     return '';
   };
+
   const toggleCode = (e: any) => {
     if (!showCode) {
       e.target.blur();


### PR DESCRIPTION
## Summary

Support external demo for module doc.For example:

```md
<code src="../src/components/Button.tsx" />
```

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fd1e36</samp>

This pull request adds a new feature to the `@modern-js/doc-plugin-preview` package, which allows using external files as interactive demos for the code blocks in the module documentation. It also improves the code quality and functionality of the `codeToDemo` module and the `Container` component, and updates the webpack config and the changeset file accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fd1e36</samp>

*  Add support for external demo files for module documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-fe82ea875780f75c1d44390ed067b0a316c5c58addf6eff9f04727a39212a12cR1-R7))
  * Register external demo meta data by visiting AST nodes and finding `code` elements with `src` attribute ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR51-R93))
  * Generate AST node for rendering external demo content as code block with syntax highlighting ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eR12-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL19-R151))
  * Handle raw resource query for external demo files and return source code as asset in webpack config ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR180-R182))
  * Render external demo content as code block with syntax highlighting in `Container` component ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aR33), [link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aR45))
* Refactor and simplify code for constructing and registering demo nodes ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL43-L47), [link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eR179), [link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL64-R190), [link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaL79-R123))
  * Extract common logic of constructing demo node into `constructDemoNode` function ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL19-R151))
  * Use `registerDemo` function to avoid duplication of adding demo meta data to `demoMeta` object ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaR51-R93), [link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaL79-R123))
  * Assign demo node properties by using `constructDemoNode` function instead of repeating logic ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL64-R190))
  * Move code of generating `id` for demo node to the beginning of `visit` function to avoid duplication ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eR179))
  * Remove redundant code of getting `pageName` from `routeMeta` ([link](https://github.com/web-infra-dev/modern.js/pull/4079/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL43-L47))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
