### PR TITLE
fix(plugin-testing): missing babel-preset-app dependency

### DIFF
--- a/.changeset/modern-carpets-design.md
+++ b/.changeset/modern-carpets-design.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-testing': patch
+---
+
+fix(plugin-testing): missing babel-preset-app dependency
+
+fix(plugin-testing): 缺少 babel-preset-app 依赖

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -118,6 +118,7 @@
   "dependencies": {
     "@babel/core": "^7.21.8",
     "@babel/preset-env": "^7.21.5",
+    "@modern-js/babel-preset-app": "workspace:*",
     "@modern-js-reduck/plugin-auto-actions": "^1.1.10",
     "@modern-js-reduck/plugin-effects": "^1.1.10",
     "@modern-js-reduck/plugin-immutable": "^1.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3735,6 +3735,9 @@ importers:
       '@modern-js/babel-compiler':
         specifier: workspace:*
         version: link:../../toolkit/compiler/babel
+      '@modern-js/babel-preset-app':
+        specifier: workspace:*
+        version: link:../../cli/babel-preset-app
       '@modern-js/plugin':
         specifier: workspace:*
         version: link:../../toolkit/plugin


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98c8eb2</samp>

This pull request fixes a missing dependency issue in the `@modern-js/plugin-testing` package by adding `@modern-js/babel-preset-app` as a dependency. This allows the package to use the babel preset for modern.js applications when running tests.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 98c8eb2</samp>

*  Add missing dependency on `@modern-js/babel-preset-app` to `@modern-js/plugin-testing` package ([link](https://github.com/web-infra-dev/modern.js/pull/4091/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bR121), [link](https://github.com/web-infra-dev/modern.js/pull/4091/files?diff=unified&w=0#diff-72b99e9a5d4c08e4362bbb0626cf0718bb3a6e9cb4bb9d341d388024b2f12ed8R1-R7))
*  Update changeset file for `@modern-js/plugin-testing` package with patch level bump and fix summary ([link](https://github.com/web-infra-dev/modern.js/pull/4091/files?diff=unified&w=0#diff-72b99e9a5d4c08e4362bbb0626cf0718bb3a6e9cb4bb9d341d388024b2f12ed8R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
