### PR TITLE
fix(doc-core): fix code block background style in dark mode

### DIFF
--- a/.changeset/polite-masks-perform.md
+++ b/.changeset/polite-masks-perform.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): fix codeblock background style in dark mode
+
+fix(doc-core): 修复代码块在暗色模式下的背景样式问题

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/docComponents/code.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/docComponents/code.tsx
@@ -110,6 +110,7 @@ export function Code(props: CodeProps) {
         style={style}
         wrapLines={true}
         className="code"
+        customStyle={{ backgroundColor: 'inherit' }}
         // Notice: if the highlight line is specified, the line number must be displayed
         showLineNumbers={showLineNumbers || highlightLines.length > 0}
         lineProps={lineNumber => {

--- a/packages/cli/doc-core/src/theme-default/styles/doc/code.css
+++ b/packages/cli/doc-core/src/theme-default/styles/doc/code.css
@@ -15,7 +15,7 @@
 .dark {
   --modern-code-block-color: rgb(229, 231, 235);
   --modern-code-block-bg: #242424;
-  --modern-code-title-bg: #000;
+  --modern-code-title-bg: rgba(255, 255, 255, 0.04);
   --modern-code-line-highlight-color: rgba(255, 255, 255, 0.1);
   --modern-code-line-number-color: rgba(60, 60, 60, 0.33);
 }


### PR DESCRIPTION
## Summary

### Before

<img width="1058" alt="Screen Shot 2023-07-10 at 10 46 43" src="https://github.com/web-infra-dev/modern.js/assets/7237365/32475426-2f48-4a7c-bf67-6e25dab247cf">

### After

<img width="1028" alt="Screen Shot 2023-07-10 at 11 00 44" src="https://github.com/web-infra-dev/modern.js/assets/7237365/3053cdb8-b090-4f2d-8a03-47f4cacf715a">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31ec1eb</samp>

This pull request fixes a bug in the `@modern-js/doc-core` package that caused code blocks to have inconsistent background colors in dark mode. It also adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31ec1eb</samp>

*  Fix code block background color mismatch in dark mode (`[link](https://github.com/web-infra-dev/modern.js/pull/4163/files?diff=unified&w=0#diff-18aea653e780c501c311f5831a19b22364820956042eb216a70eac5e4f44bf4aR113)`, `[link](https://github.com/web-infra-dev/modern.js/pull/4163/files?diff=unified&w=0#diff-dd51640013ecae5b2442a1e06cf5f06287f1eff23edf752ff87ea0cdb0d60ae3L18-R18)`)

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
