### PR TITLE
fix(module-tools): support i18n for checkConfig warning message

### DIFF
--- a/.changeset/forty-turkeys-crash.md
+++ b/.changeset/forty-turkeys-crash.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): support i18n for checkConfig warning message
+
+fix(module-tools): checkConfig 的 warning 日志支持 i18n

--- a/packages/solutions/module-tools/src/config/normalize.ts
+++ b/packages/solutions/module-tools/src/config/normalize.ts
@@ -151,9 +151,8 @@ export const checkConfig = async (config: ModuleUserConfig) => {
   const { buildConfig, buildPreset } = config;
   if (buildConfig && buildPreset) {
     const { logger } = await import('@modern-js/utils');
-    logger.warn(
-      `因为同时出现 'buildConfig' 和 'buildPreset' 配置，因此仅 'buildConfig' 配置生效`,
-    );
+    const local = await import('../locale');
+    logger.warn(local.i18n.t(local.localeKeys.log.buildConfigTip));
   }
 };
 

--- a/packages/solutions/module-tools/src/locale/en.ts
+++ b/packages/solutions/module-tools/src/locale/en.ts
@@ -41,6 +41,8 @@ export const EN_LOCALE = {
     dev: {
       noDevtools: noDevTools,
     },
+    buildConfigTip:
+      'The configuration file of the current project has both `buildConfig` and `buildPreset` options. However, only the `buildConfig` configuration will take effect. If you need to override the content of `buildPreset`, please use the function type of `buildPreset` (refer to the API documentation for details).',
   },
   errors: {
     externalHelpers: `The 'externalHelpers' configuration is currently enabled, but the "@swc/helpers" dependency declaration was not found. This will cause issues with the build output.Use the following for installation:

--- a/packages/solutions/module-tools/src/locale/zh.ts
+++ b/packages/solutions/module-tools/src/locale/zh.ts
@@ -40,6 +40,8 @@ export const ZH_LOCALE = {
     dev: {
       noDevtools: noDevTools,
     },
+    buildConfigTip:
+      '当前项目的配置文件中同时设置了 `buildConfig` 和 `buildPreset`，因此仅有 `buildConfig` 配置能够生效。如果你需要覆盖 `buildPreset` 的内容，请使用 `buildPreset` 的函数配置方式（详见 API 文档）。',
   },
   errors: {
     externalHelpers: `当前开启了 'externalHelpers' 配置，未找到 "@swc/helpers" 依赖声明，构建产物会存在问题。使用下面的方式进行安装：


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 206f713</samp>

This pull request fixes the i18n support for the checkConfig warning message in the `@modern-js/module-tools` package. It adds a changeset file, modifies the `normalize.ts` file to use the i18n module, and adds the English and Chinese translations for the message in the `en.ts` and `zh.ts` files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 206f713</samp>

* Add a changeset file to document the patch update for the `@modern-js/module-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4151/files?diff=unified&w=0#diff-6911eae8e56473da903599b738b41e4b82218b803c0cff497bd5c9e6c8d531cdR1-R7))
  - Importing the i18n and logger modules in the normalize.ts file ([link](https://github.com/web-infra-dev/modern.js/pull/4151/files?diff=unified&w=0#diff-8aa7727ba828087c3fa3ee640d59bd8addf83d27904d7917c8c0c59890ecfd93L154-R155))
  - Using the i18n.t method with the localeKeys.log.buildConfigTip key to get the localized message ([link](https://github.com/web-infra-dev/modern.js/pull/4151/files?diff=unified&w=0#diff-8aa7727ba828087c3fa3ee640d59bd8addf83d27904d7917c8c0c59890ecfd93L154-R155))
  - Adding the English and Chinese translations for the buildConfigTip message in the en.ts and zh.ts files ([link](https://github.com/web-infra-dev/modern.js/pull/4151/files?diff=unified&w=0#diff-044266080bf8162ec64961353e7f64de96a77d536bc9b2aacda435ba28b0c55cR44-R45), [link](https://github.com/web-infra-dev/modern.js/pull/4151/files?diff=unified&w=0#diff-6f0fa3593edef4f07b0b158eda75b877e7307c02189b5681f15beef8195f02f2R43-R44))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
