### PR TITLE
chore(builder): add some e2e test cases

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -68,7 +68,7 @@ All configurations and capabilities under html are available within rspack.
 
 Unsupported configurations and capabilities include:
 
-- [source.sri](/api/config-security.html#securitysri) ([track issue](https://github.com/web-infra-dev/rspack/issues/2669))
+- [security.sri](/api/config-security.html#securitysri) ([track issue](https://github.com/web-infra-dev/rspack/issues/2669))
 
 #### Dev Config
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -68,7 +68,7 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 
 不支持的配置项及能力包括：
 
-- [source.sri](/api/config-security.html#securitysri) ([issue 追踪](https://github.com/web-infra-dev/rspack/issues/2669))
+- [security.sri](/api/config-security.html#securitysri) ([issue 追踪](https://github.com/web-infra-dev/rspack/issues/2669))
 
 #### Dev Config
 

--- a/tests/e2e/builder/cases/check-syntax/index.test.ts
+++ b/tests/e2e/builder/cases/check-syntax/index.test.ts
@@ -15,7 +15,6 @@ test('should throw error when exist syntax errors', async () => {
           checkSyntax: true,
         },
         tools: {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error
           rspack: config => {
             config.target = ['web'];

--- a/tests/e2e/builder/cases/output/rem/.gitignore
+++ b/tests/e2e/builder/cases/output/rem/.gitignore
@@ -1,2 +1,1 @@
-dist-1
-dist-2
+dist-*

--- a/tests/e2e/builder/cases/source/plugin-import/index.test.ts
+++ b/tests/e2e/builder/cases/source/plugin-import/index.test.ts
@@ -2,8 +2,8 @@ import path from 'path';
 import { rspackOnlyTest, webpackOnlyTest } from '@scripts/helper';
 import { build } from '@scripts/shared';
 import { expect } from '@modern-js/e2e/playwright';
-import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
 import { ensureDirSync, copySync } from 'fs-extra';
+import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
 import { SharedTransformImport } from '@modern-js/builder-shared';
 import { BuilderConfig } from '@modern-js/builder-webpack-provider';
 
@@ -46,7 +46,7 @@ webpackOnlyTest('should import with function customName', async () => {
             customName: (member: string) => `foo/lib/${member}`,
           },
         ],
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+
         // @ts-expect-error rspack and webpack all support this
         disableDefaultEntries: true,
         entries: {

--- a/tests/e2e/builder/cases/source/source-exclude/index.test.ts
+++ b/tests/e2e/builder/cases/source/source-exclude/index.test.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import { expect } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
+
+webpackOnlyTest(
+  'should not compile specified file when source.exclude',
+  async () => {
+    await expect(
+      build({
+        cwd: __dirname,
+        entry: { index: path.resolve(__dirname, './src/index.js') },
+        builderConfig: {
+          source: {
+            exclude: [path.resolve(__dirname, './src/test.js')],
+          },
+          security: {
+            checkSyntax: true,
+          },
+        },
+      }),
+    ).rejects.toThrowError('[Syntax Checker]');
+  },
+);

--- a/tests/e2e/builder/cases/source/source-exclude/src/index.js
+++ b/tests/e2e/builder/cases/source/source-exclude/src/index.js
@@ -1,0 +1,3 @@
+import { printLog } from './test';
+
+printLog();

--- a/tests/e2e/builder/cases/source/source-exclude/src/test.js
+++ b/tests/e2e/builder/cases/source/source-exclude/src/test.js
@@ -1,0 +1,4 @@
+export const printLog = () => {
+  const arr = [1, 2, 3, 4, [5, 6, [7, 8]]];
+  console.log(arr, arr.flat());
+};

--- a/tests/e2e/builder/cases/source/source-include/index.test.ts
+++ b/tests/e2e/builder/cases/source/source-include/index.test.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
+
+webpackOnlyTest(
+  'should not compile file which outside of project by default',
+  async () => {
+    await expect(
+      build({
+        cwd: __dirname,
+        entry: { index: path.resolve(__dirname, './src/index.js') },
+        builderConfig: {
+          security: {
+            checkSyntax: true,
+          },
+        },
+      }),
+    ).rejects.toThrowError('[Syntax Checker]');
+  },
+);
+
+test('should compile specified file when source.include', async () => {
+  await expect(
+    build({
+      cwd: __dirname,
+      entry: { index: path.resolve(__dirname, './src/index.js') },
+      builderConfig: {
+        source: {
+          include: [path.resolve(__dirname, '../test.js')],
+        },
+        security: {
+          checkSyntax: true,
+        },
+      },
+    }),
+  ).resolves.toBeDefined();
+});

--- a/tests/e2e/builder/cases/source/source-include/src/index.js
+++ b/tests/e2e/builder/cases/source/source-include/src/index.js
@@ -1,0 +1,3 @@
+import { printLog } from '../../test';
+
+printLog();

--- a/tests/e2e/builder/cases/source/source.test.ts
+++ b/tests/e2e/builder/cases/source/source.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
@@ -44,7 +43,8 @@ test.describe('source configure multi', () => {
   });
 });
 
-webpackOnlyTest('module-scopes', async ({ page }) => {
+// todo: moduleScopes not work when buildCache is false ???
+test.skip('module-scopes', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'module-scopes'),
     entry: {

--- a/tests/e2e/builder/cases/source/source.test.ts
+++ b/tests/e2e/builder/cases/source/source.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
@@ -43,8 +44,7 @@ test.describe('source configure multi', () => {
   });
 });
 
-// todo: moduleScopes not work when buildCache is false ???
-test.skip('module-scopes', async ({ page }) => {
+webpackOnlyTest('module-scopes', async ({ page }) => {
   const buildOpts = {
     cwd: join(fixtures, 'module-scopes'),
     entry: {

--- a/tests/e2e/builder/cases/source/test.js
+++ b/tests/e2e/builder/cases/source/test.js
@@ -1,0 +1,4 @@
+export const printLog = () => {
+  const arr = [1, 2, 3, 4, [5, 6, [7, 8]]];
+  console.log(arr, arr.flat());
+};

--- a/tests/e2e/builder/cases/sri/index.test.ts
+++ b/tests/e2e/builder/cases/sri/index.test.ts
@@ -1,0 +1,35 @@
+import path from 'path';
+import { expect } from '@modern-js/e2e/playwright';
+import { build, getHrefByEntryName } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
+
+webpackOnlyTest('security.sri', async ({ page }) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    runServer: true,
+    builderConfig: {
+      security: {
+        sri: true,
+      },
+    },
+  });
+
+  const files = await builder.unwrapOutputJSON();
+  const htmlFileName = Object.keys(files).find(f => f.endsWith('.html'))!;
+
+  const regex = /integrity=/g;
+
+  const matches = files[htmlFileName].match(regex);
+
+  // at least 1 js file and 1 css file
+  expect(matches?.length).toBeGreaterThanOrEqual(2);
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+
+  await expect(
+    page.evaluate(`document.getElementById('test').innerHTML`),
+  ).resolves.toBe('Hello Builder!');
+
+  builder.close();
+});

--- a/tests/e2e/builder/cases/sri/index.test.ts
+++ b/tests/e2e/builder/cases/sri/index.test.ts
@@ -25,7 +25,7 @@ webpackOnlyTest('security.sri', async ({ page }) => {
   // at least 1 js file and 1 css file
   expect(matches?.length).toBeGreaterThanOrEqual(2);
 
-  await page.goto(getHrefByEntryName('main', builder.port));
+  await page.goto(getHrefByEntryName('index', builder.port));
 
   await expect(
     page.evaluate(`document.getElementById('test').innerHTML`),

--- a/tests/e2e/builder/cases/sri/src/App.css
+++ b/tests/e2e/builder/cases/sri/src/App.css
@@ -1,0 +1,19 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: nunito_for_arco, Helvetica Neue, Helvetica, PingFang SC,
+    Hiragino Sans GB, Microsoft YaHei, 微软雅黑, Arial, sans-serif;
+}
+
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  box-sizing: border-box;
+}
+
+.description {
+  text-align: center;
+  line-height: 1.5;
+  font-size: 16px;
+}

--- a/tests/e2e/builder/cases/sri/src/App.jsx
+++ b/tests/e2e/builder/cases/sri/src/App.jsx
@@ -1,0 +1,9 @@
+import './App.css';
+
+const App = () => (
+  <div className="container">
+    <div id="test">Hello Builder!</div>
+  </div>
+);
+
+export default App;

--- a/tests/e2e/builder/cases/sri/src/index.js
+++ b/tests/e2e/builder/cases/sri/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { render } from 'react-dom';
+import App from './App';
+
+// eslint-disable-next-line no-undef
+render(React.createElement(App), document.getElementById('root'));

--- a/tests/e2e/builder/cases/tools.test.ts
+++ b/tests/e2e/builder/cases/tools.test.ts
@@ -32,6 +32,30 @@ test('postcss plugins overwrite', async ({ page }) => {
   builder.close();
 });
 
+test('bundlerChain', async ({ page }) => {
+  const builder = await build({
+    cwd: join(fixtures, 'source/basic'),
+    entry: {
+      main: join(fixtures, 'source/basic/src/index.js'),
+    },
+    runServer: true,
+    builderConfig: {
+      tools: {
+        bundlerChain: chain => {
+          chain.resolve.alias.merge({
+            '@common': './src/common',
+          });
+        },
+      },
+    },
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+  await expect(page.innerHTML('#test')).resolves.toBe('Hello Builder! 1');
+
+  builder.close();
+});
+
 webpackOnlyTest('webpackChain plugin', async ({ page }) => {
   const builder = await build({
     cwd: join(fixtures, 'source/global-vars'),

--- a/tests/e2e/builder/cases/tools.test.ts
+++ b/tests/e2e/builder/cases/tools.test.ts
@@ -43,7 +43,7 @@ test('bundlerChain', async ({ page }) => {
       tools: {
         bundlerChain: chain => {
           chain.resolve.alias.merge({
-            '@common': './src/common',
+            '@common': join(fixtures, 'source/basic/src/common'),
           });
         },
       },

--- a/tests/e2e/builder/scripts/helper.ts
+++ b/tests/e2e/builder/scripts/helper.ts
@@ -9,7 +9,6 @@ export const getProviderTest = (supportType: string[] = ['webpack']) => {
 
   const testSkip = test.skip;
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
   testSkip.describe = test.describe.skip;
   return testSkip as typeof test.skip & {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 409a0c5</samp>

Added and updated e2e tests for various builder features, such as inline chunk, output, source, security, and bundlerChain. Fixed a documentation error for the security.sri configuration. Simplified some test files and removed unnecessary eslint comments.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 409a0c5</samp>

*  Correct the configuration name for enabling SRI from `source.sri` to `security.sri` in the English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L71-R71), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L71-R71))
  - disabling inline runtime chunk ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caR23-R71))
  - using RegExp to inline styles ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL169-R218))
  - enabling sourcemap for CSS but not for JS ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbR60-R73))
  - disabling sourcemap for both CSS and JS ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbR107-R134))
  - excluding a file from compilation ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-bac00880662adcc679fd5ea491f5365f019cffd1361ea17ed682c71c41605999R1-R24), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-6c675d68990da34c941c996e1b42fb7947f3a42eb9b95bf2dfe8ebe70fcfd7c8R1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-bbb4b14fcb7194d7b306c747f6649951004ebe853cf51610c84f62d7ebf1fd98R1-R4))
  - including a file that is outside of the project by default ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-eee09a9c5ebba449aeb92471015b33b98915b60cfb931bcf9a81459ee548bea1R1-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-cfbfff2edb23b6b6b5191a8addacddb495919274b2f707b8e55bf674bd7ff1cdR1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-3fc2b5f547a529be1bc41d864faf62ac67ca845508743cb30effb4a964a7db67R1-R4))
  - enabling SRI and generating integrity attributes ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-6dc530a849d10c89de8bdde1b9dd62a1c157e541bc79f9578b1c7c6e582052d8R1-R35), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-c0ea58bfcfd11b642354ebbb7a0132d3af64c44a63f76f7f23dbe210fac7434bR1-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-91ca6cf513f64ffd3bdbc01be4a9aad36b17bc448736dec6e96f34bdde90630eR1-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-99504ba777bac1a415643e519030ea9ff2fae89b81212580766b80bf79f7027fR1-R6))
  - using a custom function to modify the bundler configuration and resolve aliases ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-7c3a599e58fd98fbd9c8ee67292317d46d1d8890a8fe9f42ff7952b0c0751708R35-R58))
* Use the `webpackOnlyTest` helper function to skip tests that are not relevant for other bundlers, such as module-scopes and inline styles ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL2-R2), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbR5), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44R4), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L46-R47))
* Simplify the `.gitignore` file for the `rem` test case to ignore all `dist-*` folders ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-770a387803746fa5ebbcc5260ff0fc27814d7ab13930385c5de37449b963cc9dL1-R1))
* Remove unnecessary eslint comments for disabling TypeScript type checking in two test files ([link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-cd7580de9aa167a62592927f8c3bc122ab4adb1a4066eb1cb795097f77f9d90bL18), [link](https://github.com/web-infra-dev/modern.js/pull/4105/files?diff=unified&w=0#diff-d6a21090ae5eddea1ebf342f2a8f48f677f2027ef08c17af8c3a3e9c2cd14f44L12))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
