### PR TITLE
docs(builder): improve the doc and e2e of path aliases

### DIFF
--- a/packages/document/builder-doc/docs/en/config/source/alias.md
+++ b/packages/document/builder-doc/docs/en/config/source/alias.md
@@ -7,6 +7,10 @@ Create aliases to import or require certain modules, same as the [resolve.alias]
 For TypeScript projects, you only need to configure [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) in `tsconfig.json`, Builder will automatically recognize the aliases in `tsconfig.json`, so the `alias` config is unnecessary.
 :::
 
+:::tip
+For TypeScript projects, you only need to configure [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) in the `tsconfig.json` file. The Builder will automatically recognize it, so there is no need to configure the `source.alias` option separately. For more details, please refer to [Path Aliases](https://modernjs.dev/builder/en/guide/advanced/alias.html).
+:::
+
 ### Object Type
 
 The `alias` can be an Object, and the relative path will be automatically converted to absolute path.
@@ -21,7 +25,7 @@ export default {
 };
 ```
 
-With above configuration, if `@common/Foo.tsx` is import in the code, it will be mapped to the `<root>/src/common/Foo.tsx` path.
+With above configuration, if `@common/Foo.tsx` is import in the code, it will be mapped to the `<project>/src/common/Foo.tsx` path.
 
 ### Function Type
 

--- a/packages/document/builder-doc/docs/en/config/source/alias.md
+++ b/packages/document/builder-doc/docs/en/config/source/alias.md
@@ -4,10 +4,6 @@
 Create aliases to import or require certain modules, same as the [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config of webpack.
 
 :::tip
-For TypeScript projects, you only need to configure [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) in `tsconfig.json`, Builder will automatically recognize the aliases in `tsconfig.json`, so the `alias` config is unnecessary.
-:::
-
-:::tip
 For TypeScript projects, you only need to configure [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) in the `tsconfig.json` file. The Builder will automatically recognize it, so there is no need to configure the `source.alias` option separately. For more details, please refer to [Path Aliases](https://modernjs.dev/builder/en/guide/advanced/alias.html).
 :::
 

--- a/packages/document/builder-doc/docs/en/guide/advanced/alias.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/alias.md
@@ -1,19 +1,51 @@
-# Alias
+# Path Aliases
 
-Alias is a way to specify a short name for a module or a path to a directory or file. This can be useful when you want to use a short, easy-to-remember name for a module instead of a long, complex path.
+Path aliases allow developers to define aliases for modules, making it easier to reference them in code. This can be useful when you want to use a short, easy-to-remember name for a module instead of a long, complex path.
 
-For example, if you have a file at `src/common/request.ts`, you could create an alias called `@request` for it, so you could import the file like this: `import request from '@request'`. This makes it easier to reference the file in your code, and also allows you to move the file to a different location without having to update all the import statements in your code.
+For example, if you frequently reference the `src/common/request.ts` module in your project, you can define an alias for it as `@request` and then use `import request from '@request'` in your code instead of writing the full relative path every time. This also allows you to move the module to a different location without needing to update all the import statements in your code.
 
-In Builder, you can set aliases in two ways:
+In Builder, there are two ways to set up path aliases:
 
-- [source.alias](/en/api/config-source.html#sourcealias)
-- `paths` in `tsconfig.json`
+- Through the `paths` configuration in `tsconfig.json`.
+- Through the [source.alias](/api/config-source.html#sourcealias) configuration.
 
-## Using `source.alias` config
+## Using `tsconfig.json`'s `paths` Configuration
 
-[source.alias](/en/api/config-source.html#sourcealias) corresponds to webpack's native [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config, you can configure it as an object or a function.
+You can configure aliases through the `paths` configuration in `tsconfig.json`, which is the recommended approach in TypeScript projects as it also resolves the TS type issues related to path aliases.
 
-First, you can configure it as an object, for example:
+For example:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "paths": {
+      "@common/*": ["./src/common/*"]
+    }
+  }
+}
+```
+
+After configuring, if you reference `@common/Foo.tsx` in your code, it will be mapped to the `<project>/src/common/Foo.tsx` path.
+
+:::tip
+You can refer to the [TypeScript - paths](https://www.typescriptlang.org/tsconfig#paths) documentation for more details.
+:::
+
+## Use `source.alias` Configuration
+
+Builder provides the [source.alias](/api/config-source.html#sourcealias) configuration option, which corresponds to the webpack/Rspack native [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) configuration. You can configure this option using an object or a function.
+
+### Use Cases
+
+Since the `paths` configuration in `tsconfig.json` is written in a static JSON file, it lacks dynamism.
+
+The `source.alias` configuration can address this limitation by allowing you to dynamically set the `source.alias` using JavaScript code, such as based on environment variables.
+
+### Object Usage
+
+You can configure `source.alias` using an object, where the relative paths will be automatically resolved to absolute paths by Builder.
+
+For example:
 
 ```js
 export default {
@@ -25,9 +57,13 @@ export default {
 };
 ```
 
-The relative path in it will be parsed as an absolute path in Builder.
+After configuring, if you reference `@common/Foo.tsx` in your code, it will be mapped to the `<project>/src/common/Foo.tsx` path.
 
-You can also configure it as a function to get the preset `alias` object and modify it, for example:
+### Function Usage
+
+You can also configure `source.alias` as a function, which receives the built-in `alias` object and allows you to modify it.
+
+For example:
 
 ```js
 export default {
@@ -40,22 +76,6 @@ export default {
 };
 ```
 
-## Using `paths` config in `tsconfig.json`
+### Priority
 
-In addition to `source.alias`, you can also configure it by `paths` in `tsconfig.json`. We recommend to use this way in TypeScript projects, because it can solve type problem of alias path.
-
-For example:
-
-```json
-{
-  "compilerOptions": {
-    "paths": {
-      "@common/*": ["./src/common/*"]
-    }
-  }
-}
-```
-
-:::tip Priority
-The `paths` config has higher priority than `source.alias`.
-:::
+The `paths` configuration in `tsconfig.json` takes precedence over the `source.alias` configuration. When a path matches the rules defined in both `paths` and `source.alias`, the value defined in `paths` will be used.

--- a/packages/document/builder-doc/docs/zh/config/source/alias.md
+++ b/packages/document/builder-doc/docs/zh/config/source/alias.md
@@ -4,7 +4,7 @@
 设置文件引用的别名，对应 webpack 的 [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) 配置。
 
 :::tip
-对于 TypeScript 项目，只需要在 `tsconfig.json` 中配置 [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) 即可，Builder 会自动识别 `tsconfig.json` 里的别名，因此不需要额外配置 `alias` 字段。
+对于 TypeScript 项目，你只需要在 `tsconfig.json` 中配置 [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#paths) 即可，Builder 会自动识别它，不需要额外配置 `source.alias` 字段，详见 [「路径别名」](https://modernjs.dev/builder/guide/advanced/alias.html)。
 :::
 
 ### Object 类型
@@ -21,7 +21,7 @@ export default {
 };
 ```
 
-以上配置完成后，如果在代码中引用 `@common/Foo.tsx`, 则会映射到 `<root>/src/common/Foo.tsx` 路径上。
+以上配置完成后，如果你在代码中引用 `@common/Foo.tsx`, 则会映射到 `<project>/src/common/Foo.tsx` 路径上。
 
 ### Function 类型
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/alias.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/alias.md
@@ -1,19 +1,51 @@
 # 路径别名
 
-路径别名（alias）允许开发者为模块定义别名，以便于在代码中更方便的引用它们。
+路径别名（alias）允许开发者为模块定义别名，以便于在代码中更方便的引用它们。当你想要使用一个简短、易于记忆的名称来代替冗长复杂的路径时，这将非常有用。
 
 例如，假如你在项目中经常引用 `src/common/request.ts` 模块，你可以为它定义一个别名 `@request`，然后在代码中通过 `import request from '@request'` 来引用它，而不需要每次都写出完整的相对路径。同时，这也允许你将模块移动到不同的位置，而不需要更新代码中的所有 import 语法。
 
 在 Builder 中，你有两种方式可以设置路径别名:
 
-- 通过 [source.alias](/api/config-source.html#sourcealias) 配置。
 - 通过 `tsconfig.json` 中的 `paths` 配置。
+- 通过 [source.alias](/api/config-source.html#sourcealias) 配置。
+
+## 通过 `tsconfig.json` 的 `paths` 配置
+
+你可以通过 `tsconfig.json` 中的 `paths` 来配置别名，这是我们在 TypeScript 项目中推荐使用的方式，因为它可以解决路径别名的 TS 类型问题。
+
+比如：
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "paths": {
+      "@common/*": ["./src/common/*"]
+    }
+  }
+}
+```
+
+以上配置完成后，如果你在代码中引用 `@common/Foo.tsx`, 则会映射到 `<project>/src/common/Foo.tsx` 路径上。
+
+:::tip
+你可以阅读 [TypeScript - paths](https://www.typescriptlang.org/tsconfig#paths) 文档来了解更多用法。
+:::
 
 ## 通过 `source.alias` 配置
 
-[source.alias](/api/config-source.html#sourcealias) 对应 webpack 原生的 [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) 配置，你可以通过对象或者函数的方式进行配置。
+Builder 提供了 [source.alias](/api/config-source.html#sourcealias) 配置项，对应 webpack / Rspack 原生的 [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) 配置，你可以通过对象或者函数的方式来配置这个选项。
 
-首先你可以通过对象的方式进行配置，比如：
+### 使用场景
+
+由于 `tsconfig.json` 的 `paths` 配置是写在静态 JSON 文件里的，因此它不具备动态性。
+
+而 `source.alias` 则可以弥补这一不足，你可以通过 JavaScript 代码来动态设置 `source.alias`（比如基于环境变量来设置）。
+
+### 对象用法
+
+你可以通过对象的方式来配置 `source.alias`，其中的相对路径会被 Builder 自动补全为绝对路径。
+
+比如：
 
 ```js
 export default {
@@ -25,9 +57,13 @@ export default {
 };
 ```
 
-其中的相对路径会被 Builder 自动补全为绝对路径。
+以上配置完成后，如果你在代码中引用 `@common/Foo.tsx`, 则会映射到 `<project>/src/common/Foo.tsx` 路径上。
 
-你也可以配置为一个函数，拿到预设的 `alias` 对象，对其进行修改，比如：
+### 函数用法
+
+你也可以将 `source.alias` 配置为一个函数，拿到内置的 `alias` 对象，对其进行修改。
+
+比如：
 
 ```js
 export default {
@@ -40,22 +76,6 @@ export default {
 };
 ```
 
-## 通过 `tsconfig.json` 中的 `paths` 配置
+### 优先级
 
-除了 `source.alias`，你还可以通过 `tsconfig.json` 中的 `paths` 进行配置，这是我们在 TypeScript 项目中推荐使用的方式，因为可以解决路径别名的类型问题。
-
-比如：
-
-```json
-{
-  "compilerOptions": {
-    "paths": {
-      "@common/*": ["./src/common/*"]
-    }
-  }
-}
-```
-
-:::tip 优先级
-`paths` 配置的优先级高于 `source.alias`。
-:::
+`tsconfig.json` 的 `paths` 配置的优先级高于 `source.alias`，当一个路径同时匹配到这两者定义的规则时，会优先使用 `tsconfig.json` 的 `paths` 定义的值。

--- a/packages/document/module-doc/docs/en/api/config/build-config.md
+++ b/packages/document/module-doc/docs/en/api/config/build-config.md
@@ -36,7 +36,7 @@ export default {
 };
 ```
 
-After the above configuration is done, if `@common/Foo.tsx` is referenced in the code, it will map to the `<root>/src/common/Foo.tsx` path.
+After the above configuration is done, if `@common/Foo.tsx` is referenced in the code, it will map to the `<project>/src/common/Foo.tsx` path.
 
 When the value of `alias` is defined as a function, you can accept the pre-defined alias object and modify it.
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.md
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.md
@@ -36,7 +36,7 @@ export default defineConfig({
 });
 ```
 
-以上配置完成后，如果在代码中引用 `@common/Foo.tsx`, 则会映射到 `<root>/src/common/Foo.tsx` 路径上。
+以上配置完成后，如果在代码中引用 `@common/Foo.tsx`, 则会映射到 `<project>/src/common/Foo.tsx` 路径上。
 
 `alias` 的值定义为函数时，可以接受预设的 alias 对象，并对其进行修改。
 

--- a/tests/e2e/builder/cases/source/global-vars/src/App.tsx
+++ b/tests/e2e/builder/cases/source/global-vars/src/App.tsx
@@ -1,16 +1,9 @@
-import { content } from '@/common/test';
-
 if (ENABLE_TEST === true) {
   const test = document.createElement('div');
   test.id = 'test-el';
   test.innerHTML = 'aaaaa';
   document.body.appendChild(test);
 }
-
-const testAliasEl = document.createElement('div');
-testAliasEl.id = 'test-alias-el';
-testAliasEl.innerHTML = content;
-document.body.appendChild(testAliasEl);
 
 const App = () => <div id="test">Hello Builder!</div>;
 

--- a/tests/e2e/builder/cases/source/global-vars/src/common/test.js
+++ b/tests/e2e/builder/cases/source/global-vars/src/common/test.js
@@ -1,1 +1,0 @@
-export const content = 'alias work correctly';

--- a/tests/e2e/builder/cases/source/source.test.ts
+++ b/tests/e2e/builder/cases/source/source.test.ts
@@ -87,7 +87,7 @@ test.skip('module-scopes', async ({ page }) => {
   builder.close();
 });
 
-test('global-vars & tsConfigPath', async ({ page }) => {
+test('global-vars', async ({ page }) => {
   const builder = await build({
     cwd: join(fixtures, 'global-vars'),
     entry: {
@@ -107,10 +107,6 @@ test('global-vars & tsConfigPath', async ({ page }) => {
   await expect(
     page.evaluate(`document.getElementById('test-el').innerHTML`),
   ).resolves.toBe('aaaaa');
-
-  await expect(
-    page.evaluate(`document.getElementById('test-alias-el').innerHTML`),
-  ).resolves.toBe('alias work correctly');
 
   builder.close();
 });
@@ -135,6 +131,33 @@ test('define', async ({ page }) => {
   await expect(
     page.evaluate(`document.getElementById('test-el').innerHTML`),
   ).resolves.toBe('aaaaa');
+
+  builder.close();
+});
+
+test('tsconfig paths should work and override the alias config', async ({
+  page,
+}) => {
+  const cwd = join(fixtures, 'tsconfig-paths');
+  const builder = await build({
+    cwd,
+    entry: {
+      main: join(cwd, 'src/index.ts'),
+    },
+    runServer: true,
+    builderConfig: {
+      source: {
+        alias: {
+          '@common': './src/common2',
+        },
+      },
+    },
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+  await expect(
+    page.evaluate(`document.getElementById('foo').innerHTML`),
+  ).resolves.toBe('tsconfig paths worked');
 
   builder.close();
 });

--- a/tests/e2e/builder/cases/source/tsconfig-paths/src/App.tsx
+++ b/tests/e2e/builder/cases/source/tsconfig-paths/src/App.tsx
@@ -1,0 +1,10 @@
+import { content } from '@/common/test';
+
+const testAliasEl = document.createElement('div');
+testAliasEl.id = 'foo';
+testAliasEl.innerHTML = content;
+document.body.appendChild(testAliasEl);
+
+const App = () => <div id="test">Hello Builder!</div>;
+
+export default App;

--- a/tests/e2e/builder/cases/source/tsconfig-paths/src/common/test.ts
+++ b/tests/e2e/builder/cases/source/tsconfig-paths/src/common/test.ts
@@ -1,0 +1,1 @@
+export const content = 'tsconfig paths worked';

--- a/tests/e2e/builder/cases/source/tsconfig-paths/src/common2/test.ts
+++ b/tests/e2e/builder/cases/source/tsconfig-paths/src/common2/test.ts
@@ -1,0 +1,1 @@
+export const content = 'source.alias worked';

--- a/tests/e2e/builder/cases/source/tsconfig-paths/src/index.ts
+++ b/tests/e2e/builder/cases/source/tsconfig-paths/src/index.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+import { render } from 'react-dom';
+import App from './App';
+
+render(React.createElement(App), document.getElementById('root'));

--- a/tests/e2e/builder/cases/source/tsconfig-paths/tsconfig.json
+++ b/tests/e2e/builder/cases/source/tsconfig-paths/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4b950b</samp>

This pull request improves the documentation and testing of the `alias` feature in the `source` and `buildConfig` modules. It updates the English and Chinese guides and config files to use consistent and accurate terminology and examples. It also removes the redundant `alias` test cases and adds a new test case for `tsconfig-paths` to verify the compatibility with TypeScript path mapping.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4b950b</samp>

*  Rename and rewrite the English and Chinese guides on alias to path aliases and explain the purpose and benefits of using path aliases ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-cb9851533a983f5947b945ab3bf2487e6cc788d8c0616218a8d86f1e89a2454cL1-R49), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-12c3f9e8ef12388f76e98f0b872f287f4891a0308ce521167f023bb2d8d488a8L3-R3))
*  Reorder the sections in the English and Chinese guides on path aliases to put the `tsconfig.json`'s `paths` configuration first, as it is the recommended approach for TypeScript projects, and add a tip to refer to the TypeScript documentation for more details ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-cb9851533a983f5947b945ab3bf2487e6cc788d8c0616218a8d86f1e89a2454cL28-R67), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-12c3f9e8ef12388f76e98f0b872f287f4891a0308ce521167f023bb2d8d488a8L9-R49))
*  Remove the redundant sections on `tsconfig.json`'s `paths` configuration in the English and Chinese guides on path aliases, as they are already covered in the previous sections, and add subsections on priority to explain how the `paths` and `source.alias` configurations are resolved when they conflict ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-cb9851533a983f5947b945ab3bf2487e6cc788d8c0616218a8d86f1e89a2454cL43-R81), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-12c3f9e8ef12388f76e98f0b872f287f4891a0308ce521167f023bb2d8d488a8L43-R81))
*  Reorder the subsections in the Chinese guide on path aliases to put the object usage before the function usage, as it is more common and simpler, and add a subsection on use cases to explain why the function usage can be useful for dynamic scenarios ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-12c3f9e8ef12388f76e98f0b872f287f4891a0308ce521167f023bb2d8d488a8L28-R67))
*  Update the tips in the English and Chinese documentation of `source.alias` to mention the new guide on path aliases and to remove the unnecessary `alias` config ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-f212ade1efdbbc002404b77d2f3d5e250bc9d7b381af9af2a2fd779ea662d6c8L7-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-d9696b21023425217a3ccf0302e394ff69074766a854f341b6ce598cd5c8921aL7-R7))
*  Update the example paths in the English and Chinese documentation of `source.alias` and `buildConfig.alias` to use `<project>` instead of `<root>` to avoid confusion with the root directory of the repository ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-f212ade1efdbbc002404b77d2f3d5e250bc9d7b381af9af2a2fd779ea662d6c8L24-R24), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-d9696b21023425217a3ccf0302e394ff69074766a854f341b6ce598cd5c8921aL24-R24), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-8d3bb4a24d8a8fdd33af7a5667f8393b60456abd6af1ed500a0556cebcf1ab07L39-R39), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-a6331c3b4534ce6274690af5f0e767a41a566d14559e22554d0d180723b2a07eL39-R39))
*  Add a new test case for `tsconfig-paths` to verify that the `paths` configuration in `tsconfig.json` works and overrides the `source.alias` configuration, and add the corresponding files in the `src` directory and the `tsconfig.json` file ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44R137-R163), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-4af19e36e77ed4789cdacaa7534029810cebb9983364e140c5f79727d1a612b2R1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-06be8669b9ae18a4c74fd3090b4c305fe82ffb1a3694195f38f45d512bbe486eR1), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-83806c7dad5aa6db2cc2d97d5453a1ce65c6b0c3f36c27f5b82c9329e90346e6R1), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-199b7b6bcedca072677f1936cc163801d802a2b49b9b9297d88a79d21a038832R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-16252a55f0964d6e7cd7d103536b0119df9e7fcf6546b7793b7b892b0c6624a2R1-R13))
*  Remove the import statement of `@common/test` and the code that creates and appends a `test-alias-el` element from the `App.tsx` file in the `global-vars` test case, as they are no longer needed after the removal of the `alias` config ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-e6e3effdaaa47b31d12237f00131ba4728ceacd1cc8aeaa79ed66a8f61a1057bL1-L2), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-e6e3effdaaa47b31d12237f00131ba4728ceacd1cc8aeaa79ed66a8f61a1057bL10-L14))
*  Update the test name and remove the assertion that checks the content of the `test-alias-el` element in the `global-vars` test case, as they are no longer relevant after the removal of the `alias` config ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L90-R90), [link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-9dfbb7cffc05a5b1b6f99c7d5bfcb9559ca8b24cff9d736f2510fd89f6d61d44L111-L114))
*  Delete the `test.js` file in the `src/common` directory for the `global-vars` test case, as it is no longer used after the removal of the `alias` config ([link](https://github.com/web-infra-dev/modern.js/pull/4160/files?diff=unified&w=0#diff-acd99a97865cf35601354bdaf3e14f8fe11857ca5905f6ae9fdef08d0cf22465))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
