### PR TITLE
fix(builder): failed to set publicPath function

### DIFF
--- a/.changeset/red-bugs-reflect.md
+++ b/.changeset/red-bugs-reflect.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): failed to set publicPath function
+
+fix(builder): 修复设置 publicPath 函数时报错的问题
+

--- a/packages/builder/builder-rspack-provider/src/plugins/define.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/define.ts
@@ -13,7 +13,7 @@ export const builderPluginDefine = (): BuilderPlugin => ({
       const config = api.getNormalizedConfig();
       const publicPath = rspackConfig.output?.publicPath;
       const assetPrefix =
-        publicPath && typeof publicPath !== 'function'
+        publicPath && typeof publicPath === 'string'
           ? publicPath
           : config.output.assetPrefix;
 

--- a/packages/builder/builder-rspack-provider/src/plugins/define.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/define.ts
@@ -11,12 +11,15 @@ export const builderPluginDefine = (): BuilderPlugin => ({
         '@modern-js/utils'
       );
       const config = api.getNormalizedConfig();
+      const publicPath = rspackConfig.output?.publicPath;
+      const assetPrefix =
+        publicPath && typeof publicPath !== 'function'
+          ? publicPath
+          : config.output.assetPrefix;
 
       const builtinVars: GlobalVars = {
         'process.env.NODE_ENV': getNodeEnv(),
-        'process.env.ASSET_PREFIX': removeTailSlash(
-          rspackConfig.output?.publicPath || '/',
-        ),
+        'process.env.ASSET_PREFIX': removeTailSlash(assetPrefix),
       };
 
       // Serialize global vars. User can customize value of `builtinVars`.

--- a/packages/builder/builder-shared/src/apply/output.ts
+++ b/packages/builder/builder-shared/src/apply/output.ts
@@ -5,7 +5,7 @@ import type {
   SharedNormalizedConfig,
 } from '../types';
 import { getDistPath, getFilename } from '../fs';
-import { DEFAULT_PORT } from '../constants';
+import { DEFAULT_PORT, DEFAULT_ASSET_PREFIX } from '../constants';
 import { addTrailingSlash } from '../utils';
 import { DEFAULT_DEV_HOST } from '@modern-js/utils';
 
@@ -71,7 +71,7 @@ function getPublicPath({
 }) {
   const { dev, output } = config;
 
-  let publicPath = '/';
+  let publicPath = DEFAULT_ASSET_PREFIX;
 
   if (isProd) {
     if (output.assetPrefix) {

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -14,6 +14,7 @@ import {
   SERVER_WORKER_DIST_DIR,
   DEFAULT_MOUNT_ID,
   DEFAULT_DATA_URL_SIZE,
+  DEFAULT_ASSET_PREFIX,
 } from './constants';
 import { generateMetaTags } from './generateMetaTags';
 import type {
@@ -40,7 +41,7 @@ export const getDefaultDevConfig = (): NormalizedSharedDevConfig => ({
   hmr: true,
   https: false,
   port: DEFAULT_PORT,
-  assetPrefix: '/',
+  assetPrefix: DEFAULT_ASSET_PREFIX,
   startUrl: false,
   progressBar: true,
   host: DEFAULT_DEV_HOST,
@@ -94,7 +95,7 @@ export const getDefaultOutputConfig = (): NormalizedSharedOutputConfig => ({
     server: SERVER_DIST_DIR,
     worker: SERVER_WORKER_DIST_DIR,
   },
-  assetPrefix: '/',
+  assetPrefix: DEFAULT_ASSET_PREFIX,
   filename: {},
   charset: 'ascii',
   polyfill: 'entry',

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -94,6 +94,7 @@ export const getDefaultOutputConfig = (): NormalizedSharedOutputConfig => ({
     server: SERVER_DIST_DIR,
     worker: SERVER_WORKER_DIST_DIR,
   },
+  assetPrefix: '/',
   filename: {},
   charset: 'ascii',
   polyfill: 'entry',

--- a/packages/builder/builder-shared/src/constants.ts
+++ b/packages/builder/builder-shared/src/constants.ts
@@ -60,6 +60,7 @@ export const MEDIA_EXTENSIONS = [
   'aac',
   'mov',
 ];
+export const DEFAULT_ASSET_PREFIX = '/';
 
 // RegExp
 export const JS_REGEX = /\.(js|mjs|cjs|jsx)$/;

--- a/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
@@ -12,6 +12,7 @@ import type { Compiler, Compilation } from 'webpack';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { HtmlTagObject } from 'html-webpack-plugin';
 import { COMPILATION_PROCESS_STAGE } from './util';
+import { DEFAULT_ASSET_PREFIX } from '../constants';
 
 export type InlineChunkHtmlPluginOptions = {
   tests: RegExp[];
@@ -195,7 +196,7 @@ export class InlineChunkHtmlPlugin {
       const publicPath =
         typeof compiler.options.output.publicPath === 'string'
           ? addTrailingSlash(compiler.options.output.publicPath)
-          : '/';
+          : DEFAULT_ASSET_PREFIX;
 
       const tagFunction = (tag: HtmlTagObject) =>
         this.getInlinedTag(publicPath, tag, compilation);

--- a/packages/builder/builder-shared/src/plugins/util.ts
+++ b/packages/builder/builder-shared/src/plugins/util.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { fs } from '@modern-js/utils';
 import type { Compiler } from 'webpack';
+import { DEFAULT_ASSET_PREFIX } from '../constants';
 
 /** The intersection of webpack and Rspack */
 export const COMPILATION_PROCESS_STAGE = {
@@ -24,7 +25,7 @@ export const getPublicPathFromCompiler = (compiler: Compiler) =>
   typeof compiler.options.output.publicPath === 'string'
     ? compiler.options.output.publicPath
     : // publicPath function is not supported yet
-      '/';
+      DEFAULT_ASSET_PREFIX;
 
 export const getBuilderVersion = async (): Promise<string> => {
   const pkgJson = await fs.readJSON(path.join(__dirname, '../../package.json'));

--- a/packages/builder/builder-shared/src/types/config/output.ts
+++ b/packages/builder/builder-shared/src/types/config/output.ts
@@ -279,7 +279,7 @@ export interface NormalizedSharedOutputConfig extends SharedOutputConfig {
   filename: FilenameConfig;
   distPath: DistPathConfig;
   polyfill: Polyfill;
-  assetsRetry?: AssetsRetryOptions;
+  assetPrefix: string;
   dataUriLimit: NormalizedDataUriLimit;
   cleanDistPath: boolean;
   disableCssExtract: boolean;

--- a/packages/builder/builder-webpack-provider/src/plugins/define.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/define.ts
@@ -13,7 +13,7 @@ export const builderPluginDefine = (): BuilderPlugin => ({
       const config = api.getNormalizedConfig();
       const publicPath = chain.output.get('publicPath');
       const assetPrefix =
-        publicPath && typeof publicPath !== 'function'
+        publicPath && typeof publicPath === 'string'
           ? publicPath
           : config.output.assetPrefix;
 

--- a/packages/builder/builder-webpack-provider/src/plugins/define.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/define.ts
@@ -11,12 +11,15 @@ export const builderPluginDefine = (): BuilderPlugin => ({
         '@modern-js/utils'
       );
       const config = api.getNormalizedConfig();
+      const publicPath = chain.output.get('publicPath');
+      const assetPrefix =
+        publicPath && typeof publicPath !== 'function'
+          ? publicPath
+          : config.output.assetPrefix;
 
       const builtinVars: GlobalVars = {
         'process.env.NODE_ENV': getNodeEnv(),
-        'process.env.ASSET_PREFIX': removeTailSlash(
-          chain.output.get('publicPath') || '/',
-        ),
+        'process.env.ASSET_PREFIX': removeTailSlash(assetPrefix),
       };
       // Serialize global vars. User can customize value of `builtinVars`.
       const globalVars = applyOptionsChain(

--- a/packages/document/builder-doc/docs/en/config/output/assetPrefix.md
+++ b/packages/document/builder-doc/docs/en/config/output/assetPrefix.md
@@ -1,4 +1,4 @@
-- **Type:** `boolean | string`
+- **Type:** `string`
 - **Default:** `'/'`
 
 When using CDN in the production environment, you can use this option to set the URL prefix of static assets, similar to the [output.publicPath](https://webpack.js.org/guides/public-path/) config of webpack.

--- a/packages/document/builder-doc/docs/zh/config/output/assetPrefix.md
+++ b/packages/document/builder-doc/docs/zh/config/output/assetPrefix.md
@@ -1,4 +1,4 @@
-- **类型：** `boolean | string`
+- **类型：** `string`
 - **默认值：** `'/'`
 
 在生产环境使用 CDN 部署时，可使用该选项设置静态资源的 URL 前缀，对应 webpack 的 [output.publicPath](https://webpack.js.org/guides/public-path/) 配置。

--- a/tests/e2e/builder/cases/tools.webpack.test.ts
+++ b/tests/e2e/builder/cases/tools.webpack.test.ts
@@ -4,7 +4,7 @@ import { build, getHrefByEntryName } from '../scripts/shared';
 
 const fixtures = __dirname;
 
-test('webpackChain plugin', async ({ page }) => {
+test('webpackChain - register plugin', async ({ page }) => {
   const builder = await build({
     cwd: join(fixtures, 'source/global-vars'),
     entry: {


### PR DESCRIPTION
## Summary

Example:

```ts
export default {
  tools: {
    bundlerChain: chain => {
      chain.output.publicPath(() => 'https://www.foo.com/');
    },
  },
};
```

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ade1377</samp>

This pull request fixes the issue of setting publicPath function in the `@modern-js/builder-webpack-provider` and `@modern-js/builder-rspack-provider` packages by using the `assetPrefix` option as a fallback. It also adds the `assetPrefix` option to the `@modern-js/builder-shared` package and updates the documentation and tests accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ade1377</samp>

*  Add a changeset file to document the patch updates and the fix for publicPath function issue ([link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-421181f34d8dcebf9081ebe3262cc535667758150dd974a13b986bd670593157R1-R10))
*  Add the `assetPrefix` option to the output config and its interface, with a default value of `'/'` ([link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eR97), [link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-42e9c77fc1a6c3a3d3cecbfed0575b9b07c1b9dec393e5dabeef20b3c68ce516L282-R282))
*  Modify the `builderPluginDefine` function in both webpack and rspack providers to use the `assetPrefix` option as a fallback for `process.env.ASSET_PREFIX` ([link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-36332986ba3b93b1c665c01d6e8a6f4d450bbc941ed86dfbe6e8229d9bfcb53bL14-R22), [link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-00d5aa28926497c2c1ffa126bf1d9b546d81040f23a7c669a54977f2acda6fc7L14-R22))
*  Update the documentation for the `assetPrefix` option in both English and Chinese, changing the type from `boolean | string` to `string` ([link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-e5a5487000138cf687ee1baae17b8a78bd96e76d84e84ad791677e212c8e99edL1-R1), [link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-ac39e9487ef8ab01e8b7c8ced6874d7d56dc158c9609cb06d8ba8c6c3b33d5c2L1-R1))
*  Import the `webpackOnlyTest` helper function in `tools.test.ts` to run tests that only apply to webpack ([link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-7c3a599e58fd98fbd9c8ee67292317d46d1d8890a8fe9f42ff7952b0c0751708R3))
*  Rename the test cases for the `bundlerChain` and `webpackChain` tools, adding descriptions of the scenarios ([link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-7c3a599e58fd98fbd9c8ee67292317d46d1d8890a8fe9f42ff7952b0c0751708L34-R35), [link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-2957c89b6d615e9a3d0e64de47d3192a8aeb566f81c6508bab99a4177b80407fL7-R7))
*  Add a new test case for the `bundlerChain` tool, testing the customization of the publicPath function using webpack chain ([link](https://github.com/web-infra-dev/modern.js/pull/4136/files?diff=unified&w=0#diff-7c3a599e58fd98fbd9c8ee67292317d46d1d8890a8fe9f42ff7952b0c0751708R58-R90))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
