### PR TITLE
docs: add '[object Object] is not a PostCSS plugin' faq

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
@@ -46,9 +46,9 @@ For details, see [source.include usage introduction](/en/api/config-source.html#
 
 ### Compile error `Error: [object Object] is not a PostCSS plugin` ?
 
-If you encounter the `Error: [object Object] is not a PostCSS plugin` error during the compilation process, it is usually caused by referencing the wrong version of postcss, for example, the version of `postcss` (peerDependencies) in `cssnano` does not meet expectations.
+Currently, Modern.js is using PostCSS v8. If you encounter the `Error: [object Object] is not a PostCSS plugin` error during the compilation process, it is usually caused by referencing the wrong version of PostCSS, for example, the version of `postcss` (peerDependencies) in `cssnano` does not meet expectations.
 
-You can find the dependencies of `UNMET PEER DEPENDENCY` through `npm ls postcss`, and then install the correct version of dependencies by specifying the postcss version in package.json.
+You can find the dependencies of `UNMET PEER DEPENDENCY` through `npm ls postcss`, and then install the correct version of dependencies by specifying the PostCSS version in package.json.
 
 ```
 npm ls postcss

--- a/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
@@ -44,6 +44,23 @@ For details, see [source.include usage introduction](/en/api/config-source.html#
 
 ---
 
+### Compile error `Error: [object Object] is not a PostCSS plugin` ?
+
+If you encounter the `Error: [object Object] is not a PostCSS plugin` error during the compilation process, it is usually caused by referencing the wrong version of postcss, for example, the version of `postcss` (peerDependencies) in `cssnano` does not meet expectations.
+
+You can find the dependencies of `UNMET PEER DEPENDENCY` through `npm ls postcss`, and then install the correct version of dependencies by specifying the postcss version in package.json.
+
+```
+npm ls postcss
+
+ ├─┬ css-loader@6.3.0
+ │ └── UNMET PEER DEPENDENCY postcss@8.3.9
+ ├─┬ css-minimizer-webpack-plugin@3.0.0
+ │ └── UNMET PEER DEPENDENCY postcss@8.3.9
+```
+
+---
+
 ### Compile error `You may need additional loader`?
 
 If the following error message is encountered during the compilation process, it means that there are individual files that cannot be compiled correctly.

--- a/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
@@ -63,6 +63,23 @@ You may need an additional loader to handle the result of these loaders.
 
 ---
 
+### 编译时报错 `Error: [object Object] is not a PostCSS plugin` ?
+
+如果编译过程中遇到了 `Error: [object Object] is not a PostCSS plugin` 报错提示，通常是由于引用到了错误的 postcss 版本导致，常见的如 `cssnano` 中 `postcss` (peerDependencies) 版本不符合预期。
+
+可以通过 `npm ls postcss` 查找 `UNMET PEER DEPENDENCY` 的依赖，然后在 package.json 中通过指定 postcss 版本等方式安装正确的依赖版本即可。
+
+```
+npm ls postcss
+
+ ├─┬ css-loader@6.3.0
+ │ └── UNMET PEER DEPENDENCY postcss@8.3.9
+ ├─┬ css-minimizer-webpack-plugin@3.0.0
+ │ └── UNMET PEER DEPENDENCY postcss@8.3.9
+```
+
+---
+
 ### 打开页面后报错，提示 exports is not defined？
 
 如果编译正常，但是打开页面后出现 `exports is not defined` 报错，通常是因为在项目中使用 Babel 编译了一个 CommonJS 模块，导致 Babel 出现异常。

--- a/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
@@ -65,9 +65,9 @@ You may need an additional loader to handle the result of these loaders.
 
 ### 编译时报错 `Error: [object Object] is not a PostCSS plugin` ?
 
-如果编译过程中遇到了 `Error: [object Object] is not a PostCSS plugin` 报错提示，通常是由于引用到了错误的 postcss 版本导致，常见的如 `cssnano` 中 `postcss` (peerDependencies) 版本不符合预期。
+目前，Modern.js 使用的是 v8 版本的 PostCSS。如果编译过程中遇到了 `Error: [object Object] is not a PostCSS plugin` 报错提示，通常是由于引用到了错误的 PostCSS 版本导致，常见的如 `cssnano` 中 `postcss` (peerDependencies) 版本不符合预期。
 
-可以通过 `npm ls postcss` 查找 `UNMET PEER DEPENDENCY` 的依赖，然后在 package.json 中通过指定 postcss 版本等方式安装正确的依赖版本即可。
+可以通过 `npm ls postcss` 查找 `UNMET PEER DEPENDENCY` 的依赖，然后在 package.json 中通过指定 PostCSS 版本等方式安装正确的依赖版本即可。
 
 ```
 npm ls postcss


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db167bf</samp>

This pull request updates the FAQ documents in both English and Chinese to include a new section on how to resolve the `Error: [object Object] is not a PostCSS plugin` error. This error may occur when compiling a project using modern.js and the postcss dependencies are mismatched.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db167bf</samp>

*  Add a new section to the FAQ document in both English and Chinese, explaining how to resolve the `Error: [object Object] is not a PostCSS plugin` error ([link](https://github.com/web-infra-dev/modern.js/pull/4129/files?diff=unified&w=0#diff-e973d8362ca617a8bab5334833fc15ebff93d5823ae87ab98597eb0a7935fe81R47-R63), [link](https://github.com/web-infra-dev/modern.js/pull/4129/files?diff=unified&w=0#diff-61e9b6308f8819db84914f183dd09d9d0a5995e2102aff1170697d54aa53c62bR66-R82))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
