### PR TITLE
fix(module-tools): fix concurrent copy error

### DIFF
--- a/.changeset/cuddly-bears-remain.md
+++ b/.changeset/cuddly-bears-remain.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): fix error in concurrent copy when generate dts files.
+fix(module-tools): 修复在生成类型文件的时候并发复制产生的错误

--- a/packages/solutions/module-tools/src/utils/dts.ts
+++ b/packages/solutions/module-tools/src/utils/dts.ts
@@ -114,6 +114,8 @@ export const resolveAlias = async (
     fs.writeFileSync(r.path, r.content);
   }
 
+  // why use `ensureDir` before copy? look this: https://github.com/jprichardson/node-fs-extra/issues/957
+  await fs.ensureDir(distAbsPath);
   await fs.copy(tempDistAbsSrcPath, distAbsPath);
 };
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d0c864</samp>

This pull request fixes a bug in the `module-tools` package that may cause errors when copying type declaration files with alias paths. It also adds a changeset file to document the patch version update for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5d0c864</samp>

*  Add changeset file to document fixes for module-tools package (.changeset/cuddly-bears-remain.md)
*  Ensure destination directory exists before copying files in resolveAlias function ([link](https://github.com/web-infra-dev/modern.js/pull/4139/files?diff=unified&w=0#diff-43cfe1f033a3b57bf1d9ed4a34db61e1bfd4e00b4b96c995171ce53d25073061R117-R118))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
