### PR TITLE
fix(builder): checkSyntax targets should get default browserlist when only set checkSyntax.exclude

### DIFF
--- a/.changeset/fix-checksyntax-exclude.md
+++ b/.changeset/fix-checksyntax-exclude.md
@@ -5,4 +5,4 @@
 
 fix(builder): checkSyntax targets should get default browserlist when only set checkSyntax.exclude
 
-fix(builder): 当只设置 checkSyntax.exclude 时，checkSyntax targets 应该使用默认的 broserlists 值
+fix(builder): 当只设置 checkSyntax.exclude 时，checkSyntax targets 应该使用默认的 broserlist 值

--- a/.changeset/fix-checksyntax-exclude.md
+++ b/.changeset/fix-checksyntax-exclude.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): checkSyntax targets should get default browserlist when only set checkSyntax.exclude
+
+fix(builder): 当只设置 checkSyntax.exclude 时，checkSyntax targets 应该使用默认的 broserlists 值

--- a/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/index.ts
+++ b/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/index.ts
@@ -26,7 +26,10 @@ export class CheckSyntaxPlugin {
 
   exclude: CheckSyntaxExclude | undefined;
 
-  constructor(options: CheckSyntaxOptions) {
+  constructor(options: {
+    targets: string[];
+    exclude: CheckSyntaxOptions['exclude'];
+  }) {
     this.targets = options.targets;
     this.exclude = options.exclude;
     this.ecmaVersion = getEcmaVersion(this.targets);

--- a/packages/builder/builder-shared/src/types/config/security.ts
+++ b/packages/builder/builder-shared/src/types/config/security.ts
@@ -5,7 +5,7 @@ export type SriOptions = {
 };
 
 export interface CheckSyntaxOptions {
-  targets: string[];
+  targets?: string[];
   exclude?: RegExp | Array<RegExp>;
 }
 

--- a/packages/builder/builder/src/plugins/checkSyntax.ts
+++ b/packages/builder/builder/src/plugins/checkSyntax.ts
@@ -5,6 +5,7 @@ import {
   getBrowserslistWithDefault,
   DefaultBuilderPlugin,
   SharedNormalizedConfig,
+  CheckSyntaxOptions,
 } from '@modern-js/builder-shared';
 
 export function builderPluginCheckSyntax(): DefaultBuilderPlugin {
@@ -47,16 +48,16 @@ async function getCheckTargets(
   builderContext: BuilderContext,
   builderConfig: SharedNormalizedConfig,
   builderTarget: BuilderTarget,
-  checkSyntax: { targets: string[] } | true,
+  checkSyntax: CheckSyntaxOptions | true,
 ) {
-  if (checkSyntax === true) {
-    const browserslist = await getBrowserslistWithDefault(
+  const browserslist =
+    (await getBrowserslistWithDefault(
       builderContext.rootPath,
       builderConfig,
       builderTarget,
-    );
-
-    return browserslist || DEFAULT_BROWSERSLIST[builderTarget];
+    )) ?? DEFAULT_BROWSERSLIST[builderTarget];
+  if (checkSyntax === true) {
+    return browserslist;
   }
-  return checkSyntax.targets;
+  return checkSyntax.targets ?? browserslist;
 }

--- a/packages/builder/builder/tests/plugins/__snapshots__/checkSyntax.test.ts.snap
+++ b/packages/builder/builder/tests/plugins/__snapshots__/checkSyntax.test.ts.snap
@@ -29,9 +29,11 @@ exports[`plugins/check-syntax > should use default browserlist as targets when o
         /\\$\\.html/,
       ],
       "targets": [
-        "> 0.01%",
+        "iOS 9",
+        "Android 4.4",
+        "last 2 versions",
+        "> 0.2%",
         "not dead",
-        "not op_mini all",
       ],
     },
   ],

--- a/packages/builder/builder/tests/plugins/__snapshots__/checkSyntax.test.ts.snap
+++ b/packages/builder/builder/tests/plugins/__snapshots__/checkSyntax.test.ts.snap
@@ -18,3 +18,22 @@ exports[`plugins/check-syntax > should add check-syntax plugin properly 1`] = `
 `;
 
 exports[`plugins/check-syntax > should not add check-syntax plugin when target node 1`] = `{}`;
+
+exports[`plugins/check-syntax > should use default browserlist as targets when only set checksyntax.exclude 1`] = `
+{
+  "plugins": [
+    CheckSyntaxPlugin {
+      "ecmaVersion": 5,
+      "errors": [],
+      "exclude": [
+        /\\$\\.html/,
+      ],
+      "targets": [
+        "> 0.01%",
+        "not dead",
+        "not op_mini all",
+      ],
+    },
+  ],
+}
+`;

--- a/packages/builder/builder/tests/plugins/checkSyntax.test.ts
+++ b/packages/builder/builder/tests/plugins/checkSyntax.test.ts
@@ -63,4 +63,36 @@ describe('plugins/check-syntax', () => {
 
     expect(chain.toConfig()).toMatchSnapshot();
   });
+
+  it('should use default browserlist as targets when only set checksyntax.exclude', async () => {
+    let modifyBundlerChainCb: any;
+
+    const api: any = {
+      modifyBundlerChain: (fn: any) => {
+        modifyBundlerChainCb = fn;
+      },
+      getNormalizedConfig: () => ({
+        security: {
+          checkSyntax: {
+            exclude: [/$.html/],
+          },
+        },
+      }),
+      context: {
+        rootPath: __dirname,
+      },
+    };
+
+    builderPluginCheckSyntax().setup(api);
+
+    const chain = await shared.getBundlerChain();
+
+    await modifyBundlerChainCb(chain, {
+      CHAIN_ID,
+      isProd: true,
+      target: 'web',
+    });
+
+    expect(chain.toConfig()).toMatchSnapshot();
+  });
 });

--- a/packages/builder/builder/tests/plugins/checkSyntax.test.ts
+++ b/packages/builder/builder/tests/plugins/checkSyntax.test.ts
@@ -77,6 +77,15 @@ describe('plugins/check-syntax', () => {
             exclude: [/$.html/],
           },
         },
+        output: {
+          overrideBrowserslist: [
+            'iOS 9',
+            'Android 4.4',
+            'last 2 versions',
+            '> 0.2%',
+            'not dead',
+          ],
+        },
       }),
       context: {
         rootPath: __dirname,


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42084a4</samp>

This pull request fixes and enhances the `checkSyntax` plugin for the `@modern-js/builder` package. It adds a type definition, a modern operator, and a test case for the plugin, and updates the `CheckSyntaxOptions` interface and the changeset file. It also improves the type safety and readability of the plugin code.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42084a4</samp>

*  Add changeset file to document patch updates and fix for checkSyntax plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4095/files?diff=unified&w=0#diff-67cd5cdc33517f1629fa6da67a0f99abac25eb9d5655946e0ea80746ba27b17eR1-R8))
*  Refine type of options parameter for CheckSyntaxPlugin constructor ([link](https://github.com/web-infra-dev/modern.js/pull/4095/files?diff=unified&w=0#diff-e650927f0aa75ae5d30efa9654832171892a90fdf5e25b9693c0f178cc0bcba9L29-R32))
*  Make targets property optional in CheckSyntaxOptions interface ([link](https://github.com/web-infra-dev/modern.js/pull/4095/files?diff=unified&w=0#diff-d90b2be94a4a8b4008e86784feee6ef03f820d173858d21cd7cb2bbe508ec999L8-R8))
*  Import CheckSyntaxOptions type and refactor getCheckTargets function in `checkSyntax.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4095/files?diff=unified&w=0#diff-9df8158cec3fc39e4a038d8046f10d174b8ee42d4a1eaf79095de9f12d4b1039R8), [link](https://github.com/web-infra-dev/modern.js/pull/4095/files?diff=unified&w=0#diff-9df8158cec3fc39e4a038d8046f10d174b8ee42d4a1eaf79095de9f12d4b1039L50-R62))
*  Add test case to verify default browserlist usage when only exclude property is set in `checkSyntax.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4095/files?diff=unified&w=0#diff-d0e3ffb847595da2b9519603e9dba58ce1d9deaa1e1da4a4a7320b29f1aa8f32R66-R106))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
