### PR TITLE
feat(doc-core): display aside bar in 14 inch MacBook by default

### DIFF
--- a/.changeset/fluffy-shirts-compare.md
+++ b/.changeset/fluffy-shirts-compare.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+feat(doc-core): display aside bar in 14 inch MacBook by default
+
+feat(doc-core): 在 14 英寸 MacBook 上默认展示 aside 栏

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.module.scss
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.module.scss
@@ -43,10 +43,10 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (min-width: 1280px) {
   .docLayout {
-    width: calc(1440px - 100vw + 100%);
-    margin-left: calc((100vw - 1440px) / 2);
+    width: calc(1280px - 100vw + 100%);
+    margin-left: calc((100vw - 1280px) / 2);
   }
 
   .aside-container {
@@ -57,7 +57,25 @@
   .content {
     margin-left: var(--modern-sidebar-width);
     width: calc(100% - var(--modern-sidebar-width));
+    padding: 48px 0 72px 0;
+
+    :global(.modern-doc) {
+      width: calc(
+        1280px - var(--modern-sidebar-width) - var(--modern-aside-width)
+      );
+    }
+  }
+}
+
+@media (min-width: 1440px) {
+  .docLayout {
+    width: calc(1440px - 100vw + 100%);
+    margin-left: calc((100vw - 1440px) / 2);
+  }
+
+  .content {
     padding: 48px 0 72px 64px;
+
     :global(.modern-doc) {
       padding-right: 64px;
       width: calc(


### PR DESCRIPTION
## Summary

We display aside bar in 14-inch MacBook by default, because many developers is using 14-inch devices, and aside bar is useful for them.

### Before

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/24e22e48-a31d-4673-9360-746c1e9c7679)

### After

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/07e99905-2e42-478a-94b6-2b856e06d4dd)


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04cef16</samp>

This pull request enhances the doc theme for the `@modern-js/doc-core` package, by improving the responsiveness, layout, and localization of the documentation pages. It also updates the changeset file for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04cef16</samp>

*  Add a changeset file to document the features and patches for `@modern-js/doc-core` ([link](https://github.com/web-infra-dev/modern.js/pull/4165/files?diff=unified&w=0#diff-5363404575e0af8b3b9d6dba03c42792de90f14b0a36aadb65a63c1544904412R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
