### PR TITLE
fix: react-router-dom version

### DIFF
--- a/.changeset/rare-mails-battle.md
+++ b/.changeset/rare-mails-battle.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+fix: react-router-dom version
+
+fix: 修复 react-router-dom 版本

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -294,7 +294,7 @@
     "caniuse-lite": "^1.0.30001489",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0",
-    "react-router-dom": "6.11.2",
+    "react-router-dom": "^6.8.1",
     "@remix-run/router": "1.6.2",
     "@swc/helpers": "0.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5177,7 +5177,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       react-router-dom:
-        specifier: 6.11.2
+        specifier: ^6.8.1
         version: 6.11.2(react-dom@18.2.0)(react@18.2.0)
       serialize-javascript:
         specifier: ^6.0.0


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93a833b</samp>

This pull request fixes a compatibility issue between `@modern-js/utils` and `@remix-run/router` by downgrading the `react-router-dom` dependency version. It also adds a changeset file to document the patch update of `@modern-js/utils`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93a833b</samp>

* Patch update `@modern-js/utils` package to fix compatibility issue with `@remix-run/router` ([link](https://github.com/web-infra-dev/modern.js/pull/4097/files?diff=unified&w=0#diff-b86ba704fc1506d1e15fa629a25470c9fb121b608e5969f93058e34e74c73ea2R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4097/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L297-R297))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
