### PR TITLE
chore: migrate packages from tsc to module-lib build

### DIFF
--- a/.changeset/funny-turtles-hug.md
+++ b/.changeset/funny-turtles-hug.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-plugin-typedoc': patch
+---
+
+feat(doc-tools): upgrade typedoc to 0.24.8
+
+feat(doc-tools): 升级 typedoc 到 0.24.8

--- a/.changeset/gold-laws-tease.md
+++ b/.changeset/gold-laws-tease.md
@@ -1,0 +1,34 @@
+---
+'@modern-js/friendly-errors-webpack-plugin': patch
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-plugin-image-compress': patch
+'@modern-js/builder-plugin-node-polyfill': patch
+'@modern-js/generator-common': patch
+'@modern-js/generator-utils': patch
+'@modern-js/plugin-module-doc': patch
+'@modern-js/plugin-router-v5': patch
+'@modern-js/builder-shared': patch
+'@modern-js/builder-plugin-esbuild': patch
+'@modern-js/plugin-garfish': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/babel-compiler': patch
+'@modern-js/builder-plugin-stylus': patch
+'@modern-js/babel-preset-base': patch
+'@modern-js/plugin-storybook': patch
+'@modern-js/new-action': patch
+'@modern-js/builder-cli': patch
+'@modern-js/builder-plugin-swc': patch
+'@modern-js/builder-plugin-vue': patch
+'@modern-js/builder': patch
+'@modern-js/plugin-i18n': patch
+'@modern-js/plugin-lint': patch
+'@modern-js/plugin-swc': patch
+'@modern-js/e2e': patch
+'@modern-js/core': patch
+---
+
+chore: migrate packages from tsc to module-lib build
+
+chore: 将使用 tsc 的包迁移到 module-lib 构建

--- a/packages/builder/builder-cli/modern.config.js
+++ b/packages/builder/builder-cli/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-cli/package.json
+++ b/packages/builder/builder-cli/package.json
@@ -35,8 +35,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
@@ -44,11 +44,13 @@
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/node-bundle-require": "workspace:*",
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5"
   },

--- a/packages/builder/builder-rspack-provider/modern.config.js
+++ b/packages/builder/builder-rspack-provider/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -43,8 +43,8 @@
   },
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -59,6 +59,7 @@
     "@rspack/core": "0.2.5",
     "@rspack/dev-client": "0.2.5",
     "@rspack/plugin-html": "0.2.5",
+    "@swc/helpers": "0.5.1",
     "rspack-manifest-plugin": "5.0.0-alpha0",
     "caniuse-lite": "^1.0.30001489",
     "core-js": "~3.30.0",
@@ -69,6 +70,7 @@
   },
   "devDependencies": {
     "@arco-design/web-react": "^2.46.0",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",
     "antd": "4",

--- a/packages/builder/builder-shared/modern.config.js
+++ b/packages/builder/builder-shared/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc && node scripts/postCompile.js",
-    "dev": "tsc --watch",
+    "build": "modern-lib build && node scripts/postCompile.js",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -115,13 +115,14 @@
     }
   },
   "dependencies": {
+    "@babel/core": "^7.21.8",
     "@babel/types": "^7.21.5",
     "@babel/parser": "^7.21.8",
     "@modern-js/prod-server": "workspace:*",
     "@modern-js/server": "workspace:*",
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@babel/core": "^7.21.8",
+    "@swc/helpers": "0.5.1",
     "fork-ts-checker-webpack-plugin": "8.0.0",
     "acorn": "^8.8.1",
     "caniuse-lite": "^1.0.30001489",

--- a/packages/builder/builder-webpack-provider/modern.config.js
+++ b/packages/builder/builder-webpack-provider/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -81,8 +81,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch --sourceMap",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -98,6 +98,7 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.9",
+    "@swc/helpers": "0.5.1",
     "caniuse-lite": "^1.0.30001489",
     "css-minimizer-webpack-plugin": "5.0.0",
     "html-webpack-plugin": "5.5.0",
@@ -112,6 +113,7 @@
   "devDependencies": {
     "@arco-design/web-react": "^2.46.0",
     "@modern-js/e2e": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/caniuse-lite": "^1.0.1",
     "@types/node": "^14",

--- a/packages/builder/builder/modern.config.js
+++ b/packages/builder/builder/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -32,8 +32,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -42,11 +42,13 @@
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/monorepo-utils": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@svgr/webpack": "8.0.1"
+    "@svgr/webpack": "8.0.1",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/babel__core": "^7.20.0",
     "@types/node": "^14",

--- a/packages/builder/friendly-errors-webpack-plugin/modern.config.js
+++ b/packages/builder/friendly-errors-webpack-plugin/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/friendly-errors-webpack-plugin/package.json
+++ b/packages/builder/friendly-errors-webpack-plugin/package.json
@@ -56,8 +56,8 @@
   },
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch --sourceMap",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "echo foo",
     "test:local": "vitest run",
     "test:watch": "vitest dev --no-coverage",
@@ -65,11 +65,13 @@
     "example:build": "webpack -c example/webpack.config.js"
   },
   "dependencies": {
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/e2e": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",
     "ansi-to-html": "^0.7.2",

--- a/packages/builder/plugin-esbuild/modern.config.js
+++ b/packages/builder/plugin-esbuild/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-esbuild/package.json
+++ b/packages/builder/plugin-esbuild/package.json
@@ -32,19 +32,21 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
-    "esbuild": "0.17.19",
-    "@modern-js/builder-shared": "workspace:*"
+    "@modern-js/builder-shared": "workspace:*",
+    "@swc/helpers": "0.5.1",
+    "esbuild": "0.17.19"
   },
   "devDependencies": {
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5"
   },

--- a/packages/builder/plugin-image-compress/modern.config.js
+++ b/packages/builder/plugin-image-compress/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-image-compress/package.json
+++ b/packages/builder/plugin-image-compress/package.json
@@ -25,8 +25,8 @@
   "module": "./dist/index.js",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch --sourceMap",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
@@ -51,11 +51,13 @@
   "dependencies": {
     "@modern-js/utils": "workspace:*",
     "@napi-rs/image": "^1.3.0",
+    "@swc/helpers": "0.5.1",
     "svgo": "^3.0.2"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/e2e": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",
     "typescript": "^5",

--- a/packages/builder/plugin-node-polyfill/modern.config.js
+++ b/packages/builder/plugin-node-polyfill/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-node-polyfill/package.json
+++ b/packages/builder/plugin-node-polyfill/package.json
@@ -32,13 +32,14 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "node-libs-browser": "2.2.1"
   },
   "devDependencies": {
@@ -46,6 +47,7 @@
     "@modern-js/builder-rspack-provider": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5"
   },

--- a/packages/builder/plugin-stylus/modern.config.js
+++ b/packages/builder/plugin-stylus/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-stylus/package.json
+++ b/packages/builder/plugin-stylus/package.json
@@ -32,14 +32,15 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "stylus": "0.59.0",
     "stylus-loader": "7.1.0"
   },
@@ -48,6 +49,7 @@
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5",
     "webpack": "^5.88.1"

--- a/packages/builder/plugin-swc/modern.config.js
+++ b/packages/builder/plugin-swc/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -10,8 +10,8 @@
   "main": "./dist/index.js",
   "types": "./src/index.ts",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc -w",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:update": "SNAPSHOT_UPDATE=1 vitest watch",
@@ -51,12 +51,23 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "@babel/core": "^7.21.8",
+    "@babel/preset-env": "^7.21.5",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.21.5",
+    "@modern-js/builder-shared": "workspace:*",
+    "@modern-js/swc-plugins": "0.4.0",
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1",
+    "core-js": "~3.30.0"
+  },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@swc/core": "1.3.42",
-    "@swc/helpers": "0.5.1",
     "@types/babel__core": "^7.20.0",
     "antd": "4",
     "lodash": "^4.17.21",
@@ -66,17 +77,6 @@
     "webpack": "^5.88.1",
     "react": "^18",
     "react-dom": "^18"
-  },
-  "dependencies": {
-    "@babel/core": "^7.21.8",
-    "@babel/preset-env": "^7.21.5",
-    "@babel/preset-react": "^7.18.6",
-    "@babel/preset-typescript": "^7.21.5",
-    "@swc/helpers": "0.5.1",
-    "core-js": "~3.30.0",
-    "@modern-js/builder-shared": "workspace:*",
-    "@modern-js/swc-plugins": "0.4.0",
-    "@modern-js/utils": "workspace:*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/builder/plugin-vue/modern.config.js
+++ b/packages/builder/plugin-vue/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-vue/package.json
+++ b/packages/builder/plugin-vue/package.json
@@ -32,13 +32,14 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "@vue/babel-plugin-jsx": "1.1.1",
     "vue-loader": "^17.2.2"
   },
@@ -48,6 +49,7 @@
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5",
     "webpack": "^5.88.1"

--- a/packages/cli/babel-preset-base/modern.config.js
+++ b/packages/cli/babel-preset-base/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/cli/babel-preset-base/package.json
+++ b/packages/cli/babel-preset-base/package.json
@@ -34,8 +34,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern-lib new",
-    "dev": "tsc --watch",
-    "build": "tsc",
+    "dev": "modern-lib build --watch",
+    "build": "modern-lib build",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
@@ -51,6 +51,7 @@
     "@babel/preset-typescript": "^7.21.5",
     "@babel/runtime": "^7.21.5",
     "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "@types/babel__core": "^7.20.0",
     "lodash": "^4.17.21"
   },
@@ -64,11 +65,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/cli/core/modern.config.js
+++ b/packages/cli/core/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -71,14 +71,15 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern-lib new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "jest"
   },
   "dependencies": {
     "@modern-js/node-bundle-require": "workspace:*",
     "@modern-js/plugin": "workspace:*",
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-shared": "workspace:*",

--- a/packages/cli/core/tests/tsm.test.ts
+++ b/packages/cli/core/tests/tsm.test.ts
@@ -1,15 +1,13 @@
 import path from 'path';
 import { spawnSync } from 'child_process';
 
-const kPackageDir = path.resolve(__dirname, '..');
-
 describe('jsnext:source', () => {
   test('process exit status is 0', () => {
     const { status, stdout, stderr } = spawnSync(
       process.execPath,
-      ['--conditions=jsnext:source', '-r', 'tsm', 'src/bin.ts'],
+      ['--conditions=jsnext:source', '-r', 'tsm', '../../../../src/bin.ts'],
       {
-        cwd: kPackageDir,
+        cwd: path.resolve(__dirname, 'fixtures/config/no-config'),
         encoding: 'utf-8',
       },
     );

--- a/packages/cli/doc-plugin-typedoc/package.json
+++ b/packages/cli/doc-plugin-typedoc/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@modern-js/utils": "workspace:*",
-    "typedoc": "0.23.24",
-    "typedoc-plugin-markdown": "3.14.0"
+    "typedoc": "0.24.8",
+    "typedoc-plugin-markdown": "3.15.3"
   }
 }

--- a/packages/cli/doc-plugin-typedoc/src/index.ts
+++ b/packages/cli/doc-plugin-typedoc/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { Application, TSConfigReader } from 'typedoc';
 import type { DocPlugin } from '@modern-js/doc-core/src/shared/types/Plugin';
+import { load } from 'typedoc-plugin-markdown';
 import { API_DIR } from './constants';
 import { resolveSidebar } from './sidebar';
 
@@ -34,21 +35,23 @@ export function pluginTypeDoc(options: PluginTypeDocOptions): DocPlugin {
       const app = new Application();
       docRoot = config.root;
       app.options.addReader(new TSConfigReader());
+      load(app);
       app.bootstrap({
         name: config.title,
         entryPoints,
-        plugin: ['typedoc-plugin-markdown'],
         theme: 'markdown',
         disableSources: true,
         readme: 'none',
         githubPages: false,
-        // @ts-expect-error hide bread crumbs and members symbol
+        requiredToBeDocumented: ['Class', 'Function', 'Interface'],
+        plugin: ['typedoc-plugin-markdown'],
+        // @ts-expect-error MarkdownTheme has no export
         hideBreadcrumbs: true,
         hideMembersSymbol: true,
         allReflectionsHaveOwnDocument: true,
       });
-
       const project = app.convert();
+
       if (project) {
         // 1. Generate module doc by typedoc
         const absoluteOutputdir = path.join(docRoot!, outDir);

--- a/packages/cli/doc-plugin-typedoc/src/sidebar.ts
+++ b/packages/cli/doc-plugin-typedoc/src/sidebar.ts
@@ -8,56 +8,67 @@ import {
   getFunctionPath,
 } from './utils';
 
+interface ModuleItem {
+  id: number;
+  name: string;
+  children: {
+    id: number;
+    name: string;
+  }[];
+  groups: {
+    title: string;
+    children: number[];
+  }[];
+}
+
 export async function resolveSidebar(jsonDir: string): Promise<SidebarGroup[]> {
   const result: SidebarGroup[] = [];
   const data = JSON.parse(await fs.readFile(jsonDir, 'utf-8'));
   if (!data.children || data.children.length <= 0) {
     return result;
   }
-  data.children.forEach(
-    (module: {
-      name: string;
-      children: {
-        name: string;
-        kindString: 'Class' | 'Interface' | 'Function';
-      }[];
-    }) => {
-      const moduleNames = module.name.split('/');
-      const name = moduleNames[moduleNames.length - 1];
-      const moduleConfig = {
-        text: `Module:${name}`,
-        items: [{ text: 'Overview', link: getModulePath(module.name) }],
-      };
-      if (!module.children || module.children.length <= 0) {
+  data.children.forEach((module: ModuleItem) => {
+    const moduleNames = module.name.split('/');
+    const name = moduleNames[moduleNames.length - 1];
+    const moduleConfig = {
+      text: `Module:${name}`,
+      items: [{ text: 'Overview', link: getModulePath(module.name) }],
+    };
+    if (!module.children || module.children.length <= 0) {
+      return;
+    }
+    module.children.forEach(sub => {
+      const kindString = module.groups
+        .find(item => item.children.includes(sub.id))
+        ?.title.slice(0, -1);
+      if (!kindString) {
         return;
       }
-      module.children.forEach(sub => {
-        switch (sub.kindString) {
-          case 'Class':
-            moduleConfig.items.push({
-              text: `Class:${sub.name}`,
-              link: getClassPath(module.name, sub.name),
-            });
-            break;
-          case 'Interface':
-            moduleConfig.items.push({
-              text: `Interface:${sub.name}`,
-              link: getInterfacePath(module.name, sub.name),
-            });
-            break;
-          case 'Function':
-            moduleConfig.items.push({
-              text: `Function:${sub.name}`,
-              link: getFunctionPath(module.name, sub.name),
-            });
-            break;
-          default:
-            break;
-        }
-      });
-      result.push(moduleConfig);
-    },
-  );
+      switch (kindString) {
+        case 'Class':
+          moduleConfig.items.push({
+            text: `Class:${sub.name}`,
+            link: getClassPath(module.name, sub.name),
+          });
+          break;
+        case 'Interface':
+          moduleConfig.items.push({
+            text: `Interface:${sub.name}`,
+            link: getInterfacePath(module.name, sub.name),
+          });
+          break;
+        case 'Function':
+          moduleConfig.items.push({
+            text: `Function:${sub.name}`,
+            link: getFunctionPath(module.name, sub.name),
+          });
+          break;
+        default:
+          break;
+      }
+    });
+    result.push(moduleConfig);
+  });
   // Patch /api/README.md
   const readmeFile = path.join(path.dirname(jsonDir), 'README.md');
   const readme = await fs.readFile(readmeFile, 'utf-8');

--- a/packages/cli/plugin-i18n/package.json
+++ b/packages/cli/plugin-i18n/package.json
@@ -66,7 +66,6 @@
     "@scripts/jest-config": "workspace:*"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/cli/plugin-lint/package.json
+++ b/packages/cli/plugin-lint/package.json
@@ -57,7 +57,6 @@
     "jest": "^29",
     "typescript": "^5"
   },
-  "modernConfig": {},
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -96,7 +96,6 @@
     "react-dom": ">=17"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/cli/plugin-swc/modern.config.js
+++ b/packages/cli/plugin-swc/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/cli/plugin-swc/package.json
+++ b/packages/cli/plugin-swc/package.json
@@ -32,13 +32,14 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern-lib new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "jest"
   },
   "dependencies": {
     "@modern-js/builder-plugin-swc": "workspace:*",
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@types/jest": "^29",

--- a/packages/generator/generator-common/package.json
+++ b/packages/generator/generator-common/package.json
@@ -53,7 +53,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/generator/generator-utils/package.json
+++ b/packages/generator/generator-utils/package.json
@@ -51,11 +51,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/generator/new-action/package.json
+++ b/packages/generator/new-action/package.json
@@ -52,11 +52,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/module/plugin-module-doc/package.json
+++ b/packages/module/plugin-module-doc/package.json
@@ -62,7 +62,6 @@
   "sideEffects": [
     "**/*.scss"
   ],
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -107,7 +107,6 @@
     "webpack-chain": "^6.5.1"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-router-v5/package.json
+++ b/packages/runtime/plugin-router-v5/package.json
@@ -93,7 +93,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -206,7 +206,6 @@
     "webpack": "^5.88.1"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -168,7 +168,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/toolkit/compiler/babel/package.json
+++ b/packages/toolkit/compiler/babel/package.json
@@ -54,11 +54,6 @@
     "@scripts/jest-config": "workspace:*"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/toolkit/e2e/modern.config.js
+++ b/packages/toolkit/e2e/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -4,8 +4,8 @@
   "version": "2.25.2",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -37,11 +37,13 @@
   "dependencies": {
     "@modern-js/utils": "workspace:*",
     "@playwright/test": "1.33.0",
+    "@swc/helpers": "0.5.1",
     "connect": "^3.7.0",
     "playwright": "1.33.0",
     "serve-static": "^1.14.1"
   },
   "devDependencies": {
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/connect": "^3.4.35",
     "@types/got": "^9.6.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1305,11 +1305,11 @@ importers:
         specifier: '>=17'
         version: 17.0.2
       typedoc:
-        specifier: 0.23.24
-        version: 0.23.24(typescript@5.0.4)
+        specifier: 0.24.8
+        version: 0.24.8(typescript@5.0.4)
       typedoc-plugin-markdown:
-        specifier: 3.14.0
-        version: 3.14.0(typedoc@0.23.24)
+        specifier: 3.15.3
+        version: 3.15.3(typedoc@0.24.8)
     devDependencies:
       '@modern-js/doc-core':
         specifier: workspace:*
@@ -16282,6 +16282,10 @@ packages:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
 
+  /ansi-sequence-parser@1.1.0:
+    resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
+    dev: false
+
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -25714,6 +25718,13 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
 
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
@@ -30327,8 +30338,8 @@ packages:
   /shiki@0.10.1:
     resolution: {integrity: sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==}
     dependencies:
-      jsonc-parser: 3.0.0
-      vscode-oniguruma: 1.6.2
+      jsonc-parser: 3.2.0
+      vscode-oniguruma: 1.7.0
       vscode-textmate: 5.2.0
     dev: false
 
@@ -30340,9 +30351,10 @@ packages:
       vscode-textmate: 6.0.0
     dev: false
 
-  /shiki@0.12.1:
-    resolution: {integrity: sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==}
+  /shiki@0.14.3:
+    resolution: {integrity: sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==}
     dependencies:
+      ansi-sequence-parser: 1.1.0
       jsonc-parser: 3.2.0
       vscode-oniguruma: 1.7.0
       vscode-textmate: 8.0.0
@@ -32144,26 +32156,26 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
-  /typedoc-plugin-markdown@3.14.0(typedoc@0.23.24):
-    resolution: {integrity: sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==}
+  /typedoc-plugin-markdown@3.15.3(typedoc@0.24.8):
+    resolution: {integrity: sha512-idntFYu3vfaY3eaD+w9DeRd0PmNGqGuNLKihPU9poxFGnATJYGn9dPtEhn2QrTdishFMg7jPXAhos+2T6YCWRQ==}
     peerDependencies:
-      typedoc: '>=0.23.0'
+      typedoc: '>=0.24.0'
     dependencies:
       handlebars: 4.7.7
-      typedoc: 0.23.24(typescript@5.0.4)
+      typedoc: 0.24.8(typescript@5.0.4)
     dev: false
 
-  /typedoc@0.23.24(typescript@5.0.4):
-    resolution: {integrity: sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==}
+  /typedoc@0.24.8(typescript@5.0.4):
+    resolution: {integrity: sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==}
     engines: {node: '>= 14.14'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 5.1.6
-      shiki: 0.12.1
+      minimatch: 9.0.3
+      shiki: 0.14.3
       typescript: 5.0.4
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@svgr/webpack':
         specifier: 8.0.1
         version: 8.0.1
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-rspack-provider':
         specifier: workspace:*
@@ -94,6 +97,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -121,6 +127,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-rspack-provider':
         specifier: workspace:*
@@ -128,6 +137,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -164,6 +176,9 @@ importers:
       '@rspack/plugin-html':
         specifier: 0.2.5
         version: 0.2.5(@rspack/core@0.2.5)
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       caniuse-lite:
         specifier: ^1.0.30001489
         version: 1.0.30001489
@@ -189,6 +204,9 @@ importers:
       '@arco-design/web-react':
         specifier: ^2.46.0
         version: 2.46.1(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -234,6 +252,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       acorn:
         specifier: ^8.8.1
         version: 8.8.1
@@ -331,6 +352,9 @@ importers:
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.9
         version: 0.5.9(react-refresh@0.14.0)(webpack@5.88.1)
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       caniuse-lite:
         specifier: ^1.0.30001489
         version: 1.0.30001489
@@ -368,6 +392,9 @@ importers:
       '@modern-js/e2e':
         specifier: workspace:*
         version: link:../../toolkit/e2e
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -395,6 +422,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-shared':
         specifier: workspace:*
@@ -402,6 +432,9 @@ importers:
       '@modern-js/e2e':
         specifier: workspace:*
         version: link:../../toolkit/e2e
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -426,6 +459,9 @@ importers:
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       esbuild:
         specifier: 0.17.19
         version: 0.17.19
@@ -439,6 +475,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -454,6 +493,9 @@ importers:
       '@napi-rs/image':
         specifier: ^1.3.0
         version: 1.4.1
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       svgo:
         specifier: ^3.0.2
         version: 3.0.2
@@ -464,6 +506,9 @@ importers:
       '@modern-js/e2e':
         specifier: workspace:*
         version: link:../../toolkit/e2e
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -482,6 +527,9 @@ importers:
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       node-libs-browser:
         specifier: 2.2.1
         version: 2.2.1
@@ -498,6 +546,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -513,6 +564,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       stylus:
         specifier: 0.59.0
         version: 0.59.0
@@ -529,6 +583,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -572,6 +629,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -611,6 +671,9 @@ importers:
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       '@vue/babel-plugin-jsx':
         specifier: 1.1.1
         version: 1.1.1(@babel/core@7.21.8)
@@ -633,6 +696,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -724,6 +790,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -764,6 +833,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-shared':
         specifier: workspace:*
@@ -1841,6 +1913,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/app-tools':
         specifier: workspace:*
@@ -5075,6 +5150,9 @@ importers:
       '@playwright/test':
         specifier: 1.33.0
         version: 1.33.0
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       connect:
         specifier: ^3.7.0
         version: 3.7.0
@@ -5085,6 +5163,9 @@ importers:
         specifier: ^1.14.1
         version: 1.15.0
     devDependencies:
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config

--- a/scripts/build/src/index.js
+++ b/scripts/build/src/index.js
@@ -136,8 +136,19 @@ const extendUniversalBuildConfig = extendConfig => {
   });
 };
 
+const tscLikeBuildConfig = [
+  {
+    buildType: 'bundleless',
+    format: 'cjs',
+    target: 'es2019',
+    outDir: './dist',
+    externalHelpers,
+  },
+];
+
 module.exports = {
   nodeBuildConfig,
+  tscLikeBuildConfig,
   extendNodeBuildConfig,
   universalBuildConfig,
   extendUniversalBuildConfig,


### PR DESCRIPTION
## Summary

This PR adds a new build preset to help migrate tsc packages to the module-lib build.

After this PR, all the modern.js packages are built with Module Tools, and we should optimize the build performance in the next phase.

```ts
const tscLikeBuildConfig = [
  {
    buildType: 'bundleless',
    format: 'cjs',
    target: 'es2019',
    outDir: './dist',
    externalHelpers,
  },
];
```

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c9b255</samp>

This pull request migrates the builder packages and plugins from using `tsc` to using `module-lib build` with `swc` and `babel` as the compilers. This improves the build performance and consistency with the rest of the modern.js project. It also adds a changeset file to document the patches needed for the packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c9b255</samp>

*  Migrate packages from using `tsc` to using `module-lib` for building ([link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-19c075eee5d662025da4e8e45caba0c6bf8eecf161cee2427f499bb665511b96R1-R34))
*  Add `modern.config.js` files to each package that export the `tscLikeBuildConfig` from the `scripts/build` package ([link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-9f20d72ed02bc1331d63c91ba2de3a99d1f082acab42ab23b71f08ada7ed3921R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-f343d08302e5b66303b8a3ffca75d0baa445c0edcad87e9952f35c17dc23f159R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-bf986fbecd1784a880a9f11a8f2e387e0b75c6b3b3eb99dd7eddfec53091c68cR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-b1be4fe25125abf50b0701b6c293db51c479e174587d009aa8636d64a3e9367cR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-a81263b9278648754f80a1115e93206e2a8e025a9ac14d6bef3700ea5dcdf634R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-79fb4d8168f25b9a1cb59cf2be49977671c009c8a1456fadc5bee05817bb3a77R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-988cc17593d65a48f186b99733400ebcf5fcb95133d8c349668416ec0b83e082R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-e24585fb1b720689efc3f8197ee85d0501887b08d7ea19ddcb0786104bc3faedR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-0768381a0b83ac1d8b14c5230b778b8cd0181284ff78f44747838e1e728aa92eR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-8c21b8c1274fa8cd484ad6d10b1629706487e5b078900781d340e87b80af03a3R1-R5))
*  Replace `tsc` with `modern-lib build` in the scripts section of each package.json file ([link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-f6b7b53aacfc32941f744f7d0ec86be3f6c93cb2f9763bbf6266820020c0b241L38-R39), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L46-R47), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L29-R30), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1L84-R85), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-9cf8545b55c9e3ca88938fac70f48ca84c6f0a1337da7e022df9cc950f831f19L35-R36), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-ce4be520f70a2ce04d870a56070a41ced322352fee1ed843789c0afb1cc34cddL59-R60), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-1d53290d033ea716ac22edbd5126d45cd42bd1b029214bfe509a0f40abeec276L35-R43), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-b5d6b23b96c26eeefb50da649b47d738e36adea24f0701339bd622a69128f8d2L28-R29), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-faf5c5adb3c8183e33feaf15f3b0c45f4545319333a40d7d9846c5e4604cd4ceL35-R36))
*  Add `@swc/helpers` as a dependency to each package that uses `swc` as the compiler ([link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-f6b7b53aacfc32941f744f7d0ec86be3f6c93cb2f9763bbf6266820020c0b241L47-R53), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7R62), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L124-R125), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1R101), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-9cf8545b55c9e3ca88938fac70f48ca84c6f0a1337da7e022df9cc950f831f19L45-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-ce4be520f70a2ce04d870a56070a41ced322352fee1ed843789c0afb1cc34cddL68-R74), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-b5d6b23b96c26eeefb50da649b47d738e36adea24f0701339bd622a69128f8d2R54), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-faf5c5adb3c8183e33feaf15f3b0c45f4545319333a40d7d9846c5e4604cd4ceR42))
*  Add `@scripts/build` as a devDependency to each package that imports the `tscLikeBuildConfig` from the `scripts/build` package ([link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7R73), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1R116), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-1d53290d033ea716ac22edbd5126d45cd42bd1b029214bfe509a0f40abeec276R49), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-b5d6b23b96c26eeefb50da649b47d738e36adea24f0701339bd622a69128f8d2R60), [link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-faf5c5adb3c8183e33feaf15f3b0c45f4545319333a40d7d9846c5e4604cd4ceR50))
*  Add `@babel/core` as a dependency to the `builder-shared` package that uses `babel` as the post-processor ([link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9R118))
*  Move `esbuild` from the dependencies to the devDependencies section of the `plugin-esbuild` package, as it is only used for testing ([link](https://github.com/web-infra-dev/modern.js/pull/4189/files?diff=unified&w=0#diff-1d53290d033ea716ac22edbd5126d45cd42bd1b029214bfe509a0f40abeec276L35-R43))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
