### PR TITLE
feat(api-docgen): improve entries that can support indicate parse tool

### DIFF
--- a/.changeset/slimy-points-obey.md
+++ b/.changeset/slimy-points-obey.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-plugin-api-docgen': minor
+'@modern-js/plugin-module-doc': minor
+---
+
+feat: improve entries that can support indicate parse tool
+feat： 支持在 entries 里面指定解析工具

--- a/packages/cli/doc-plugin-api-docgen/src/index.ts
+++ b/packages/cli/doc-plugin-api-docgen/src/index.ts
@@ -65,3 +65,5 @@ export function pluginApiDocgen(options?: PluginOptions): DocPlugin {
     },
   };
 }
+
+export type { PluginOptions };

--- a/packages/cli/doc-plugin-api-docgen/src/types.ts
+++ b/packages/cli/doc-plugin-api-docgen/src/types.ts
@@ -1,8 +1,32 @@
 import type { PageIndexInfo } from '@modern-js/doc-core';
 
+export type Entries = Record<string, string>;
+
+export type ToolEntries = {
+  documentation: Entries;
+  'react-docgen-typescript': Entries;
+};
+
+export type ApiParseTool = 'documentation' | 'react-docgen-typescript';
+
 export type PluginOptions = {
-  entries?: Record<string, string>;
-  apiParseTool?: 'documentation' | 'react-docgen-typescript';
+  /**
+   * Module entries
+   * @zh 传入自动生成文档的模块名称及相对路径
+   */
+  entries?: Entries | ToolEntries;
+  /**
+   * apiParseTool
+   * @experimental
+   * @zh 解析工具
+   * @default 'react-docgen-typescript'
+   */
+  apiParseTool?: ApiParseTool;
+  /**
+   * appDirectory
+   * @zh 项目根目录
+   * @default process.cwd()
+   */
   appDir?: string;
 };
 

--- a/packages/module/plugin-module-doc/src/types.ts
+++ b/packages/module/plugin-module-doc/src/types.ts
@@ -1,4 +1,5 @@
 import type { DocConfig } from '@modern-js/doc-core';
+import type { PluginOptions as DocGenOptions } from '@modern-js/doc-plugin-api-docgen';
 
 export type APIParseTools = 'ts-document' | 'react-docgen-typescript';
 
@@ -10,11 +11,6 @@ export type PluginOptions = Pick<
 >;
 
 export type Options = {
-  /**
-   * Module entries
-   * @zh 传入自动生成文档的模块名称及相对路径
-   */
-  entries?: Record<string, string>;
   /**
    * Target language
    * @zh 文档站的目标语言
@@ -33,22 +29,9 @@ export type Options = {
    */
   isProduction?: boolean;
   /**
-   * appDirectory
-   * @zh 项目根目录
-   * @default process.cwd()
-   */
-  appDir?: string;
-  /**
    * previewMode
    * @zh 预览方式
    * @default 'web'
    */
   previewMode?: 'mobile' | 'web';
-  /**
-   * apiParseTool
-   * @experimental
-   * @zh 解析工具
-   * @default 'react-docgen-typescript'
-   */
-  apiParseTool?: 'react-docgen-typescript' | 'documentation';
-};
+} & DocGenOptions;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38cdc8b</samp>

This pull request enhances the `@modern-js/doc-plugin-api-docgen` and `@modern-js/plugin-module-doc` packages to support different parse tools for different modules and to simplify the options type. It also adds a changeset file and exports the `PluginOptions` type for documentation purposes. The main files affected are `docgen.ts`, `types.ts`, `index.ts`, and `.changeset/slimy-points-obey.md`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38cdc8b</samp>

*  Add a changeset file to document the changes to the `@modern-js/doc-plugin-api-docgen` and `@modern-js/plugin-module-doc` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-72cc5b24df6f1bf55816a70a63e280310d044d0ed8f9da8ff3bf35e336c6aa5bR1-R7))
*  Refactor the `docgen` function in `docgen.ts` to handle different types of `entries` and parse tools ([link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-2e683e71a3e3531285d1f308ff48bdacdb95742957368882b0531feae7d50482L15-R78))
*  Import and define new types in `types.ts` and `docgen.ts` to support the `docgen` function ([link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-2e683e71a3e3531285d1f308ff48bdacdb95742957368882b0531feae7d50482L7-R17), [link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-3e9ec08290d9a49a78160a0162778b0dabdcfcb6ef22cb08caa571cb8308c0ecL3-R29))
*  Export the `PluginOptions` type from `index.ts` for type checking and documentation purposes ([link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-07bcd894662f87af0dc109a9f075587e6bb73ee1b8798783647c8773e472e25bR68-R69))
*  Extend the `Options` type of the `@modern-js/plugin-module-doc` package with the `DocGenOptions` type from the `@modern-js/doc-plugin-api-docgen` package in `types.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-b14937422d83f6cb1b42d6f1e9d2fe01708688d902c2924586424a85b4d5d825R2), [link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-b14937422d83f6cb1b42d6f1e9d2fe01708688d902c2924586424a85b4d5d825L47-R37))
*  Remove the redundant `entries` and `appDir` options from the `Options` type of the `@modern-js/plugin-module-doc` package in `types.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-b14937422d83f6cb1b42d6f1e9d2fe01708688d902c2924586424a85b4d5d825L14-L18), [link](https://github.com/web-infra-dev/modern.js/pull/4208/files?diff=unified&w=0#diff-b14937422d83f6cb1b42d6f1e9d2fe01708688d902c2924586424a85b4d5d825L36-L41))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
