### PR TITLE
fix(module-doc): set locales undefined by default

### DIFF
--- a/.changeset/shy-impalas-eat.md
+++ b/.changeset/shy-impalas-eat.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+fix: set locales undefined by default
+fix: 默认情况下设置locales为空

--- a/packages/module/plugin-module-doc/src/features/lanchDoc.ts
+++ b/packages/module/plugin-module-doc/src/features/lanchDoc.ts
@@ -91,7 +91,19 @@ export async function launchDoc({
       ],
     };
   };
-
+  const locales =
+    languages.length === 2
+      ? [
+          {
+            lang: 'zh',
+            label: '简体中文',
+          },
+          {
+            lang: 'en',
+            label: 'English',
+          },
+        ]
+      : undefined;
   const modernDocConfig = mergeModuleDocConfig<UserConfig>(
     {
       doc: {
@@ -109,16 +121,7 @@ export async function launchDoc({
           // TODO: support dark mode in code block
           darkMode: false,
           sidebar: await getAutoSidebar(),
-          locales: [
-            {
-              lang: 'zh',
-              label: '简体中文',
-            },
-            {
-              lang: 'en',
-              label: 'English',
-            },
-          ],
+          locales,
         },
         markdown: {
           globalComponents: [


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3961225</samp>

This pull request fixes the locales option for the documentation site in the `plugin-module-doc` package and adds a changeset file to document the change. The change allows the documentation site to use the user config and the default config for the locales option instead of a hardcoded value.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3961225</samp>

*  Add a changeset file to document the fixes in the plugin-module-doc package (.changeset/shy-impalas-eat.md)
*  Fix the locales option for the documentation site by using the user config and the default config ([link](https://github.com/web-infra-dev/modern.js/pull/4216/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L94-R106), [link](https://github.com/web-infra-dev/modern.js/pull/4216/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L112-R124))
   * Use a new variable `locales` to store the language options as an array of objects or undefined ([link](https://github.com/web-infra-dev/modern.js/pull/4216/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L94-R106))
   * Replace the hardcoded locales option in the modernDocConfig object with the `locales` variable ([link](https://github.com/web-infra-dev/modern.js/pull/4216/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L112-R124))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
