### PR TITLE
fix(doc-tools): custom theme doc

### DIFF
--- a/packages/document/doc-tools-doc/docs/en/guide/advanced/custom-theme.mdx
+++ b/packages/document/doc-tools-doc/docs/en/guide/advanced/custom-theme.mdx
@@ -41,11 +41,11 @@ On the one hand, you need to export a theme configuration object through `export
 It is worth noting that the Layout component has designed a series of props to support slot elements. You can use these props to extend the layout of the default theme. For example, change the above Layout component to the following form:
 
 ```tsx
-import { Layout as DefaultLayout } from '@modern-js/doc-tools/theme';
+import Theme from '@modern-js/doc-tools/theme';
 
 // Show all props below
 const Layout = () => (
-  <DefaultLayout
+  <Theme.Layout
     /* Before home hero */
     beforeHero={<div>beforeHero</div>}
     /* After home hero */

--- a/packages/document/doc-tools-doc/docs/zh/guide/advanced/custom-theme.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/guide/advanced/custom-theme.mdx
@@ -41,11 +41,11 @@ export * from '@modern-js/doc-tools/theme';
 值得注意的是，Layout 组件设计了一系列的 props 支持插槽元素，你可以通过这些 props 来扩展默认主题的布局，比如将上面的 Layout 组件改成如下的形式:
 
 ```tsx
-import { Layout as DefaultLayout } from '@modern-js/doc-tools/theme';
+import Theme from '@modern-js/doc-tools/theme';
 
 // 以下展示所有的 Props
 const Layout = () => (
-  <DefaultLayout
+  <Theme.Layout
     /* Home 页 Hero 部分之前 */
     beforeHero={<div>beforeHero</div>}
     /* Home 页 Hero 部分之后 */


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eeba4e3</samp>

Updated the documentation for customizing themes in `doc-tools-doc` to use the new `Theme` export from `@modern-js/doc-tools/theme`. This change is part of a refactoring to simplify the theme API and avoid naming conflicts.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eeba4e3</samp>

* Refactor theme API to use `Theme` export instead of `Layout` export from `@modern-js/doc-tools/theme` ([link](https://github.com/web-infra-dev/modern.js/pull/4212/files?diff=unified&w=0#diff-55ad149fb8c67d837c187967f59b2cacb53c0af9f85f0d8077b626a3320d439aL44-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4212/files?diff=unified&w=0#diff-e64c47d9ea9a73c4e0ae8f47ab24ef373315e6343e29c30076c69fac32ec8a8bL44-R48))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
