### PR TITLE
fix: should load typescript from direct dependencies on demand

### DIFF
--- a/.changeset/eighty-falcons-join.md
+++ b/.changeset/eighty-falcons-join.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-utils': patch
+---
+
+fix: should load typescript from direct dependencies on demand
+fix: 按需从直接依赖中加载 typescript

--- a/packages/server/utils/src/common/index.ts
+++ b/packages/server/utils/src/common/index.ts
@@ -4,8 +4,6 @@ import type {
   ToolsNormalizedConfig,
 } from '@modern-js/server-core';
 import { fs } from '@modern-js/utils';
-import { compileByTs } from '../compilers/typescript';
-import { compileByBabel } from '../compilers/babel';
 
 export interface Pattern {
   from: string;
@@ -66,8 +64,10 @@ export const compile: CompileFunc = async (
 
   const isTsProject = tsconfigPath && (await fs.pathExists(tsconfigPath));
   if (!isTsProject || compiler === 'babel') {
+    const { compileByBabel } = await import('../compilers/babel');
     await compileByBabel(appDirectory, modernConfig, compileOptions);
   } else {
+    const { compileByTs } = await import('../compilers/typescript');
     await compileByTs(appDirectory, modernConfig, compileOptions);
   }
 };

--- a/packages/server/utils/src/compilers/typescript/index.ts
+++ b/packages/server/utils/src/compilers/typescript/index.ts
@@ -1,16 +1,16 @@
 import path from 'path';
 import { logger, getAliasConfig, fs } from '@modern-js/utils';
-import type { Program } from 'typescript';
-import ts from 'typescript';
+import type { Program, ParseConfigFileHost } from 'typescript';
+import type ts from 'typescript';
 import type { CompileFunc } from '../../common';
 import { TypescriptLoader } from './typescriptLoader';
 import { tsconfigPathsBeforeHookFactory } from './tsconfigPathsPlugin';
 
-const readTsConfigByFile = (tsConfigFile: string) => {
-  const parsedCmd = ts.getParsedCommandLineOfConfigFile(
+const readTsConfigByFile = (tsConfigFile: string, tsInstance: typeof ts) => {
+  const parsedCmd = tsInstance.getParsedCommandLineOfConfigFile(
     tsConfigFile,
     undefined,
-    ts.sys as unknown as ts.ParseConfigFileHost,
+    tsInstance.sys as unknown as ParseConfigFileHost,
   );
   const { options, fileNames, projectReferences } = parsedCmd!;
   return { options, fileNames, projectReferences };
@@ -56,8 +56,10 @@ export const compileByTs: CompileFunc = async (
     tsconfigPath,
   });
   const { paths = {}, absoluteBaseUrl = './' } = aliasOption;
-  const { options, fileNames, projectReferences } =
-    readTsConfigByFile(tsconfigPath);
+  const { options, fileNames, projectReferences } = readTsConfigByFile(
+    tsconfigPath,
+    ts,
+  );
 
   const sourcePosixPaths = sourceDirs.map(sourceDir =>
     sourceDir.split(path.sep).join(path.posix.sep),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39358b8</samp>

This pull request improves the performance and compatibility of the server-side compilation process by using dynamic imports and dependency injection for TypeScript and Babel. It also adds a changeset file for the `@modern-js/server-utils` package with fix messages in both languages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 39358b8</samp>

* Improve compilation performance and memory usage by dynamically importing TypeScript and Babel dependencies ([link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-da31f592085b6c0bdd3e10fc9a934bda10d07fb3fddd1aca6e65dd5de1063adcL7-L8),[link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-da31f592085b6c0bdd3e10fc9a934bda10d07fb3fddd1aca6e65dd5de1063adcL69-R70),[link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-cb53866b9b31486e4cedbdaf17b7d51684cff11ccea43220e883745f5934baf7L3-R13),[link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-cb53866b9b31486e4cedbdaf17b7d51684cff11ccea43220e883745f5934baf7L59-R62))
  * Remove static imports of `compileByTs` and `compileByBabel` from `common/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-da31f592085b6c0bdd3e10fc9a934bda10d07fb3fddd1aca6e65dd5de1063adcL7-L8))
  * Modify `compile` function in `common/index.ts` to use dynamic imports based on project configuration and compiler option ([link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-da31f592085b6c0bdd3e10fc9a934bda10d07fb3fddd1aca6e65dd5de1063adcL69-R70))
  * Modify TypeScript compiler module in `compilers/typescript/index.ts` to use type-only import of `ts` and parameter of `tsInstance` for `readTsConfigByFile` function ([link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-cb53866b9b31486e4cedbdaf17b7d51684cff11ccea43220e883745f5934baf7L3-R13))
  * Modify `compileByTs` function in `compilers/typescript/index.ts` to pass `ts` instance to `readTsConfigByFile` function ([link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-cb53866b9b31486e4cedbdaf17b7d51684cff11ccea43220e883745f5934baf7L59-R62))
* Add changeset file for patch updates of `@modern-js/server-utils` package with fix messages in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4170/files?diff=unified&w=0#diff-818e0ed486f8fdbe9158ffe7ca137531cf1d07ab6c0aa892dbcbcdaed8ca17f9R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
