### PR TITLE
fix(module-tools): limit concurrency count

### DIFF
--- a/.changeset/clean-berries-relax.md
+++ b/.changeset/clean-berries-relax.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): limit concurrency count
+fix(module-tools): 限制并行的数量

--- a/packages/solutions/module-tools/src/builder/index.ts
+++ b/packages/solutions/module-tools/src/builder/index.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import type { PluginAPI } from '@modern-js/core';
 import { logger } from '@modern-js/utils/logger';
 import type { ModuleContext } from '../types/context';
@@ -39,19 +40,23 @@ export const run = async (
     }
 
     try {
-      await pMap(resolvedBuildConfig, async config => {
-        const buildConfig = await runner.beforeBuildTask(config);
+      await pMap(
+        resolvedBuildConfig,
+        async config => {
+          const buildConfig = await runner.beforeBuildTask(config);
 
-        await runBuildTask(
-          {
-            buildConfig,
-            buildCmdOptions: cmdOptions,
-            context,
-          },
-          api,
-        );
-        await runner.afterBuildTask({ status: 'success', config });
-      });
+          await runBuildTask(
+            {
+              buildConfig,
+              buildCmdOptions: cmdOptions,
+              context,
+            },
+            api,
+          );
+          await runner.afterBuildTask({ status: 'success', config });
+        },
+        { concurrency: os.cpus().length },
+      );
     } catch (e) {
       const { isInternalError, ModuleBuildError } = await import('../error');
       if (isInternalError(e)) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad51ae4</samp>

The pull request enhances the performance and usability of the `@modern-js/module-tools` package by optimizing the module building process and adding changelog support. It also updates the `.changeset` folder with a patch-level change file for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad51ae4</samp>

*  Add `.changeset` file to generate changelog and version update for `@modern-js/module-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4237/files?diff=unified&w=0#diff-657ed2288bb066a19f61dc30c1b7213c1479f2acb1066a5d73483f0f6532349eR1-R6))
*  Improve module building performance and stability by limiting concurrency to number of CPU cores ([link](https://github.com/web-infra-dev/modern.js/pull/4237/files?diff=unified&w=0#diff-fa01db21d10eb93a5a98d6545fbe49c63eab71da53447ace99b81543097aa95aR1), [link](https://github.com/web-infra-dev/modern.js/pull/4237/files?diff=unified&w=0#diff-fa01db21d10eb93a5a98d6545fbe49c63eab71da53447ace99b81543097aa95aL42-R59))
   * Import `os` module to access system information in `builder/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4237/files?diff=unified&w=0#diff-fa01db21d10eb93a5a98d6545fbe49c63eab71da53447ace99b81543097aa95aR1))
   * Add `concurrency` option to `pMap` function in `run` function ([link](https://github.com/web-infra-dev/modern.js/pull/4237/files?diff=unified&w=0#diff-fa01db21d10eb93a5a98d6545fbe49c63eab71da53447ace99b81543097aa95aL42-R59))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
