### PR TITLE
docs(builder): add guide for dynamic import

### DIFF
--- a/packages/document/builder-doc/docs/en/config/experiments/lazyCompilation.md
+++ b/packages/document/builder-doc/docs/en/config/experiments/lazyCompilation.md
@@ -76,3 +76,9 @@ When you enable lazy compilation, in order to ensure the compilation results, Bu
 #### Use proxy
 
 Lazy Compilation relies on the local development server of webpack. When you proxy a domain name to localhost, Lazy Compilation will not work properly. Therefore, if you need to develop with proxy, please disable Lazy Compilation.
+
+#### Other Potential Issues
+
+Considering that Lazy Compilation is still an experimental feature of webpack, you may encounter some potential issues while using it, such as changes in the behavior of compiled artifacts or compilation errors.
+
+When you encounter these issues, you can refer to [webpack Issues](https://github.com/webpack/webpack/issues) to find solutions or disable the `lazyCompilation` configuration option.

--- a/packages/document/builder-doc/docs/en/guide/optimization/split-chunk.md
+++ b/packages/document/builder-doc/docs/en/guide/optimization/split-chunk.md
@@ -196,3 +196,24 @@ export default {
 ```
 
 The config in `override` will be merged with the bundler config. For specific config details, please refer to [webpack - splitChunks](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks) or [Rspack - splitChunks](https://rspack.dev/config/optimization.html#optimization-splitchunks).
+
+## Using Dynamic Import for Code Splitting
+
+In addition to the `chunkSplit` configurations, using dynamic import for code splitting is also an important optimization technique that can effectively reduce the initial bundle size.
+
+:::tip About dynamic import
+Dynamic import is a new feature introduced in ECMAScript 2020 that allows you to dynamically load JavaScript modules. The underlying Rspack/webpack used by the Builder supports dynamic import by default, so you can use it directly in your code.
+:::
+
+When the bundler encounters the `import()` syntax, it automatically splits the relevant code into a new chunk and loads it on-demand at runtime.
+
+For example, if your project has a large module called `bigModule.ts` (which can also be a third-party dependency), you can use dynamic import to load it on-demand:
+
+```js
+// Somewhere in your code where you need to use bigModule
+import('./bigModule.ts').then(bigModule => {
+  // Use bigModule here
+});
+```
+
+When you run the build command, `bigModule.ts` will be automatically split into a new chunk and loaded on-demand at runtime.

--- a/packages/document/builder-doc/docs/zh/config/experiments/lazyCompilation.md
+++ b/packages/document/builder-doc/docs/zh/config/experiments/lazyCompilation.md
@@ -76,3 +76,9 @@ export default {
 #### 使用代理
 
 Lazy Compilation 依赖 webpack 在本地启动的开发服务器，当你将某个域名代理到 localhost 进行开发时，Lazy Compilation 将无法正常工作。因此，如果你需要使用代理时，请禁用 Lazy Compilation。
+
+#### 其他潜在的问题
+
+考虑到 Lazy Compilation 仍然是 webpack 的实验性功能，因此你在使用过程中，可能会遇到一些潜在的问题，比如编译产物的行为变化，或是编译出现异常。
+
+当你遇到这些问题时，可以参考 [webpack 的 Issues](https://github.com/webpack/webpack/issues) 寻找解决方案，也可以关闭 `lazyCompilation` 配置项。

--- a/packages/document/builder-doc/docs/zh/guide/optimization/split-chunk.md
+++ b/packages/document/builder-doc/docs/zh/guide/optimization/split-chunk.md
@@ -192,3 +192,24 @@ export default {
 ```
 
 其中 `override` 中的配置会和 bundler 的配置进行合并，具体配置项请参考 [webpack - splitChunks](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks) 或 [Rspack - splitChunks](https://rspack.dev/zh/config/optimization.html#optimization-splitchunks)。
+
+## 使用 Dynamic Import 拆包
+
+除了 `chunkSplit` 配置，使用 dynamic import 拆包也是一项重要的优化手段，它可以有效减少首屏的包体积。
+
+:::tip 关于 dynamic import
+Dynamic import 是 ECMAScript 2020 引入的一个新特性，它允许你动态地加载一些 JavaScript 模块。Builder 底层的 Rspack / webpack 默认支持 dynamic import，所以你可以直接在代码中使用它。
+:::
+
+当打包工具遇到 `import()` 语法时，它会自动将相关的代码分割成一个新的 chunk，并在运行时按需加载。
+
+例如，项目中有一个大的模块 `bigModule.ts`（也可以是一个第三方依赖），你可以使用 dynamic import 来按需加载它：
+
+```js
+// 在某个需要使用 bigModule 的地方
+import('./bigModule.ts').then(bigModule => {
+  // 使用 bigModule
+});
+```
+
+当你运行构建命令时，`bigModule.ts` 就会被自动分割成一个新的 chunk，并在运行时按需加载。


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d9634d</samp>

This pull request updates the `lazyCompilation` and `split-chunk` documents in both English and Chinese. It adds warnings and guidance for using experimental features and dynamic import for code optimization.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d9634d</samp>

*  Add a warning subsection about the potential issues of using the experimental feature of webpack for lazy compilation in both English and Chinese configuration documents ([link](https://github.com/web-infra-dev/modern.js/pull/4158/files?diff=unified&w=0#diff-ebcb138a1b1587a607107c3dd3da9ecde90127d44929262b3691a8e1562b94b9R79-R84), [link](https://github.com/web-infra-dev/modern.js/pull/4158/files?diff=unified&w=0#diff-892069418a468fcf237cbe7b18a3840c9971a4e67ba7bd3ee12d564d560ff4a8R79-R84))
*  Introduce the concept and usage of dynamic import for code splitting in both English and Chinese optimization guide documents ([link](https://github.com/web-infra-dev/modern.js/pull/4158/files?diff=unified&w=0#diff-84baee97a9077b4549e4ccb10160fec61e43cbee567c3d333f661d4a1ae43b15R199-R219), [link](https://github.com/web-infra-dev/modern.js/pull/4158/files?diff=unified&w=0#diff-da9e3bd8d1312e45b9dea9898669d58d211280981ed3100cdb8d3e58f2c891a0R195-R215))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
