### PR TITLE
fix(bundle-require): bundle esm package with cjs modules

### DIFF
--- a/.changeset/smart-cheetahs-clean.md
+++ b/.changeset/smart-cheetahs-clean.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/node-bundle-require': patch
+---
+
+fix(bundle-require): bundle esm package with cjs modules
+
+fix(bundle-require): 支持打包 esm package 包含 cjs 模块的情况

--- a/packages/toolkit/node-bundle-require/src/bundle.ts
+++ b/packages/toolkit/node-bundle-require/src/bundle.ts
@@ -173,17 +173,6 @@ export async function bundle(filepath: string, options?: Options) {
               const resolvedPath = require.resolve(args.path, {
                 paths: [args.resolveDir],
               });
-              if (resolvedPath.includes('yargs')) {
-                console.log(resolvedPath);
-                console.log(
-                  'BUNDLED_EXT_RE.test(resolvedPath)',
-                  BUNDLED_EXT_RE.test(resolvedPath),
-                );
-                console.log(
-                  'await isTypeModulePkg(resolvedPath)',
-                  await isTypeModulePkg(resolvedPath),
-                );
-              }
               // If it is a typescript or esm package, we should bundle it.
               if (
                 BUNDLED_EXT_RE.test(resolvedPath) ||

--- a/packages/toolkit/node-bundle-require/tests/fixture/inputImportEsmWithCjs.ts
+++ b/packages/toolkit/node-bundle-require/tests/fixture/inputImportEsmWithCjs.ts
@@ -1,0 +1,5 @@
+import { bar } from 'test-package-esm-with-cjs';
+
+export default {
+  bar,
+};

--- a/packages/toolkit/node-bundle-require/tests/fixture/test-package-esm-with-cjs/index.cjs
+++ b/packages/toolkit/node-bundle-require/tests/fixture/test-package-esm-with-cjs/index.cjs
@@ -1,0 +1,1 @@
+module.exports.bar = 1;

--- a/packages/toolkit/node-bundle-require/tests/fixture/test-package-esm-with-cjs/index.mjs
+++ b/packages/toolkit/node-bundle-require/tests/fixture/test-package-esm-with-cjs/index.mjs
@@ -1,0 +1,1 @@
+export const bar = 1;

--- a/packages/toolkit/node-bundle-require/tests/fixture/test-package-esm-with-cjs/package.json
+++ b/packages/toolkit/node-bundle-require/tests/fixture/test-package-esm-with-cjs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-package-esm-with-cjs",
+  "type": "module",
+  "main": "index.cjs",
+  "module": "index.mjs"
+}

--- a/packages/toolkit/node-bundle-require/tests/index.test.ts
+++ b/packages/toolkit/node-bundle-require/tests/index.test.ts
@@ -4,7 +4,11 @@ import { bundleRequire } from '../src';
 import { EXTERNAL_REGEXP } from '../src/bundle';
 
 describe('bundleRequire', () => {
-  const symlinkPackages = ['test-package-ts', 'test-package-esm'];
+  const symlinkPackages = [
+    'test-package-ts',
+    'test-package-esm',
+    'test-package-esm-with-cjs',
+  ];
 
   beforeAll(() => {
     symlinkPackages.forEach(pkg => {
@@ -49,6 +53,14 @@ describe('bundleRequire', () => {
   test('should bundle esm package correctly', async () => {
     const result = await bundleRequire(
       path.join(__dirname, './fixture/inputImportEsm.ts'),
+    );
+
+    expect(result.default).toEqual({ bar: 1 });
+  });
+
+  test('should bundle esm with cjs package correctly', async () => {
+    const result = await bundleRequire(
+      path.join(__dirname, './fixture/inputImportEsmWithCjs.ts'),
     );
 
     expect(result.default).toEqual({ bar: 1 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f23cc4</samp>

This pull request fixes the `node-bundle-require` tool to handle packages that have both esm and cjs modules, and adds a test case for this scenario. It also updates the package version and the changeset file with the fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f23cc4</samp>

*  Fix the bundle-require package to handle packages that have both esm and cjs files, and use the cjs file as the main entry point ([link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-5c46371fc0c3f5b6959c76f8611a5b4c9fc63afcf569e29200bf127319123205L29-R40), [link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-5c46371fc0c3f5b6959c76f8611a5b4c9fc63afcf569e29200bf127319123205R176-R186), [link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-19f896359e1fcb5fa82b2347591a7c9fa639efffa7feebcf47177b98e389d700R60-R67))
* Add a test package `test-package-esm-with-cjs` and a test fixture file `inputImportEsmWithCjs.ts` to verify the fix ([link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-c0effaf5da4d057a87715c21b6fc78ce2ca4f2b0d2cf5dc2ab6d49646cef3f04R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-55a03ba8d8a3cc30472099d0016327da61c7d8c6490e6e8661b8083be5aeee5dR1), [link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-16c77dd4c43a28612422096704e83e0861b18fdf8c14eb61ad55fc6b639888d8R1), [link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-d1690b30373836a6b7fd3dbca82deff4539c08478741520a1b6d173c4855ae94R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-19f896359e1fcb5fa82b2347591a7c9fa639efffa7feebcf47177b98e389d700L7-R11))
* Add a changeset file to document the patch version update and the fix message in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4080/files?diff=unified&w=0#diff-c0994c67a869eede2a60de693754e2e63777f64cf0885f82ccd0801dd0df4cf5R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
