### PR TITLE
chore(doc-core): delete empty dir

### DIFF
--- a/.changeset/moody-meals-hope.md
+++ b/.changeset/moody-meals-hope.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): delete empty `html` dir

--- a/packages/cli/doc-core/src/node/build.ts
+++ b/packages/cli/doc-core/src/node/build.ts
@@ -200,7 +200,7 @@ export async function renderPages(
     );
     // Remove ssr bundle
     await fs.remove(join(outputPath, 'ssr'));
-    await fs.remove(join(outputPath, 'html', 'main', 'index.html'));
+    await fs.remove(join(outputPath, 'html'));
 
     const totalTime = Date.now() - startTime;
     logger.success(`Pages rendered in ${chalk.yellow(totalTime)} ms.`);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5c4a56</samp>

This pull request fixes a bug in the `doc-core` package that generated an empty `html` directory during the documentation site build process. It also adds a changeset file to document the patch update for the `@modern-js/doc-core` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e5c4a56</samp>

*  Delete the empty `html` directory generated by the `doc-core` build process ([link](https://github.com/web-infra-dev/modern.js/pull/4211/files?diff=unified&w=0#diff-7fbf3ad720fdf4192a3f89280736cdf4345a95d02a5db937ac760b752b412826L203-R203), [link](https://github.com/web-infra-dev/modern.js/pull/4211/files?diff=unified&w=0#diff-afcf925d6e9721354641132b535be9fff63fe8d202f9c205ba54ac32f3f8aeaaR1-R5))
  * Modify the `renderPages` function in `packages/cli/doc-core/src/node/build.ts` to remove the entire `html` directory instead of just the `index.html` file ([link](https://github.com/web-infra-dev/modern.js/pull/4211/files?diff=unified&w=0#diff-7fbf3ad720fdf4192a3f89280736cdf4345a95d02a5db937ac760b752b412826L203-R203))
  * Add a changeset file in `.changeset/moody-meals-hope.md` to document the patch update for the `@modern-js/doc-core` package and the fix for the `html` directory issue ([link](https://github.com/web-infra-dev/modern.js/pull/4211/files?diff=unified&w=0#diff-afcf925d6e9721354641132b535be9fff63fe8d202f9c205ba54ac32f3f8aeaaR1-R5))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
