### PR TITLE
chore(deps): bump esbuild from v15/v16 to v17

### DIFF
--- a/.changeset/wise-tigers-chew.md
+++ b/.changeset/wise-tigers-chew.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/node-bundle-require': patch
+'@modern-js/builder-plugin-esbuild': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-storybook': patch
+'@modern-js/app-tools': patch
+---
+
+chore(deps): bump esbuild from v15/v16 to v17
+
+chore(deps): 将 esbuild 从 v15/v16 升级到 v17

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@vitest/ui": "^0.21.1",
     "babel-plugin-module-resolver": "^4.1.0",
     "cypress": "^10.1.0",
-    "esbuild": "0.15.7",
+    "esbuild": "0.17.19",
     "execa": "^5.1.1",
     "globby": "^11.0.4",
     "husky": "^8.0.0",

--- a/packages/builder/plugin-esbuild/package.json
+++ b/packages/builder/plugin-esbuild/package.json
@@ -38,7 +38,7 @@
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
-    "esbuild": "0.16.17",
+    "esbuild": "0.17.19",
     "@modern-js/builder-shared": "workspace:*"
   },
   "devDependencies": {

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -61,7 +61,7 @@
     "@storybook/manager-webpack5": "6.5.12",
     "@storybook/react": "6.5.12",
     "@swc/helpers": "0.5.1",
-    "esbuild": "0.15.7",
+    "esbuild": "0.17.19",
     "findup-sync": "^4.0.0",
     "fs-extra": "^10.0.0",
     "process.argv": "^0.6.0",

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -170,7 +170,7 @@
     "@types/react-helmet": "^6.1.2",
     "@types/redux-logger": "^3.0.9",
     "@types/styled-components": "^5.1.14",
-    "esbuild": "0.15.7",
+    "esbuild": "0.17.19",
     "hoist-non-react-statics": "^3.3.2",
     "invariant": "^2.2.4",
     "react-helmet": "^6.1.0",

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -94,7 +94,7 @@
     "@modern-js/upgrade": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "es-module-lexer": "^1.1.0",
-    "esbuild": "0.15.7",
+    "esbuild": "0.17.19",
     "rspack-plugin-virtual-module": "0.1.0",
     "@swc/helpers": "0.5.1"
   },

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -40,11 +40,7 @@ export const dev = async (
     appDirectory,
     distDirectory,
     configFile: serverConfigFile,
-    options: {
-      esbuildOptions: {
-        watch: true,
-      },
-    },
+    watch: true,
   });
 
   await hookRunners.beforeDev();

--- a/packages/solutions/app-tools/src/utils/config.ts
+++ b/packages/solutions/app-tools/src/utils/config.ts
@@ -17,11 +17,13 @@ export const buildServerConfig = async ({
   distDirectory,
   configFile,
   options,
+  watch,
 }: {
   appDirectory: string;
   distDirectory: string;
   configFile: string;
   options?: Parameters<typeof bundle>[1];
+  watch?: boolean;
 }) => {
   const configFilePath = await getServerConfig(appDirectory, configFile);
 
@@ -46,6 +48,7 @@ export const buildServerConfig = async ({
     await fs.writeFile(configHelperFilePath, helperCode);
     await bundle(configFilePath, {
       ...options,
+      watch,
       getOutputFile,
       esbuildPlugins: [
         {

--- a/packages/toolkit/node-bundle-require/package.json
+++ b/packages/toolkit/node-bundle-require/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@modern-js/utils": "workspace:*",
-    "esbuild": "0.15.7",
+    "esbuild": "0.17.19",
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {

--- a/packages/toolkit/node-bundle-require/src/bundle.ts
+++ b/packages/toolkit/node-bundle-require/src/bundle.ts
@@ -203,6 +203,7 @@ export async function bundle(filepath: string, options?: Options) {
 
   if (options?.watch) {
     const ctx = await context(esbuildOptions);
+    await ctx.rebuild();
     await ctx.watch();
   } else {
     await build(esbuildOptions);

--- a/packages/toolkit/node-bundle-require/src/bundle.ts
+++ b/packages/toolkit/node-bundle-require/src/bundle.ts
@@ -6,7 +6,7 @@ import {
   CONFIG_CACHE_DIR,
   createDebugger,
 } from '@modern-js/utils';
-import { build, Loader, Plugin, BuildOptions } from 'esbuild';
+import { build, context, Loader, Plugin, BuildOptions } from 'esbuild';
 
 const debug = createDebugger('node-bundle');
 
@@ -67,6 +67,11 @@ export interface Options {
    * auto clear bundle file
    */
   autoClear?: boolean;
+
+  /**
+   * Whether to enable watch mode
+   */
+  watch?: boolean;
 }
 
 export const defaultGetOutputFile = async (filepath: string) =>
@@ -85,7 +90,7 @@ export async function bundle(filepath: string, options?: Options) {
   const getOutputFile = options?.getOutputFile || defaultGetOutputFile;
   const outfile = await getOutputFile(path.basename(filepath));
 
-  await build({
+  const esbuildOptions: BuildOptions = {
     entryPoints: [filepath],
     outfile,
     format: 'cjs',
@@ -194,7 +199,14 @@ export async function bundle(filepath: string, options?: Options) {
         },
       },
     ],
-  });
+  };
+
+  if (options?.watch) {
+    const ctx = await context(esbuildOptions);
+    await ctx.watch();
+  } else {
+    await build(esbuildOptions);
+  }
 
   return outfile;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^10.1.0
         version: 10.2.0
       esbuild:
-        specifier: 0.15.7
-        version: 0.15.7
+        specifier: 0.17.19
+        version: 0.17.19
       execa:
         specifier: ^5.1.1
         version: 5.1.1
@@ -178,7 +178,7 @@ importers:
         version: 3.3.1(webpack@5.82.1)
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
     devDependencies:
       '@arco-design/web-react':
         specifier: ^2.46.0
@@ -254,7 +254,7 @@ importers:
         version: 0.7.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
       webpack-sources:
         specifier: ^3.2.3
         version: 3.2.3
@@ -330,7 +330,7 @@ importers:
         version: 1.0.30001489
       css-minimizer-webpack-plugin:
         specifier: 5.0.0
-        version: 5.0.0(esbuild@0.15.7)(webpack@5.82.1)
+        version: 5.0.0(esbuild@0.17.19)(webpack@5.82.1)
       html-webpack-plugin:
         specifier: 5.5.0
         version: 5.5.0(webpack@5.82.1)
@@ -348,13 +348,13 @@ importers:
         version: 3.3.1(webpack@5.82.1)
       terser-webpack-plugin:
         specifier: 5.3.6
-        version: 5.3.6(esbuild@0.15.7)(webpack@5.82.1)
+        version: 5.3.6(esbuild@0.17.19)(webpack@5.82.1)
       ts-loader:
         specifier: 9.4.1
         version: 9.4.1(typescript@5.0.4)(webpack@5.82.1)
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
     devDependencies:
       '@arco-design/web-react':
         specifier: ^2.46.0
@@ -390,8 +390,8 @@ importers:
         specifier: workspace:*
         version: link:../builder-shared
       esbuild:
-        specifier: 0.16.17
-        version: 0.16.17
+        specifier: 0.17.19
+        version: 0.17.19
     devDependencies:
       '@modern-js/builder':
         specifier: workspace:*
@@ -438,7 +438,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
 
   packages/builder/plugin-node-polyfill:
     dependencies:
@@ -500,7 +500,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
 
   packages/builder/plugin-swc:
     dependencies:
@@ -567,7 +567,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(@swc/core@1.3.42)(esbuild@0.15.7)
+        version: 5.82.1(@swc/core@1.3.42)(esbuild@0.17.19)
 
   packages/builder/plugin-vue:
     dependencies:
@@ -604,7 +604,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
 
   packages/cli/babel-preset-app:
     dependencies:
@@ -1010,7 +1010,7 @@ importers:
         version: 0.21.1(@vitest/ui@0.21.1)(jsdom@20.0.3)
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
 
   packages/cli/doc-plugin-api-generator:
     dependencies:
@@ -1318,13 +1318,13 @@ importers:
         version: 3.4.12
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
       webpack-chain:
         specifier: ^6.5.1
         version: 6.5.1
@@ -1443,13 +1443,13 @@ importers:
         version: 6.2.3
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
       webpack-chain:
         specifier: ^6.5.1
         version: 6.5.1
@@ -1651,22 +1651,22 @@ importers:
         version: 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/builder-webpack5':
         specifier: 6.5.12
-        version: 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+        version: 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core':
         specifier: 6.5.12
         version: 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.82.1)
       '@storybook/manager-webpack5':
         specifier: 6.5.12
-        version: 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+        version: 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/react':
         specifier: 6.5.12
-        version: 6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4)
+        version: 6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4)
       '@swc/helpers':
         specifier: 0.5.1
         version: 0.5.1
       esbuild:
-        specifier: 0.15.7
-        version: 0.15.7
+        specifier: 0.17.19
+        version: 0.17.19
       findup-sync:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1736,7 +1736,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
       webpack-chain:
         specifier: ^6.5.1
         version: 6.5.1
@@ -3553,7 +3553,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -3627,8 +3627,8 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
       esbuild:
-        specifier: 0.15.7
-        version: 0.15.7
+        specifier: 0.17.19
+        version: 0.17.19
       hoist-non-react-statics:
         specifier: ^3.3.2
         version: 3.3.2
@@ -3701,13 +3701,13 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
 
   packages/runtime/plugin-testing:
     dependencies:
@@ -3782,7 +3782,7 @@ importers:
         version: 6.2.3
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       yargs:
         specifier: ^17.0.1
         version: 17.5.1
@@ -3914,7 +3914,7 @@ importers:
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -3957,7 +3957,7 @@ importers:
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -4493,7 +4493,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
       websocket:
         specifier: ^1
         version: 1.0.34
@@ -4557,7 +4557,7 @@ importers:
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -4631,8 +4631,8 @@ importers:
         specifier: ^1.1.0
         version: 1.2.1
       esbuild:
-        specifier: 0.15.7
-        version: 0.15.7
+        specifier: 0.17.19
+        version: 0.17.19
       rspack-plugin-virtual-module:
         specifier: 0.1.0
         version: 0.1.0
@@ -4669,7 +4669,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
 
   packages/solutions/doc-tools:
     dependencies:
@@ -5024,8 +5024,8 @@ importers:
         specifier: 0.5.1
         version: 0.5.1
       esbuild:
-        specifier: 0.15.7
-        version: 0.15.7
+        specifier: 0.17.19
+        version: 0.17.19
     devDependencies:
       '@scripts/build':
         specifier: workspace:*
@@ -5215,7 +5215,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
 
   scripts/build:
     devDependencies:
@@ -5287,8 +5287,8 @@ importers:
         specifier: 5.12.0
         version: 5.12.0
       esbuild:
-        specifier: 0.15.7
-        version: 0.15.7
+        specifier: 0.17.19
+        version: 0.17.19
       jest:
         specifier: ^29
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
@@ -5343,7 +5343,7 @@ importers:
         version: 5.0.4
       webpack:
         specifier: ^5.82.1
-        version: 5.82.1(esbuild@0.15.7)
+        version: 5.82.1(esbuild@0.17.19)
     devDependencies:
       '@babel/helper-annotate-as-pure':
         specifier: 7.18.6
@@ -5431,7 +5431,7 @@ importers:
         version: 4.0.1
       '@types/webpack-bundle-analyzer':
         specifier: 4.4.1
-        version: 4.4.1(esbuild@0.15.7)
+        version: 4.4.1(esbuild@0.17.19)
       address:
         specifier: 1.1.2
         version: 1.1.2
@@ -10365,6 +10365,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.17.19:
@@ -10390,6 +10391,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.17.19:
@@ -10406,6 +10408,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.17.19:
@@ -10422,6 +10425,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.17.19:
@@ -10438,6 +10442,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.17.19:
@@ -10454,6 +10459,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.17.19:
@@ -10470,6 +10476,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.17.19:
@@ -10486,6 +10493,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.17.19:
@@ -10502,6 +10510,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.17.19:
@@ -10518,6 +10527,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.17.19:
@@ -10537,20 +10547,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.15.7:
-    resolution: {integrity: sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@esbuild/linux-loong64@0.16.17:
     resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.17.19:
@@ -10567,6 +10570,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.17.19:
@@ -10583,6 +10587,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.17.19:
@@ -10599,6 +10604,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.17.19:
@@ -10615,6 +10621,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.17.19:
@@ -10631,6 +10638,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.17.19:
@@ -10647,6 +10655,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.17.19:
@@ -10663,6 +10672,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.17.19:
@@ -10679,6 +10689,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.17.19:
@@ -10695,6 +10706,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.17.19:
@@ -10711,6 +10723,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.17.19:
@@ -10727,6 +10740,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.17.19:
@@ -11350,7 +11364,7 @@ packages:
       webpack: '>=4.6.0'
     dependencies:
       make-dir: 3.1.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /@manypkg/find-root@1.1.0:
@@ -11380,7 +11394,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.2.1
       source-map: 0.7.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12312,7 +12326,7 @@ packages:
       react-refresh: 0.14.0
       schema-utils: 3.1.2
       source-map: 0.7.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.9(react-refresh@0.11.0)(webpack@5.82.1):
@@ -12351,7 +12365,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.2
       source-map: 0.7.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.9(react-refresh@0.14.0)(webpack@5.82.1):
@@ -12390,7 +12404,7 @@ packages:
       react-refresh: 0.14.0
       schema-utils: 3.1.2
       source-map: 0.7.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /@polka/url@0.5.0:
@@ -13034,7 +13048,7 @@ packages:
       '@storybook/addon-viewport': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/api': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       core-js: 3.30.0
@@ -13042,7 +13056,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - eslint
@@ -13319,7 +13333,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/builder-webpack5@6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/builder-webpack5@6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-jK5jWxhSbMAM/onPB6WN7xVqwZnAmzJljOG24InO/YIjW8pQof7MeAXCYBM4rYM+BbK61gkZ/RKxwlkqXBWv+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -13362,11 +13376,11 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       stable: 0.1.8
       style-loader: 2.0.0(webpack@5.82.1)
-      terser-webpack-plugin: 5.3.6(esbuild@0.15.7)(webpack@5.82.1)
+      terser-webpack-plugin: 5.3.6(esbuild@0.17.19)(webpack@5.82.1)
       ts-dedent: 2.2.0
       typescript: 5.0.4
       util-deprecate: 1.0.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
       webpack-dev-middleware: 4.3.0(webpack@5.82.1)
       webpack-hot-middleware: 2.25.2
       webpack-virtual-modules: 0.4.6
@@ -13535,7 +13549,7 @@ packages:
       typescript: 5.0.4
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /@storybook/core-common@6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
@@ -13632,14 +13646,14 @@ packages:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@storybook/builder-webpack4': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-client': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@4.46.0)
       '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.12
       '@storybook/manager-webpack4': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/manager-webpack5': 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -13710,14 +13724,14 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-client': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.82.1)
       '@storybook/core-server': 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/manager-webpack5': 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       typescript: 5.0.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - bluebird
@@ -13836,7 +13850,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/manager-webpack5@6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/manager-webpack5@6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-F+KgoINhfo1ArbirCc9L+EyADYD8Z4t0LyZYDVcBiZ8DlRIMIoUSye6tDsnyEm+OPloLVAcGwRMYgFhuHB70Lg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -13874,11 +13888,11 @@ packages:
       resolve-from: 5.0.0
       style-loader: 2.0.0(webpack@5.82.1)
       telejson: 6.0.8
-      terser-webpack-plugin: 5.3.6(esbuild@0.15.7)(webpack@5.82.1)
+      terser-webpack-plugin: 5.3.6(esbuild@0.17.19)(webpack@5.82.1)
       ts-dedent: 2.2.0
       typescript: 5.0.4
       util-deprecate: 1.0.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
       webpack-dev-middleware: 4.3.0(webpack@5.82.1)
       webpack-virtual-modules: 0.4.6
     transitivePeerDependencies:
@@ -13968,12 +13982,12 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.0.4)
       tslib: 2.4.0
       typescript: 5.0.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@storybook/react@6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4):
+  /@storybook/react@6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-1tG8EdSfp+OZAKAWPT2UrexF4o007jEMwQFFXw1atIQrQOADzSnZ7lTYJ08o5TyJwksswtr18tH3oJJ9sG3KPw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -14006,13 +14020,13 @@ packages:
       '@babel/preset-react': 7.18.6(@babel/core@7.21.8)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.9(react-refresh@0.11.0)(webpack@5.82.1)
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/client-logger': 6.5.12
       '@storybook/core': 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.82.1)
       '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/manager-webpack5': 6.5.12(esbuild@0.15.7)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0(typescript@5.0.4)(webpack@5.82.1)
       '@storybook/semver': 7.3.2
@@ -14042,7 +14056,7 @@ packages:
       ts-dedent: 2.2.0
       typescript: 5.0.4
       util-deprecate: 1.0.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - '@swc/core'
@@ -15298,12 +15312,12 @@ packages:
     resolution: {integrity: sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==}
     dev: true
 
-  /@types/webpack-bundle-analyzer@4.4.1(esbuild@0.15.7):
+  /@types/webpack-bundle-analyzer@4.4.1(esbuild@0.17.19):
     resolution: {integrity: sha512-yQAj3l7bIYL+QRRlNJt6gyP+zrXZOlgaR4wsX0WY4yzZIbv41ZibREfZvuYjxY0iVtvQQlbhx0AeokkCuqUAQg==}
     dependencies:
       '@types/node': 18.11.17
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -16643,7 +16657,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /babel-loader@9.1.0(@babel/core@7.21.8)(webpack@5.82.1):
@@ -16656,7 +16670,7 @@ packages:
       '@babel/core': 7.21.8
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /babel-plugin-add-react-displayname@0.0.5:
@@ -18229,7 +18243,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /core-js-compat@3.26.1:
@@ -18484,7 +18498,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.2
       semver: 7.3.7
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /css-loader@6.7.1(webpack@5.82.1):
@@ -18501,10 +18515,10 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.21)
       postcss-value-parser: 4.2.0
       semver: 7.3.7
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
-  /css-minimizer-webpack-plugin@5.0.0(esbuild@0.15.7)(webpack@5.82.1):
+  /css-minimizer-webpack-plugin@5.0.0(esbuild@0.17.19)(webpack@5.82.1):
     resolution: {integrity: sha512-1wZ/PYvg+ZKwi5FX6YrvbB31jMAdurS+CmRQLwWCVSlfzJC85l/a6RVICqUHFa+jXyhilfnCyjafzJGbmz5tcA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -18530,13 +18544,13 @@ packages:
         optional: true
     dependencies:
       cssnano: 6.0.0(postcss@8.4.21)
-      esbuild: 0.15.7
+      esbuild: 0.17.19
       jest-worker: 29.5.0
       postcss: 8.4.21
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /css-select@4.3.0:
@@ -19661,14 +19675,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-android-64@0.15.7:
-    resolution: {integrity: sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    optional: true
-
   /esbuild-android-arm64@0.15.18:
     resolution: {integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==}
     engines: {node: '>=12'}
@@ -19676,14 +19682,6 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-android-arm64@0.15.7:
-    resolution: {integrity: sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
     optional: true
 
   /esbuild-darwin-64@0.15.18:
@@ -19695,14 +19693,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-darwin-64@0.15.7:
-    resolution: {integrity: sha512-KGPt3r1c9ww009t2xLB6Vk0YyNOXh7hbjZ3EecHoVDxgtbUlYstMPDaReimKe6eOEfyY4hBEEeTvKwPsiH5WZg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /esbuild-darwin-arm64@0.15.18:
     resolution: {integrity: sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==}
     engines: {node: '>=12'}
@@ -19710,14 +19700,6 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-darwin-arm64@0.15.7:
-    resolution: {integrity: sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
     optional: true
 
   /esbuild-freebsd-64@0.15.18:
@@ -19729,14 +19711,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-freebsd-64@0.15.7:
-    resolution: {integrity: sha512-hESZB91qDLV5MEwNxzMxPfbjAhOmtfsr9Wnuci7pY6TtEh4UDuevmGmkUIjX/b+e/k4tcNBMf7SRQ2mdNuK/HQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    optional: true
-
   /esbuild-freebsd-arm64@0.15.18:
     resolution: {integrity: sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==}
     engines: {node: '>=12'}
@@ -19744,14 +19718,6 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-freebsd-arm64@0.15.7:
-    resolution: {integrity: sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
     optional: true
 
   /esbuild-linux-32@0.15.18:
@@ -19763,14 +19729,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-32@0.15.7:
-    resolution: {integrity: sha512-v3gT/LsONGUZcjbt2swrMjwxo32NJzk+7sAgtxhGx1+ZmOFaTRXBAi1PPfgpeo/J//Un2jIKm/I+qqeo4caJvg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-64@0.15.18:
     resolution: {integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==}
     engines: {node: '>=12'}
@@ -19778,14 +19736,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-linux-64@0.15.7:
-    resolution: {integrity: sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /esbuild-linux-arm64@0.15.18:
@@ -19797,14 +19747,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-arm64@0.15.7:
-    resolution: {integrity: sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-arm@0.15.18:
     resolution: {integrity: sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==}
     engines: {node: '>=12'}
@@ -19812,14 +19754,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-linux-arm@0.15.7:
-    resolution: {integrity: sha512-JKgAHtMR5f75wJTeuNQbyznZZa+pjiUHV7sRZp42UNdyXC6TiUYMW/8z8yIBAr2Fpad8hM1royZKQisqPABPvQ==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /esbuild-linux-mips64le@0.15.18:
@@ -19831,14 +19765,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-mips64le@0.15.7:
-    resolution: {integrity: sha512-T7XKuxl0VpeFLCJXub6U+iybiqh0kM/bWOTb4qcPyDDwNVhLUiPcGdG2/0S7F93czUZOKP57YiLV8YQewgLHKw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-ppc64le@0.15.18:
     resolution: {integrity: sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==}
     engines: {node: '>=12'}
@@ -19846,14 +19772,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le@0.15.7:
-    resolution: {integrity: sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /esbuild-linux-riscv64@0.15.18:
@@ -19865,14 +19783,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-linux-riscv64@0.15.7:
-    resolution: {integrity: sha512-uUJsezbswAYo/X7OU/P+PuL/EI9WzxsEQXDekfwpQ23uGiooxqoLFAPmXPcRAt941vjlY9jtITEEikWMBr+F/g==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /esbuild-linux-s390x@0.15.18:
     resolution: {integrity: sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==}
     engines: {node: '>=12'}
@@ -19880,14 +19790,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-linux-s390x@0.15.7:
-    resolution: {integrity: sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /esbuild-loader@2.21.0(webpack@5.82.1):
@@ -19900,7 +19802,7 @@ packages:
       json5: 2.2.3
       loader-utils: 2.0.4
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
       webpack-sources: 1.4.3
     dev: true
 
@@ -19913,14 +19815,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-netbsd-64@0.15.7:
-    resolution: {integrity: sha512-yVc4Wz+Pu3cP5hzm5kIygNPrjar/v5WCSoRmIjCPWfBVJkZNb5brEGKUlf+0Y759D48BCWa0WHrWXaNy0DULTQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    optional: true
-
   /esbuild-openbsd-64@0.15.18:
     resolution: {integrity: sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==}
     engines: {node: '>=12'}
@@ -19928,14 +19822,6 @@ packages:
     os: [openbsd]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-openbsd-64@0.15.7:
-    resolution: {integrity: sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
     optional: true
 
   /esbuild-sunos-64@0.15.18:
@@ -19947,14 +19833,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-sunos-64@0.15.7:
-    resolution: {integrity: sha512-8CDI1aL/ts0mDGbWzjEOGKXnU7p3rDzggHSBtVryQzkSOsjCHRVe0iFYUuhczlxU1R3LN/E7HgUO4NXzGGP/Ag==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    optional: true
-
   /esbuild-windows-32@0.15.18:
     resolution: {integrity: sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==}
     engines: {node: '>=12'}
@@ -19962,14 +19840,6 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-windows-32@0.15.7:
-    resolution: {integrity: sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
     optional: true
 
   /esbuild-windows-64@0.15.18:
@@ -19981,14 +19851,6 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-windows-64@0.15.7:
-    resolution: {integrity: sha512-7MI08Ec2sTIDv+zH6StNBKO+2hGUYIT42GmFyW6MBBWWtJhTcQLinKS6ldIN1d52MXIbiJ6nXyCJ+LpL4jBm3Q==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /esbuild-windows-arm64@0.15.18:
     resolution: {integrity: sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==}
     engines: {node: '>=12'}
@@ -19996,14 +19858,6 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
-    optional: true
-
-  /esbuild-windows-arm64@0.15.7:
-    resolution: {integrity: sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
     optional: true
 
   /esbuild@0.15.18:
@@ -20036,34 +19890,6 @@ packages:
       esbuild-windows-arm64: 0.15.18
     dev: true
 
-  /esbuild@0.15.7:
-    resolution: {integrity: sha512-7V8tzllIbAQV1M4QoE52ImKu8hT/NLGlGXkiDsbEU5PS6K8Mn09ZnYoS+dcmHxOS9CRsV4IRAMdT3I67IyUNXw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/linux-loong64': 0.15.7
-      esbuild-android-64: 0.15.7
-      esbuild-android-arm64: 0.15.7
-      esbuild-darwin-64: 0.15.7
-      esbuild-darwin-arm64: 0.15.7
-      esbuild-freebsd-64: 0.15.7
-      esbuild-freebsd-arm64: 0.15.7
-      esbuild-linux-32: 0.15.7
-      esbuild-linux-64: 0.15.7
-      esbuild-linux-arm: 0.15.7
-      esbuild-linux-arm64: 0.15.7
-      esbuild-linux-mips64le: 0.15.7
-      esbuild-linux-ppc64le: 0.15.7
-      esbuild-linux-riscv64: 0.15.7
-      esbuild-linux-s390x: 0.15.7
-      esbuild-netbsd-64: 0.15.7
-      esbuild-openbsd-64: 0.15.7
-      esbuild-sunos-64: 0.15.7
-      esbuild-windows-32: 0.15.7
-      esbuild-windows-64: 0.15.7
-      esbuild-windows-arm64: 0.15.7
-
   /esbuild@0.16.17:
     resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
     engines: {node: '>=12'}
@@ -20092,6 +19918,7 @@ packages:
       '@esbuild/win32-arm64': 0.16.17
       '@esbuild/win32-ia32': 0.16.17
       '@esbuild/win32-x64': 0.16.17
+    dev: true
 
   /esbuild@0.17.19:
     resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
@@ -20989,7 +20816,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /file-system-cache@1.1.0:
@@ -21336,7 +21163,7 @@ packages:
       semver: 7.3.7
       tapable: 1.1.3
       typescript: 5.0.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.0.4)(webpack@5.82.1):
@@ -21359,7 +21186,7 @@ packages:
       semver: 7.3.7
       tapable: 2.2.1
       typescript: 5.0.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /form-data@2.3.3:
@@ -22455,7 +22282,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
 
   /html5shiv@3.7.3:
     resolution: {integrity: sha512-SZwGvLGNtgp8GbgFX7oXEp8OR1aBt5LliX6dG0kdD1kl3KhMonN0QcSa/A3TsTgFewaGCbIryQunjayWDXzxmw==}
@@ -24479,7 +24306,7 @@ packages:
     dependencies:
       klona: 2.0.5
       less: 4.1.3
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /less@4.1.3:
@@ -25763,7 +25590,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /minimalistic-assert@1.0.1:
@@ -27267,7 +27094,7 @@ packages:
       klona: 2.0.5
       postcss: 8.4.21
       semver: 7.5.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /postcss-media-minmax@5.0.0(postcss@8.4.21):
@@ -29028,7 +28855,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.0.4)
       tslib: 2.4.0
       typescript: 5.0.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -30013,7 +29840,7 @@ packages:
       webpack: ^5.75.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
       webpack-sources: 2.3.1
     dev: false
 
@@ -30128,7 +29955,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.54.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /sass@1.54.4:
@@ -30880,7 +30707,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /string-similarity@4.0.4:
@@ -31089,7 +30916,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /style-loader@3.3.1(webpack@5.82.1):
@@ -31098,7 +30925,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
 
   /style-to-object@0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
@@ -31159,7 +30986,7 @@ packages:
       klona: 2.0.5
       normalize-path: 3.0.0
       stylus: 0.59.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /stylus@0.59.0:
@@ -31455,7 +31282,7 @@ packages:
       - bluebird
     dev: false
 
-  /terser-webpack-plugin@5.3.6(esbuild@0.15.7)(webpack@5.82.1):
+  /terser-webpack-plugin@5.3.6(esbuild@0.17.19)(webpack@5.82.1):
     resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -31472,15 +31299,15 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
-      esbuild: 0.15.7
+      esbuild: 0.17.19
       jest-worker: 27.5.1
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.3
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
-  /terser-webpack-plugin@5.3.8(@swc/core@1.3.42)(esbuild@0.15.7)(webpack@5.82.1):
+  /terser-webpack-plugin@5.3.8(@swc/core@1.3.42)(esbuild@0.17.19)(webpack@5.82.1):
     resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -31498,15 +31325,15 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       '@swc/core': 1.3.42
-      esbuild: 0.15.7
+      esbuild: 0.17.19
       jest-worker: 27.5.1
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.3
-      webpack: 5.82.1(@swc/core@1.3.42)(esbuild@0.15.7)
+      webpack: 5.82.1(@swc/core@1.3.42)(esbuild@0.17.19)
     dev: true
 
-  /terser-webpack-plugin@5.3.8(esbuild@0.15.7)(webpack@5.82.1):
+  /terser-webpack-plugin@5.3.8(esbuild@0.17.19)(webpack@5.82.1):
     resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -31523,12 +31350,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
-      esbuild: 0.15.7
+      esbuild: 0.17.19
       jest-worker: 27.5.1
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.3
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
 
   /terser@4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
@@ -31802,7 +31629,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-jest@29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.15.7)(jest@29.5.0)(typescript@5.0.4):
+  /ts-jest@29.1.0(@babel/core@7.21.8)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -31827,7 +31654,7 @@ packages:
       '@jest/types': 29.5.0
       babel-jest: 29.5.0(@babel/core@7.21.8)
       bs-logger: 0.2.6
-      esbuild: 0.15.7
+      esbuild: 0.17.19
       fast-json-stable-stringify: 2.1.0
       jest: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
       jest-util: 29.5.0
@@ -31850,7 +31677,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.7
       typescript: 5.0.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /ts-loader@9.4.1(typescript@5.0.4)(webpack@5.82.1):
@@ -31865,7 +31692,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.7
       typescript: 5.0.4
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /ts-node@10.9.1(@swc/core@1.3.42)(@types/node@14.18.35)(typescript@5.0.4):
@@ -32632,7 +32459,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.1.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /url-parse@1.5.10:
@@ -33021,7 +32848,7 @@ packages:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /vue-template-compiler@2.7.14:
@@ -33193,7 +33020,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 3.1.2
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: false
 
   /webpack-dev-middleware@6.0.1(webpack@5.82.1):
@@ -33207,7 +33034,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /webpack-filter-warnings-plugin@1.2.1(webpack@4.46.0):
@@ -33242,7 +33069,7 @@ packages:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
       webpack-sources: 2.3.1
     dev: true
 
@@ -33282,7 +33109,7 @@ packages:
         optional: true
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.82.1(esbuild@0.15.7)
+      webpack: 5.82.1(esbuild@0.17.19)
     dev: true
 
   /webpack-virtual-modules@0.2.2:
@@ -33337,7 +33164,7 @@ packages:
       - supports-color
     dev: false
 
-  /webpack@5.82.1(@swc/core@1.3.42)(esbuild@0.15.7):
+  /webpack@5.82.1(@swc/core@1.3.42)(esbuild@0.17.19):
     resolution: {integrity: sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -33368,7 +33195,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.8(@swc/core@1.3.42)(esbuild@0.15.7)(webpack@5.82.1)
+      terser-webpack-plugin: 5.3.8(@swc/core@1.3.42)(esbuild@0.17.19)(webpack@5.82.1)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -33377,7 +33204,7 @@ packages:
       - uglify-js
     dev: true
 
-  /webpack@5.82.1(esbuild@0.15.7):
+  /webpack@5.82.1(esbuild@0.17.19):
     resolution: {integrity: sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -33408,7 +33235,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.8(esbuild@0.15.7)(webpack@5.82.1)
+      terser-webpack-plugin: 5.3.8(esbuild@0.17.19)(webpack@5.82.1)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/scripts/jest-config/package.json
+++ b/scripts/jest-config/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^29",
     "@types/node": "^14",
     "enhanced-resolve": "5.12.0",
-    "esbuild": "0.15.7",
+    "esbuild": "0.17.19",
     "jest": "^29"
   }
 }


### PR DESCRIPTION
## Summary

esbuild v17 removed the `watch: true` option, we need to use `esbuild.context` instead, see: https://github.com/evanw/esbuild/releases/tag/v0.17.0

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17dae9b</samp>

This pull request updates the esbuild dependency to v17 and enables watch mode for server bundle and node bundle functions. It affects several packages that use esbuild for bundling and transforming code, such as `@modern-js/app-tools`, `@modern-js/node-bundle-require`, and `@modern-js/builder-plugin-esbuild`. It also adds a changeset file to document the patches and translations.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 17dae9b</samp>

*  Update esbuild dependency from v15/v16 to v17 across several packages and scripts ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-a576d8898e740e4c5b1bd1fccc17f2a1182332cd2df9a4c918d4d93b3f4c7a74R1-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L84-R84), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-1d53290d033ea716ac22edbd5126d45cd42bd1b029214bfe509a0f40abeec276L41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-4ba9c298e0c9aceb8c9f170f6ad80c539f36a3ceae0575c46dfc5976b735ace4L64-R64), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-a90f331e2d4e9320efe81c8af64349df4b94c4c63c247993e91f00bcfc1a8561L173-R173), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-48f59b5651ff1f982a17a10d709daf19b68a669d2fa3d26644935ca6d922f255L97-R97), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-c0a9ee24ee1af8efe92424d3af863d9395ebf491e186d7380dd803acf0d9b75fL55-R55), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-d1d55fe40c30fe1926a0867c89123ae9820db312b4a034a63e9134a74a279f89L12-R12))
*  Simplify the options passed to the `buildServerConfig` function in the `dev` command of the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-c5e04e972eb500f233ab890a23fb40f4f77c017c51676f25562d1f37b356564aL43-R43))
*  Add the `watch` parameter and property to the `buildServerConfig` function and the `ServerConfig` interface in the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-022809e91016093b79e71cc561337e42d781d455a51def1bde694ec2e8031256R20), [link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-022809e91016093b79e71cc561337e42d781d455a51def1bde694ec2e8031256R26))
*  Pass the `watch` option to the esbuild `build` function in the `buildServerConfig` function in the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-022809e91016093b79e71cc561337e42d781d455a51def1bde694ec2e8031256R51))
*  Import the `context` function from esbuild in the `bundle` module of the `@modern-js/node-bundle-require` package ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-5c46371fc0c3f5b6959c76f8611a5b4c9fc63afcf569e29200bf127319123205L9-R9))
*  Add the `watch` option to the `BundleOptions` interface in the `@modern-js/node-bundle-require` package ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-5c46371fc0c3f5b6959c76f8611a5b4c9fc63afcf569e29200bf127319123205R70-R74))
*  Create an `esbuildOptions` object in the `bundle` function of the `@modern-js/node-bundle-require` package ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-5c46371fc0c3f5b6959c76f8611a5b4c9fc63afcf569e29200bf127319123205L88-R93))
*  Add conditional logic to the `bundle` function of the `@modern-js/node-bundle-require` package to enable the esbuild watch mode for the bundle if the `watch` option is true ([link](https://github.com/web-infra-dev/modern.js/pull/4098/files?diff=unified&w=0#diff-5c46371fc0c3f5b6959c76f8611a5b4c9fc63afcf569e29200bf127319123205L197-R210))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
