### PR TITLE
feat: support worker hmr using dev-server

### DIFF
--- a/.changeset/moody-shirts-kick.md
+++ b/.changeset/moody-shirts-kick.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': minor
+'@modern-js/prod-server': minor
+'@modern-js/server': minor
+---
+
+feat: support worker hmr using dev-server
+feat: 借用 dev-server 支持 wokrer hmr

--- a/packages/server/prod-server/src/index.ts
+++ b/packages/server/prod-server/src/index.ts
@@ -7,6 +7,7 @@ export { ModernServer } from './server/modernServer';
 export { createProxyHandler } from './libs/proxy';
 export * from './type';
 export * from './constants';
+export { createRenderHandler } from './libs/render';
 
 export default (options: ModernServerOptions): Promise<Server> => {
   if (options == null) {

--- a/packages/server/prod-server/src/libs/render/index.ts
+++ b/packages/server/prod-server/src/libs/render/index.ts
@@ -9,7 +9,22 @@ import { readFile } from './reader';
 import * as ssr from './ssr';
 import { injectServerData } from './utils';
 
-export const createRenderHandler = ({
+export type RenderHandler = (options: {
+  ctx: ModernServerContext;
+  route: ModernRoute;
+  runner: ServerHookRunner;
+}) => Promise<RenderResult | null>;
+
+type CreateRenderHandler = (ctx: {
+  distDir: string;
+  staticGenerate: boolean;
+  ssrRender?: typeof ssr.render;
+  forceCSR?: boolean;
+  nonce?: string;
+  metaName?: string;
+}) => RenderHandler;
+
+export const createRenderHandler: CreateRenderHandler = ({
   distDir,
   staticGenerate,
   forceCSR,
@@ -23,7 +38,7 @@ export const createRenderHandler = ({
   forceCSR?: boolean;
   nonce?: string;
   metaName?: string;
-}) =>
+}): RenderHandler =>
   async function render({
     ctx,
     route,

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -99,7 +99,11 @@ export class ModernServer implements ModernServerInterface {
 
   protected readonly proxyTarget: ModernServerOptions['proxyTarget'];
 
-  private routeRenderHandler!: ReturnType<typeof createRenderHandler>;
+  protected routeRenderHandler!: ReturnType<typeof createRenderHandler>;
+
+  protected readonly staticGenerate: boolean;
+
+  protected readonly metaName?: string;
 
   private loaderHandler: LoaderHandler | null = null;
 
@@ -110,10 +114,6 @@ export class ModernServer implements ModernServerInterface {
   private proxyHandler: ReturnType<typeof createProxyHandler> = null;
 
   private _handler!: (context: ModernServerContext, next: NextFunction) => void;
-
-  private readonly staticGenerate: boolean;
-
-  private readonly metaName?: string;
 
   constructor({
     pwd,

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -33,7 +33,7 @@ import {
   ModernRouteInterface,
   ModernRoute,
 } from '../libs/route';
-import { createRenderHandler } from '../libs/render';
+import { RenderHandler, createRenderHandler } from '../libs/render';
 import {
   createStaticFileHandler,
   faviconFallbackHandler,
@@ -99,7 +99,7 @@ export class ModernServer implements ModernServerInterface {
 
   protected readonly proxyTarget: ModernServerOptions['proxyTarget'];
 
-  protected routeRenderHandler!: ReturnType<typeof createRenderHandler>;
+  protected routeRenderHandler!: RenderHandler;
 
   protected readonly staticGenerate: boolean;
 

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -148,7 +148,7 @@ export class ModernServer implements ModernServerInterface {
   public async onInit(runner: ServerHookRunner, app: Server) {
     this.runner = runner;
 
-    const { distDir, staticGenerate, conf, metaName } = this;
+    const { distDir, conf } = this;
 
     this.initReader();
 
@@ -176,16 +176,7 @@ export class ModernServer implements ModernServerInterface {
     await this.prepareFrameHandler();
     await this.prepareLoaderHandler(usageRoutes, distDir);
 
-    const ssrConfig = this.conf.server?.ssr;
-    const forceCSR = typeof ssrConfig === 'object' ? ssrConfig.forceCSR : false;
-    this.routeRenderHandler = createRenderHandler({
-      distDir,
-      staticGenerate,
-      forceCSR,
-      nonce: conf.security?.nonce,
-      metaName,
-    });
-
+    this.routeRenderHandler = this.getRenderHandler();
     await this.setupBeforeProdMiddleware();
 
     // Only work when without setting `assetPrefix`.
@@ -199,6 +190,20 @@ export class ModernServer implements ModernServerInterface {
 
     // compose middlewares to http handler
     this.compose();
+  }
+
+  public getRenderHandler() {
+    const { distDir, staticGenerate, conf, metaName } = this;
+    const ssrConfig = this.conf.server?.ssr;
+    const forceCSR = typeof ssrConfig === 'object' ? ssrConfig.forceCSR : false;
+
+    return createRenderHandler({
+      distDir,
+      staticGenerate,
+      forceCSR,
+      nonce: conf.security?.nonce,
+      metaName,
+    });
   }
 
   // server ready

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -57,7 +57,8 @@
     "http-compression": "1.0.6",
     "minimatch": "^3.0.4",
     "path-to-regexp": "^6.2.0",
-    "ws": "^8.2.0"
+    "ws": "^8.2.0",
+    "axios": "0.27.2"
   },
   "devDependencies": {
     "@modern-js/server-core": "workspace:*",

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -58,7 +58,7 @@
     "minimatch": "^3.0.4",
     "path-to-regexp": "^6.2.0",
     "ws": "^8.2.0",
-    "axios": "0.27.2"
+    "axios": "^1.2.1"
   },
   "devDependencies": {
     "@modern-js/server-core": "workspace:*",

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -132,6 +132,8 @@ export class ModernDevServer extends ModernServer {
       const ssrConfig = this.conf.server?.ssr;
       const forceCSR =
         typeof ssrConfig === 'object' ? ssrConfig.forceCSR : false;
+
+      // if we use worker ssr, we need override the routeRenderHandler
       this.routeRenderHandler = createRenderHandler({
         ssrRender: workerSSRRender,
         distDir,

--- a/packages/server/server/src/server/workerSSRRender.ts
+++ b/packages/server/server/src/server/workerSSRRender.ts
@@ -14,10 +14,14 @@ async function sleep(time: number) {
 
 export async function workerSSRRender(
   _ctx: any,
-  _renderOptions: any,
+  renderOptions: {
+    urlPath: string;
+    [props: string]: any;
+  },
   _runner: ServerHookRunner,
 ) {
-  const url = `http://0.0.0.0:${PORT}`;
+  const { urlPath } = renderOptions;
+  const url = `http://0.0.0.0:${PORT}/${urlPath}`;
   await sleep(1000);
   const resposne = await axios.get(url, {
     timeout: 5000,

--- a/packages/server/server/src/server/workerSSRRender.ts
+++ b/packages/server/server/src/server/workerSSRRender.ts
@@ -4,14 +4,6 @@ import { mime } from '@modern-js/utils';
 
 const PORT = 9230;
 
-async function sleep(time: number) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve(null);
-    }, time);
-  });
-}
-
 export async function workerSSRRender(
   _ctx: any,
   renderOptions: {
@@ -22,7 +14,6 @@ export async function workerSSRRender(
 ) {
   const { urlPath } = renderOptions;
   const url = `http://0.0.0.0:${PORT}/${urlPath}`;
-  await sleep(1000);
   const resposne = await axios.get(url, {
     timeout: 5000,
     responseType: 'text',

--- a/packages/server/server/src/server/workerSSRRender.ts
+++ b/packages/server/server/src/server/workerSSRRender.ts
@@ -1,0 +1,31 @@
+import { ServerHookRunner } from '@modern-js/prod-server';
+import axios from 'axios';
+import { mime } from '@modern-js/utils';
+
+const PORT = 9230;
+
+async function sleep(time: number) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(null);
+    }, time);
+  });
+}
+
+export async function workerSSRRender(
+  _ctx: any,
+  _renderOptions: any,
+  _runner: ServerHookRunner,
+) {
+  const url = `http://0.0.0.0:${PORT}`;
+  await sleep(1000);
+  const resposne = await axios.get(url, {
+    timeout: 5000,
+    responseType: 'text',
+  });
+
+  return {
+    content: resposne.data,
+    contentType: mime.contentType('html') as string,
+  };
+}

--- a/packages/server/server/src/server/workerSSRRender.ts
+++ b/packages/server/server/src/server/workerSSRRender.ts
@@ -1,22 +1,27 @@
+// for worker ssr hmr
 import { ServerHookRunner } from '@modern-js/prod-server';
 import axios from 'axios';
 import { mime } from '@modern-js/utils';
+import { ModernServerContext } from '@modern-js/types/server';
 
 const PORT = 9230;
 
 export async function workerSSRRender(
-  _ctx: any,
+  ctx: ModernServerContext,
   renderOptions: {
     urlPath: string;
     [props: string]: any;
   },
   _runner: ServerHookRunner,
 ) {
+  const { headers, params } = ctx;
   const { urlPath } = renderOptions;
   const url = `http://0.0.0.0:${PORT}/${urlPath}`;
   const resposne = await axios.get(url, {
     timeout: 5000,
     responseType: 'text',
+    headers: headers as Record<string, any>,
+    params,
   });
 
   return {

--- a/packages/server/server/src/types.ts
+++ b/packages/server/server/src/types.ts
@@ -50,6 +50,7 @@ export type DevMiddleware = (options: DevMiddlewareOptions) => DevMiddlewareAPI;
 export type ExtraOptions = {
   dev: boolean | Partial<DevServerOptions>;
   devMiddleware?: DevMiddleware;
+  useWorkerSSR?: boolean;
 };
 
 export type ModernDevServerOptions = ModernServerOptions & ExtraOptions;

--- a/packages/solutions/app-tools/src/analyze/utils.ts
+++ b/packages/solutions/app-tools/src/analyze/utils.ts
@@ -169,7 +169,14 @@ export const getServerCombinedModueFile = (
 };
 
 export const checkIsBuildCommands = () => {
-  const buildCommands = ['dev', 'start', 'build', 'inspect', 'deploy'];
+  const buildCommands = [
+    'dev',
+    'start',
+    'build',
+    'inspect',
+    'deploy',
+    'dev-worker',
+  ];
   const command = getCommand();
 
   return buildCommands.includes(command);

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -12,9 +12,14 @@ import { buildServerConfig } from '../utils/config';
 import type { AppTools } from '../types';
 import { getServerInternalPlugins } from '../utils/getServerInternalPlugins';
 
+export interface ExtraServerOptions {
+  useSSRWorker?: boolean;
+}
+
 export const dev = async (
   api: PluginAPI<AppTools<'shared'>>,
   options: DevOptions,
+  devServerOptions: ExtraServerOptions = {},
 ) => {
   if (options.analyze) {
     // Builder will read this env var to enable bundle analyzer
@@ -52,7 +57,6 @@ export const dev = async (
   }
 
   await generateRoutes(appContext);
-  const useWorkerSSR = Boolean(normalizedConfig.deploy.worker?.ssr);
   const serverInternalPlugins = await getServerInternalPlugins(api);
 
   const serverOptions = {
@@ -73,7 +77,7 @@ export const dev = async (
     config: normalizedConfig,
     serverConfigFile,
     internalPlugins: injectDataLoaderPlugin(serverInternalPlugins),
-    useWorkerSSR,
+    ...devServerOptions,
   };
 
   if (apiOnly) {

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -52,6 +52,7 @@ export const dev = async (
   }
 
   await generateRoutes(appContext);
+  const useWorkerSSR = Boolean(normalizedConfig.deploy.worker?.ssr);
   const serverInternalPlugins = await getServerInternalPlugins(api);
 
   const serverOptions = {
@@ -72,6 +73,7 @@ export const dev = async (
     config: normalizedConfig,
     serverConfigFile,
     internalPlugins: injectDataLoaderPlugin(serverInternalPlugins),
+    useWorkerSSR,
   };
 
   if (apiOnly) {

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -25,6 +25,7 @@ import { restart } from './utils/restart';
 import { generateWatchFiles } from './utils/generateWatchFiles';
 
 export { mergeConfig } from '@modern-js/core';
+export { dev } from './commands';
 export * from './defineConfig';
 // eslint-disable-next-line import/export
 export * from './types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4710,6 +4710,9 @@ importers:
       '@swc/helpers':
         specifier: 0.5.1
         version: 0.5.1
+      axios:
+        specifier: ^1.2.1
+        version: 1.2.1
       connect-history-api-fallback:
         specifier: ^2.0.0
         version: 2.0.0


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 164be18</samp>

This pull request adds a new feature to the `@modern-js/server` and `@modern-js/app-tools` packages, which allows using worker-based SSR rendering for better performance and scalability. It introduces new functions, types, options, and commands to enable and implement this feature in different server scenarios. It also refactors some existing code to make it more flexible and extensible.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 164be18</samp>

*  Export `createRenderHandler` function from `./libs/render` module to create custom render handlers for different server scenarios ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-391b3f0de2099e58507acdda0ece93f029641941ee2de00df562842cfce96c8eR10))
*  Add type annotations, `ssrRender` parameter, and conditional logic to `createRenderHandler` function to support custom SSR render functions, such as worker-based SSR rendering ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bL12-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bL59-R99))
*  Refactor `ModernServer` class to make `routeRenderHandler`, `staticGenerate`, and `metaName` properties protected and remove them from constructor, and import `RenderHandler` type from `../libs/render` module ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL36-R36), [link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL102-R107), [link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL114-L117))
*  Add `axios` dependency to `@modern-js/server` package to make HTTP requests to worker SSR server ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-4e5229a5eda5177170934d4faa8f34e6413ab98d6652b8173bbc236a97251b31L60-R61))
*  Import `createRenderHandler` and `workerSSRRender` functions from `@modern-js/prod-server` and `./workerSSRRender` modules, respectively, to implement worker-based SSR rendering logic for development server scenario ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aR18), [link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aR33))
*  Add `useWorkerSSR` property and option to `ModernDevServer` class and constructor to enable or disable worker-based SSR rendering feature ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aR40-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aR56-R57))
*  Assign custom render handler using `createRenderHandler` and `workerSSRRender` functions to `routeRenderHandler` property in `init` method of `ModernDevServer` class if `useWorkerSSR` is true ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-7d7530ee958c6d949a528b1db7ef0b3a3aec6ee3b2d63bc970719b293b9a3a7aR130-R144))
*  Add `workerSSRRender` module and function to make HTTP request to worker SSR server and return render result object ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-8c11c4b54dccee4b24357977f8efaeb1530c208b4ccedac0300f6f9452be1181R1-R26))
*  Add `useSSRWorker` property to `ExtraOptions` type to pass extra option for development server scenario ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-28ba86ec9f2161d146c4af9a0588f2252db1aa640dc29cfd4cb531b339f953cbR53))
*  Add `dev-worker` value to `buildCommands` array to check if current command is for starting worker SSR server ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-0079e528411b9e11c7e8393a72120660449938bf82a9404088bbc310e3922a00L172-R179))
*  Add `devServerOptions` parameter to `dev` function and constructor call of `ModernDevServer` class to pass extra option for development server scenario, including `useSSRWorker` property ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-c5e04e972eb500f233ab890a23fb40f4f77c017c51676f25562d1f37b356564aL15-R22), [link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-c5e04e972eb500f233ab890a23fb40f4f77c017c51676f25562d1f37b356564aR80))
*  Export `dev` function from `./commands` module to expose `dev` command for `@modern-js/app-tools` package, which starts development server scenario ([link](https://github.com/web-infra-dev/modern.js/pull/4171/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR29))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
