### PR TITLE
docs: add guide for extend asset types

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/basic/static-assets.md
+++ b/packages/document/builder-doc/docs/en/guide/basic/static-assets.md
@@ -14,7 +14,7 @@ The following are the formats supported by Builder by default:
 - **Fonts**: woff, woff2, eot, ttf, otf, ttc.
 - **Media**: mp4, webm, ogg, mp3, wav, flac, aac, mov.
 
-If you need to import static resources in other formats, please provide feedback through [GitHub Issues](https://github.com/web-infra-dev/modern.js/issues).
+If you need to import assets in other formats, please refer to [Extend Asset Types](#extend-asset-types).
 
 :::tip SVG images
 SVG image is a special case. Builder support convert SVG to React components, so SVG is processed separately. For details, see [Import SVG Assets](/guide/basic/svg-assets.html).
@@ -116,6 +116,38 @@ declare module '*.png' {
 ```
 
 After adding the type declaration, if the type error still exists, you can try to restart the current IDE, or adjust the directory where `global.d.ts` is located, making sure the TypeScript can correctly identify the type definition.
+
+## Extend Asset Types
+
+If the built-in asset types in Builder cannot meet your requirements, you can modify the built-in webpack/Rspack configuration and extend the asset types you need using [tools.bundlerChain](/api/config-tools.html#toolsbundlerchain).
+
+For example, if you want to treat `*.pdf` files as assets and directly output them to the dist directory, you can add the following configuration:
+
+```ts
+export default {
+  tools: {
+    bundlerChain(chain) {
+      chain.module
+        .rule('pdf')
+        .test(/\.pdf$/)
+        .type('asset/resource');
+    },
+  },
+};
+```
+
+After adding the above configuration, you can import `*.pdf` files in your code, for example:
+
+```js
+import myFile from './static/myFile.pdf';
+
+console.log(myFile); // "/static/myFile.6c12aba3.pdf"
+```
+
+For more information about asset modules, please refer to:
+
+- [Rspack Documentation - Asset modules](https://www.rspack.dev/guide/asset-module.html#asset-modules)
+- [webpack Documentation - Asset modules](https://webpack.js.org/guides/asset-modules/)
 
 ## Image Format
 

--- a/packages/document/builder-doc/docs/zh/guide/basic/static-assets.md
+++ b/packages/document/builder-doc/docs/zh/guide/basic/static-assets.md
@@ -14,7 +14,7 @@ Builder 支持在代码中引用图片、字体、媒体类型的静态资源。
 - **字体**：woff、woff2、eot、ttf、otf、ttc。
 - **媒体**：mp4、webm、ogg、mp3、wav、flac、aac、mov。
 
-如果你需要引用其他格式的静态资源，请通过 [GitHub Issues](https://github.com/web-infra-dev/modern.js/issues) 进行反馈。
+如果你需要引用其他格式的静态资源，请参考 [扩展静态资源类型](#扩展静态资源类型)。
 
 :::tip SVG 图片
 SVG 图片是一种特殊情况，Builder 提供了 SVG 转 React 组件的能力，对 SVG 进行单独处理，详见 [引用 SVG 资源](/guide/basic/svg-assets.html)。
@@ -116,6 +116,38 @@ declare module '*.png' {
 ```
 
 添加类型声明后，如果依然存在上述错误提示，请尝试重启当前 IDE，或者调整 `global.d.ts` 所在的目录，使 TypeScript 能够正确识别类型定义。
+
+## 扩展静态资源类型
+
+如果 Builder 内置的静态资源类型不能满足你的需求，那么你可以通过 [tools.bundlerChain](/api/config-tools.html#toolsbundlerchain) 来修改内置的 webpack / Rspack 配置，并扩展你需要的静态资源类型。
+
+比如，你需要把 `*.pdf` 文件当做静态资源直接输出到产物目录，可以添加以下配置：
+
+```ts
+export default {
+  tools: {
+    bundlerChain(chain) {
+      chain.module
+        .rule('pdf')
+        .test(/\.pdf$/)
+        .type('asset/resource');
+    },
+  },
+};
+```
+
+添加以上配置后，你就可以在代码里引用 `*.pdf` 文件了，比如：
+
+```js
+import myFile from './static/myFile.pdf';
+
+console.log(myFile); // "/static/myFile.6c12aba3.pdf"
+```
+
+关于以上配置的更多介绍，请参考：
+
+- [Rspack 文档 - Asset modules](https://www.rspack.dev/guide/asset-module.html#asset-modules)
+- [webpack 文档 - Asset modules](https://webpack.js.org/guides/asset-modules/)
 
 ## 图片格式
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afed061</samp>

Updated the documentation for static assets in Builder to cover new features and options. Added a section on how to use `tools.bundlerChain` to import and bundle different asset types. Synced the Chinese document with the English version.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at afed061</samp>

*  Add a new section `Extend Asset Types` to the English and Chinese versions of the `static-assets.md` document ([link](https://github.com/web-infra-dev/modern.js/pull/4152/files?diff=unified&w=0#diff-f10a496c9f2c29876e69ff782909748d337e1cdb4e80e35d87d334c97921ab0fR120-R151), [link](https://github.com/web-infra-dev/modern.js/pull/4152/files?diff=unified&w=0#diff-bb36fae3ecda844703e64adf600959f1d9d74140db19a6d4e8efb4f317d85bf9R120-R151)). The section explains how to use the `tools.bundlerChain` configuration option to import assets in other formats using Rspack or webpack asset modules. The section also provides links to the Rspack and webpack documentation for more information.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
