### PR TITLE
fix: move @modern-js/server-core to dependencies

### DIFF
--- a/.changeset/shiny-ads-fry.md
+++ b/.changeset/shiny-ads-fry.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: @modern-js/server-core should be a dependencies of @modern-js/app-tools
+fix: @modern-js/server-core 应该是 @modern-js/app-tools 的 dependencies

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -96,12 +96,12 @@
     "es-module-lexer": "^1.1.0",
     "esbuild": "0.17.19",
     "rspack-plugin-virtual-module": "0.1.0",
-    "@swc/helpers": "0.5.1"
+    "@swc/helpers": "0.5.1",
+    "@modern-js/server-core": "workspace:*"
   },
   "devDependencies": {
     "@modern-js/builder-plugin-swc": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
-    "@modern-js/server-core": "workspace:*",
     "@scripts/build": "workspace:*",
     "@scripts/jest-config": "workspace:*",
     "@types/babel__traverse": "^7.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4643,6 +4643,9 @@ importers:
       '@modern-js/server':
         specifier: workspace:*
         version: link:../../server/server
+      '@modern-js/server-core':
+        specifier: workspace:*
+        version: link:../../server/core
       '@modern-js/types':
         specifier: workspace:*
         version: link:../../toolkit/types
@@ -4671,9 +4674,6 @@ importers:
       '@modern-js/builder-rspack-provider':
         specifier: workspace:*
         version: link:../../builder/builder-rspack-provider
-      '@modern-js/server-core':
-        specifier: workspace:*
-        version: link:../../server/core
       '@scripts/build':
         specifier: workspace:*
         version: link:../../../scripts/build


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3978773</samp>

This pull request fixes a dependency issue for the `@modern-js/app-tools` package that affects the server-side rendering feature. It also adds a changeset file with a bilingual changelog message for the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3978773</samp>

* Fix dependency issue for `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4155/files?diff=unified&w=0#diff-c61c3bea4973eed6c6c450d60327524b2e1feca56bd1e007098f054166199739R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4155/files?diff=unified&w=0#diff-48f59b5651ff1f982a17a10d709daf19b68a669d2fa3d26644935ca6d922f255L99-R104))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
