### PR TITLE
feat(module-tools): apply PostCSS plugins according to the target

### DIFF
--- a/.changeset/funny-timers-remain.md
+++ b/.changeset/funny-timers-remain.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+---
+
+feat(module-tools): apply PostCSS plugins according to the target
+
+feat(module-tools): 基于 target 启用 PostCSS 插件

--- a/packages/solutions/module-tools/src/utils/style.ts
+++ b/packages/solutions/module-tools/src/utils/style.ts
@@ -51,6 +51,14 @@ export const getPostcssConfig = async (config: PartialBaseBuildConfig) => {
     },
   };
 
+  const targetLegacyBrowsers = config.target === 'es5';
+  const getLegacyPostCSSPlugins = async () => [
+    require(await getCompiledPath('postcss-custom-properties')),
+    require(await getCompiledPath('postcss-initial')),
+    require(await getCompiledPath('postcss-page-break')),
+    require(await getCompiledPath('postcss-font-variant')),
+  ];
+
   const mergedConfig = applyOptionsChain<
     PostcssOptions & { $$tools?: string },
     PostCSSConfigUtils
@@ -59,11 +67,8 @@ export const getPostcssConfig = async (config: PartialBaseBuildConfig) => {
       // TODO: when schema support redefine
       // $$tools: 'module-tools',
       plugins: [
+        ...(targetLegacyBrowsers ? await getLegacyPostCSSPlugins() : []),
         require(await getCompiledPath('postcss-flexbugs-fixes')),
-        require(await getCompiledPath('postcss-custom-properties')),
-        require(await getCompiledPath('postcss-initial')),
-        require(await getCompiledPath('postcss-page-break')),
-        require(await getCompiledPath('postcss-font-variant')),
         require(await getCompiledPath('postcss-media-minmax')),
         require(await getCompiledPath('postcss-nesting')),
       ].filter(Boolean),

--- a/packages/solutions/module-tools/tests/__snapshots__/designSystem.test.ts.snap
+++ b/packages/solutions/module-tools/tests/__snapshots__/designSystem.test.ts.snap
@@ -4,7 +4,6 @@ exports[`\`designSystem\` case buildType is bundle 1`] = `
 "/* src/index.css */
 .box {
   --tw-bg-opacity: 1;
-  background-color: rgb(0 0 0 / 1);
   background-color: rgb(0 0 0 / var(--tw-bg-opacity));
 }
 "
@@ -13,7 +12,6 @@ exports[`\`designSystem\` case buildType is bundle 1`] = `
 exports[`\`designSystem\` case buildType is bundleless 1`] = `
 ".box {
   --tw-bg-opacity: 1;
-  background-color: rgb(0 0 0 / 1);
   background-color: rgb(0 0 0 / var(--tw-bg-opacity));
 }
 "


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b4d35f</samp>

This pull request enhances the `@modern-js/module-tools` package to support legacy browsers for module builds. It modifies the `style.ts` file to apply PostCSS plugins based on the target environment, and adds a `.changeset` file to document the feature.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9b4d35f</samp>

*  Add a feature to apply different PostCSS plugins according to the target environment of the module build ([link](https://github.com/web-infra-dev/modern.js/pull/4166/files?diff=unified&w=0#diff-883820ade31f8b570e03213e0b1fe0a0566f6250c2359f7ca9e6857ac9417a27R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4166/files?diff=unified&w=0#diff-35d690ed7aa97eb8f3aea29681f603ecd3621f88d55673bcdc32432f6148816fR54-R61), [link](https://github.com/web-infra-dev/modern.js/pull/4166/files?diff=unified&w=0#diff-35d690ed7aa97eb8f3aea29681f603ecd3621f88d55673bcdc32432f6148816fL62-R71))
  * Create a `.changeset` file with English and Chinese descriptions of the feature ([link](https://github.com/web-infra-dev/modern.js/pull/4166/files?diff=unified&w=0#diff-883820ade31f8b570e03213e0b1fe0a0566f6250c2359f7ca9e6857ac9417a27R1-R7))
  * Define a helper function `getLegacyPostCSSPlugins` to return an array of PostCSS plugins for the legacy browsers (es5 target) in `style.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4166/files?diff=unified&w=0#diff-35d690ed7aa97eb8f3aea29681f603ecd3621f88d55673bcdc32432f6148816fR54-R61))
  * Modify the `getPostcssConfig` function in `style.ts` to conditionally insert the legacy plugins to the `plugins` array if the target is es5 ([link](https://github.com/web-infra-dev/modern.js/pull/4166/files?diff=unified&w=0#diff-35d690ed7aa97eb8f3aea29681f603ecd3621f88d55673bcdc32432f6148816fL62-R71))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
