### PR TITLE
fix: we should't repeatly registe the script, if template has it.

### DIFF
--- a/.changeset/bright-needles-fail.md
+++ b/.changeset/bright-needles-fail.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(plugin-runtime): we should not repeatly registe the script, if template has it.
+fix(plugin-runtime): 如果模版中已经有了,我们不应该重复添加 script 链接

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
@@ -65,6 +65,8 @@ export default class Entry {
 
   public logger: SSRServerContext['logger'];
 
+  private readonly template: string;
+
   private readonly App: ModernSSRReactComponent;
 
   private readonly fragments: Fragment[];
@@ -85,6 +87,7 @@ export default class Entry {
     } = ctx;
 
     this.fragments = toFragments(template, entryName);
+    this.template = template;
     this.entryName = entryName;
     this.host = host;
     this.App = options.App;
@@ -187,6 +190,7 @@ export default class Entry {
         entryName: this.entryName,
         config: this.pluginConfig,
         nonce: this.nonce,
+        template: this.template,
       };
       html = reduce(App, renderContext, [
         styledComponentRenderer.toHtml,

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
@@ -50,10 +50,14 @@ export const toHtml: RenderHandler = (jsx, renderer, next) => {
     }
 
     if (fileType === 'js') {
-      // `nonce` attrs just for script tag
-      attributes.nonce = nonce;
-      const attrsStr = attributesToString(attributes);
-      chunksMap[fileType] += `<script${attrsStr} src="${v.url}"></script>`;
+      const jsChunkReg = new RegExp(`<script .*src="${v.url}".*>`);
+      // we should't repeatly registe the script, if template already has it.
+      if (!jsChunkReg.test(renderer.template)) {
+        // `nonce` attrs just for script tag
+        attributes.nonce = nonce;
+        const attrsStr = attributesToString(attributes);
+        chunksMap[fileType] += `<script${attrsStr} src="${v.url}"></script>`;
+      }
     } else if (fileType === 'css') {
       const attrsStr = attributesToString(attributes);
       chunksMap[

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/type.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/type.ts
@@ -21,6 +21,7 @@ export interface RenderEntry {
   result: RenderResult;
   stats: Record<string, any>;
   config: SSRPluginConfig;
+  template: string;
   nonce?: string;
 }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46f4904</samp>

This pull request improves the SSR feature of the `@modern-js/runtime` package by allowing custom HTML templates, fixing duplicate script tag issues, and updating the documentation and version. It mainly affects the `plugin-runtime` module and its `renderToString` function.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46f4904</samp>

*  Add `template` property to `RenderEntry` class and interface to store HTML template string for SSR output ([link](https://github.com/web-infra-dev/modern.js/pull/4178/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR68-R69), [link](https://github.com/web-infra-dev/modern.js/pull/4178/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR90), [link](https://github.com/web-infra-dev/modern.js/pull/4178/files?diff=unified&w=0#diff-da2197dba630dc870e1dc6bdcf288514090bbcd5923cd4fb5d77272688784c95R24))
*  Pass `template` property to `Loadable.toHtml` method to generate HTML tags for dynamic chunks ([link](https://github.com/web-infra-dev/modern.js/pull/4178/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR193))
*  Avoid adding duplicate script tags for the same chunk if template already has them in `Loadable.toHtml` method ([link](https://github.com/web-infra-dev/modern.js/pull/4178/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L53-R60))
*  Document patch version update and bug fixes for `@modern-js/runtime` package in `.changeset/bright-needles-fail.md` file ([link](https://github.com/web-infra-dev/modern.js/pull/4178/files?diff=unified&w=0#diff-819f79c98fe1aaa5f22f00c87011ea34f5faa5b0275fd0000b91d18912caf567R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
