### PR TITLE
fix: should not clean dist path if run deploy command but skip build

### DIFF
--- a/.changeset/mean-flowers-kick.md
+++ b/.changeset/mean-flowers-kick.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: should not clean dist path if run deploy command but skip build
+fix: 如果运行 deploy 命令，但是跳过构建阶段，不应该清理产物目录

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -6,6 +6,7 @@ import {
   Import,
   Command,
   getCommand,
+  getArgv,
 } from '@modern-js/utils';
 import { castArray } from '@modern-js/utils/lodash';
 import { CliPlugin, PluginAPI } from '@modern-js/core';
@@ -272,6 +273,15 @@ export const appTools = (
 
       async prepare() {
         const command = getCommand();
+        if (command === 'deploy') {
+          const isSkipBuild = ['-s', '--skip-build'].some(tag => {
+            return getArgv().includes(tag);
+          });
+          // if skip build, do not clean dist path
+          if (isSkipBuild) {
+            return;
+          }
+        }
 
         // clean dist path before building
         if (


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21836f5</samp>

This pull request adds a new feature and fixes two bugs in the `@modern-js/app-tools` package. The new feature is a `getArgv` function that enables command-line arguments for the tool. The bugs are related to the `clean` method that should not delete the dist path when deploying without building. The changeset file reflects these changes in both English and Chinese.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 21836f5</samp>

*  Export `getArgv` function from `appTools` object to access command-line arguments ([link](https://github.com/web-infra-dev/modern.js/pull/4110/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR9))
*  Prevent `clean` method from deleting dist path if `deploy` command is run with `-s` or `--skip-build` flags ([link](https://github.com/web-infra-dev/modern.js/pull/4110/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR276-R284))
*  Update changeset file for `@modern-js/app-tools` package with patch version and bug fix descriptions ([link](https://github.com/web-infra-dev/modern.js/pull/4110/files?diff=unified&w=0#diff-7cca630fbc44d093dcd0a94b833d93f1e948e12639838da05150685e211fdd29R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
