### PR TITLE
docs: replace dead link

### DIFF
--- a/packages/document/builder-doc/docs/en/config/experiments/sourceBuild.md
+++ b/packages/document/builder-doc/docs/en/config/experiments/sourceBuild.md
@@ -12,4 +12,4 @@ export default {
 };
 ```
 
-More detail can see ["Advanced - Source-code Build Mode"](en/guide/advanced/source-build.md)。
+More detail can see ["Advanced - Source-code Build Mode"](https://modernjs.dev/builder/en/guide/advanced/source-build.html)。

--- a/packages/document/builder-doc/docs/zh/config/experiments/sourceBuild.md
+++ b/packages/document/builder-doc/docs/zh/config/experiments/sourceBuild.md
@@ -12,4 +12,4 @@ export default {
 };
 ```
 
-更多信息可参考[「进阶-源码构建模式」](/guide/advanced/source-build.md)。
+更多信息可参考[「进阶-源码构建模式」](https://modernjs.dev/builder/guide/advanced/source-build.html)。


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e02ade</samp>

Updated the link to the source-code build mode guide in the English and Chinese versions of the `builder-doc` package. This fixes the broken link on the modernjs.dev website.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e02ade</samp>

* Updated the link to the "Advanced - Source-code Build Mode" guide in both English and Chinese versions of the document (`[link](https://github.com/web-infra-dev/modern.js/pull/4223/files?diff=unified&w=0#diff-ab1fd40cd5c07f361a9bfbd9e2d8dbd8e96da18c359e6ae59e020a70b1527892L15-R15)`, `[link](https://github.com/web-infra-dev/modern.js/pull/4223/files?diff=unified&w=0#diff-1370e6d9a0d3cfe804d49f6043b72c115a08ab6bc406b7aeb5e0cb333ee29d82L15-R15)`). This fixes the broken link when the document is rendered on the modernjs.dev website. The files affected are `packages/document/builder-doc/docs/en/config/experiments/sourceBuild.md` and `packages/document/builder-doc/docs/zh/config/experiments/sourceBuild.md`.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
