### PR TITLE
docs(main): add description for app-tools

### DIFF
--- a/packages/document/main-doc/docs/en/components/prerequisites.mdx
+++ b/packages/document/main-doc/docs/en/components/prerequisites.mdx
@@ -9,7 +9,7 @@ import NodeVersion from '@modern-js/builder-doc/docs/en/shared/nodeVersion.md';
 It is recommended to use [pnpm](https://pnpm.io/installation) to manage dependencies:
 
 ```bash
-npm install -g pnpm@7
+npm install -g pnpm@8
 ```
 
 :::note

--- a/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
@@ -13,7 +13,7 @@ import Prerequisites from "@site-docs-en/components/prerequisites"
 
 ## Installation
 
-Modern.js provides the `@modern-js/create` tool to create projects. Do not install it globally, use `npx` to run it.
+Modern.js provides the `@modern-js/create` tool to create projects. It does not require global installation and can be run on-demand using `npx`.
 
 You can create a project in an existing empty directory:
 
@@ -47,20 +47,40 @@ In a Modern.js project created using `@modern-js/create`, a `modern.config.ts` f
 You can modify the configuration through this file to override the default behavior of Modern.js. For example, to enable SSR, add the following configuration:
 
 ```ts
-import { defineConfig } from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 
 export default defineConfig({
   runtime: {
     router: true,
-    state: true,
   },
   server: {
     ssr: true,
   },
+  plugins: [appTools()],
 });
 ```
 
 After running `pnpm run dev` again, you can find that the project has completed page rendering on the server in the browser's Network menu.
+
+## Core npm Package
+
+In a newly created project, the `@modern-js/app-tools` npm package is installed by default. It is the core package of the Modern.js framework and provides the following capabilities:
+
+- It offers commonly used CLI commands such as `modern dev`, `modern build`, and more.
+- It integrates Modern.js Core, providing capabilities for configuration parsing, plugin loading, and more.
+- It integrates Modern.js Builder, providing build capabilities.
+- It integrates Modern.js Server, providing capabilities for development and production servers.
+- It integrates some commonly used plugins, such as `plugin-lint`, `plugin-data-loader`, and more.
+
+`@modern-js/app-tools` is implemented based on the plugin system of Modern.js. Essentially, it is a plugin. Therefore, you need to register `appTools` in the `plugins` field of the configuration file:
+
+```ts title="modern.config.ts"
+import { appTools, defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  plugins: [appTools()],
+});
+```
 
 ## Build the project
 

--- a/packages/document/main-doc/docs/zh/components/prerequisites.mdx
+++ b/packages/document/main-doc/docs/zh/components/prerequisites.mdx
@@ -9,7 +9,7 @@ import NodeVersion from '@modern-js/builder-doc/docs/zh/shared/nodeVersion.md';
 推荐使用 [pnpm](https://pnpm.io/installation) 来管理依赖：
 
 ```bash
-npm install -g pnpm@7
+npm install -g pnpm@8
 ```
 
 :::note

--- a/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
@@ -2,19 +2,20 @@
 title: 快速上手
 sidebar_position: 2
 ---
+
 # 快速上手
 
 ## 环境准备
 
-import Prerequisites from "@site-docs/components/prerequisites"
+import Prerequisites from '@site-docs/components/prerequisites';
 
 <Prerequisites />
 
 ## 安装
 
-Modern.js 提供了 `@modern-js/create` 工具来创建项目，不要全局安装，使用 `npx` 按需运行。
+Modern.js 提供了 `@modern-js/create` 工具来创建项目，不需要全局安装，直接使用 `npx` 按需运行即可。
 
-可以在已有的空目录来创建项目：
+你可以在已有的空目录来创建项目：
 
 ```bash
 mkdir myapp && cd myapp
@@ -29,13 +30,13 @@ npx @modern-js/create@latest myapp
 
 ## 初始化项目
 
-import InitApp from "@site-docs/components/init-app"
+import InitApp from '@site-docs/components/init-app';
 
 <InitApp />
 
 ## 启动项目
 
-import DebugApp from "@site-docs/components/debug-app"
+import DebugApp from '@site-docs/components/debug-app';
 
 <DebugApp />
 
@@ -43,7 +44,7 @@ import DebugApp from "@site-docs/components/debug-app"
 
 通过 `@modern-js/create` 创建的 Modern.js 项目中，会默认生成 `modern.config.ts` 文件。
 
-可以通过该配置文件修改配置，覆盖 Modern.js 的默认行为。例如添加如下配置，开启 SSR：
+你可以通过该配置文件修改配置，覆盖 Modern.js 的默认行为。例如添加如下配置，开启 SSR：
 
 ```ts title="modern.config.ts"
 import { appTools, defineConfig } from '@modern-js/app-tools';
@@ -60,6 +61,26 @@ export default defineConfig({
 ```
 
 重新执行 `pnpm run dev`，在浏览器 Network 菜单中，可以发现项目已经在服务端完成了页面渲染。
+
+## 核心 npm 包
+
+在新创建的工程中，默认会安装 `@modern-js/app-tools` npm 包，它是 Modern.js 框架的核心包，主要提供以下能力：
+
+- 提供 `modern dev`, `modern build` 等常用的 CLI 命令。
+- 集成 Modern.js Core，提供配置解析、插件加载等能力。
+- 集成 Modern.js Builder，提供构建能力。
+- 集成 Modern.js Server，提供开发和生产服务器相关能力。
+- 集成一些最为常用的插件，比如 `plugin-lint`、`plugin-data-loader` 等。
+
+`@modern-js/app-tools` 是基于 Modern.js 的插件体系实现的，本质上是一个插件，因此你需要在配置文件的 `plugins` 字段中注册 `appTools`：
+
+```ts title="modern.config.ts"
+import { appTools, defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  plugins: [appTools()],
+});
+```
 
 ## 构建项目
 
@@ -125,6 +146,6 @@ info    App running at:
 
 ## 部署
 
-import Deploy from "@site-docs/components/deploy"
+import Deploy from '@site-docs/components/deploy';
 
 <Deploy />


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dac02d7</samp>

This pull request updates the documentation for the `quick-start` guide and the `prerequisites` section in both English and Chinese languages. It aims to improve the accuracy, clarity, and completeness of the documentation and to reflect the latest version of the `@modern-js/app-tools` and `pnpm` packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dac02d7</samp>

*  Update `pnpm` version to 8 in prerequisites sections of both English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-adb8e12c4e92d34d5395c1da1df93a152a77a5fab53f07526366259470933c91L12-R12), [link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-ff389ed99743ab96a2e1577fad397d58bf96625a7f38c410efccd80959e51489L12-R12))
*  Rephrase installation sections of both English and Chinese documentation to avoid negative form and emphasize on-demand nature of `npx` ([link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-ce3a7f7ae52a67dc63d410676872c45e0b16b385de83a8888193dcf21aa0562eL16-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-3019d6cde6ed35eb2153c28cf6103e822b6ec6af1641764a0274dcbeb619ccf1L15-R18))
*  Add `appTools` plugin registration to configuration file example in English documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-ce3a7f7ae52a67dc63d410676872c45e0b16b385de83a8888193dcf21aa0562eL50-R59))
*  Add new sections to both English and Chinese documentation to explain the core package `@modern-js/app-tools` and its features ([link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-ce3a7f7ae52a67dc63d410676872c45e0b16b385de83a8888193dcf21aa0562eR65-R84), [link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-3019d6cde6ed35eb2153c28cf6103e822b6ec6af1641764a0274dcbeb619ccf1R65-R84))
*  Replace double quotes with single quotes in import statements of Chinese documentation to follow code style and linting rules ([link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-3019d6cde6ed35eb2153c28cf6103e822b6ec6af1641764a0274dcbeb619ccf1L5-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-3019d6cde6ed35eb2153c28cf6103e822b6ec6af1641764a0274dcbeb619ccf1L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-3019d6cde6ed35eb2153c28cf6103e822b6ec6af1641764a0274dcbeb619ccf1L38-R39), [link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-3019d6cde6ed35eb2153c28cf6103e822b6ec6af1641764a0274dcbeb619ccf1L128-R149))
*  Rephrase configuration file section of Chinese documentation to add the word "你" for consistency and politeness ([link](https://github.com/web-infra-dev/modern.js/pull/4157/files?diff=unified&w=0#diff-3019d6cde6ed35eb2153c28cf6103e822b6ec6af1641764a0274dcbeb619ccf1L46-R47))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
