### PR TITLE
fix(doc-core): can not find path only in windows bacause of the escape char

### DIFF
--- a/.changeset/good-masks-sing.md
+++ b/.changeset/good-masks-sing.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+'@modern-js/doc-plugin-preview': patch
+---
+
+fix: can not find path only in windows bacause of the escape char
+fix: 在windows系统下因为转义字符而无法找到路径

--- a/packages/cli/doc-core/src/node/runtimeModule/globalStyles.ts
+++ b/packages/cli/doc-core/src/node/runtimeModule/globalStyles.ts
@@ -11,7 +11,7 @@ export async function globalStylesVMPlugin(context: FactoryContext) {
     ...globalStylesByPlugins,
   ]
     .filter(source => source.length > 0)
-    .map(source => `import '${source}';`)
+    .map(source => `import ${JSON.stringify(source)};`)
     .join('');
 
   return new RuntimeModulesPlugin({

--- a/packages/cli/doc-core/src/node/runtimeModule/globalUIComponents.ts
+++ b/packages/cli/doc-core/src/node/runtimeModule/globalUIComponents.ts
@@ -14,7 +14,7 @@ export async function globalUIComponentsVMPlugin(context: FactoryContext) {
     ...(config.doc?.globalUIComponents || []),
     ...globalUIComponentsByPlugins,
   ]
-    .map(source => `import Comp_${index++} from '${source}';`)
+    .map(source => `import Comp_${index++} from ${JSON.stringify(source)};`)
     .concat(
       `export default [${Array.from(
         { length: index },

--- a/packages/cli/doc-core/src/node/utils/getASTNodeImport.ts
+++ b/packages/cli/doc-core/src/node/utils/getASTNodeImport.ts
@@ -5,7 +5,7 @@ import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
 export const getASTNodeImport = (name: string, from: string) =>
   ({
     type: 'mdxjsEsm',
-    value: `import ${name} from "${from}"`,
+    value: `import ${name} from ${JSON.stringify(from)}`,
     data: {
       estree: {
         type: 'Program',
@@ -22,7 +22,7 @@ export const getASTNodeImport = (name: string, from: string) =>
             source: {
               type: 'Literal',
               value: from,
-              raw: `"${from}"`,
+              raw: `${JSON.stringify(from)}`,
             },
           },
         ],

--- a/packages/cli/doc-plugin-preview/src/codeToDemo.ts
+++ b/packages/cli/doc-plugin-preview/src/codeToDemo.ts
@@ -199,7 +199,7 @@ export const remarkCodeToDemo: Plugin<
 const getASTNodeImport = (name: string, from: string) =>
   ({
     type: 'mdxjsEsm',
-    value: `import ${name} from "${from}"`,
+    value: `import ${name} from ${JSON.stringify(from)}`,
     data: {
       estree: {
         type: 'Program',
@@ -216,7 +216,7 @@ const getASTNodeImport = (name: string, from: string) =>
             source: {
               type: 'Literal',
               value: from,
-              raw: `"${from}"`,
+              raw: `${JSON.stringify(from)}`,
             },
           },
         ],

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -39,7 +39,7 @@ export function pluginPreview(options?: Options): DocPlugin {
 pageType: "blank"
 ---
 
-import Demo from '${demoComponentPath}'
+import Demo from ${JSON.stringify(demoComponentPath)}
 
 <Demo />
           `,

--- a/tests/integration/doc/fixtures/plugin/modern.config.ts
+++ b/tests/integration/doc/fixtures/plugin/modern.config.ts
@@ -1,16 +1,12 @@
 import * as path from 'path';
 import { docTools, defineConfig } from '@modern-js/doc-tools';
-// import { pluginPreview } from '@modern-js/doc-plugin-preview';
+import { pluginPreview } from '@modern-js/doc-plugin-preview';
 import { docPluginDemo } from './plugin';
 
 export default defineConfig({
   plugins: [docTools()],
   doc: {
     root: path.join(__dirname, 'doc'),
-    plugins: [
-      docPluginDemo(),
-      // FIX: adapt windows path
-      // pluginPreview({ isMobile: true }),
-    ],
+    plugins: [docPluginDemo(), pluginPreview({ isMobile: true })],
   },
 });

--- a/tests/integration/module-doc/tests/basic.test.ts
+++ b/tests/integration/module-doc/tests/basic.test.ts
@@ -1,0 +1,60 @@
+import { join } from 'path';
+import type { Page, Browser } from 'puppeteer';
+import puppeteer from 'puppeteer';
+import {
+  launchApp,
+  getPort,
+  killApp,
+  launchOptions,
+} from '../../../utils/modernTestUtils';
+
+describe('Check basic render in development', () => {
+  let app: any;
+  let page: Page;
+  let browser: Browser;
+  let appPort: number;
+  beforeAll(async () => {
+    const appDir = join(__dirname, '..');
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort);
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await killApp(app);
+    }
+    if (page) {
+      await page.close();
+    }
+    if (browser) {
+      browser.close();
+    }
+  });
+
+  it('Index page', async () => {
+    await page.goto(`http://localhost:${appPort}/en/`, {
+      waitUntil: ['networkidle0'],
+    });
+    const h1 = await page.$('h1');
+    const text = await page.evaluate(h1 => h1?.textContent, h1);
+    expect(text).toContain('Components Overview');
+    // expect the .header-anchor to be rendered and take the correct href
+    const headerAnchor = await page.$('.header-anchor');
+    const href = await page.evaluate(
+      headerAnchor => headerAnchor?.getAttribute('href'),
+      headerAnchor,
+    );
+    expect(href).toBe('#components-overview');
+  });
+
+  it('404 page', async () => {
+    await page.goto(`http://localhost:${appPort}/404`, {
+      waitUntil: ['networkidle0'],
+    });
+    // find the 404 text in the page
+    const text = await page.evaluate(() => document.body.textContent);
+    expect(text).toContain('404');
+  });
+});

--- a/tests/integration/module-doc/tsconfig.json
+++ b/tests/integration/module-doc/tsconfig.json
@@ -7,5 +7,5 @@
       "demo": ["."]
     }
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
When we  run doc-core in windows, we will find the following error: 'os error 3'.
Because when we use `import '${source}'` directly, the source is `xxx\global-components\Container.tsx`,
`\` is a escape char, so we need use `JSON.stringify` to fix it, and the source will be `xxx\\global-components\\Container.tsx`.


## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a63ad54</samp>

This pull request fixes several bugs related to importing and generating code for MDX, global styles, and global UI components in the `doc-core` and `doc-plugin-preview` packages. It also adds a new integration test file for the `module-doc` fixture that checks the basic rendering of the pages in development mode.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a63ad54</samp>

*  Fix bug in generating import source for global styles and UI components ([link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-4cc4e56f2c9217c1c048a2c00aba5dcb8a1d2d63987d88ccb4ab0bfb7a538218L14-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-3637e6fc00c78db717265981630213de98680578a4c4dd7057ac9a872bca69afL17-R17), [link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaL42-R42))
*  Fix bug in creating AST node for import statement in various plugins and utils ([link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-4566742424408602aa69ddb9f45c0d096da02883bc5ed181f9bbbb98d3d81134L8-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-4566742424408602aa69ddb9f45c0d096da02883bc5ed181f9bbbb98d3d81134L25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL202-R202), [link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-f8693c99a510897a675de9308d8a2de7ca5a78782d4dac6f86e3eecd2e0c3c6eL219-R219))
*  Enable `pluginPreview` import and plugin in `plugin` fixture for integration testing ([link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-040cd191471118bc1891e5319efd67e3f067180875c36311f7870f8b24524959L3-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-040cd191471118bc1891e5319efd67e3f067180875c36311f7870f8b24524959L10-R10))
*  Add integration test for basic rendering of `module-doc` fixture using puppeteer ([link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-9ed88e0bd742bf923b38e01ee5170f6bd2b9da828406c0d3bee1e69bb72e68d0R1-R60))
*  Include `tests` folder in TypeScript compilation for `module-doc` fixture ([link](https://github.com/web-infra-dev/modern.js/pull/4182/files?diff=unified&w=0#diff-6245cd63f7f672a620763eac64d3d67379d51274edbd0e673811562a05db51c9L10-R10))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
