### PR TITLE
fix(eslint-config): allow $ in filenames

### DIFF
--- a/.changeset/gorgeous-emus-type.md
+++ b/.changeset/gorgeous-emus-type.md
@@ -1,0 +1,8 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+fix(eslint-config): allow $ in filenames
+
+fix(eslint-config): 允许文件名包含 $ 符号
+

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -1138,7 +1138,7 @@ module.exports = {
      * use Pascal Case for class and react component
      * use Camel Case for others
      */
-    'filenames/match-regex': ['error', '^[\\[\\]_a-zA-Z0-9.-]+$'],
+    'filenames/match-regex': ['error', '^[\\[\\]\\$_a-zA-Z0-9.-]+$'],
     // https://www.npmjs.com/package/eslint-plugin-filenames#dont-allow-indexjs-files-no-index
     'filenames/no-index': 'off',
 


### PR DESCRIPTION
## Summary

Allow `$` in filenames, because the name of Modern.js nested routes files when contain `$`.

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/c28548e8-4858-40f4-816c-2ec697a13c96)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aac7379</samp>

This pull request fixes a bug in the `@modern-js-app/eslint-config` package that prevented the use of `$` in filenames. It also updates the changelog and adds a Chinese translation for the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aac7379</samp>

* Allow `$` in filenames for `@modern-js-app/eslint-config` package ([link](https://github.com/web-infra-dev/modern.js/pull/4132/files?diff=unified&w=0#diff-dfb9c4751fe9d35995c953bd819bd71cd9fc983a7cd582cc8c90d415583e135dR1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4132/files?diff=unified&w=0#diff-aaca3b5dde0cf9edd549873e1239bcf625e4c9603b312c3cdb6ecafa9817bcc4L1141-R1141))
  - Update changelog with patch version and fix message in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4132/files?diff=unified&w=0#diff-dfb9c4751fe9d35995c953bd819bd71cd9fc983a7cd582cc8c90d415583e135dR1-R8))
  - Modify `filenames/match-regex` rule in `eslint-config-app/base.js` to include `$` as valid character ([link](https://github.com/web-infra-dev/modern.js/pull/4132/files?diff=unified&w=0#diff-aaca3b5dde0cf9edd549873e1239bcf625e4c9603b312c3cdb6ecafa9817bcc4L1141-R1141))

## Related Issue

- https://github.com/web-infra-dev/modern.js/issues/4127

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
