### PR TITLE
fix(doc-core): flatten error when meeting `$` in mdx file

### DIFF
--- a/.changeset/bright-flies-sit.md
+++ b/.changeset/bright-flies-sit.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): flatten error when meeting `$` in mdx file
+
+fix(doc-core): 当出现 `$` 字符时，mdx 内容扁平化结果异常

--- a/packages/cli/doc-core/src/node/utils/flattenMdxContent.ts
+++ b/packages/cli/doc-core/src/node/utils/flattenMdxContent.ts
@@ -101,11 +101,12 @@ export async function flattenMdxContent(
     if (MDX_REGEXP.test(absoluteImportPath)) {
       // replace import statement with the content of the imported file
       const importedContent = fs.readFileSync(absoluteImportPath, 'utf-8');
-
-      result = result.replace(
-        new RegExp(`<${id}\\s*/>`),
-        await flattenMdxContent(importedContent, absoluteImportPath, alias),
+      const replacedValue = await flattenMdxContent(
+        importedContent,
+        absoluteImportPath,
+        alias,
       );
+      result = result.replace(new RegExp(`<${id}\\s*/>`), () => replacedValue);
     }
   }
 


### PR DESCRIPTION
## Summary

Fix #4229 

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a620b6a</samp>

This pull request fixes a bug in the `@modern-js/doc-core` package that could cause flattening error when meeting `$` in mdx file. It updates the `flattenMdxContent` function to use a safer replacement method and adds a changeset file to document the patch version update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a620b6a</samp>

* Fix bug of flattening error when meeting `$` in mdx file for `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4234/files?diff=unified&w=0#diff-2ce8de590c529b28f3a2bf80a62718455661c3ad2ba9e4efb2de10b59093d5ebL104-R109), [link](https://github.com/web-infra-dev/modern.js/pull/4234/files?diff=unified&w=0#diff-ba04d95e5ff8ae00b7410c099ff865150656d93a84b918f58ed126a20d0e0bc0R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
