### PR TITLE
perf: optimize route manifest size for multiple entries

### DIFF
--- a/.changeset/sixty-seals-tell.md
+++ b/.changeset/sixty-seals-tell.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+perf: Optimize route manifest size for multiple entries
+perf: 优化路由 manifest 在多 entry 场景下的体积

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -245,7 +245,6 @@ export class RouterPlugin {
 
             const result = await transform(newContent, {
               loader: path.extname(file).slice(1) as Loader,
-              format: 'esm',
               sourcemap: true,
             });
 

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -216,7 +216,7 @@ export class RouterPlugin {
 
             const relatedAssets: typeof routeAssets = {};
             Object.keys(routeAssets).forEach(routeId => {
-              if (routeId.startsWith(`${chunkId}_`)) {
+              if (routeId.startsWith(`${chunkId}`)) {
                 relatedAssets[routeId] = routeAssets[routeId];
               }
             });

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -188,23 +188,6 @@ export class RouterPlugin {
             routeAssets,
           };
 
-          const injectedContent = `
-            ;(function(){
-              window.${ROUTE_MANIFEST} = ${JSON.stringify(manifest, (k, v) => {
-            if (
-              (k === 'assets' || k === 'referenceCssAssets') &&
-              Array.isArray(v)
-            ) {
-              // should hide publicPath in browser
-              return v.map(item => {
-                return item.replace(publicPath, '');
-              });
-            }
-            return v;
-          })};
-            })();
-          `;
-
           const entrypointsArray = Array.from(
             compilation.entrypoints.entries() as IterableIterator<
               [string, unknown]
@@ -230,6 +213,32 @@ export class RouterPlugin {
             if (!asset || !chunkId) {
               continue;
             }
+
+            const relatedAssets: typeof routeAssets = {};
+            Object.keys(routeAssets).forEach(routeId => {
+              if (routeId.startsWith(`${chunkId}_`)) {
+                relatedAssets[routeId] = routeAssets[routeId];
+              }
+            });
+
+            const manifest = { routeAssets: relatedAssets };
+
+            const injectedContent = `
+            ;(function(){
+              window.${ROUTE_MANIFEST} = ${JSON.stringify(manifest, (k, v) => {
+              if (
+                (k === 'assets' || k === 'referenceCssAssets') &&
+                Array.isArray(v)
+              ) {
+                // should hide publicPath in browser
+                return v.map(item => {
+                  return item.replace(publicPath, '');
+                });
+              }
+              return v;
+            })};
+            })();
+          `;
 
             const { source, map } = chunkToSourceAndMap.get(chunkId)!;
             const newContent = `${injectedContent}${source.toString()}`;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 267f835</samp>

This pull request improves the performance of the `@modern-js/app-tools` package by optimizing the RouterPlugin to inject smaller route manifests into entry chunks. It also updates the `.changeset` folder with a patch level changelog for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 267f835</samp>

*  Reduce HTML file size and improve performance by injecting smaller route manifest objects into each entry chunk ([link](https://github.com/web-infra-dev/modern.js/pull/4235/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L178-L194), [link](https://github.com/web-infra-dev/modern.js/pull/4235/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3R203-R228))
*  Add a patch level update and a performance improvement message for `@modern-js/app-tools` package in `.changeset/sixty-seals-tell.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4235/files?diff=unified&w=0#diff-ca87d679fa3b07a84a644e6a19e60bd397313d44d00ffb18df233c36de6ade8aR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
