### PR TITLE
docs(module-tools): improve externals, format, jsx, metafile

### DIFF
--- a/packages/document/module-doc/docs/en/api/config/build-config.md
+++ b/packages/document/module-doc/docs/en/api/config/build-config.md
@@ -445,7 +445,7 @@ type External = (string | RegExp)[];
 ```
 
 - **Default**: `[]`
-
+- **Build Type**: `Only supported for buildType: 'bundle'`
 - **Example**:
 
 ```js modern.config.ts

--- a/packages/document/module-doc/docs/en/api/config/build-config.md
+++ b/packages/document/module-doc/docs/en/api/config/build-config.md
@@ -438,21 +438,127 @@ export var yourCode = function () {
 
 Configure external dependencies that will not be packaged into the final bundle
 
-- **Type**: `(string | RegExp)[]`
+- **Type**:
+
+```ts
+type External = (string | RegExp)[];
+```
+
 - **Default**: `[]`
+
+- **Example**:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    // do not bundle React
+    externals: ['react'],
+  },
+});
+```
 
 ## format
 
-The format of the js product output, where `iife` and `umd` can only take effect when `buildType` is `bundle`
+## externals
+
+Used to exclude certain external dependencies during bundling, avoiding them from being included in the final bundle.
+
+- **Type**:
+
+```ts
+type Externals = (string | RegExp)[];
+```
+
+- **Default**: `[]`
+
+- **Example**:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    // Exclude React from the bundle
+    externals: ['react'],
+  },
+});
+```
+
+## format
+
+Used to set the output format of JavaScript files. The options `iife` and `umd` only take effect when `buildType` is `bundle`.
 
 - **Type**: `'esm' | 'cjs' | 'iife' | 'umd'`
 - **Default**: `cjs`
+
+### format: 'esm'
+
+`esm` stands for "ECMAScript module" and requires the runtime environment to support import and export syntax.
+
+- **Example**:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'esm',
+  },
+});
+```
+
+### format: 'cjs'
+
+`cjs` stands for "CommonJS" and requires the runtime environment to support exports, require, and module syntax. This format is commonly used in Node.js environments.
+
+- **Example**:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'cjs',
+  },
+});
+```
+
+### format: 'iife'
+
+`iife` stands for "immediately-invoked function expression" and wraps the code in a function expression to ensure that any variables in the code do not accidentally conflict with variables in the global scope. This format is commonly used in browser environments.
+
+- **Example**:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'iife',
+  },
+});
+```
+
+### format: 'umd'
+
+`umd` stands for "Universal Module Definition" and is used to run modules in different environments such as browsers and Node.js. Modules in UMD format can be used in various environments, either as global variables or loaded as modules using module loaders like RequireJS.
+
+- **Example**:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'umd',
+  },
+});
+```
 
 ## input
 
 Specify the entry file for the build, in the form of an array that can specify the directory
 
-- **Type**: `string[] | Record<string, string>`
+- **Type**:
+
+```ts
+type Input =
+  | string[];
+  | {
+      [name: string]: string;
+    }
+```
+
 - **Default**: `['src/index.ts']` in `bundle` mode, `['src']` in `bundleless` mode
 
 **Array usage:**
@@ -484,23 +590,48 @@ export default defineConfig({
 
 ## jsx
 
-Specify the compilation method of JSX, default support React17, automatically inject JSX Runtime code. If you need to support React16, set `jsx` to `transform`.
-
-> For more information about JSX Transform, you can refer to the following links:
->
-> - [React Blog](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)。
-> - [esbuild JSX](https://esbuild.github.io/api/#jsx)
->
+Specify the compilation method for JSX, which by default supports React 17 and higher versions and automatically injects JSX runtime code.
 
 - **Type**: `automatic | transform`
 - **Default**: `automatic`
 
+If you need to support React 16, you can set `jsx` to `transform`:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    jsx: 'transform',
+  },
+});
+```
+
+:::tip
+For more information about JSX Transform, you can refer to the following links:
+
+- [React Blog - Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+- [esbuild - JSX](https://esbuild.github.io/api/#jsx).
+  :::
+
 ## metafile
 
-esbuild to produce some metadata about the build in JSON format, which can be visualized by tools such as [bundle-buddy](https://bundle-buddy.com/esbuild)
+This option is used for build analysis. When enabled, esbuild will generate metadata about the build in JSON format.
 
 - **Type**: `boolean`
 - **Default**: `false`
+- **Build Type**: `Only supported for buildType: 'bundle'`
+
+To enable `metafile` generation:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    buildType: 'bundle',
+    metafile: true,
+  },
+});
+```
+
+After executing the build, a `metafile-[xxx].json` file will be generated in the output directory. You can use tools like [esbuild analyze](https://esbuild.github.io/analyze/) and [bundle-buddy](https://bundle-buddy.com/esbuild) for visual analysis.
 
 ## minify
 
@@ -771,14 +902,12 @@ See [PostCSS](https://github.com/postcss/postcss#options) for detailed configura
 
 **Basic usage：**
 
-``` js modern.config.ts
+```js modern.config.ts
 export default defineConfig({
   buildConfig: {
     style: {
       postcss: {
-        plugins: [
-          yourPostCSSPlugin,
-        ],
+        plugins: [yourPostCSSPlugin],
       },
     },
   },

--- a/packages/document/module-doc/docs/en/api/config/build-config.md
+++ b/packages/document/module-doc/docs/en/api/config/build-config.md
@@ -459,31 +459,6 @@ export default defineConfig({
 
 ## format
 
-## externals
-
-Used to exclude certain external dependencies during bundling, avoiding them from being included in the final bundle.
-
-- **Type**:
-
-```ts
-type Externals = (string | RegExp)[];
-```
-
-- **Default**: `[]`
-
-- **Example**:
-
-```js modern.config.ts
-export default defineConfig({
-  buildConfig: {
-    // Exclude React from the bundle
-    externals: ['react'],
-  },
-});
-```
-
-## format
-
 Used to set the output format of JavaScript files. The options `iife` and `umd` only take effect when `buildType` is `bundle`.
 
 - **Type**: `'esm' | 'cjs' | 'iife' | 'umd'`

--- a/packages/document/module-doc/docs/zh/api/config/build-config.md
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.md
@@ -435,24 +435,105 @@ export var yourCode = function () {
 
 ## externals
 
-配置外部依赖，不会被打包到最终的 bundle 中。
+用于在打包时排除一些外部依赖，避免将这些依赖打包到最终的 bundle 中。
 
-- 类型： `(string | RegExp)[]`
+- 类型：
+
+```ts
+type Externals = (string | RegExp)[];
+```
+
 - 默认值： `[]`
+
+- 示例：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    // 避免打包 React
+    externals: ['react'],
+  },
+});
+```
 
 ## format
 
-js 产物输出的格式,其中 `iife` 和 `umd` 只能在 `buildType` 为 `bundle` 时生效。
+用于设置 JavaScript 产物输出的格式，其中 `iife` 和 `umd` 只在 `buildType` 为 `bundle` 时生效。
 
-- 类型： `'esm' | 'cjs' | 'iife' | 'umd'`
-- 默认值： `cjs`
+- 类型：`'esm' | 'cjs' | 'iife' | 'umd'`
+- 默认值：`cjs`
+
+### format: 'esm'
+
+esm 代表 "ECMAScript 模块"，它需要运行环境支持 import 和 export 语法。
+
+- 示例：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'esm',
+  },
+});
+```
+
+### format: 'cjs'
+
+cjs 代表 "CommonJS"，它需要运行环境支持 exports、require 和 module 语法，通常为 Node.js 环境。
+
+- 示例：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'cjs',
+  },
+});
+```
+
+### format: 'iife'
+
+iife 代表 "立即调用函数表达式"，它将代码包裹在函数表达式中，确保代码中的任何变量不会意外地与全局范围中的变量冲突，通常在浏览器环境中运行。
+
+- 示例：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'iife',
+  },
+});
+```
+
+### format: 'umd'
+
+umd 代表 "Universal Module Definition"，用于在不同环境（浏览器、Node.js 等）中运行。umd 格式的模块可以在多种环境下使用，既可以作为全局变量访问，也可以通过模块加载器（如 RequireJS）进行模块化加载。
+
+- 示例：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    format: 'umd',
+  },
+});
+```
 
 ## input
 
 指定构建的入口文件，数组形式可以指定目录。
 
-- 类型： `string[] | Record<string, string>`
-- 默认值： `bundle` 模式下默认为 `['src/index.ts']`，`bundleless` 模式下默认为 `['src']`
+- 类型：
+
+```ts
+type Input =
+  | string[];
+  | {
+      [name: string]: string;
+    }
+```
+
+- 默认值：`bundle` 模式下默认为 `['src/index.ts']`，`bundleless` 模式下默认为 `['src']`
 
 **数组用法：**
 
@@ -483,22 +564,49 @@ export default defineConfig({
 
 ## jsx
 
-指定 JSX 的编译方式，默认支持 React17 以上，自动注入 JSX 运行时代码。如果需要支持 React16，则设置 `jsx` 为 `transform`。
+指定 JSX 的编译方式，默认支持 React 17 及更高版本，自动注入 JSX 运行时代码。
 
-> 关于 JSX Transform，可以参考以下链接：
->
-> - [React Blog](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)。
-> - [esbuild JSX](https://esbuild.github.io/api/#jsx)
->
 - 类型： `automatic | transform`
 - 默认值： `automatic`
 
+如果你需要支持 React 16，则可以设置 `jsx` 为 `transform`：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    jsx: 'transform',
+  },
+});
+```
+
+:::tip
+关于 JSX Transform 的更多说明，可以参考以下链接：
+
+- [React Blog - Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
+- [esbuild - JSX](https://esbuild.github.io/api/#jsx).
+
+:::
+
 ## metafile
 
-esbuild 以 JSON 格式生成有关构建的一些元数据，可以通过例如 [bundle-buddy](https://bundle-buddy.com/esbuild) 的工具可视化
+这个选项用于构建分析，开启该选项后，esbuild 会以 JSON 格式生成有关构建的一些元数据。
 
 - 类型：`boolean`
 - 默认值：`false`
+- 构建类型：`仅支持 buildType: 'bundle'`
+
+开启 `metafile` 生成：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    buildType: 'bundle',
+    metafile: true,
+  },
+});
+```
+
+在执行 build 构建后，产物目录下会生成 `metafile-[xxx].json` 文件，你可以通过 [esbuild analyze](https://esbuild.github.io/analyze/) 和 [bundle-buddy](https://bundle-buddy.com/esbuild) 等工具进行可视化分析。
 
 ## minify
 
@@ -770,14 +878,12 @@ export default defineConfig({
 
 **基础使用：**
 
-``` js modern.config.ts
+```js modern.config.ts
 export default defineConfig({
   buildConfig: {
     style: {
       postcss: {
-        plugins: [
-          yourPostCSSPlugin,
-        ],
+        plugins: [yourPostCSSPlugin],
       },
     },
   },

--- a/packages/document/module-doc/docs/zh/api/config/build-config.md
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.md
@@ -444,7 +444,7 @@ type Externals = (string | RegExp)[];
 ```
 
 - 默认值： `[]`
-
+- 构建类型：`仅支持 buildType: 'bundle'`
 - 示例：
 
 ```js modern.config.ts


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d9f0dc</samp>

This pull request improves the documentation of the `buildConfig` option in the `modern.config.ts` file for both English and Chinese languages. It adds more information, examples, and sections for some of the configuration options, and fixes some formatting issues in the `buildConfig.md` files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d9f0dc</samp>

*  Improve the documentation of the `buildConfig` section of the `modern.config.ts` file in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L441-R561), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L487-R635), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L774-R910), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL438-R537), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL486-R610), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL773-R886))
  * Add type annotations, examples, and descriptions for the `externals` and `format` options, and move the `format` section below the `externals` section for consistency ([link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L441-R561), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL438-R537))
  * Add an example of how to set `jsx` to `transform` for React 16 support, and wrap the links to JSX Transform in a tip box ([link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L487-R635), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL486-R610))
  * Add a section for the `metafile` option, which was missing in the original documentation, and explain its purpose, type, default value, and build type, and provide an example of how to enable it and use tools for analysis ([link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L487-R635), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL486-R610))
  * Remove the extra space before the `js` syntax highlighter and the trailing comma in the `plugins` array in the `style.postcss` section ([link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L774-R910), [link](https://github.com/web-infra-dev/modern.js/pull/4096/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL773-R886))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
