### PR TITLE
refactor: use import syntax for reduck plugin types

### DIFF
--- a/.changeset/lucky-birds-battle.md
+++ b/.changeset/lucky-birds-battle.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+refactor: use import syntax for reduck plugin types
+refactor: 使用 import 语法加载 reduck 插件的类型文件

--- a/packages/runtime/plugin-runtime/types/model.d.ts
+++ b/packages/runtime/plugin-runtime/types/model.d.ts
@@ -1,7 +1,7 @@
-/// <reference types="@modern-js-reduck/plugin-auto-actions" />
-/// <reference types="@modern-js-reduck/plugin-devtools" />
-/// <reference types="@modern-js-reduck/plugin-effects" />
-/// <reference types="@modern-js-reduck/plugin-immutable" />
+import '@modern-js-reduck/plugin-auto-actions';
+import '@modern-js-reduck/plugin-devtools';
+import '@modern-js-reduck/plugin-effects';
+import '@modern-js-reduck/plugin-immutable';
 
 export { default } from '../dist/types/state';
 export * from '../dist/types/state';


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2f182d</samp>

Refactor `@modern-js/runtime` package to use import syntax for reduck plugin types. This improves code quality and consistency.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

Currently, we use reference syntax to load types for reduck plugins. However, different subprojects in a monorepo may depend on different versions of the same plugin, leading to the possibility of loading the wrong version of a plugin.

For example, in a pnpm workspace:

Subproject A has this dependency relation: A -> @modern-js/runtime@1.0.0 -> @modern-js-reduck/plugin-auto-actions@1.0.0.
Subproject B has this dependency relation: B -> @modern-js/runtime@1.1.0 -> @modern-js-reduck/plugin-auto-actions@1.1.0.

In this case, Subproject B may use the types of @modern-js-reduck/plugin-auto-actions@1.0.0.

By using import syntax to load types, we can guarantee that the correct versions are used. 


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
