### PR TITLE
fix: README The link is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Modern.js is a web engineering system, including multiple solutions:
 
 - Use [Modern.js Framework](https://modernjs.dev/en/guides/get-started/quick-start) to develop a web application.
 - Use [Modern.js Module](https://modernjs.dev/module-tools/en/guide/intro/getting-started.html) to develop an npm package.
-- Use [Modern.js Doc](https://modernjs.dev/doc-tools/guide/getting-started.html) to develop a documentation site.
+- Use [Modern.js Doc](https://modernjs.dev/doc-tools/guide/start/getting-started.html) to develop a documentation site.
 - Use [Modern.js Builder](https://modernjs.dev/builder/en/guide/quick-start.html) to provide build capabilities for your own web framework.
 
 ## Ecosystem

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ Modern.js 是一个 Web 工程体系，包含以下解决方案：
 
 - 使用 [Modern.js Framework](https://modernjs.dev/guides/get-started/quick-start) 来开发一个 Web 应用。
 - 使用 [Modern.js Module](https://modernjs.dev/module-tools/guide/intro/getting-started.html) 来开发一个 npm 包。
-- 使用 [Modern.js Doc](https://modernjs.dev/doc-tools/zh/guide/getting-started.html) 来开发一个文档站点。
+- 使用 [Modern.js Doc](https://modernjs.dev/doc-tools/zh/guide/start/getting-started.html) 来开发一个文档站点。
 - 使用 [Modern.js Builder](https://modernjs.dev/builder/guide/quick-start.html) 来为你的 Web 框架提供构建能力。
 
 ## 生态


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 050fdef</samp>

Updated a link to the getting started guide in the Chinese README file. This fixes a broken link and improves the user experience.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 050fdef</samp>

* Updated the link to the Modern.js Doc getting started guide in the Chinese README ([link](https://github.com/web-infra-dev/modern.js/pull/4146/files?diff=unified&w=0#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L32-R32))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
