### PR TITLE
fix: set formatStats fn as sync-fn so that info can print quikly

### DIFF
--- a/.changeset/chatty-feet-lay.md
+++ b/.changeset/chatty-feet-lay.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder-shared): set formatStats fn as sync-fn so that info can print quikly
+fix(builder-shared): 将 formatStats 设置成同步函数使构建信息能够尽快的打印出来

--- a/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
@@ -33,7 +33,7 @@ export async function createCompiler({
       });
     }
 
-    const { message, level } = await formatStats(stats);
+    const { message, level } = formatStats(stats);
 
     if (level === 'error' || level === 'warning') {
       logger.log(message);

--- a/packages/builder/builder-shared/src/format.ts
+++ b/packages/builder/builder-shared/src/format.ts
@@ -1,17 +1,12 @@
 import chalk from '@modern-js/utils/chalk';
 import type { Stats, MultiStats } from './types';
+import { formatWebpackMessages } from '@modern-js/utils/universal/format-webpack';
 
-export async function formatStats(
-  stats: Stats | MultiStats,
-  showWarnings = true,
-) {
+export function formatStats(stats: Stats | MultiStats, showWarnings = true) {
   const statsData = stats.toJson({
     preset: 'errors-warnings',
   });
 
-  const { formatWebpackMessages } = await import(
-    '@modern-js/utils/universal/format-webpack'
-  );
   const { errors, warnings } = formatWebpackMessages(statsData);
 
   if (errors.length) {

--- a/packages/builder/builder-webpack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-webpack-provider/src/core/createCompiler.ts
@@ -29,7 +29,7 @@ export async function createCompiler({
   let isFirstCompile = true;
 
   compiler.hooks.done.tap('done', async (stats: unknown) => {
-    const { message, level } = await formatStats(stats as Stats);
+    const { message, level } = formatStats(stats as Stats);
 
     if (level === 'error') {
       logger.log(message);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7341dc8</samp>

This pull request fixes a bug in the `formatStats` function that caused slow build information printing. It changes the function to be synchronous and updates the calls to it in the `builder-rspack-provider` and `builder-webpack-provider` packages. It also updates the changeset metadata and description.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7341dc8</samp>

*  Make `formatStats` function synchronous to print build information faster ([link](https://github.com/web-infra-dev/modern.js/pull/4150/files?diff=unified&w=0#diff-8dc6e5e9db15efc7918d82c179534ebfbdea20648c3d828819694b84de3e6a28L3-R9))
*  Remove unnecessary `await` from calls to `formatStats` in `createCompiler` functions of `builder-rspack-provider` and `builder-webpack-provider` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4150/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L36-R36), [link](https://github.com/web-infra-dev/modern.js/pull/4150/files?diff=unified&w=0#diff-94bc9eab83c71565c622faba3fa5c6bdae0f76d6ce8d9eae7fe73b47d7894948L32-R32))
*  Update changeset metadata and description in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4150/files?diff=unified&w=0#diff-e8950e4ffe6fcf563596e7c7504686002167445435c532c3f2ac86cbfae679c8R1-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
