### PR TITLE
feat(builder-cli): support register builder plugins

### DIFF
--- a/.changeset/fresh-insects-marry.md
+++ b/.changeset/fresh-insects-marry.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-cli': patch
+---
+
+feat(builder-cli): support register builder plugins
+
+feat(builder-cli): 支持注册 builder 插件
+

--- a/packages/builder/builder-cli/src/config.ts
+++ b/packages/builder/builder-cli/src/config.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { findExists } from '@modern-js/utils';
 import { existsSync } from '@modern-js/utils/fs-extra';
 import { bundleRequire } from '@modern-js/node-bundle-require';
-import type { BuilderEntry } from '@modern-js/builder-shared';
+import type { BuilderEntry, BuilderPlugin } from '@modern-js/builder-shared';
 import type { BuilderConfig as WebpackBuilderConfig } from '@modern-js/builder-webpack-provider';
 import type { BuilderConfig as RspackBuilderConfig } from '@modern-js/builder-rspack-provider';
 
@@ -11,6 +11,7 @@ export type BuilderConfig<Bundler extends 'rspack' | 'webpack' = 'webpack'> =
     source?: {
       entries?: BuilderEntry;
     };
+    builderPlugins?: BuilderPlugin[];
   };
 
 export const defineConfig = <Bundler extends 'rspack' | 'webpack' = 'webpack'>(

--- a/packages/builder/builder-cli/src/index.ts
+++ b/packages/builder/builder-cli/src/index.ts
@@ -17,5 +17,9 @@ export async function run() {
     },
   );
 
+  if (config.builderPlugins) {
+    builder.addPlugins(config.builderPlugins);
+  }
+
   setupProgram(builder);
 }

--- a/packages/document/builder-doc/docs/en/guide/basic/builder-cli.mdx
+++ b/packages/document/builder-doc/docs/en/guide/basic/builder-cli.mdx
@@ -112,3 +112,18 @@ export default defineConfig({
   },
 });
 ```
+
+## Registering Plugins
+
+You can register Builder plugins using the `builderPlugins` option in `builder.config.ts`.
+
+For example, to register a Vue plugin:
+
+```ts title="builder.config.ts"
+import { defineConfig } from '@modern-js/builder-cli';
+import { builderPluginVue } from '@modern-js/builder-plugin-vue';
+
+export default defineConfig({
+  builderPlugins: [builderPluginVue()],
+});
+```

--- a/packages/document/builder-doc/docs/zh/guide/basic/builder-cli.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/basic/builder-cli.mdx
@@ -112,3 +112,18 @@ export default defineConfig({
   },
 });
 ```
+
+## 注册插件
+
+你可以在 `builder.config.ts` 中使用 `builderPlugins` 选项来注册 Builder 插件。
+
+比如注册 Vue 插件：
+
+```ts title="builder.config.ts"
+import { defineConfig } from '@modern-js/builder-cli';
+import { builderPluginVue } from '@modern-js/builder-plugin-vue';
+
+export default defineConfig({
+  builderPlugins: [builderPluginVue()],
+});
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5912,6 +5912,21 @@ importers:
         specifier: ^5
         version: 5.0.4
 
+  tests/e2e/builder/cases/builder-cli/builder-cli-vue:
+    devDependencies:
+      '@modern-js/builder-cli':
+        specifier: workspace:*
+        version: link:../../../../../../packages/builder/builder-cli
+      '@modern-js/builder-rspack-provider':
+        specifier: workspace:*
+        version: link:../../../../../../packages/builder/builder-rspack-provider
+      '@types/node':
+        specifier: ^14
+        version: 14.18.35
+      typescript:
+        specifier: ^5
+        version: 5.0.4
+
   tests/e2e/builder/cases/builder-cli/builder-cli-webpack:
     devDependencies:
       '@modern-js/builder-cli':

--- a/tests/e2e/builder/cases/builder-cli/builder-cli-vue/builder.config.ts
+++ b/tests/e2e/builder/cases/builder-cli/builder-cli-vue/builder.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@modern-js/builder-cli';
+import { builderPluginVue } from '@modern-js/builder-plugin-vue';
+
+export default defineConfig({
+  output: {
+    disableTsChecker: true,
+  },
+  builderPlugins: [builderPluginVue()],
+});

--- a/tests/e2e/builder/cases/builder-cli/builder-cli-vue/index.test.ts
+++ b/tests/e2e/builder/cases/builder-cli/builder-cli-vue/index.test.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { execSync } from 'child_process';
+import { expect } from '@modern-js/e2e/playwright';
+import { globContentJSON } from '@modern-js/e2e';
+import { rspackOnlyTest } from '../../../scripts/helper';
+
+rspackOnlyTest('should build Vue sfc correctly', async () => {
+  execSync('npm run build', {
+    cwd: __dirname,
+  });
+
+  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputFiles = Object.keys(outputs);
+
+  expect(
+    outputFiles.find(item => item.includes('html/index/index.html')),
+  ).toBeTruthy();
+  expect(
+    outputFiles.find(item => item.includes('static/js/index.')),
+  ).toBeTruthy();
+});

--- a/tests/e2e/builder/cases/builder-cli/builder-cli-vue/package.json
+++ b/tests/e2e/builder/cases/builder-cli/builder-cli-vue/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "name": "@e2e/builder-cli-vue",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "builder dev",
+    "build": "builder build",
+    "serve": "builder serve"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "eslintIgnore": [
+    "node_modules/",
+    "dist/"
+  ],
+  "devDependencies": {
+    "@modern-js/builder-cli": "workspace:*",
+    "@modern-js/builder-rspack-provider": "workspace:*",
+    "typescript": "^5",
+    "@types/node": "^14"
+  }
+}

--- a/tests/e2e/builder/cases/builder-cli/builder-cli-vue/src/A.vue
+++ b/tests/e2e/builder/cases/builder-cli/builder-cli-vue/src/A.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>The count is {{ count }}</div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const count = ref(0);
+
+    return {
+      count,
+    };
+  },
+};
+</script>

--- a/tests/e2e/builder/cases/builder-cli/builder-cli-vue/src/index.js
+++ b/tests/e2e/builder/cases/builder-cli/builder-cli-vue/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import A from './A.vue';
+
+createApp(A).mount('#root');

--- a/tests/e2e/builder/cases/builder-cli/builder-cli-vue/tsconfig.json
+++ b/tests/e2e/builder/cases/builder-cli/builder-cli-vue/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@modern-js/tsconfig/base",
   "compilerOptions": {
     "declaration": false,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"],

--- a/tests/e2e/builder/cases/builder-cli/builder-cli-vue/tsconfig.json
+++ b/tests/e2e/builder/cases/builder-cli/builder-cli-vue/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "shared", "config"]
+}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6eb4a3f</samp>

This pull request adds support for registering builder plugins in the `@modern-js/builder-cli` package, which allows users to customize the build process for different frameworks and scenarios. It also updates the documentation, the changeset, and the e2e test cases for this feature. It includes an example of using the `@modern-js/builder-plugin-vue` package to build a Vue app with the `builder-cli`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6eb4a3f</samp>

*  Add a changeset file to document the patch update of `@modern-js/builder-cli` package and the feature of supporting registering builder plugins in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-941da80cdb8d1a9eaf0258b3880d0ed38a22e56797a6f8ea06542b5cfcbdb883R1-R8))
*  Import the `BuilderPlugin` type from `@modern-js/builder-shared` package and add the `builderPlugins` option to the `BuilderConfig` type in the `config.ts` file of `@modern-js/builder-cli` package ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-256ea6f5d8143f5a1af34ca29c02d5cda470371a07ef6ea2b3b78086456049b9L5-R5),[link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-256ea6f5d8143f5a1af34ca29c02d5cda470371a07ef6ea2b3b78086456049b9R14))
*  Check the `builderPlugins` option in the builder config and call the `addPlugins` method of the builder instance with the plugins array as the argument in the `run` function of the `index.ts` file of `@modern-js/builder-cli` package ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-ac5c164bae7fdaa9a9fe83cf53dd914566818a6b3f076b09c4d5559dc83ea8f0R20-R23))
*  Add a section to the English and Chinese documentation of the `builder-cli` guide, explaining how to register builder plugins using the `builderPlugins` option in the `builder.config.ts` file and giving an example of registering a Vue plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-8a27c71bae5b793a484bf943f251456c4011798436b438195d6cd57f5e3b11b6R115-R129),[link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-6c324d1a3b606256571d3365e6d4c3f2e3a5acdda622b855412972d9fd03dcdfR115-R129))
*  Add a new e2e test case for the `builder-cli` package, using the `builderPluginVue` from `@modern-js/builder-plugin-vue` package as one of the `builderPlugins` option in the `builder.config.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-e58c7173d30477290f4e444b991533a81a60a053bef93e758574434d744747b8R1-R9))
*  Run the `builder build` command and assert that the output files contain the expected HTML and JS files for the Vue app in the `index.test.ts` file of the e2e test case ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-ff99a148e8634e04acd48a22f715ff091628a77c4229eb40600d0de891b6535dR1-R21))
*  Add a `package.json` file to the e2e test case, specifying the scripts, engines, eslintIgnore and devDependencies, including the `@modern-js/builder-cli` and `@modern-js/builder-rspack-provider` packages as workspace dependencies ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-367168a7b2cc73d78ad0ce5ff54ef1c01a9305daa96b22d8a5b421034f0957d3R1-R23))
*  Add a `A.vue` file and an `index.js` file to the `src` folder of the e2e test case, which are the Vue single file component and the entry point of the Vue app respectively ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-63d9bf9fd6b8b10e4fcb8bf84dd23205fe1f1e2d619b2a33ba87024759dfa5f2R1-R17),[link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-78a2f8e005de6992592d51ae822a62ee7345d7e822e0d12bd901dd20e5b79c21R1-R4))
*  Add a `tsconfig.json` file to the e2e test case, extending the base TypeScript configuration from `@modern-js/tsconfig/base` package and setting some compiler options and include paths ([link](https://github.com/web-infra-dev/modern.js/pull/4123/files?diff=unified&w=0#diff-b3d49328bed616246263225ed87d4bcb0becaa46a09d42524dd7f325c929ac1fR1-R13))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
