### PR TITLE
chore: migrate packages from tsc to module-lib build

### DIFF
--- a/.changeset/gold-laws-tease.md
+++ b/.changeset/gold-laws-tease.md
@@ -1,0 +1,34 @@
+---
+'@modern-js/friendly-errors-webpack-plugin': patch
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-plugin-image-compress': patch
+'@modern-js/builder-plugin-node-polyfill': patch
+'@modern-js/generator-common': patch
+'@modern-js/generator-utils': patch
+'@modern-js/plugin-module-doc': patch
+'@modern-js/plugin-router-v5': patch
+'@modern-js/builder-shared': patch
+'@modern-js/builder-plugin-esbuild': patch
+'@modern-js/plugin-garfish': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/babel-compiler': patch
+'@modern-js/builder-plugin-stylus': patch
+'@modern-js/babel-preset-base': patch
+'@modern-js/plugin-storybook': patch
+'@modern-js/new-action': patch
+'@modern-js/builder-cli': patch
+'@modern-js/builder-plugin-swc': patch
+'@modern-js/builder-plugin-vue': patch
+'@modern-js/builder': patch
+'@modern-js/plugin-i18n': patch
+'@modern-js/plugin-lint': patch
+'@modern-js/plugin-swc': patch
+'@modern-js/e2e': patch
+'@modern-js/core': patch
+---
+
+chore: migrate packages from tsc to module-lib build
+
+chore: 将使用 tsc 的包迁移到 module-lib 构建

--- a/packages/builder/builder-cli/modern.config.js
+++ b/packages/builder/builder-cli/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-cli/package.json
+++ b/packages/builder/builder-cli/package.json
@@ -35,8 +35,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
@@ -44,11 +44,13 @@
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/node-bundle-require": "workspace:*",
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5"
   },

--- a/packages/builder/builder-rspack-provider/modern.config.js
+++ b/packages/builder/builder-rspack-provider/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -43,8 +43,8 @@
   },
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -59,6 +59,7 @@
     "@rspack/core": "0.2.5",
     "@rspack/dev-client": "0.2.5",
     "@rspack/plugin-html": "0.2.5",
+    "@swc/helpers": "0.5.1",
     "rspack-manifest-plugin": "5.0.0-alpha0",
     "caniuse-lite": "^1.0.30001489",
     "core-js": "~3.30.0",
@@ -69,6 +70,7 @@
   },
   "devDependencies": {
     "@arco-design/web-react": "^2.46.0",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",
     "antd": "4",

--- a/packages/builder/builder-shared/modern.config.js
+++ b/packages/builder/builder-shared/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc && node scripts/postCompile.js",
-    "dev": "tsc --watch",
+    "build": "modern-lib build && node scripts/postCompile.js",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -115,13 +115,14 @@
     }
   },
   "dependencies": {
+    "@babel/core": "^7.21.8",
     "@babel/types": "^7.21.5",
     "@babel/parser": "^7.21.8",
     "@modern-js/prod-server": "workspace:*",
     "@modern-js/server": "workspace:*",
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@babel/core": "^7.21.8",
+    "@swc/helpers": "0.5.1",
     "fork-ts-checker-webpack-plugin": "8.0.0",
     "acorn": "^8.8.1",
     "caniuse-lite": "^1.0.30001489",

--- a/packages/builder/builder-webpack-provider/modern.config.js
+++ b/packages/builder/builder-webpack-provider/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -81,8 +81,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch --sourceMap",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -98,6 +98,7 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.9",
+    "@swc/helpers": "0.5.1",
     "caniuse-lite": "^1.0.30001489",
     "css-minimizer-webpack-plugin": "5.0.0",
     "html-webpack-plugin": "5.5.0",
@@ -112,6 +113,7 @@
   "devDependencies": {
     "@arco-design/web-react": "^2.46.0",
     "@modern-js/e2e": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/caniuse-lite": "^1.0.1",
     "@types/node": "^14",

--- a/packages/builder/builder/modern.config.js
+++ b/packages/builder/builder/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -32,8 +32,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -42,11 +42,13 @@
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/monorepo-utils": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@svgr/webpack": "8.0.1"
+    "@svgr/webpack": "8.0.1",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/babel__core": "^7.20.0",
     "@types/node": "^14",

--- a/packages/builder/friendly-errors-webpack-plugin/modern.config.js
+++ b/packages/builder/friendly-errors-webpack-plugin/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/friendly-errors-webpack-plugin/package.json
+++ b/packages/builder/friendly-errors-webpack-plugin/package.json
@@ -56,8 +56,8 @@
   },
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch --sourceMap",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "echo foo",
     "test:local": "vitest run",
     "test:watch": "vitest dev --no-coverage",
@@ -65,11 +65,13 @@
     "example:build": "webpack -c example/webpack.config.js"
   },
   "dependencies": {
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/e2e": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",
     "ansi-to-html": "^0.7.2",

--- a/packages/builder/plugin-esbuild/modern.config.js
+++ b/packages/builder/plugin-esbuild/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-esbuild/package.json
+++ b/packages/builder/plugin-esbuild/package.json
@@ -32,19 +32,21 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
-    "esbuild": "0.17.19",
-    "@modern-js/builder-shared": "workspace:*"
+    "@modern-js/builder-shared": "workspace:*",
+    "@swc/helpers": "0.5.1",
+    "esbuild": "0.17.19"
   },
   "devDependencies": {
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5"
   },

--- a/packages/builder/plugin-image-compress/modern.config.js
+++ b/packages/builder/plugin-image-compress/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-image-compress/package.json
+++ b/packages/builder/plugin-image-compress/package.json
@@ -25,8 +25,8 @@
   "module": "./dist/index.js",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch --sourceMap",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
@@ -51,11 +51,13 @@
   "dependencies": {
     "@modern-js/utils": "workspace:*",
     "@napi-rs/image": "^1.3.0",
+    "@swc/helpers": "0.5.1",
     "svgo": "^3.0.2"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/e2e": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/node": "^14",
     "typescript": "^5",

--- a/packages/builder/plugin-node-polyfill/modern.config.js
+++ b/packages/builder/plugin-node-polyfill/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-node-polyfill/package.json
+++ b/packages/builder/plugin-node-polyfill/package.json
@@ -32,13 +32,14 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "node-libs-browser": "2.2.1"
   },
   "devDependencies": {
@@ -46,6 +47,7 @@
     "@modern-js/builder-rspack-provider": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5"
   },

--- a/packages/builder/plugin-stylus/modern.config.js
+++ b/packages/builder/plugin-stylus/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-stylus/package.json
+++ b/packages/builder/plugin-stylus/package.json
@@ -32,14 +32,15 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "stylus": "0.59.0",
     "stylus-loader": "7.1.0"
   },
@@ -48,6 +49,7 @@
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5",
     "webpack": "^5.88.1"

--- a/packages/builder/plugin-swc/modern.config.js
+++ b/packages/builder/plugin-swc/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -10,8 +10,8 @@
   "main": "./dist/index.js",
   "types": "./src/index.ts",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc -w",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:update": "SNAPSHOT_UPDATE=1 vitest watch",
@@ -51,12 +51,23 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "@babel/core": "^7.21.8",
+    "@babel/preset-env": "^7.21.5",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.21.5",
+    "@modern-js/builder-shared": "workspace:*",
+    "@modern-js/swc-plugins": "0.4.0",
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1",
+    "core-js": "~3.30.0"
+  },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@swc/core": "1.3.42",
-    "@swc/helpers": "0.5.1",
     "@types/babel__core": "^7.20.0",
     "antd": "4",
     "lodash": "^4.17.21",
@@ -66,17 +77,6 @@
     "webpack": "^5.88.1",
     "react": "^18",
     "react-dom": "^18"
-  },
-  "dependencies": {
-    "@babel/core": "^7.21.8",
-    "@babel/preset-env": "^7.21.5",
-    "@babel/preset-react": "^7.18.6",
-    "@babel/preset-typescript": "^7.21.5",
-    "@swc/helpers": "0.5.1",
-    "core-js": "~3.30.0",
-    "@modern-js/builder-shared": "workspace:*",
-    "@modern-js/swc-plugins": "0.4.0",
-    "@modern-js/utils": "workspace:*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/builder/plugin-vue/modern.config.js
+++ b/packages/builder/plugin-vue/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/builder/plugin-vue/package.json
+++ b/packages/builder/plugin-vue/package.json
@@ -32,13 +32,14 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "@vue/babel-plugin-jsx": "1.1.1",
     "vue-loader": "^17.2.2"
   },
@@ -48,6 +49,7 @@
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
     "@modern-js/utils": "workspace:*",
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "typescript": "^5",
     "webpack": "^5.88.1"

--- a/packages/cli/babel-preset-base/modern.config.js
+++ b/packages/cli/babel-preset-base/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/cli/babel-preset-base/package.json
+++ b/packages/cli/babel-preset-base/package.json
@@ -34,8 +34,8 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern-lib new",
-    "dev": "tsc --watch",
-    "build": "tsc",
+    "dev": "modern-lib build --watch",
+    "build": "modern-lib build",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
@@ -51,6 +51,7 @@
     "@babel/preset-typescript": "^7.21.5",
     "@babel/runtime": "^7.21.5",
     "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1",
     "@types/babel__core": "^7.20.0",
     "lodash": "^4.17.21"
   },
@@ -64,11 +65,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/cli/core/modern.config.js
+++ b/packages/cli/core/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -71,14 +71,15 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern-lib new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "jest"
   },
   "dependencies": {
     "@modern-js/node-bundle-require": "workspace:*",
     "@modern-js/plugin": "workspace:*",
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@modern-js/builder-shared": "workspace:*",

--- a/packages/cli/core/tests/tsm.test.ts
+++ b/packages/cli/core/tests/tsm.test.ts
@@ -1,15 +1,13 @@
 import path from 'path';
 import { spawnSync } from 'child_process';
 
-const kPackageDir = path.resolve(__dirname, '..');
-
 describe('jsnext:source', () => {
   test('process exit status is 0', () => {
     const { status, stdout, stderr } = spawnSync(
       process.execPath,
-      ['--conditions=jsnext:source', '-r', 'tsm', 'src/bin.ts'],
+      ['--conditions=jsnext:source', '-r', 'tsm', '../../../../src/bin.ts'],
       {
-        cwd: kPackageDir,
+        cwd: path.resolve(__dirname, 'fixtures/config/no-config'),
         encoding: 'utf-8',
       },
     );

--- a/packages/cli/doc-core/src/node/createBuilder.ts
+++ b/packages/cli/doc-core/src/node/createBuilder.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { createRequire } from 'module';
 import { UserConfig } from 'shared/types';
-import { BuilderInstance, mergeBuilderConfig } from '@modern-js/builder';
+import type { BuilderInstance } from '@modern-js/builder';
 import type {
   BuilderConfig,
   BuilderRspackProvider,
@@ -196,10 +196,14 @@ export async function createModernBuilder(
     scanDir: userRoot,
     pluginDriver,
   });
-  const { createBuilder } = await import('@modern-js/builder');
-  const { builderRspackProvider } = await import(
-    '@modern-js/builder-rspack-provider'
-  );
+  const {
+    // @ts-expect-error esm/cjs interop issue
+    default: { createBuilder, mergeBuilderConfig },
+  } = await import('@modern-js/builder');
+  const {
+    // @ts-expect-error esm/cjs interop issue
+    default: { builderRspackProvider },
+  } = await import('@modern-js/builder-rspack-provider');
 
   const internalBuilderConfig = await createInternalBuildConfig(
     userRoot,

--- a/packages/cli/doc-core/src/node/runtimeModule/index.ts
+++ b/packages/cli/doc-core/src/node/runtimeModule/index.ts
@@ -1,5 +1,5 @@
 import type { UserConfig } from 'shared/types/index';
-import { BuilderPlugin } from '@modern-js/builder';
+import type { BuilderPlugin } from '@modern-js/builder';
 import { RouteService } from '../route/RouteService';
 import { PluginDriver } from '../PluginDriver';
 import RuntimeModulesPlugin from './RuntimeModulePlugin';

--- a/packages/cli/plugin-i18n/package.json
+++ b/packages/cli/plugin-i18n/package.json
@@ -66,7 +66,6 @@
     "@scripts/jest-config": "workspace:*"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/cli/plugin-lint/package.json
+++ b/packages/cli/plugin-lint/package.json
@@ -57,7 +57,6 @@
     "jest": "^29",
     "typescript": "^5"
   },
-  "modernConfig": {},
   "sideEffects": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -96,7 +96,6 @@
     "react-dom": ">=17"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/cli/plugin-swc/modern.config.js
+++ b/packages/cli/plugin-swc/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/cli/plugin-swc/package.json
+++ b/packages/cli/plugin-swc/package.json
@@ -32,13 +32,14 @@
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
     "new": "modern-lib new",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "jest"
   },
   "dependencies": {
     "@modern-js/builder-plugin-swc": "workspace:*",
-    "@modern-js/utils": "workspace:*"
+    "@modern-js/utils": "workspace:*",
+    "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
     "@types/jest": "^29",

--- a/packages/generator/generator-common/package.json
+++ b/packages/generator/generator-common/package.json
@@ -53,7 +53,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/generator/generator-utils/package.json
+++ b/packages/generator/generator-utils/package.json
@@ -51,11 +51,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/generator/new-action/package.json
+++ b/packages/generator/new-action/package.json
@@ -52,11 +52,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/module/plugin-module-doc/package.json
+++ b/packages/module/plugin-module-doc/package.json
@@ -62,7 +62,6 @@
   "sideEffects": [
     "**/*.scss"
   ],
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -107,7 +107,6 @@
     "webpack-chain": "^6.5.1"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-router-v5/package.json
+++ b/packages/runtime/plugin-router-v5/package.json
@@ -93,7 +93,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -206,7 +206,6 @@
     "webpack": "^5.88.1"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -168,7 +168,6 @@
     "typescript": "^5"
   },
   "sideEffects": false,
-  "modernConfig": {},
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/toolkit/compiler/babel/package.json
+++ b/packages/toolkit/compiler/babel/package.json
@@ -54,11 +54,6 @@
     "@scripts/jest-config": "workspace:*"
   },
   "sideEffects": false,
-  "modernConfig": {
-    "output": {
-      "packageMode": "node-js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/toolkit/e2e/modern.config.js
+++ b/packages/toolkit/e2e/modern.config.js
@@ -1,0 +1,5 @@
+const { tscLikeBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: tscLikeBuildConfig,
+};

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -4,8 +4,8 @@
   "version": "2.25.2",
   "scripts": {
     "prepublishOnly": "only-allow-pnpm",
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "modern-lib build",
+    "dev": "modern-lib build --watch",
     "test": "vitest run",
     "test:watch": "vitest dev --no-coverage",
     "test:ui": "vitest --ui"
@@ -37,11 +37,13 @@
   "dependencies": {
     "@modern-js/utils": "workspace:*",
     "@playwright/test": "1.33.0",
+    "@swc/helpers": "0.5.1",
     "connect": "^3.7.0",
     "playwright": "1.33.0",
     "serve-static": "^1.14.1"
   },
   "devDependencies": {
+    "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/connect": "^3.4.35",
     "@types/got": "^9.6.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@svgr/webpack':
         specifier: 8.0.1
         version: 8.0.1
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-rspack-provider':
         specifier: workspace:*
@@ -94,6 +97,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -121,6 +127,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-rspack-provider':
         specifier: workspace:*
@@ -128,6 +137,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -164,6 +176,9 @@ importers:
       '@rspack/plugin-html':
         specifier: 0.2.5
         version: 0.2.5(@rspack/core@0.2.5)
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       caniuse-lite:
         specifier: ^1.0.30001489
         version: 1.0.30001489
@@ -189,6 +204,9 @@ importers:
       '@arco-design/web-react':
         specifier: ^2.46.0
         version: 2.46.1(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -234,6 +252,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       acorn:
         specifier: ^8.8.1
         version: 8.8.1
@@ -331,6 +352,9 @@ importers:
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.9
         version: 0.5.9(react-refresh@0.14.0)(webpack@5.88.1)
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       caniuse-lite:
         specifier: ^1.0.30001489
         version: 1.0.30001489
@@ -368,6 +392,9 @@ importers:
       '@modern-js/e2e':
         specifier: workspace:*
         version: link:../../toolkit/e2e
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -395,6 +422,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-shared':
         specifier: workspace:*
@@ -402,6 +432,9 @@ importers:
       '@modern-js/e2e':
         specifier: workspace:*
         version: link:../../toolkit/e2e
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -426,6 +459,9 @@ importers:
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       esbuild:
         specifier: 0.17.19
         version: 0.17.19
@@ -439,6 +475,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -454,6 +493,9 @@ importers:
       '@napi-rs/image':
         specifier: ^1.3.0
         version: 1.4.1
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       svgo:
         specifier: ^3.0.2
         version: 3.0.2
@@ -464,6 +506,9 @@ importers:
       '@modern-js/e2e':
         specifier: workspace:*
         version: link:../../toolkit/e2e
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -482,6 +527,9 @@ importers:
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       node-libs-browser:
         specifier: 2.2.1
         version: 2.2.1
@@ -498,6 +546,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -513,6 +564,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       stylus:
         specifier: 0.59.0
         version: 0.59.0
@@ -529,6 +583,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -572,6 +629,9 @@ importers:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
         version: link:../builder-webpack-provider
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -611,6 +671,9 @@ importers:
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       '@vue/babel-plugin-jsx':
         specifier: 1.1.1
         version: 1.1.1(@babel/core@7.21.8)
@@ -633,6 +696,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -724,6 +790,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
@@ -764,6 +833,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/builder-shared':
         specifier: workspace:*
@@ -1841,6 +1913,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
     devDependencies:
       '@modern-js/app-tools':
         specifier: workspace:*
@@ -5075,6 +5150,9 @@ importers:
       '@playwright/test':
         specifier: 1.33.0
         version: 1.33.0
+      '@swc/helpers':
+        specifier: 0.5.1
+        version: 0.5.1
       connect:
         specifier: ^3.7.0
         version: 3.7.0
@@ -5085,6 +5163,9 @@ importers:
         specifier: ^1.14.1
         version: 1.15.0
     devDependencies:
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../scripts/build
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config

--- a/scripts/build/src/index.js
+++ b/scripts/build/src/index.js
@@ -136,8 +136,19 @@ const extendUniversalBuildConfig = extendConfig => {
   });
 };
 
+const tscLikeBuildConfig = [
+  {
+    buildType: 'bundleless',
+    format: 'cjs',
+    target: 'es2019',
+    outDir: './dist',
+    externalHelpers,
+  },
+];
+
 module.exports = {
   nodeBuildConfig,
+  tscLikeBuildConfig,
   extendNodeBuildConfig,
   universalBuildConfig,
   extendUniversalBuildConfig,


### PR DESCRIPTION
## Summary

There is a new change compared to the reverted #4189. 

See: https://github.com/web-infra-dev/modern.js/pull/4197/files#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R199-R206

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99c15b3</samp>

This pull request migrates several packages in the modern.js monorepo from using `tsc` to using `module-lib` and `swc` for building and watching JavaScript files. It updates the `package.json` files with the necessary dependencies and scripts, and adds a `modern.config.js` file to each package that exports the `tscLikeBuildConfig` from the `scripts/build` package. The change is a chore that improves the build performance and compatibility of the packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99c15b3</samp>

*  Migrate packages from using `tsc` to using `module-lib` for building ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-19c075eee5d662025da4e8e45caba0c6bf8eecf161cee2427f499bb665511b96R1-R34))
  * Add `modern.config.js` files that export `tscLikeBuildConfig` from `scripts/build` to each package ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-9f20d72ed02bc1331d63c91ba2de3a99d1f082acab42ab23b71f08ada7ed3921R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-f343d08302e5b66303b8a3ffca75d0baa445c0edcad87e9952f35c17dc23f159R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-bf986fbecd1784a880a9f11a8f2e387e0b75c6b3b3eb99dd7eddfec53091c68cR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-b1be4fe25125abf50b0701b6c293db51c479e174587d009aa8636d64a3e9367cR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-a81263b9278648754f80a1115e93206e2a8e025a9ac14d6bef3700ea5dcdf634R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-79fb4d8168f25b9a1cb59cf2be49977671c009c8a1456fadc5bee05817bb3a77R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-988cc17593d65a48f186b99733400ebcf5fcb95133d8c349668416ec0b83e082R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-e24585fb1b720689efc3f8197ee85d0501887b08d7ea19ddcb0786104bc3faedR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-0768381a0b83ac1d8b14c5230b778b8cd0181284ff78f44747838e1e728aa92eR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-8c21b8c1274fa8cd484ad6d10b1629706487e5b078900781d340e87b80af03a3R1-R5))
  * Replace `tsc` with `modern-lib` in the `scripts` section of each package's `package.json` file ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-f6b7b53aacfc32941f744f7d0ec86be3f6c93cb2f9763bbf6266820020c0b241L38-R39), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L46-R47), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L29-R30), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1L84-R85), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-9cf8545b55c9e3ca88938fac70f48ca84c6f0a1337da7e022df9cc950f831f19L35-R36), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-ce4be520f70a2ce04d870a56070a41ced322352fee1ed843789c0afb1cc34cddL59-R60), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-1d53290d033ea716ac22edbd5126d45cd42bd1b029214bfe509a0f40abeec276L35-R43), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-b5d6b23b96c26eeefb50da649b47d738e36adea24f0701339bd622a69128f8d2L28-R29), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-faf5c5adb3c8183e33feaf15f3b0c45f4545319333a40d7d9846c5e4604cd4ceL35-R36))
  * Add `@swc/helpers` dependency to each package's `package.json` file to provide helper functions for the `swc` compiler that `module-lib` uses ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-f6b7b53aacfc32941f744f7d0ec86be3f6c93cb2f9763bbf6266820020c0b241L47-R53), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7R62), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L124-R125), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1R101), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-9cf8545b55c9e3ca88938fac70f48ca84c6f0a1337da7e022df9cc950f831f19L45-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-ce4be520f70a2ce04d870a56070a41ced322352fee1ed843789c0afb1cc34cddL68-R74), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-b5d6b23b96c26eeefb50da649b47d738e36adea24f0701339bd622a69128f8d2R54), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-faf5c5adb3c8183e33feaf15f3b0c45f4545319333a40d7d9846c5e4604cd4ceR42))
  * Add `@scripts/build` devDependency to some packages' `package.json` files to provide the `tscLikeBuildConfig` for the packages ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7R73), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1R116), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-1d53290d033ea716ac22edbd5126d45cd42bd1b029214bfe509a0f40abeec276R49), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-b5d6b23b96c26eeefb50da649b47d738e36adea24f0701339bd622a69128f8d2R60), [link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-faf5c5adb3c8183e33feaf15f3b0c45f4545319333a40d7d9846c5e4604cd4ceR50))
  * Remove unused `@modern-js/types` dependency from `builder-shared` package's `package.json` file ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9R118))
  * Add `@babel/core` dependency to `builder-shared` package's `package.json` file to provide the `babel` compiler for the package ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9R118))
  * Reorder dependencies alphabetically in `plugin-esbuild` package's `package.json` file ([link](https://github.com/web-infra-dev/modern.js/pull/4197/files?diff=unified&w=0#diff-1d53290d033ea716ac22edbd5126d45cd42bd1b029214bfe509a0f40abeec276L35-R43))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
