### PR TITLE
fix: should use req.logger when createContext throw error

### DIFF
--- a/.changeset/breezy-cats-watch.md
+++ b/.changeset/breezy-cats-watch.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix: should use `req.logger` to log error when request handler throw error
+fix: 当请求处理函数出错时，应该使用 `req.logger` 来上报错误日志

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -666,7 +666,7 @@ export class ModernServer implements ModernServerInterface {
     try {
       context = this.createContext(req, res);
     } catch (e) {
-      this.logger.error(e as Error);
+      req.logger.error(e as Error);
       res.statusCode = 500;
       res.setHeader('content-type', mime.contentType('html') as string);
       return res.end(createErrorDocument(500, ERROR_PAGE_TEXT[500]));


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a690f2</samp>

This pull request fixes a logging bug in the `@modern-js/prod-server` package that caused errors to be logged with the wrong context. It also updates the changeset file to document the fix and bump the patch version.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a690f2</samp>

* Fix error logging in `ModernServer` class by using correct logger instance ([link](https://github.com/web-infra-dev/modern.js/pull/4082/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL669-R669))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
