### PR TITLE
fix(builder-plugin-vue2): failed to handle styles when using Rspack

### DIFF
--- a/.changeset/proud-crabs-tickle.md
+++ b/.changeset/proud-crabs-tickle.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-vue2': patch
+---
+
+fix(builder-plugin-vue2): failed to handle styles when using Rspack
+
+fix(builder-plugin-vue2): 修复使用 Rspack 时无法加载样式的问题

--- a/tests/e2e/builder/cases/vue2/index.test.ts
+++ b/tests/e2e/builder/cases/vue2/index.test.ts
@@ -26,6 +26,31 @@ test('should build basic Vue sfc correctly', async ({ page }) => {
   builder.close();
 });
 
+test('should build Vue sfc style correctly', async ({ page }) => {
+  const root = join(__dirname, 'sfc-style');
+
+  const builder = await build({
+    cwd: root,
+    entry: {
+      main: join(root, 'src/index.js'),
+    },
+    runServer: true,
+    plugins: [builderPluginVue2()],
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+  await expect(
+    page.evaluate(
+      `window.getComputedStyle(document.getElementById('button')).color`,
+    ),
+  ).resolves.toBe('rgb(255, 0, 0)');
+  await expect(
+    page.evaluate(`window.getComputedStyle(document.body).backgroundColor`),
+  ).resolves.toBe('rgb(0, 0, 255)');
+
+  builder.close();
+});
+
 test('should build basic Vue jsx correctly', async ({ page }) => {
   const root = join(__dirname, 'jsx-basic');
 

--- a/tests/e2e/builder/cases/vue2/sfc-style/src/App.vue
+++ b/tests/e2e/builder/cases/vue2/sfc-style/src/App.vue
@@ -1,0 +1,14 @@
+<template>
+  <button id="button">A</button>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style>
+#button {
+  color: red;
+  background-color: green;
+}
+</style>

--- a/tests/e2e/builder/cases/vue2/sfc-style/src/a.less
+++ b/tests/e2e/builder/cases/vue2/sfc-style/src/a.less
@@ -1,0 +1,3 @@
+body {
+  background-color: blue;
+}

--- a/tests/e2e/builder/cases/vue2/sfc-style/src/index.js
+++ b/tests/e2e/builder/cases/vue2/sfc-style/src/index.js
@@ -1,0 +1,9 @@
+import Vue from 'vue';
+import App from './A.vue';
+import './a.less';
+
+// eslint-disable-next-line no-new
+new Vue({
+  el: '#root',
+  render: h => h(App),
+});


### PR DESCRIPTION
## Summary

The `experimental.css` option of Rspack do not support Vue 2 yet, ref: https://www.rspack.dev/guide/vue.html#vue2

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e571d0c</samp>

This pull request fixes a bug in the `@modern-js/builder-plugin-vue2` package that caused incorrect CSS extraction when using Rspack. It also adds a new test case to verify the fix and updates the package version and changeset file. The main files affected are `packages/builder/plugin-vue2/src/index.ts`, `.changeset/proud-crabs-tickle.md`, and `tests/e2e/builder/cases/vue2/index.test.ts`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e571d0c</samp>

*  Add a changeset file to document the patch version update and the bug fix for the `@modern-js/builder-plugin-vue2` package ([link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-7c5b50d3643233fa11cb476da12fd235531d2d4c9714fbb00335cbd806b8059eR1-R7))
*  Import the `SharedBuilderConfig` type from `@modern-js/builder-shared` and use it to declare a `builderConfig` variable that contains the output configuration for the Vue2 plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-ff7fa8d3e4513c06b0e6671f53e3612b1b89fdeb7d42166451ffc0e5af31020cR5), [link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-ff7fa8d3e4513c06b0e6671f53e3612b1b89fdeb7d42166451ffc0e5af31020cL36-R37))
*  Disable CSS extraction for Rspack bundler in the Vue2 plugin to avoid compatibility issues and add a reference link to the Rspack documentation for Vue2 ([link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-ff7fa8d3e4513c06b0e6671f53e3612b1b89fdeb7d42166451ffc0e5af31020cL53-R63))
*  Add a new test case to verify that the Vue2 plugin can handle styles correctly when using Rspack, using a Vue2 SFC file (`App.vue`), a less file (`a.less`), and an entry file (`index.js`) ([link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-67a9d533565f90b7e809b2784acf2db2dd797a07befc8eb579d1e513839f9778R29-R53), [link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-b23dd19f3a12cfacd6d5990ad79588c15f65cb7ca2a2ee007a16d34ff0b6ad2cR1-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-e61261bba05975b769b4a61bd55c85acc4add99a723f18dbcf66315df24e83d8R1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4245/files?diff=unified&w=0#diff-562cebec6bf3e17124a55497646305687cfa8178dc87d75153a10b4104891e2aR1-R9))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
