### PR TITLE
docs: fix mistakes and add descriptions for build hooks

### DIFF
--- a/packages/document/builder-doc/docs/en/api/builder-instance.mdx
+++ b/packages/document/builder-doc/docs/en/api/builder-instance.mdx
@@ -426,7 +426,7 @@ Inspect the final generated builder config and bundler config.
 :::tip
 The `inspectConfig` method does not support simultaneous use with the `startDevServer` / `build` method.
 
-When you need to view the complete builder and bundler config during the build process, you can use [debug mode](/guide/debug/debug-mode.html).
+When you need to view the complete builder and bundler configurations during the build process, you can use the [debug mode](/guide/debug/debug-mode.html) or obtain them through hooks such as `onBeforeBuild` and `onBeforeCreateCompile`.
 :::
 
 - **Type**

--- a/packages/document/builder-doc/docs/en/shared/onAfterBuild.md
+++ b/packages/document/builder-doc/docs/en/shared/onAfterBuild.md
@@ -1,4 +1,7 @@
-Called after executing the production build, you can get the build result information through the `stats` parameter.
+`onAfterBuild` is a callback function that is triggered after running the production build. You can access the build result information via the `stats' parameter:
+
+- If the current bundler is webpack, you will get webpack Stats.
+- If the current bundler is Rspack, you will get Rspack Stats.
 
 - **Type**
 

--- a/packages/document/builder-doc/docs/en/shared/onAfterCreateCompiler.md
+++ b/packages/document/builder-doc/docs/en/shared/onAfterCreateCompiler.md
@@ -1,4 +1,9 @@
-Called after creating a compiler instance, before executing a build, when you execute `builder.startDevServer`, `builder.build` or `builder.createCompiler`, this hook will be called. You can get the compiler instance through the `compiler` parameter.
+`onAfterCreateCompiler` is a callback function that is triggered after the compiler instance has been created, but before the build process. This hook is called when you run `builder.startDevServer`, `builder.build`, or `builder.createCompiler`.
+
+You can access the Compiler instance object through the `compiler` parameter:
+
+- If the current bundler is webpack, you will get the webpack Compiler object.
+- If the current bundler is Rspack, you will get the Rspack Compiler object.
 
 - **Type**
 

--- a/packages/document/builder-doc/docs/en/shared/onBeforeBuild.md
+++ b/packages/document/builder-doc/docs/en/shared/onBeforeBuild.md
@@ -1,4 +1,8 @@
-Called before executing the production environment build, you can get the final config object of the bundler through the `bundlerConfigs` parameter.
+`onBeforeBuild` is a callback function that is triggered before the production build is executed. You can access the final configuration array of the underlying bundler through the `bundlerConfigs' parameter:
+
+- If the current bundler is webpack, you will get a webpack configuration array.
+- If the current bundler is Rspack, you will get an Rspack configuration array.
+- The configuration array can contain one or more configurations, depending on the current `target` config of Builder.
 
 - **Type**
 

--- a/packages/document/builder-doc/docs/en/shared/onBeforeCreateCompiler.md
+++ b/packages/document/builder-doc/docs/en/shared/onBeforeCreateCompiler.md
@@ -1,4 +1,9 @@
-Called before creating the compiler instance, when you execute `builder.startDevServer`, `builder.build` or `builder.createCompiler`, this hook will be called. You can get the final config object of the bundler through the `bundlerConfigs` parameter.
+`onBeforeCreateCompiler` is a callback function that is triggered after the Compiler instance has been created, but before the build process begins. This hook is called when you run `builder.startDevServer`, `builder.build`, or `builder.createCompiler`.
+
+You can access the Compiler instance object through the `compiler` parameter:
+
+- If the current bundler is webpack, you will get the webpack Compiler object.
+- If the current bundler is Rspack, you will get the Rspack Compiler object.
 
 - **Type**
 

--- a/packages/document/builder-doc/docs/zh/api/builder-instance.mdx
+++ b/packages/document/builder-doc/docs/zh/api/builder-instance.mdx
@@ -427,7 +427,7 @@ builder.isPluginExists(builderPluginFoo().name); // true
 :::tip
 `inspectConfig` 方法不支持与 `startDevServer` / `build` 方法同时使用。
 
-当你需要在构建过程中查看完整的 builder 和 bundler 配置时，可以使用 [调试模式](/guide/debug/debug-mode.html)。
+当你需要在构建过程中查看完整的 builder 和 bundler 配置时，可以使用 [调试模式](/guide/debug/debug-mode.html)，也可以通过 `onBeforeBuild`、`onBeforeCreateCompile` 等钩子函数来获取。
 :::
 
 - **类型**

--- a/packages/document/builder-doc/docs/zh/shared/onAfterBuild.md
+++ b/packages/document/builder-doc/docs/zh/shared/onAfterBuild.md
@@ -1,4 +1,7 @@
-在执行生产环境构建后调用，你可以通过 `stats` 参数获取到构建结果信息。
+`onAfterBuild` 是在执行生产环境构建后触发的回调函数，你可以通过 `stats` 参数获取到构建结果信息：
+
+- 如果当前打包工具为 webpack，则获取到的是 webpack Stats。
+- 如果当前打包工具为 Rspack，则获取到的是 Rspack Stats。
 
 - **类型**
 

--- a/packages/document/builder-doc/docs/zh/shared/onAfterCreateCompiler.md
+++ b/packages/document/builder-doc/docs/zh/shared/onAfterCreateCompiler.md
@@ -1,4 +1,9 @@
-在创建 compiler 实例后、执行构建前调用，当你执行 `builder.startDevServer`、`builder.build` 或 `builder.createCompiler` 时，都会调用此钩子。你可以通过 `compiler` 参数获取到 compiler 实例对象。
+`onAfterCreateCompiler` 是在创建 Compiler 实例后、执行构建前触发的回调函数，当你执行 `builder.startDevServer`、`builder.build` 或 `builder.createCompiler` 时，都会调用此钩子。
+
+你可以通过 `compiler` 参数获取到 Compiler 实例对象:
+
+- 如果当前打包工具为 webpack，则获取到的是 webpack Compiler 对象。
+- 如果当前打包工具为 Rspack，则获取到的是 Rspack Compiler 对象。
 
 - **类型**
 

--- a/packages/document/builder-doc/docs/zh/shared/onBeforeBuild.md
+++ b/packages/document/builder-doc/docs/zh/shared/onBeforeBuild.md
@@ -1,4 +1,8 @@
-在执行生产环境构建前调用，你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置对象。
+`onBeforeBuild` 是在执行生产环境构建前触发的回调函数，你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置数组：
+
+- 如果当前打包工具为 webpack，则获取到的是 webpack 配置数组。
+- 如果当前打包工具为 Rspack，则获取到的是 Rspack 配置数组。
+- 配置数组中可能包含一份或多份配置，这取决于 Builder 当前 target 配置的值。
 
 - **类型**
 

--- a/packages/document/builder-doc/docs/zh/shared/onBeforeCreateCompiler.md
+++ b/packages/document/builder-doc/docs/zh/shared/onBeforeCreateCompiler.md
@@ -1,4 +1,12 @@
-在创建 compiler 实例前调用，当你执行 `builder.startDevServer`、`builder.build` 或 `builder.createCompiler` 时，都会调用此钩子。你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置对象。
+`onBeforeCreateCompiler` 是在创建底层 Compiler 实例前触发的回调函数，当你执行 `builder.startDevServer`、`builder.build` 或 `builder.createCompiler` 时，都会调用此钩子。
+
+你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置数组：
+
+- 如果当前打包工具为 webpack，则获取到的是 webpack 配置数组。
+- 如果当前打包工具为 Rspack，则获取到的是 Rspack 配置数组。
+- 配置数组中可能包含一份或多份配置，这取决于你是否开启了 SSR 等功能。
+
+你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置对象。
 
 - **类型**
 

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -299,10 +299,21 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `beforeCreateCompiler`
 
-- Function: Provides access to the Webpack configuration used to create the Webpack Compiler within middleware functions.
-- Execution Stage: Executed before creating the Webpack Compiler.
-- Hook Model: AsyncWorkflow.
-- Type: `AsyncWorkflow<{ webpackConfigs: Configuration[];}, unknown>`.
+- Function: A callback function triggered before creating the underlying Compiler instance, and you can get the final configuration array of the underlying bundler through the `bundlerConfigs` parameter:
+  - If the current bundler is webpack, you will get the webpack Compiler object.
+  - If the current bundler is Rspack, you will get the Rspack Compiler object.
+  - The configuration array may contain one or multiple configurations, depending on whether you have enabled features such as SSR.
+- Execution Stage: Executed before creating the Compiler instance when running the `dev` or `build` command.
+- Hook Model: `AsyncWorkflow`.
+- Type:
+
+```ts
+type BeforeCreateCompiler = AsyncWorkflow<
+  { bundlerConfigs: Configuration[] },
+  unknown
+>;
+```
+
 - Usage Example:
 
 ```ts
@@ -311,8 +322,9 @@ import type { CliPlugin } from '@modern-js/core';
 export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
-      beforeCreateCompiler: ({ webpackConfigs }) => {
-        // do something
+      beforeCreateCompiler: ({ bundlerConfigs }) => {
+        console.log('Before create compiler.');
+        console.log(bundlerConfigs);
       },
     };
   },
@@ -321,10 +333,20 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `afterCreateCompiler`
 
-- Function: Provides access to the created Webpack Compiler within middleware functions.
-- Execution Stage: Executed after creating the Webpack Compiler.
-- Hook Model: AsyncWorkflow.
-- Type: `AsyncWorkflow<{ compiler: Compiler | MultiCompiler | undefined; }, unknown>`.
+- Function: A callback function triggered after creating a Compiler instance and before executing the build. You can access the Compiler instance object through the `compiler` parameter:
+  - If the current bundler is webpack, you will get the webpack Compiler object.
+  - If the current bundler is Rspack, you will get the Rspack Compiler object.
+- Execution Stage: Executed after creating the Compiler object.
+- Hook Model: `AsyncWorkflow`.
+- Type:
+
+```ts
+type AfterCreateCompiler = AsyncWorkflow<
+  { compiler: Compiler | MultiCompiler | undefined },
+  unknown
+>;
+```
+
 - Usage Example:
 
 ```ts
@@ -334,7 +356,8 @@ export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
       afterCreateCompiler: ({ compiler }) => {
-        // do something
+        console.log('After create compiler.');
+        console.log(compiler);
       },
     };
   },
@@ -368,10 +391,20 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `beforeBuild`
 
-- Function: Tasks to be executed before the main process of the `build` command, provides access to the Webpack configuration used for building.
-- Execution Stage: Executed before starting the project build when running the `build` command.
-- Hook Model: AsyncWorkflow.
-- Type: `AsyncWorkflow<{ webpackConfigs: Configuration[]; }>`.
+- Function: A callback function triggered before executing production environment builds. You can access the final configuration array of the underlying bundler through the `bundlerConfigs` parameter.
+  - If the current bundler is webpack, you will get the webpack Compiler object.
+  - If the current bundler is Rspack, you will get the Rspack Compiler object.
+  - The configuration array may contain one or multiple configurations, depending on whether you have enabled features such as SSR.
+- Execution Stage: Executed after running the `build` command and before the actual build process begins.
+- Hook Model: `AsyncWorkflow`.
+- Type:
+
+```ts
+type BeforeBuild = AsyncWorkflow<{
+  bundlerConfigs: WebpackConfig[] | RspackConfig[];
+}>;
+```
+
 - Usage Example:
 
 ```ts
@@ -380,8 +413,9 @@ import type { CliPlugin } from '@modern-js/core';
 export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
-      beforeBuild: () => {
-        // do something
+      beforeBuild: ({ bundlerConfigs }) => {
+        console.log('Before build.');
+        console.log(bundlerConfigs);
       },
     };
   },
@@ -390,10 +424,19 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `afterBuild`
 
-- Function: Tasks to be executed after the main process of the `build` command.
-- Execution Stage: Executed after the project build is completed when running the `build` command.
-- Hook Model: AsyncWorkflow.
-- Type: `AsyncWorkflow<void, unknown>`.
+- Function: A callback function triggered after running the production build. You can access the build result information through the `stats` parameter.
+  - If the current bundler is webpack, you will get webpack Stats.
+  - If the current bundler is Rspack, you will get Rspack Stats.
+- Execution Stage: It is executed after running the `build` command and completing the build.
+- Hook Model: `AsyncWorkflow`.
+- Type:
+
+```ts
+type AfterBuild = AsyncWorkflow<{
+  stats?: Stats | MultiStats;
+}>;
+```
+
 - Usage Example:
 
 ```ts
@@ -402,8 +445,9 @@ import type { CliPlugin } from '@modern-js/core';
 export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
-      afterBuild: () => {
-        // do something
+      afterBuild: ({ stats }) => {
+        console.log('After build.');
+        console.log(stats);
       },
     };
   },

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -299,10 +299,21 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `beforeCreateCompiler`
 
-- 功能：在中间件函数中可以拿到创建 Webpack Compiler 的 Webpack 配置
-- 执行阶段：创建 Webpack Compiler 之前执行
-- Hook 模型：AsyncWorkflow
-- 类型：`AsyncWorkflow<{ webpackConfigs: Configuration[];}, unknown>`
+- 功能：在创建底层 Compiler 实例前触发的回调函数，并且你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置数组：
+  - 如果当前打包工具为 webpack，则获取到的是 webpack 配置数组。
+  - 如果当前打包工具为 Rspack，则获取到的是 Rspack 配置数组。
+  - 配置数组中可能包含一份或多份配置，这取决于你是否开启了 SSR 等功能。
+- 执行阶段：在执行 dev 或 build 命令时，创建 Compiler 实例之前执行
+- Hook 模型：`AsyncWorkflow`
+- 类型：
+
+```ts
+type BeforeCreateCompiler = AsyncWorkflow<
+  { bundlerConfigs: Configuration[] },
+  unknown
+>;
+```
+
 - 使用示例：
 
 ```ts
@@ -311,8 +322,9 @@ import type { CliPlugin } from '@modern-js/core';
 export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
-      beforeCreateCompiler: ({ webpackConfigs }) => {
-        // do something
+      beforeCreateCompiler: ({ bundlerConfigs }) => {
+        console.log('Before create compiler.');
+        console.log(bundlerConfigs);
       },
     };
   },
@@ -321,10 +333,20 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `afterCreateCompiler`
 
-- 功能：在中间件函数中可以拿到创建的 Webpack Compiler
-- 执行阶段：创建 Webpack Compiler 之后执行
-- Hook 模型：AsyncWorkflow
-- 类型：`AsyncWorkflow<{ compiler: Compiler | MultiCompiler | undefined; }, unknown>`
+- 功能：在创建 Compiler 实例后、执行构建前触发的回调函数，并且你可以通过 `compiler` 参数获取到 Compiler 实例对象：
+  - 如果当前打包工具为 webpack，则获取到的是 webpack Compiler 对象。
+  - 如果当前打包工具为 Rspack，则获取到的是 Rspack Compiler 对象。
+- 执行阶段：创建 Compiler 对象之后执行
+- Hook 模型：`AsyncWorkflow`
+- 类型：
+
+```ts
+type AfterCreateCompiler = AsyncWorkflow<
+  { compiler: Compiler | MultiCompiler | undefined },
+  unknown
+>;
+```
+
 - 使用示例：
 
 ```ts
@@ -334,7 +356,8 @@ export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
       afterCreateCompiler: ({ compiler }) => {
-        // do something
+        console.log('After create compiler.');
+        console.log(compiler);
       },
     };
   },
@@ -368,10 +391,20 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `beforeBuild`
 
-- 功能：运行 build 主流程的之前的任务，可以拿到构建的 Webpack 配置
-- 执行阶段：`build` 命令运行时，项目构建启动前执行
-- Hook 模型：AsyncWorkflow
-- 类型：`AsyncWorkflow<{ webpackConfigs: Configuration[]; }>`
+- 功能：在执行生产环境构建前触发的回调函数，你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置数组。
+  - 如果当前打包工具为 webpack，则获取到的是 webpack 配置数组。
+  - 如果当前打包工具为 Rspack，则获取到的是 Rspack 配置数组。
+  - 配置数组中可能包含一份或多份配置，这取决于你是否开启了 SSR 等功能。
+- 执行阶段：运行 `build` 命令后，在开始构建前执行
+- Hook 模型：`AsyncWorkflow`
+- 类型：
+
+```ts
+type BeforeBuild = AsyncWorkflow<{
+  bundlerConfigs: WebpackConfig[] | RspackConfig[];
+}>;
+```
+
 - 使用示例：
 
 ```ts
@@ -380,8 +413,9 @@ import type { CliPlugin } from '@modern-js/core';
 export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
-      beforeBuild: () => {
-        // do something
+      beforeBuild: ({ bundlerConfigs }) => {
+        console.log('Before build.');
+        console.log(bundlerConfigs);
       },
     };
   },
@@ -390,10 +424,19 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `afterBuild`
 
-- 功能：运行 build 主流程的之后的任务
-- 执行阶段：`build` 命令运行时，项目构建完成之后执行
-- Hook 模型：AsyncWorkflow
-- 类型：`AsyncWorkflow<void, unknown>`
+- 功能：在执行生产环境构建后触发的回调函数，你可以通过 `stats` 参数获取到构建结果信息。
+  - 如果当前打包工具为 webpack，则获取到的是 webpack Stats。
+  - 如果当前打包工具为 Rspack，则获取到的是 Rspack Stats。
+- 执行阶段：运行 `build` 命令运行后，在项目构建完成之后执行
+- Hook 模型：`AsyncWorkflow`
+- 类型：
+
+```ts
+type AfterBuild = AsyncWorkflow<{
+  stats?: Stats | MultiStats;
+}>;
+```
+
 - 使用示例：
 
 ```ts
@@ -402,8 +445,9 @@ import type { CliPlugin } from '@modern-js/core';
 export const myPlugin = (): CliPlugin => ({
   setup(api) {
     return {
-      afterBuild: () => {
-        // do something
+      afterBuild: ({ stats }) => {
+        console.log('After build.');
+        console.log(stats);
       },
     };
   },


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cdf3704</samp>

This pull request updates and consolidates the documentation of the framework plugin hooks and the builder instance methods and hooks in both English and Chinese. It adds more details and examples about the hook parameters, such as `bundlerConfigs`, `compiler`, and `stats`, and their types and sources depending on the bundler and other features. It also moves the content of the shared files to the `builder-instance.mdx` file to avoid duplication and improve readability.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cdf3704</samp>

*  Move and update the documentation of the builder instance methods and hooks from the shared files to the `builder-instance.mdx` file for both English and Chinese languages, and add more details about the parameters such as type and source ([link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-45ba4d93ed345aa04adad80e8dd717e3c9a4212b695401d9fcaeb2d71b70683dL429-R429), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-0058a7ad2b1a7f39d037f887c7d568291833192d53c203aadeb71f5c06706b60L1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-00a91f587b103e48a5a6dfe12ab0fad8f7f38991f395252ad7ae4570e9933a4bL1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-9f3d8e0f08e48130f29e90401a09203c869a19b16fde175de40ca0fe3cb910a9L1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-075be56ef9ec9b81158b6b840f916b0b3bdd17a1c4aa8a3ca1f71305320517b2L1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-854c8cb3e207b8b4b5eee437feb44cd9d6e62a724e7bf4a360ab093bf4034f74L430-R430), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-2c04cf128055b52ceef3fe99a3eb17cf6e1ecff32646ce559c550cab8477125bL1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-493185ab3166666c87fa64d7f8bee92a1038caf59ab004f79cea10bc540864ceL1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-e48392551d3ce8216b913a53afb46aff7df197c523b967135a7ee18556da47fbL1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-e791393e8cac6909101a0052566edc5cd3bfb1697aced6ce65c26caf53e819d0L1-R10))
*  Update the documentation and usage examples of the framework plugin hooks to match the content of the `builder-instance.mdx` file, and add more details and console logs for the parameters such as `bundlerConfigs`, `compiler`, and `stats` for both English and Chinese languages ([link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L302-R316), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L314-R327), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L324-R349), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L337-R360), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L371-R407), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L383-R418), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L393-R439), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L405-R450), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L302-R316), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L314-R327), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L324-R349), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L337-R360), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L371-R407), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L383-R418), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L393-R439), [link](https://github.com/web-infra-dev/modern.js/pull/4175/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L405-R450))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
