### PR TITLE
fix(builder): remove unused source map of inlined files

### DIFF
--- a/.changeset/odd-rabbits-invent.md
+++ b/.changeset/odd-rabbits-invent.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): remove unused source map of inlined files
+
+fix(builder):  移除内联文件多余的 source map

--- a/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
@@ -219,10 +219,18 @@ export class InlineChunkHtmlPlugin {
           stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_SUMMARIZE,
         },
         () => {
+          const { devtool } = compiler.options;
+
           this.inlinedAssets.forEach(name => {
-            // use delete instead of compilation.deleteAsset
-            // because we want to preserve the related files such as source map
-            delete compilation.assets[name];
+            // If the source map reference is removed,
+            // we do not need to preserve the source map of inlined files
+            if (devtool === 'hidden-source-map') {
+              compilation.deleteAsset(name);
+            } else {
+              // use delete instead of compilation.deleteAsset
+              // because we want to preserve the related files such as source map
+              delete compilation.assets[name];
+            }
           });
           this.inlinedAssets.clear();
         },


### PR DESCRIPTION
## Summary

Fix https://github.com/web-infra-dev/modern.js/issues/4213

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2ecf43</samp>

This pull request introduces a new `bundlerChain` interface for the builder configuration, improves the source map handling of the `InlineChunkHtmlPlugin`, and adds a changeset file for the `@changesets/cli` tool. The purpose is to enhance the developer experience and the performance of the modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2ecf43</samp>

*  Add a changeset file to document the patch update for the `@modern-js/builder-shared` package (.changeset/odd-rabbits-invent.md)
*  Modify the `InlineChunkHtmlPlugin` class to delete the asset of the inlined chunk when the `devtool` option is `hidden-source-map` ([link](https://github.com/web-infra-dev/modern.js/pull/4230/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL222-R233))
*  Refactor the test file for the `inline-chunk` case to use the `bundlerChain` interface instead of `webpack` and `rspack` ([link](https://github.com/web-infra-dev/modern.js/pull/4230/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL5-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4230/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL15-R17))
*  Add a new test case to verify that the source map file of the inlined chunk is not emitted when the `devtool` option is `hidden-source-map` ([link](https://github.com/web-infra-dev/modern.js/pull/4230/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caR112-R138))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
