### PR TITLE
docs(builder): add some tips for source.include

### DIFF
--- a/packages/document/builder-doc/docs/en/config/source/include.md
+++ b/packages/document/builder-doc/docs/en/config/source/include.md
@@ -19,7 +19,7 @@ export default {
 ```
 
 :::tip
-When using Rspack as the bundler,  **all files** will be compiled by default, and at the same time, exclusion through `source.exclude` is not supported.
+When using Rspack as the bundler, **all files** will be compiled by default, and at the same time, exclusion through `source.exclude` is not supported.
 :::
 
 ### Compile Npm Packages
@@ -40,14 +40,14 @@ export default {
       path.dirname(require.resolve('query-string')),
       // Method 2:
       // Match by regular expression
-      // All paths containing `/query-string/` will be matched
-      /\/query-string\//,
+      // All paths containing `/node_modules/query-string/` will be matched
+      /\/node_modules\/query-string\//,
     ],
   },
 };
 ```
 
-> Note that this config will only compile the code of `query-string` itself, not the **sub-dependencies** of `query-string`. If you need to compile a sub-dependency of `query-string`, you need to add the corresponding npm package to `source.include`.
+The above two methods match the absolute paths of files using "path prefixes" and "regular expressions" respectively. It is worth noting that all referenced modules in the project will be matched. Therefore, you should avoid using overly loose values for matching to prevent compilation performance issues or compilation errors.
 
 ### Compile Sub Dependencies
 
@@ -58,7 +58,10 @@ Take `query-string` for example, it depends on the `decode-uri-component` packag
 ```ts
 export default {
   source: {
-    include: [/\/query-string\//, /\/decode-uri-component\//],
+    include: [
+      /\/node_modules\/query-string\//,
+      /\/node_modules\/decode-uri-component\//,
+    ],
   },
 };
 ```

--- a/packages/document/builder-doc/docs/en/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/en/config/tools/babel.md
@@ -154,14 +154,16 @@ By default, Babel will only compile the application code in the src directory. W
 export default {
   tools: {
     babel(config, { addIncludes }) {
-      addIncludes(/\/query-string\//);
+      addIncludes(/\/node_modules\/query-string\//);
     },
   },
 };
 ```
 
 :::tip
-The usage of the `addIncludes` function is basically the same as the `source.include` config, please see the [source.include documentation](https://modernjs.dev/builder/api/config-source.html#sourceinclude) for a more detailed usage. You can also use `source.include` directly instead of the `addIncludes` function.
+The usage of the `addIncludes` function is identical to the `source.include` configuration option. We recommend using `source.include` instead of `addIncludes` because `source.include` has a wider range of use cases. For example, when migrating from Babel to SWC compilation, `source.include` can still work, while the `addIncludes` function will not be effective.
+
+Please refer to the [source.include documentation](https://modernjs.dev/builder/en/api/config-source.html#sourceinclude) for more detailed usage.
 :::
 
 #### addExcludes

--- a/packages/document/builder-doc/docs/en/guide/advanced/browser-compatibility.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/browser-compatibility.md
@@ -145,7 +145,7 @@ import path from 'path';
 
 export default {
   source: {
-    include: [/\/query-string\//],
+    include: [/\/node_modules\/query-string\//],
   },
 };
 ```

--- a/packages/document/builder-doc/docs/zh/config/source/include.md
+++ b/packages/document/builder-doc/docs/zh/config/source/include.md
@@ -40,23 +40,28 @@ export default {
       path.dirname(require.resolve('query-string')),
       // 方法二:
       // 通过正则表达式进行匹配
-      // 所有包含 `/query-string/` 的路径都会被匹配到
-      /\/query-string\//,
+      // 所有包含 `/node_modules/query-string/` 的路径都会被匹配到
+      /\/node_modules\/query-string\//,
     ],
   },
 };
 ```
 
+上述两种方法分别通过 "路径前缀" 和 "正则表达式" 来匹配文件的绝对路径，值得留意的是，项目中所有被引用的模块都会经过匹配，因此你不能使用过于松散的值进行匹配，避免造成编译性能问题或编译异常。
+
 ### 编译 npm 包的子依赖
 
 当你通过 `source.include` 编译一个 npm 包时，Builder 默认只会编译匹配到的模块，不会编译对应模块的**子依赖**。
 
-以 `query-string` 为例，它依赖的 `decode-uri-component` 包中同样存在 ES6+ 代码，因此需要将 `decode-uri-component` 也加入到 `source.include` 中：
+以 `query-string` 为例，它依赖的 `decode-uri-component` 包中同样存在 ES6+ 代码，因此你需要将 `decode-uri-component` 也加入到 `source.include` 中：
 
 ```ts
 export default {
   source: {
-    include: [/\/query-string\//, /\/decode-uri-component\//],
+    include: [
+      /\/node_modules\/query-string\//,
+      /\/node_modules\/decode-uri-component\//,
+    ],
   },
 };
 ```

--- a/packages/document/builder-doc/docs/zh/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/babel.md
@@ -152,14 +152,17 @@ export default {
 export default {
   tools: {
     babel(config, { addIncludes }) {
-      addIncludes(/\/query-string\//);
+      addIncludes(/\/node_modules\/query-string\//);
     },
   },
 };
 ```
 
 :::tip
-`addIncludes` 函数的用法与 `source.include` 配置项基本一致，请查看 [source.include 文档](https://modernjs.dev/builder/api/config-source.html#sourceinclude) 来查看更详细的用法说明。也可以直接使用 `source.include` 来代替 `addIncludes` 函数。
+`addIncludes` 函数的用法与 `source.include` 配置项完全一致，我们建议直接使用 `source.include` 来代替它，因为 `source.include` 的使用场景更广。比如，当你从 Babel 迁移切换到 SWC 编译时，`source.include` 仍然可以生效，而 `addIncludes` 函数则无法生效。
+
+请查看 [「source.include 文档」](https://modernjs.dev/builder/api/config-source.html#sourceinclude) 来查看更详细的用法说明。
+
 :::
 
 #### addExcludes

--- a/packages/document/builder-doc/docs/zh/guide/advanced/browser-compatibility.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/browser-compatibility.md
@@ -145,7 +145,7 @@ import path from 'path';
 
 export default {
   source: {
-    include: [/\/query-string\//],
+    include: [/\/node_modules\/query-string\//],
   },
 };
 ```


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5b0e75</samp>

This pull request fixes some bugs and improves the documentation for the `source.include` and `babel` config features in the `builder-doc` package, both in English and Chinese. It also updates the code examples for downgrading third-party dependencies in the browser compatibility guide, using more specific regular expressions to avoid unintended matches.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5b0e75</samp>

*  Fix and clarify the regular expressions for matching the `query-string` package and its sub-dependencies in the `source.include` config, the `babel` tool config, and the browser compatibility feature. ([link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-1e7956e7fcf451b815cda6633ccc90255ffa7f8ba61ed92f661b0bb4fc09a03eL43-R44), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-1e7956e7fcf451b815cda6633ccc90255ffa7f8ba61ed92f661b0bb4fc09a03eL61-R64), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-e96809b29417d6281f84f3b6a2dd8674fb248b85f8ddffc46cb8355a18cff841L157-R157), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-2062fcddc68dde248c4a6b98e8f0a9c68b10b05fdd000cb36598b2bdfb6335d2L148-R148), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-6b59d40fbb7b06e33a3521c0472fb1f3d4e5f825698f93b4c51bea041f57f721L43-R44), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-c31daf59e1b7eb317897582e8443464d03d88a13bd5ecad2eaf44b84cf6a7d5cL155-R155), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-0e8c4bce4203c3b7c2f022e897d369f2790cfcdc5baa2bca9904242c15bf742bL148-R148))
*  Replace the misleading note sections in the English and Chinese documentation for the `source.include` config with new ones that explain the scope and usage of the two methods of matching files. ([link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-1e7956e7fcf451b815cda6633ccc90255ffa7f8ba61ed92f661b0bb4fc09a03eL50-R50), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-6b59d40fbb7b06e33a3521c0472fb1f3d4e5f825698f93b4c51bea041f57f721L50-R64))
*  Replace the vague tip sections in the English and Chinese documentation for the `babel` tool config with new ones that recommend using the `source.include` config instead of the `addIncludes` function for wider compatibility. ([link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-e96809b29417d6281f84f3b6a2dd8674fb248b85f8ddffc46cb8355a18cff841L164-R166), [link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-c31daf59e1b7eb317897582e8443464d03d88a13bd5ecad2eaf44b84cf6a7d5cL162-R165))
*  Remove an extra space before the word "all" in the tip section of the English documentation for the `source.include` config. ([link](https://github.com/web-infra-dev/modern.js/pull/4241/files?diff=unified&w=0#diff-1e7956e7fcf451b815cda6633ccc90255ffa7f8ba61ed92f661b0bb4fc09a03eL22-R22))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
