### PR TITLE
fix(utils): incorrect ora & commander exports path

### DIFF
--- a/.changeset/eleven-cups-agree.md
+++ b/.changeset/eleven-cups-agree.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/utils': patch
+---
+
+fix(utils): incorrect ora & commander exports path
+
+fix(utils): 修复错误的 ora & commander 导出路径
+

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -158,8 +158,8 @@
         "default": "./dist/cjs/universal/pluginDagSort.js"
       },
       "./ajv": "./dist/compiled/ajv/index.js",
-      "./commander": "./compiled/commander/index.js",
-      "./ora": "./compiled/ora/index.js",
+      "./commander": "./dist/compiled/commander/index.js",
+      "./ora": "./dist/compiled/ora/index.js",
       "./glob": "./dist/compiled/glob/index.js",
       "./chalk": "./dist/compiled/chalk/index.js",
       "./execa": "./dist/compiled/execa/index.js",


### PR DESCRIPTION
## Summary

Ref: https://github.com/web-infra-dev/modern.js/commit/6b9d90aecf9fab12019290ddefac791f90ba4e84#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478R131-R132

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c79f78</samp>

This pull request fixes a bug in the `@modern-js/utils` package that caused the exports of some modules to be broken. It also adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c79f78</samp>

* Fix exports path for `commander` and `ora` modules in `@modern-js/utils` package ([link](https://github.com/web-infra-dev/modern.js/pull/4122/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L161-R162))
* Add changeset file for patch update of `@modern-js/utils` package with summary of fix in English and Chinese (.changeset/eleven-cups-agree.md, [link](https://github.com/web-infra-dev/modern.js/pull/4122/files?diff=unified&w=0#diff-93ba8fb9cae08e9d57a182952d7b37aeac77ae2bfb47a8979ded9fb9cbfab7b9R1-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
