### PR TITLE
fix: get package available version error

### DIFF
--- a/.changeset/tender-balloons-melt.md
+++ b/.changeset/tender-balloons-melt.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/generator-utils': patch
+---
+
+fix: get package available version error
+
+fix: 修复获取包可用版本时报错

--- a/packages/generator/generator-utils/src/utils/package.ts
+++ b/packages/generator/generator-utils/src/utils/package.ts
@@ -3,12 +3,16 @@ import { canUseNpm, execa, logger, semver, stripAnsi } from '@modern-js/utils';
 // 判断包是否存在
 export async function isPackageExist(packageName: string, registry?: string) {
   if (await canUseNpm()) {
-    const args = ['view', packageName, 'version'];
-    if (registry) {
-      args.push(`--registry=${registry}`);
+    try {
+      const args = ['view', packageName, 'version'];
+      if (registry) {
+        args.push(`--registry=${registry}`);
+      }
+      const result = await execa('npm', args);
+      return stripAnsi(result.stdout);
+    } catch (e) {
+      return false;
     }
-    const result = await execa('npm', args);
-    return stripAnsi(result.stdout);
   }
   throw new Error('not found npm, please install npm before');
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aba6bdc</samp>

This pull request fixes a bug in the `@modern-js/generator-utils` package that caused errors when checking the existence of packages on the npm registry. It also adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aba6bdc</samp>

* Fix package version check logic by handling error case in `isPackageExist` function ([link](https://github.com/web-infra-dev/modern.js/pull/4220/files?diff=unified&w=0#diff-acd09779a9bc49d78bcf8e2a99eff03859b3ff3a8d167f438226b8b7b43ed918L6-R15))
* Add changeset file to document patch update for `@modern-js/generator-utils` package ([link](https://github.com/web-infra-dev/modern.js/pull/4220/files?diff=unified&w=0#diff-21648385e364cf215ab6f48d726a7b169d265c26bab56889d245afb89f82c018R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
