### PR TITLE
fix: optimize source-map generation in the router-plugin

### DIFF
--- a/.changeset/seven-rice-arrive.md
+++ b/.changeset/seven-rice-arrive.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: Optimize source-map generation in the router-plugin
+fix: 优化 router plugin 中的 source-map 生成

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -1,7 +1,10 @@
+import path from 'path';
+import type Buffer from 'buffer';
 import { mergeWith } from '@modern-js/utils/lodash';
 import { ROUTE_MANIFEST_FILE } from '@modern-js/utils';
 import { ROUTE_MANIFEST } from '@modern-js/utils/universal/constants';
 import type { webpack } from '@modern-js/builder-webpack-provider';
+import { Loader, transform } from 'esbuild';
 import type { Rspack } from '@modern-js/builder-rspack-provider';
 
 const PLUGIN_NAME = 'ModernjsRoutePlugin';
@@ -52,7 +55,13 @@ export class RouterPlugin {
       return path;
     };
 
-    const chunkToSourceMap = new Map();
+    const chunkToSourceAndMap: Map<
+      string | number,
+      {
+        source: string | Buffer;
+        map: unknown;
+      }
+    > = new Map();
 
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, compilation => {
       /**
@@ -63,13 +72,14 @@ export class RouterPlugin {
       compilation.hooks.processAssets.tapPromise(
         {
           name: PLUGIN_NAME,
-          stage: Compilation.PROCESS_ASSETS_STAGE_DEV_TOOLING,
+          stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_COMPATIBILITY,
         },
         async () => {
           const stats = compilation.getStats().toJson({
             all: false,
             chunkGroups: true,
             chunks: true,
+            ids: true,
           });
           const { chunks = [], namedChunkGroups } = stats;
 
@@ -102,8 +112,11 @@ export class RouterPlugin {
               continue;
             }
 
-            const { map } = asset.sourceAndMap();
-            chunkToSourceMap.set(chunkId, map);
+            const { source, map } = asset.sourceAndMap();
+            chunkToSourceAndMap.set(chunkId!, {
+              source,
+              map,
+            });
           }
         },
       );
@@ -214,16 +227,23 @@ export class RouterPlugin {
             const chunkId = entryChunkFileIds[i];
             const asset = compilation.assets[file];
             // it may be removed by InlineChunkHtmlPlugin
-            if (!asset) {
+            if (!asset || !chunkId) {
               continue;
             }
-            const { source } = asset.sourceAndMap();
-            const map = chunkToSourceMap.get(chunkId);
+
+            const { source, map } = chunkToSourceAndMap.get(chunkId)!;
             const newContent = `${injectedContent}${source.toString()}`;
+
+            const result = await transform(newContent, {
+              loader: path.extname(file).slice(1) as Loader,
+              format: 'esm',
+              sourcemap: true,
+            });
+
             const newSource = new SourceMapSource(
-              newContent,
+              result.code,
               file,
-              map,
+              result.map,
               source.toString(),
               map,
             );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b776d87</samp>

This pull request fixes a bug in the `router-plugin` of the `@modern-js/app-tools` package that caused slow and inaccurate source-map generation. It does this by using `esbuild` to transform the entry chunk code and source-map, and by adjusting the webpack hook stage and some imports and types. It also adds a `.changeset` file to document the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b776d87</samp>

* Optimize source-map generation in router-plugin by using esbuild transformation ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L55-R64), [link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L66-R75), [link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3R82), [link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L105-R119), [link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L217-R246))
  * Import `path`, `Buffer`, and `esbuild` modules in `RouterPlugin.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L1-R7))
  * Change `chunkToSourceMap` type to store source code and source-map for each chunk ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L55-R64))
  * Use earlier webpack compilation hook to avoid conflicts with other plugins ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L66-R75))
  * Use `ids: true` option to get original module ids in source-map ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3R82))
  * Use `chunkId` as key to store source code and source-map in `chunkToSourceAndMap` ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L105-R119))
  * Use esbuild `transform` function to inject route manifest content and create new `SourceMapSource` object ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L217-R246))
* Add markdown file to `.changeset` folder with fix messages for `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4232/files?diff=unified&w=0#diff-e728dec7af52c691ed70fa19869bd6ae72899a3880034f311a094a77c35ec941R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
