### PR TITLE
chore: remove unnecessary type

### DIFF
--- a/.changeset/proud-avocados-leave.md
+++ b/.changeset/proud-avocados-leave.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+chore: remove unnecessary type override
+chore: 移除多余的类型覆盖定义

--- a/packages/runtime/plugin-runtime/types/router.d.ts
+++ b/packages/runtime/plugin-runtime/types/router.d.ts
@@ -9,12 +9,6 @@ declare module '@modern-js/app-tools' {
 
 declare module '@modern-js/module-tools' {
   interface RuntimeUserConfig {
-    router?: RouterConfig | boolean;
-  }
-}
-
-declare module '@modern-js/runtime' {
-  interface AppConfig {
-    router?: RouterConfig | boolean;
+    router?: Partial<RouterConfig> | boolean;
   }
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbd9edd</samp>

Fix TypeScript error and add Chinese translation for `@modern-js/runtime` changeset. This change improves the type safety and accessibility of the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dbd9edd</samp>

* Remove unnecessary type override for `createApp` function in `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/4222/files?diff=unified&w=0#diff-61d5b0ec376abfd41713465b2402901eea45c6a7f8f7bbb9babcd86b412384b0R1-R6))
* Add Chinese translation for the change description in the changeset file for `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/4222/files?diff=unified&w=0#diff-61d5b0ec376abfd41713465b2402901eea45c6a7f8f7bbb9babcd86b412384b0R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
