### PR TITLE
fix(plugin-module-doc): global component can not resolve arco

### DIFF
--- a/.changeset/real-rice-sneeze.md
+++ b/.changeset/real-rice-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+fix: move arco to dep from devDep, let global compoennts can resolve it
+fix: 将arco从devDep移到dep里，使得全局组件能够加载到它

--- a/packages/module/plugin-module-doc/package.json
+++ b/packages/module/plugin-module-doc/package.json
@@ -38,10 +38,10 @@
   "dependencies": {
     "@modern-js/doc-core": "workspace:*",
     "@modern-js/doc-plugin-preview": "workspace:*",
-    "@modern-js/doc-plugin-api-docgen": "workspace:*"
+    "@modern-js/doc-plugin-api-docgen": "workspace:*",
+    "@arco-design/web-react": "^2.46.0"
   },
   "devDependencies": {
-    "@arco-design/web-react": "^2.46.0",
     "@modern-js/module-tools": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@scripts/build": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3105,6 +3105,9 @@ importers:
 
   packages/module/plugin-module-doc:
     dependencies:
+      '@arco-design/web-react':
+        specifier: ^2.46.0
+        version: 2.46.1(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/doc-core':
         specifier: workspace:*
         version: link:../../cli/doc-core
@@ -3115,9 +3118,6 @@ importers:
         specifier: workspace:*
         version: link:../../cli/doc-plugin-preview
     devDependencies:
-      '@arco-design/web-react':
-        specifier: ^2.46.0
-        version: 2.46.1(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/module-tools':
         specifier: workspace:*
         version: link:../../solutions/module-tools


### PR DESCRIPTION


## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3323319</samp>

This pull request fixes a dependency issue in the `@modern-js/plugin-module-doc` package that caused global components to fail to resolve. It moves `@arco-design/web-react` from devDependencies to dependencies in `package.json` and adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3323319</samp>

*  Move `@arco-design/web-react` from devDependencies to dependencies in `@modern-js/plugin-module-doc` package to fix global component resolution ([link](https://github.com/web-infra-dev/modern.js/pull/4103/files?diff=unified&w=0#diff-707bfc788f30730cbe9f23505e9968531dd79f32a244c6a58fc5a371e49ee0b0L41-R44), [link](https://github.com/web-infra-dev/modern.js/pull/4103/files?diff=unified&w=0#diff-2b22bf88de80a08bc78d020023393b7e154661517514ab1729f8c7b7ac33c4d2R1-R6))
*  Add changeset file to document the patch updates for `@modern-js/plugin-module-doc` package and provide Chinese translation of the fix message ([link](https://github.com/web-infra-dev/modern.js/pull/4103/files?diff=unified&w=0#diff-2b22bf88de80a08bc78d020023393b7e154661517514ab1729f8c7b7ac33c4d2R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
