### PR TITLE
fix(builder): enable preferRelative for CSS files by default

### DIFF
--- a/packages/builder/builder-rspack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/css.ts
@@ -137,6 +137,10 @@ export async function applyBaseCSSRule({
 
   // CSS imports should always be treated as sideEffects
   rule.merge({ sideEffects: true });
+
+  // Enable preferRelative by default, which is consistent with the default behavior of css-loader
+  // see: https://github.com/webpack-contrib/css-loader/blob/579fc13/src/plugins/postcss-import-parser.js#L234
+  rule.resolve.preferRelative(true);
 }
 
 /**

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/css.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/css.test.ts.snap
@@ -16,6 +16,9 @@ exports[`plugins/css > should override browserslist of autoprefixer when using o
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -50,6 +53,9 @@ exports[`plugins/css > should override browserslist of autoprefixer when using o
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -106,6 +112,9 @@ exports[`plugins/css > should use custom cssModules rule when using output.cssMo
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": [Function],
             "type": "css/module",
@@ -148,6 +157,9 @@ exports[`plugins/css > should use custom cssModules rule when using output.cssMo
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -204,6 +216,9 @@ exports[`plugins/css disableCssExtract > should apply ignoreCssLoader when disab
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -238,6 +253,9 @@ exports[`plugins/css disableCssExtract > should use css-loader + style-loader wh
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -308,6 +326,9 @@ exports[`plugins/less > should add less-loader 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -360,6 +381,9 @@ exports[`plugins/less > should add less-loader 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -423,6 +447,9 @@ exports[`plugins/less > should add less-loader and css-loader when disableCssExt
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.less\\$/,
         "use": [
@@ -506,6 +533,9 @@ exports[`plugins/less > should add less-loader with excludes 1`] = `
             "exclude": [
               /node_modules/,
             ],
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -561,6 +591,9 @@ exports[`plugins/less > should add less-loader with excludes 1`] = `
             "exclude": [
               /node_modules/,
             ],
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -626,6 +659,9 @@ exports[`plugins/less > should add less-loader with tools.less 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -678,6 +714,9 @@ exports[`plugins/less > should add less-loader with tools.less 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -743,6 +782,9 @@ exports[`plugins/sass > should add sass-loader 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -792,6 +834,9 @@ exports[`plugins/sass > should add sass-loader 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -852,6 +897,9 @@ exports[`plugins/sass > should add sass-loader and css-loader when disableCssExt
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
         "use": [
@@ -932,6 +980,9 @@ exports[`plugins/sass > should add sass-loader with excludes 1`] = `
             "exclude": [
               /node_modules/,
             ],
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -984,6 +1035,9 @@ exports[`plugins/sass > should add sass-loader with excludes 1`] = `
             "exclude": [
               /node_modules/,
             ],
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -287,6 +287,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -329,6 +332,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -375,6 +381,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -427,6 +436,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -483,6 +495,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -532,6 +547,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -1005,6 +1023,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -1047,6 +1068,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -1093,6 +1117,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -1145,6 +1172,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -1201,6 +1231,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -1250,6 +1283,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -1728,11 +1764,17 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
           },
@@ -1742,6 +1784,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -1759,6 +1804,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -1780,6 +1828,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -1794,6 +1845,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -2185,6 +2239,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -2227,6 +2284,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -2273,6 +2333,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -2325,6 +2388,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -2381,6 +2447,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -2430,6 +2499,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
@@ -16,6 +16,9 @@ exports[`plugins/rem > should not run htmlPlugin with enableRuntime is false 1`]
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -64,6 +67,9 @@ exports[`plugins/rem > should not run htmlPlugin with enableRuntime is false 1`]
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -134,6 +140,9 @@ exports[`plugins/rem > should not run rem plugin when false 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -176,6 +185,9 @@ exports[`plugins/rem > should not run rem plugin when false 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -240,6 +252,9 @@ exports[`plugins/rem > should not run rem plugin without config 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -282,6 +297,9 @@ exports[`plugins/rem > should not run rem plugin without config 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -346,6 +364,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -394,6 +415,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -446,6 +470,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -504,6 +531,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -566,6 +596,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -621,6 +654,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -719,6 +755,9 @@ exports[`plugins/rem > should run rem plugin with custom config 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -767,6 +806,9 @@ exports[`plugins/rem > should run rem plugin with custom config 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -863,6 +905,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -911,6 +956,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -963,6 +1011,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -1021,6 +1072,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [
@@ -1083,6 +1137,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
       {
         "oneOf": [
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
             "type": "css/module",
@@ -1138,6 +1195,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
             ],
           },
           {
+            "resolve": {
+              "preferRelative": true,
+            },
             "sideEffects": true,
             "type": "css",
             "use": [

--- a/packages/builder/builder-webpack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/css.ts
@@ -138,6 +138,10 @@ export async function applyBaseCSSRule({
 
   // CSS imports should always be treated as sideEffects
   rule.merge({ sideEffects: true });
+
+  // Enable preferRelative by default, which is consistent with the default behavior of css-loader
+  // see: https://github.com/webpack-contrib/css-loader/blob/579fc13/src/plugins/postcss-import-parser.js#L234
+  rule.resolve.preferRelative(true);
 }
 
 export const builderPluginCss = (): BuilderPlugin => {

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/css.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/css.test.ts.snap
@@ -5,6 +5,9 @@ exports[`plugins/css > should not apply postcss-loader when target is node 1`] =
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -36,6 +39,9 @@ exports[`plugins/css > should override browserslist of autoprefixer when using o
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -93,6 +99,9 @@ exports[`plugins/css > should remove some postcss plugins based on browserslist 
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -249,6 +249,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "type": "asset/resource",
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -305,6 +308,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
         "use": [
@@ -368,6 +374,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.less\\$/,
         "use": [
@@ -1169,6 +1178,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "type": "asset/resource",
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -1225,6 +1237,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
         "use": [
@@ -1288,6 +1303,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.less\\$/,
         "use": [
@@ -2137,6 +2155,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "type": "asset/resource",
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -2159,6 +2180,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
         "use": [
@@ -2188,6 +2212,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.less\\$/,
         "use": [
@@ -2921,6 +2948,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "type": "asset/resource",
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -2943,6 +2973,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
         "use": [
@@ -2972,6 +3005,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.less\\$/,
         "use": [

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
@@ -5,6 +5,9 @@ exports[`plugins/rem > should not run htmlPlugin with enableRuntime is false 1`]
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -76,6 +79,9 @@ exports[`plugins/rem > should not run rem plugin when false 1`] = `
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -141,6 +147,9 @@ exports[`plugins/rem > should not run rem plugin without config 1`] = `
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -206,6 +215,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -268,6 +280,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.less\\$/,
         "use": [
@@ -340,6 +355,9 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
         "use": [
@@ -439,6 +457,9 @@ exports[`plugins/rem > should run rem plugin with custom config 1`] = `
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -536,6 +557,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
   "module": {
     "rules": [
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "use": [
@@ -598,6 +622,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.less\\$/,
         "use": [
@@ -670,6 +697,9 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
         ],
       },
       {
+        "resolve": {
+          "preferRelative": true,
+        },
         "sideEffects": true,
         "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
         "use": [

--- a/tests/e2e/builder/cases/css/relative-import/index.test.ts
+++ b/tests/e2e/builder/cases/css/relative-import/index.test.ts
@@ -1,0 +1,16 @@
+import path from 'path';
+import { test, expect } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+
+test('should compile CSS relative imports correctly', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+  });
+  const files = await builder.unwrapOutputJSON();
+
+  const content =
+    files[Object.keys(files).find(file => file.endsWith('.css'))!];
+
+  expect(content).toContain('.foo{color:red}.bar{color:blue}.baz{color:green}');
+});

--- a/tests/e2e/builder/cases/css/relative-import/src/a.less
+++ b/tests/e2e/builder/cases/css/relative-import/src/a.less
@@ -1,0 +1,1 @@
+@import 'common/a.less';

--- a/tests/e2e/builder/cases/css/relative-import/src/b.scss
+++ b/tests/e2e/builder/cases/css/relative-import/src/b.scss
@@ -1,0 +1,1 @@
+@import 'common/b.scss';

--- a/tests/e2e/builder/cases/css/relative-import/src/c.css
+++ b/tests/e2e/builder/cases/css/relative-import/src/c.css
@@ -1,0 +1,1 @@
+@import 'common/c.css';

--- a/tests/e2e/builder/cases/css/relative-import/src/common/a.less
+++ b/tests/e2e/builder/cases/css/relative-import/src/common/a.less
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/tests/e2e/builder/cases/css/relative-import/src/common/b.scss
+++ b/tests/e2e/builder/cases/css/relative-import/src/common/b.scss
@@ -1,0 +1,3 @@
+.bar {
+  color: blue;
+}

--- a/tests/e2e/builder/cases/css/relative-import/src/common/c.css
+++ b/tests/e2e/builder/cases/css/relative-import/src/common/c.css
@@ -1,0 +1,3 @@
+.baz {
+  color: green;
+}

--- a/tests/e2e/builder/cases/css/relative-import/src/index.js
+++ b/tests/e2e/builder/cases/css/relative-import/src/index.js
@@ -1,0 +1,3 @@
+import './a.less';
+import './b.scss';
+import './c.css';


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
