### PR TITLE
test(builder): add sfc-style e2e for Vue 3

### DIFF
--- a/tests/e2e/builder/cases/vue/index.test.ts
+++ b/tests/e2e/builder/cases/vue/index.test.ts
@@ -26,6 +26,31 @@ test('should build basic Vue sfc correctly', async ({ page }) => {
   builder.close();
 });
 
+test('should build Vue sfc style correctly', async ({ page }) => {
+  const root = join(__dirname, 'sfc-style');
+
+  const builder = await build({
+    cwd: root,
+    entry: {
+      main: join(root, 'src/index.js'),
+    },
+    runServer: true,
+    plugins: [builderPluginVue()],
+  });
+
+  await page.goto(getHrefByEntryName('main', builder.port));
+  await expect(
+    page.evaluate(
+      `window.getComputedStyle(document.getElementById('button')).color`,
+    ),
+  ).resolves.toBe('rgb(255, 0, 0)');
+  await expect(
+    page.evaluate(`window.getComputedStyle(document.body).backgroundColor`),
+  ).resolves.toBe('rgb(0, 0, 255)');
+
+  builder.close();
+});
+
 test('should build basic Vue jsx correctly', async ({ page }) => {
   const root = join(__dirname, 'jsx-basic');
 

--- a/tests/e2e/builder/cases/vue/sfc-style/src/App.vue
+++ b/tests/e2e/builder/cases/vue/sfc-style/src/App.vue
@@ -1,0 +1,14 @@
+<template>
+  <button id="button">A</button>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style>
+#button {
+  color: red;
+  background-color: green;
+}
+</style>

--- a/tests/e2e/builder/cases/vue/sfc-style/src/a.less
+++ b/tests/e2e/builder/cases/vue/sfc-style/src/a.less
@@ -1,0 +1,3 @@
+body {
+  background-color: blue;
+}

--- a/tests/e2e/builder/cases/vue/sfc-style/src/index.js
+++ b/tests/e2e/builder/cases/vue/sfc-style/src/index.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import './a.less';
+import App from './App.vue';
+
+createApp(App).mount('#root');

--- a/tests/e2e/builder/cases/vue2/sfc-style/src/index.js
+++ b/tests/e2e/builder/cases/vue2/sfc-style/src/index.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import App from './A.vue';
+import App from './App.vue';
 import './a.less';
 
 // eslint-disable-next-line no-new


### PR DESCRIPTION
## Summary

Sometimes Rspack will generate invalid CSS, see: https://github.com/web-infra-dev/rspack/issues/3798

So I adjusted the CSS order to avoid that issue.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6d997e2</samp>

This pull request adds a new e2e test case for the builder plugin for Vue, which verifies the correct handling of single file components with styles. It also renames a file in another test case for consistency.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6d997e2</samp>

*  Add a new test case for the builder plugin for Vue with sfc style ([link](https://github.com/web-infra-dev/modern.js/pull/4247/files?diff=unified&w=0#diff-07314497739e976882a1ca688931294020073856e848131ad5ff3ab49fa87d40R29-R53))
  - Create a new Vue sfc file `App.vue` with a template, a script, and a style block ([link](https://github.com/web-infra-dev/modern.js/pull/4247/files?diff=unified&w=0#diff-7c9235c72a9234aa7d92abd3ebe844954ba54f8c2bfeda5e68ff85128e67e187R1-R14))
  - Create a new less file `a.less` with a CSS rule for the body element ([link](https://github.com/web-infra-dev/modern.js/pull/4247/files?diff=unified&w=0#diff-27816322ec3ba7df1a0fc6be21c013ed256d2e20c260c8d2fbb1fe23a9d4aa18R1-R3))
  - Create a new index.js file `index.js` that imports Vue, the less file, and the Vue sfc file, and mounts the App component ([link](https://github.com/web-infra-dev/modern.js/pull/4247/files?diff=unified&w=0#diff-7fa9aa809c20a61864a8e263081670028045a5e480f44adc8505b3624f2c2f7cR1-R5))
* Rename the Vue sfc file from A.vue to App.vue in the vue2 test case to match the convention and avoid confusion ([link](https://github.com/web-infra-dev/modern.js/pull/4247/files?diff=unified&w=0#diff-562cebec6bf3e17124a55497646305687cfa8178dc87d75153a10b4104891e2aL2-R2))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
