### PR TITLE
fix(builder): incorrect CSS rules when enable asset fallback

### DIFF
--- a/.changeset/quick-parents-smell.md
+++ b/.changeset/quick-parents-smell.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): incorrect CSS rules when enable asset fallback
+
+fix(builder): 修复开启 asset fallback 时 CSS 规则错误的问题

--- a/packages/builder/builder-shared/src/fallback.ts
+++ b/packages/builder/builder-shared/src/fallback.ts
@@ -17,7 +17,7 @@ export const resourceRuleFallback = (
       // "..." refers to the webpack defaults
       rule === '...' ||
       // this is a special case, put the mjs fullySpecified rule in the outside
-      (rule.resolve && !rule.mimetype)
+      (rule.resolve && 'fullySpecified' in rule.resolve && !rule.mimetype)
     ) {
       outerRules.push(rule);
     } else if (


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/modern.js/actions/runs/5506752428/jobs/10036527799

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9260be1</samp>

This pull request fixes a bug in the `@modern-js/builder-shared` package that caused incorrect CSS rules when the asset fallback feature was enabled. It also adds a changeset file and a Chinese translation for the bug fix message. Additionally, it updates the fallback logic to handle the `fullySpecified` option for `.mjs` files in webpack 5.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9260be1</samp>

* Fix incorrect CSS rules when asset fallback feature is enabled for `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/4176/files?diff=unified&w=0#diff-93e704888116a572b1556fb56f5c0778b2e96b67f2d1578290761a2d0443f19aR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4176/files?diff=unified&w=0#diff-ab26b248d82b655491ee18e931becbdb61d3363596b7e8502b19f40b5f7e6b31L20-R20))
  * Add changeset file to describe patch version update and bug fix ([link](https://github.com/web-infra-dev/modern.js/pull/4176/files?diff=unified&w=0#diff-93e704888116a572b1556fb56f5c0778b2e96b67f2d1578290761a2d0443f19aR1-R7))
  * Add condition to check `fullySpecified` property in `rule.resolve` object in `fallback.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4176/files?diff=unified&w=0#diff-ab26b248d82b655491ee18e931becbdb61d3363596b7e8502b19f40b5f7e6b31L20-R20))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
