### PR TITLE
docs(main): update CLI hooks document

### DIFF
--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -526,7 +526,7 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 - Execution stage: Before the entry file is generated, the [`prepare`](#prepare) phase triggers
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; exportStatement: string; }>`
-- Example of use:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -19,7 +19,7 @@ The following are the common CLI Hooks that can be used in both Modern.js Framew
 - Execution phase: Before the config process
 - Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<void, void>`
-- Example usage:
+- Example:
 
 ```ts
 import type { CliPlugin } from '@modern-js/core';
@@ -41,7 +41,7 @@ export const myPlugin = (): CliPlugin => ({
 - Execution phase: After parsing the configuration in `modern.config.ts`
 - Hook model: `ParallelWorkflow`
 - Type: `ParallelWorkflow<void, unknown>`
-- Example usage:
+- Example:
 
 ```ts
 import type { CliPlugin } from '@modern-js/core';
@@ -91,7 +91,7 @@ The configuration returned by the `config` hook will be collected and merged by 
 - Execution phase: After the `config` Hook has run.
 - Hook model: `ParallelWorkflow`
 - Type: `ParallelWorkflow<void, unknown>`
-- Example usage:
+- Example:
 
 ```ts
 import type { CliPlugin } from '@modern-js/core';
@@ -157,7 +157,7 @@ $ modern dev
 - Execution phase: After configuration validation.
 - Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<void, void>`
-- Example usage:
+- Example:
 
 ```ts
 import type { CliPlugin } from '@modern-js/core';
@@ -201,7 +201,7 @@ export const myPlugin = (): CliPlugin => ({
 - Execution phase: After the `prepare` Hook has run.
 - Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<{ program: Command; }, void>`
-- Example usage:
+- Example:
 
 ```ts
 import type { CliPlugin } from '@modern-js/core';
@@ -243,7 +243,7 @@ foo
 - Execution phase: Before the process exits.
 - Hook model: `Workflow`
 - Type: `Workflow<void, void>`
-- Example usage:
+- Example:
 
 ```ts
 import type { CliPlugin } from '@modern-js/core';
@@ -275,7 +275,7 @@ You need to import the `CliPlugin` and `AppTools` types from `@modern-js/app-too
 - Execution phase: Before the project starts when the `dev` command is run.
 - Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<void, unknown>`
-- Example usage:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -294,10 +294,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `afterDev`
 
 - Function: Tasks to be executed after the main process of `dev` command
-- Execution Stage: It is executed after each compilation is completed when running the `dev` command
+- Execution stage: It is executed after each compilation is completed when running the `dev` command
 - Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<{ isFirstCompile: boolean }, unknown>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -337,8 +337,8 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
   - If the current bundler is webpack, you will get the webpack Compiler object.
   - If the current bundler is Rspack, you will get the Rspack Compiler object.
   - The configuration array may contain one or multiple configurations, depending on whether you have enabled features such as SSR.
-- Execution Stage: Executed after running the `build` command and before the actual build process begins.
-- Hook Model: `AsyncWorkflow`.
+- Execution stage: Executed after running the `build` command and before the actual build process begins.
+- Hook model: `AsyncWorkflow`.
 - Type:
 
 ```ts
@@ -347,7 +347,7 @@ type BeforeBuild = AsyncWorkflow<{
 }>;
 ```
 
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -369,8 +369,8 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 - Function: A callback function triggered after running the production build. You can access the build result information through the `stats` parameter.
   - If the current bundler is webpack, you will get webpack Stats.
   - If the current bundler is Rspack, you will get Rspack Stats.
-- Execution Stage: It is executed after running the `build` command and completing the build.
-- Hook Model: `AsyncWorkflow`.
+- Execution stage: It is executed after running the `build` command and completing the build.
+- Hook model: `AsyncWorkflow`.
 - Type:
 
 ```ts
@@ -379,7 +379,7 @@ type AfterBuild = AsyncWorkflow<{
 }>;
 ```
 
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -402,8 +402,8 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
   - If the current bundler is webpack, you will get the webpack Compiler object.
   - If the current bundler is Rspack, you will get the Rspack Compiler object.
   - The configuration array may contain one or multiple configurations, depending on whether you have enabled features such as SSR.
-- Execution Stage: Executed before creating the Compiler instance when running the `dev` or `build` command.
-- Hook Model: `AsyncWorkflow`.
+- Execution stage: Executed before creating the Compiler instance when running the `dev` or `build` command.
+- Hook model: `AsyncWorkflow`.
 - Type:
 
 ```ts
@@ -413,7 +413,7 @@ type BeforeCreateCompiler = AsyncWorkflow<
 >;
 ```
 
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -435,8 +435,8 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 - Function: A callback function triggered after creating a Compiler instance and before executing the build. You can access the Compiler instance object through the `compiler` parameter:
   - If the current bundler is webpack, you will get the webpack Compiler object.
   - If the current bundler is Rspack, you will get the Rspack Compiler object.
-- Execution Stage: Executed after creating the Compiler object.
-- Hook Model: `AsyncWorkflow`.
+- Execution stage: Executed after creating the Compiler object.
+- Hook model: `AsyncWorkflow`.
 - Type:
 
 ```ts
@@ -446,7 +446,7 @@ type AfterCreateCompiler = AsyncWorkflow<
 >;
 ```
 
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -466,10 +466,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `beforePrintInstructions`
 
 - Function: Provides access to the log information that will be printed within middleware functions and allows modification of the log information.
-- Execution Stage: Executed before printing the log information.
+- Execution stage: Executed before printing the log information.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ instructions: string }>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -491,10 +491,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `modifyEntryImports`
 
 - Function: Used for modifying or adding `import` statements in the generated entry files.
-- Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
+- Execution stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ imports: ImportStatement[]; entrypoint: Entrypoint; }>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -523,7 +523,7 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `modifyEntryExport`
 
 - Function: used to modify the `export` statement in the generated entry file
-- Execution Stage: Before the entry file is generated, the [`prepare`](#prepare) phase triggers
+- Execution stage: Before the entry file is generated, the [`prepare`](#prepare) phase triggers
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; exportStatement: string; }>`
 - Example of use:
@@ -550,10 +550,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `modifyEntryRuntimePlugins`
 
 - Function: Used for adding or modifying [Runtime plugins](#Runtime) in the generated entry files.
-- Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
+- Execution stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; plugins: RuntimePlugin[]; }>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -585,10 +585,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `modifyEntryRenderFunction`
 
 - Function: Used for modifying the `render` function in the generated entry files.
-- Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
+- Execution stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; code: string; }>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -611,10 +611,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `modifyFileSystemRoutes`
 
 - Function: Used for modifying the content of the generated front-end page routing files, which must be serializable.
-- Execution Stage: Executed before generating the front-end routing files, triggered during the [`prepare`](#prepare) stage.
+- Execution stage: Executed before generating the front-end routing files, triggered during the [`prepare`](#prepare) stage.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; routes: Route[]; }>`
-- Usage Example:
+- Example:
 
 ```tsx
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -645,10 +645,10 @@ This adds a new page route for the front-end.
 ### `modifyServerRoutes`
 
 - Function: Used for modifying the content of the generated server routes.
-- Execution Stage: Executed before generating the server routing files, triggered during the [`prepare`](#prepare) stage.
+- Execution stage: Executed before generating the server routing files, triggered during the [`prepare`](#prepare) stage.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ routes: ServerRoute[]; }>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -678,10 +678,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `modifyAsyncEntry`
 
 - Function: Used for modifying the asynchronous module that wraps the entry file, see [source.enableAsyncEntry](/configure/app/source/enable-async-entry).
-- Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
+- Execution stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; code: string; }>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -704,10 +704,10 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 ### `htmlPartials`
 
 - Function: Used for customizing the generated HTML page template.
-- Execution Stage: Triggered during the [`prepare`](#prepare) stage.
+- Execution stage: Triggered during the [`prepare`](#prepare) stage.
 - Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; partials: HtmlPartials; }>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
@@ -740,10 +740,10 @@ Plugins are also supported in the Server section of the application project. The
 ### `create`
 
 - Function: In the middleware function, you will get the measurement tool configuration `measureOptions` and log tool configuration `loggerOptions` used for Server initialization, and return a custom measurement tool `measure` and log tool configuration `logger`.
-- Execution Stage: Server initialization.
-- Hook Model: AsyncPipeline.
+- Execution stage: Server initialization.
+- Hook model: `AsyncPipeline`
 - Type: `AsyncPipeline<ServerInitInput, InitExtension>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { ServerPlugin } from '@modern-js/server-core';
@@ -762,10 +762,10 @@ export const myPlugin = (): ServerPlugin => ({
 ### `prepareWebServer`
 
 - Function: Sets the handling function for the Web route. In the middleware function, you can get the front-end middleware of the Web server.
-- Execution Stage: When the request arrives.
-- Hook Model: AsyncPipeline.
+- Execution stage: When the request arrives.
+- Hook model: `AsyncPipeline`
 - Type: `AsyncPipeline<WebServerStartInput, Adapter>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { ServerPlugin } from '@modern-js/server-core';
@@ -788,10 +788,10 @@ export const myPlugin = (): ServerPlugin => ({
 ### `prepareApiServer`
 
 - Function: Sets the handling function for the API route. In the middleware function, you can get the front-end middleware of the API server.
-- Execution Stage: When the request arrives and matches the BFF basename.
-- Hook Model: AsyncPipeline.
+- Execution stage: When the request arrives and matches the BFF basename.
+- Hook model: `AsyncPipeline`
 - Type: `AsyncPipeline<APIServerStartInput, Adapter>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { ServerPlugin } from '@modern-js/server-core';
@@ -822,10 +822,10 @@ The Runtime plugin is mainly used for developers to modify the component that ne
 ### `init`
 
 - Function: Executes `App.init`.
-- Execution Stage: Rendering (SSR/CSR).
-- Hook Model: AsyncPipeline.
+- Execution stage: Rendering (SSR/CSR).
+- Hook model: `AsyncPipeline`
 - Type: `AsyncPipeline<{ context: RuntimeContext; }, unknown>`
-- Usage Example:
+- Example:
 
 ```ts
 import type { Plugin } from '@modern-js/runtime';
@@ -845,10 +845,10 @@ export const myPlugin = (): Plugin => ({
 ### `hoc`
 
 - Function: Modifies the components that need to be rendered.
-- Execution Stage: Rendering (SSR/CSR).
-- Hook Model: Pipeline.
+- Execution stage: Rendering (SSR/CSR).
+- Hook model: `Pipeline`
 - Type: `Pipeline<{ App: React.ComponentType<any>; }, React.ComponentType<any>>`
-- Usage Example:
+- Example:
 
 :::note
 When using the hoc hook, you need to copy the static properties of the original App component to the new component and pass through the props.
@@ -883,10 +883,10 @@ export const myPlugin = (): Plugin => ({
 {/* ### `provide`
 
 - Function: Modifies the Elements that need to be rendered.
-- Execution Stage: Rendering (SSR/CSR).
-- Hook Model: Pipeline.
+- Execution stage: Rendering (SSR/CSR).
+- Hook model: `Pipeline`
 - Type: `Pipeline<{ element: JSX.Element; props: AppProps; context: RuntimeContext }, JSX.Element>`
-- Usage Example:
+- Example:
 
 ```ts
 import { createContext } from 'react';
@@ -906,10 +906,10 @@ export const myPlugin = (): Plugin => ({
 ### `client`
 
 - Function: Customizes the client-side rendering process.
-- Execution Stage: Client-side rendering in the browser.
-- Hook Model: AsyncPipeline.
+- Execution stage: Client-side rendering in the browser.
+- Hook model: `AsyncPipeline`
 - Type: `AsyncPipeline<{ App: React.ComponentType<any>; context?: RuntimeContext; rootElement: HTMLElement; }, void>`
-- Usage Example:
+- Example:
 
 ```ts
 import ReactDOM from 'react-dom';
@@ -933,9 +933,9 @@ export const myPlugin = (): Plugin => ({
 
 - Function: Customize the server-side rendering process.
 - Execution Phase: SSR
-- Hook Model: AsyncPipeline
+- Hook model: `AsyncPipeline`
 - Type: `AsyncPipeline<{ App: React.ComponentType<any>; context?: RuntimeContext; }, string>`
-- Usage Example:
+- Example:
 
 ```ts
 import ReactDomServer from 'react-dom/server';

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -5,15 +5,19 @@ sidebar_position: 8
 
 # Hook List
 
-Modern.js exposes three types of plugins: CLI, Runtime, and Server.
+In the Modern.js engineering system, there are three types of plugins: CLI, Runtime, and Server. Each type of plugin can utilize different Hooks.
 
-## CLI
+In this chapter, all available Hooks are listed, and you can use the corresponding Hook based on your needs.
+
+## CLI Common Hooks
+
+The following are the common CLI Hooks that can be used in both Modern.js Framework and Modern.js Module.
 
 ### `beforeConfig`
 
 - Functionality: Running tasks before the config process
 - Execution phase: Before the config process
-- Hook model: AsyncWorkflow
+- Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<void, void>`
 - Example usage:
 
@@ -35,7 +39,7 @@ export const myPlugin = (): CliPlugin => ({
 
 - Functionality: Collect configuration
 - Execution phase: After parsing the configuration in `modern.config.ts`
-- Hook model: ParallelWorkflow
+- Hook model: `ParallelWorkflow`
 - Type: `ParallelWorkflow<void, unknown>`
 - Example usage:
 
@@ -55,13 +59,37 @@ export const myPlugin = (): CliPlugin => ({
 });
 ```
 
-The collected configuration information will be collected and processed uniformly.
+If you need to set the configuration of the Modern.js Framework, please use the `CliPlugin<AppTools>` type exported by `@modern-js/app-tools`:
+
+```ts
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
+
+export const myPlugin = (): CliPlugin => ({
+  setup(api) {
+    return {
+      config: () => {
+        return {
+          output: {
+            polyfill: 'usage',
+          },
+        };
+      },
+    };
+  },
+});
+```
+
+The configuration returned by the `config` hook will be collected and merged by Modern.js, resulting in a `NormalizedConfig`. When merging configurations, the priority is as follows, from high to low:
+
+1. Configuration defined by the user in the `modern.config.*` file.
+2. Configuration defined by the plugin through the `config` hook.
+3. Default configuration of Modern.js.
 
 ### `validateSchema`
 
 - Functionality: Collect the JSON schema used to validate user configurations in various plugins.
 - Execution phase: After the `config` Hook has run.
-- Hook model: ParallelWorkflow
+- Hook model: `ParallelWorkflow`
 - Type: `ParallelWorkflow<void, unknown>`
 - Example usage:
 
@@ -116,7 +144,7 @@ export const myPlugin = defineConfig({
 
 then throw error:
 
-```sh
+```
 $ modern dev
   1 | {
 > 2 |   "foo": {},
@@ -127,7 +155,7 @@ $ modern dev
 
 - Functionality: Preparatory process for running the main process.
 - Execution phase: After configuration validation.
-- Hook model: AsyncWorkflow
+- Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<void, void>`
 - Example usage:
 
@@ -149,7 +177,7 @@ export const myPlugin = (): CliPlugin => ({
 
 - function: Running tasks after the prepare process
 - Execution Phase: After the prepare process
-- Hook model: AsyncWorkflow
+- Hook model: `AsyncWorkflow`
 - type: `AsyncWorkflow<void, void>`
 - Usage:
 
@@ -169,9 +197,9 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `commands`
 
-- Functionality: Add new commands for the command.
+- Functionality: Add new CLI commands for the commander.
 - Execution phase: After the `prepare` Hook has run.
-- Hook model: AsyncWorkflow
+- Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<{ program: Command; }, void>`
 - Example usage:
 
@@ -213,7 +241,7 @@ foo
 
 - Functionality: Reset some file states before exiting the process.
 - Execution phase: Before the process exits.
-- Hook model: Workflow
+- Hook model: `Workflow`
 - Type: `Workflow<void, void>`
 - Example usage:
 
@@ -235,18 +263,24 @@ export const myPlugin = (): CliPlugin => ({
 Since the callback function when exiting the process in Node.js is synchronous, the type of `beforeExit` Hook is `Workflow` and cannot perform asynchronous operations.
 :::
 
+## CLI Framework Hooks
+
+The following are the CLI Hooks of the framework, which can only be used in Modern.js Framework and cannot be used in Modern.js Module.
+
+You need to import the `CliPlugin` and `AppTools` types from `@modern-js/app-tools` to get accurate type hints for Hooks.
+
 ### `beforeDev`
 
 - Functionality: Tasks before running the main dev process.
 - Execution phase: Before the project starts when the `dev` command is run.
-- Hook model: AsyncWorkflow
+- Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<void, unknown>`
 - Example usage:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       beforeDev: () => {
@@ -261,14 +295,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: Tasks to be executed after the main process of `dev` command
 - Execution Stage: It is executed after each compilation is completed when running the `dev` command
-- Hook Model: AsyncWorkflow
+- Hook model: `AsyncWorkflow`
 - Type: `AsyncWorkflow<{ isFirstCompile: boolean }, unknown>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       afterDev: () => {
@@ -282,15 +316,80 @@ export const myPlugin = (): CliPlugin => ({
 `afterDev` will be executed after each compilation is completed, you can use the `isFirstCompile` param to determine whether it is the first compilation:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       afterDev: ({ isFirstCompile }) => {
         if (isFirstCompile) {
           // do something
         }
+      },
+    };
+  },
+});
+```
+
+### `beforeBuild`
+
+- Function: A callback function triggered before executing production environment builds. You can access the final configuration array of the underlying bundler through the `bundlerConfigs` parameter.
+  - If the current bundler is webpack, you will get the webpack Compiler object.
+  - If the current bundler is Rspack, you will get the Rspack Compiler object.
+  - The configuration array may contain one or multiple configurations, depending on whether you have enabled features such as SSR.
+- Execution Stage: Executed after running the `build` command and before the actual build process begins.
+- Hook Model: `AsyncWorkflow`.
+- Type:
+
+```ts
+type BeforeBuild = AsyncWorkflow<{
+  bundlerConfigs: WebpackConfig[] | RspackConfig[];
+}>;
+```
+
+- Usage Example:
+
+```ts
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
+
+export const myPlugin = (): CliPlugin<AppTools> => ({
+  setup(api) {
+    return {
+      beforeBuild: ({ bundlerConfigs }) => {
+        console.log('Before build.');
+        console.log(bundlerConfigs);
+      },
+    };
+  },
+});
+```
+
+### `afterBuild`
+
+- Function: A callback function triggered after running the production build. You can access the build result information through the `stats` parameter.
+  - If the current bundler is webpack, you will get webpack Stats.
+  - If the current bundler is Rspack, you will get Rspack Stats.
+- Execution Stage: It is executed after running the `build` command and completing the build.
+- Hook Model: `AsyncWorkflow`.
+- Type:
+
+```ts
+type AfterBuild = AsyncWorkflow<{
+  stats?: Stats | MultiStats;
+}>;
+```
+
+- Usage Example:
+
+```ts
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
+
+export const myPlugin = (): CliPlugin<AppTools> => ({
+  setup(api) {
+    return {
+      afterBuild: ({ stats }) => {
+        console.log('After build.');
+        console.log(stats);
       },
     };
   },
@@ -317,9 +416,9 @@ type BeforeCreateCompiler = AsyncWorkflow<
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       beforeCreateCompiler: ({ bundlerConfigs }) => {
@@ -350,9 +449,9 @@ type AfterCreateCompiler = AsyncWorkflow<
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       afterCreateCompiler: ({ compiler }) => {
@@ -368,14 +467,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: Provides access to the log information that will be printed within middleware functions and allows modification of the log information.
 - Execution Stage: Executed before printing the log information.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ instructions: string }>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       beforePrintInstructions: ({ instructions }) => {
@@ -389,83 +488,18 @@ export const myPlugin = (): CliPlugin => ({
 });
 ```
 
-### `beforeBuild`
-
-- Function: A callback function triggered before executing production environment builds. You can access the final configuration array of the underlying bundler through the `bundlerConfigs` parameter.
-  - If the current bundler is webpack, you will get the webpack Compiler object.
-  - If the current bundler is Rspack, you will get the Rspack Compiler object.
-  - The configuration array may contain one or multiple configurations, depending on whether you have enabled features such as SSR.
-- Execution Stage: Executed after running the `build` command and before the actual build process begins.
-- Hook Model: `AsyncWorkflow`.
-- Type:
-
-```ts
-type BeforeBuild = AsyncWorkflow<{
-  bundlerConfigs: WebpackConfig[] | RspackConfig[];
-}>;
-```
-
-- Usage Example:
-
-```ts
-import type { CliPlugin } from '@modern-js/core';
-
-export const myPlugin = (): CliPlugin => ({
-  setup(api) {
-    return {
-      beforeBuild: ({ bundlerConfigs }) => {
-        console.log('Before build.');
-        console.log(bundlerConfigs);
-      },
-    };
-  },
-});
-```
-
-### `afterBuild`
-
-- Function: A callback function triggered after running the production build. You can access the build result information through the `stats` parameter.
-  - If the current bundler is webpack, you will get webpack Stats.
-  - If the current bundler is Rspack, you will get Rspack Stats.
-- Execution Stage: It is executed after running the `build` command and completing the build.
-- Hook Model: `AsyncWorkflow`.
-- Type:
-
-```ts
-type AfterBuild = AsyncWorkflow<{
-  stats?: Stats | MultiStats;
-}>;
-```
-
-- Usage Example:
-
-```ts
-import type { CliPlugin } from '@modern-js/core';
-
-export const myPlugin = (): CliPlugin => ({
-  setup(api) {
-    return {
-      afterBuild: ({ stats }) => {
-        console.log('After build.');
-        console.log(stats);
-      },
-    };
-  },
-});
-```
-
 ### `modifyEntryImports`
 
 - Function: Used for modifying or adding `import` statements in the generated entry files.
 - Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ imports: ImportStatement[]; entrypoint: Entrypoint; }>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryImports({ entrypoint, imports }) {
@@ -490,14 +524,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: used to modify the `export` statement in the generated entry file
 - Execution Stage: Before the entry file is generated, the [`prepare`](#prepare) phase triggers
-- Hook Model: AsyncWaterfall
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; exportStatement: string; }>`
 - Example of use:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryExport({ entrypoint, exportStatement }) {
@@ -517,14 +551,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: Used for adding or modifying [Runtime plugins](#Runtime) in the generated entry files.
 - Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; plugins: RuntimePlugin[]; }>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryRuntimePlugins({ entrypoint, plugins }) {
@@ -552,14 +586,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: Used for modifying the `render` function in the generated entry files.
 - Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; code: string; }>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryRenderFunction({ entrypoint, code }) {
@@ -578,14 +612,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: Used for modifying the content of the generated front-end page routing files, which must be serializable.
 - Execution Stage: Executed before generating the front-end routing files, triggered during the [`prepare`](#prepare) stage.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; routes: Route[]; }>`
 - Usage Example:
 
 ```tsx
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyFileSystemRoutes({ entrypoint, routes }) {
@@ -612,14 +646,14 @@ This adds a new page route for the front-end.
 
 - Function: Used for modifying the content of the generated server routes.
 - Execution Stage: Executed before generating the server routing files, triggered during the [`prepare`](#prepare) stage.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ routes: ServerRoute[]; }>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyServerRoutes({ routes }) {
@@ -645,14 +679,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: Used for modifying the asynchronous module that wraps the entry file, see [source.enableAsyncEntry](/configure/app/source/enable-async-entry).
 - Execution Stage: Executed before generating the entry files, triggered during the [`prepare`](#prepare) stage.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; code: string; }>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyAsyncEntry({ entrypoint, code }) {
@@ -671,14 +705,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - Function: Used for customizing the generated HTML page template.
 - Execution Stage: Triggered during the [`prepare`](#prepare) stage.
-- Hook Model: AsyncWaterfall.
+- Hook model: `AsyncWaterfall`
 - Type: `AsyncWaterfall<{ entrypoint: Entrypoint; partials: HtmlPartials; }>`
 - Usage Example:
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       async htmlPartials({ entrypoint, partials }) {

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -5,15 +5,19 @@ sidebar_position: 8
 
 # Hook 列表
 
-在 Modern.js 中暴露了三类插件：CLI、Runtime、Server。下面列举下各类中的 Hook：
+Modern.js 工程体系中包含三类插件：CLI、Runtime、Server，每一类插件可以使用不同的 Hooks。
 
-## CLI
+在本章节中，罗列了所有可用的 Hooks，你可以根据自己的需求来使用对应的 Hook。
+
+## CLI Common Hooks
+
+以下是通用的 CLI Hooks，可以在 Modern.js Framework 以及 Modern.js Module 中使用。
 
 ### `beforeConfig`
 
 - 功能：运行收集配置前的任务
 - 执行阶段：收集配置前
-- Hook 模型：AsyncWorkflow
+- Hook 模型：`AsyncWorkflow`
 - 类型：`AsyncWorkflow<void, void>`
 - 使用示例：
 
@@ -35,7 +39,7 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：收集配置
 - 执行阶段：解析完 `modern.config.ts` 中的配置之后
-- Hook 模型：ParallelWorkflow
+- Hook 模型：`ParallelWorkflow`
 - 类型：`ParallelWorkflow<void, unknown>`
 - 使用示例：
 
@@ -55,13 +59,37 @@ export const myPlugin = (): CliPlugin => ({
 });
 ```
 
-这里返回的配置信息，会被收集和统一处理合并。
+如果你需要设置 Modern.js Framework 的配置，请使用 `@modern-js/app-tools` 导出的 `CliPlugin<AppTools>` 类型：
+
+```ts
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
+
+export const myPlugin = (): CliPlugin => ({
+  setup(api) {
+    return {
+      config: () => {
+        return {
+          output: {
+            polyfill: 'usage',
+          },
+        };
+      },
+    };
+  },
+});
+```
+
+插件在 `config` hook 中返回的配置信息，会被 Modern.js 统一收集与合并，最终生成一份 `NormalizedConfig`。在进行配置合并时，优先级由高到低依次为：
+
+1. 用户在 `modern.config.*` 文件里定义的配置
+2. 插件通过 `config` hook 定义的配置
+3. Modern.js 默认配置。
 
 ### `validateSchema`
 
 - 功能：收集各个插件中配置的用来校验用户配置的 [JSON Schema](https://json-schema.org/)
-- 执行阶段：`config` Hook 运行完之后。
-- Hook 模型：ParallelWorkflow
+- 执行阶段：`config` Hook 运行完成之后。
+- Hook 模型：`ParallelWorkflow`
 - 类型：`ParallelWorkflow<void, unknown>`
 - 使用示例：
 
@@ -116,7 +144,7 @@ export const myPlugin = defineConfig({
 
 就会报错：
 
-```sh
+```
 $ modern dev
   1 | {
 > 2 |   "foo": {},
@@ -127,7 +155,7 @@ $ modern dev
 
 - 功能：运行主流程的前置准备流程
 - 执行阶段：校验完配置之后
-- Hook 模型：AsyncWorkflow
+- Hook 模型：`AsyncWorkflow`
 - 类型：`AsyncWorkflow<void, void>`
 - 使用示例：
 
@@ -149,7 +177,7 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：运行前置准备流程的之后的任务
 - 执行阶段：前置准备流程之后
-- Hook 模型：AsyncWorkflow
+- Hook 模型：`AsyncWorkflow`
 - 类型：`AsyncWorkflow<void, void>`
 - 使用示例：
 
@@ -169,9 +197,9 @@ export const myPlugin = (): CliPlugin => ({
 
 ### `commands`
 
-- 功能：为 command 添加新的命令
-- 执行阶段：`prepare` Hook 运行完之后
-- Hook 模型：AsyncWorkflow
+- 功能：为 commander 添加新的 CLI 命令
+- 执行阶段：`prepare` Hook 运行完成之后
+- Hook 模型：`AsyncWorkflow`
 - 类型：`AsyncWorkflow<{ program: Command; }, void>`
 - 使用示例：
 
@@ -213,7 +241,7 @@ foo
 
 - 功能：在退出进程前，重置一些文件状态
 - 执行阶段：进程退出之前
-- Hook 模型：Workflow
+- Hook 模型：`Workflow`
 - 类型：`Workflow<void, void>`
 - 使用示例：
 
@@ -235,18 +263,24 @@ export const myPlugin = (): CliPlugin => ({
 由于 Node.js 中退出进程时的回调函数是同步的，所以 `beforeExit` Hook 的类型是 `Workflow`，不能执行异步操作。
 :::
 
+## CLI Framework Hooks
+
+以下是框架的 CLI Hooks，只能在 Modern.js Framework 中使用，不能在 Modern.js Module 中使用。
+
+你需要从 `@modern-js/app-tools` 中导入 `CliPlugin` 和 `AppTools` 类型，以获得准确的 Hooks 类型提示。
+
 ### `beforeDev`
 
 - 功能：运行 dev 主流程的之前的任务
 - 执行阶段：`dev` 命令运行时，项目开始启动前执行
-- Hook 模型：AsyncWorkflow
+- Hook 模型：`AsyncWorkflow`
 - 类型：`AsyncWorkflow<void, unknown>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       beforeDev: () => {
@@ -261,14 +295,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：运行 dev 主流程的之后的任务
 - 执行阶段：运行 `dev` 命令时，每一次编译完成后执行
-- Hook 模型：AsyncWorkflow
+- Hook 模型：`AsyncWorkflow`
 - 类型：`AsyncWorkflow<{ isFirstCompile: boolean }, unknown>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       afterDev: () => {
@@ -282,15 +316,80 @@ export const myPlugin = (): CliPlugin => ({
 `afterDev` 会在每一次编译完成后执行，你可以通过 `isFirstCompile` 参数来判断是否为首次编译：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       afterDev: ({ isFirstCompile }) => {
         if (isFirstCompile) {
           // do something
         }
+      },
+    };
+  },
+});
+```
+
+### `beforeBuild`
+
+- 功能：在执行生产环境构建前触发的回调函数，你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置数组。
+  - 如果当前打包工具为 webpack，则获取到的是 webpack 配置数组。
+  - 如果当前打包工具为 Rspack，则获取到的是 Rspack 配置数组。
+  - 配置数组中可能包含一份或多份配置，这取决于你是否开启了 SSR 等功能。
+- 执行阶段：运行 `build` 命令后，在开始构建前执行
+- Hook 模型：`AsyncWorkflow`
+- 类型：
+
+```ts
+type BeforeBuild = AsyncWorkflow<{
+  bundlerConfigs: WebpackConfig[] | RspackConfig[];
+}>;
+```
+
+- 使用示例：
+
+```ts
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
+
+export const myPlugin = (): CliPlugin<AppTools> => ({
+  setup(api) {
+    return {
+      beforeBuild: ({ bundlerConfigs }) => {
+        console.log('Before build.');
+        console.log(bundlerConfigs);
+      },
+    };
+  },
+});
+```
+
+### `afterBuild`
+
+- 功能：在执行生产环境构建后触发的回调函数，你可以通过 `stats` 参数获取到构建结果信息。
+  - 如果当前打包工具为 webpack，则获取到的是 webpack Stats。
+  - 如果当前打包工具为 Rspack，则获取到的是 Rspack Stats。
+- 执行阶段：运行 `build` 命令运行后，在项目构建完成之后执行
+- Hook 模型：`AsyncWorkflow`
+- 类型：
+
+```ts
+type AfterBuild = AsyncWorkflow<{
+  stats?: Stats | MultiStats;
+}>;
+```
+
+- 使用示例：
+
+```ts
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
+
+export const myPlugin = (): CliPlugin<AppTools> => ({
+  setup(api) {
+    return {
+      afterBuild: ({ stats }) => {
+        console.log('After build.');
+        console.log(stats);
       },
     };
   },
@@ -317,9 +416,9 @@ type BeforeCreateCompiler = AsyncWorkflow<
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       beforeCreateCompiler: ({ bundlerConfigs }) => {
@@ -350,9 +449,9 @@ type AfterCreateCompiler = AsyncWorkflow<
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       afterCreateCompiler: ({ compiler }) => {
@@ -368,14 +467,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：在中间件函数中可以拿到即将打印的日志信息，并对其进行修改
 - 执行阶段：打印日志信息之前执行
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ instructions: string }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       beforePrintInstructions: ({ instructions }) => {
@@ -389,83 +488,18 @@ export const myPlugin = (): CliPlugin => ({
 });
 ```
 
-### `beforeBuild`
-
-- 功能：在执行生产环境构建前触发的回调函数，你可以通过 `bundlerConfigs` 参数获取到底层打包工具的最终配置数组。
-  - 如果当前打包工具为 webpack，则获取到的是 webpack 配置数组。
-  - 如果当前打包工具为 Rspack，则获取到的是 Rspack 配置数组。
-  - 配置数组中可能包含一份或多份配置，这取决于你是否开启了 SSR 等功能。
-- 执行阶段：运行 `build` 命令后，在开始构建前执行
-- Hook 模型：`AsyncWorkflow`
-- 类型：
-
-```ts
-type BeforeBuild = AsyncWorkflow<{
-  bundlerConfigs: WebpackConfig[] | RspackConfig[];
-}>;
-```
-
-- 使用示例：
-
-```ts
-import type { CliPlugin } from '@modern-js/core';
-
-export const myPlugin = (): CliPlugin => ({
-  setup(api) {
-    return {
-      beforeBuild: ({ bundlerConfigs }) => {
-        console.log('Before build.');
-        console.log(bundlerConfigs);
-      },
-    };
-  },
-});
-```
-
-### `afterBuild`
-
-- 功能：在执行生产环境构建后触发的回调函数，你可以通过 `stats` 参数获取到构建结果信息。
-  - 如果当前打包工具为 webpack，则获取到的是 webpack Stats。
-  - 如果当前打包工具为 Rspack，则获取到的是 Rspack Stats。
-- 执行阶段：运行 `build` 命令运行后，在项目构建完成之后执行
-- Hook 模型：`AsyncWorkflow`
-- 类型：
-
-```ts
-type AfterBuild = AsyncWorkflow<{
-  stats?: Stats | MultiStats;
-}>;
-```
-
-- 使用示例：
-
-```ts
-import type { CliPlugin } from '@modern-js/core';
-
-export const myPlugin = (): CliPlugin => ({
-  setup(api) {
-    return {
-      afterBuild: ({ stats }) => {
-        console.log('After build.');
-        console.log(stats);
-      },
-    };
-  },
-});
-```
-
 ### `modifyEntryImports`
 
 - 功能：用于修改、添加生成入口文件中的 `import` 语句
 - 执行阶段：生成入口文件之前，[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ imports: ImportStatement[]; entrypoint: Entrypoint; }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryImports({ entrypoint, imports }) {
@@ -490,14 +524,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：用于修改生成入口文件中的 `export` 语句
 - 执行阶段：生成入口文件之前，[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ entrypoint: Entrypoint; exportStatement: string; }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryExport({ entrypoint, exportStatement }) {
@@ -517,14 +551,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：用于添加、修改生成入口文件中的 [Runtime 插件](#Runtime)
 - 执行阶段：生成入口文件之前，[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ entrypoint: Entrypoint; plugins: RuntimePlugin[]; }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryRuntimePlugins({ entrypoint, plugins }) {
@@ -552,14 +586,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：用于修改生成入口文件中 `render` 函数
 - 执行阶段：生成入口文件之前，[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ entrypoint: Entrypoint; code: string; }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyEntryRenderFunction({ entrypoint, code }) {
@@ -578,14 +612,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：用于修改生成前端页面路由文件中的内容，内容都是需要可序列化的
 - 执行阶段：生成前端路由文件之前，[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ entrypoint: Entrypoint; routes: Route[]; }>`
 - 使用示例：
 
 ```tsx
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyFileSystemRoutes({ entrypoint, routes }) {
@@ -612,14 +646,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：用于修改生成服务器路由中的内容
 - 执行阶段：生成 Server 路由文件之前，[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ routes: ServerRoute[]; }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyServerRoutes({ routes }) {
@@ -645,14 +679,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：用于修改包裹入口文件的异步模块，参见 [source.enableAsyncEntry](/configure/app/source/enable-async-entry)
 - 执行阶段：生成入口文件之前，[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ entrypoint: Entrypoint; code: string; }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       modifyAsyncEntry({ entrypoint, code }) {
@@ -671,14 +705,14 @@ export const myPlugin = (): CliPlugin => ({
 
 - 功能：用于定制生成的 HTML 页面模版
 - 执行阶段：[`prepare`](#prepare) 阶段触发
-- Hook 模型：AsyncWaterfall
+- Hook 模型：`AsyncWaterfall`
 - 类型：`AsyncWaterfall<{ entrypoint: Entrypoint; partials: HtmlPartials; }>`
 - 使用示例：
 
 ```ts
-import type { CliPlugin } from '@modern-js/core';
+import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 
-export const myPlugin = (): CliPlugin => ({
+export const myPlugin = (): CliPlugin<AppTools> => ({
   setup(api) {
     return {
       async htmlPartials({ entrypoint, partials }) {

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/hook-list.mdx
@@ -742,7 +742,7 @@ export const myPlugin = (): CliPlugin<AppTools> => ({
 
 - 功能：在中间件函数中会拿到 Server 初始化用到的指标测量工具配置 `measureOptions` 和日志工具配置 `loggerOptions`，并返回自定义的指标测量工具 `measure` 和日志工具配置 `logger`
 - 执行阶段：Server 初始化
-- Hook 模型：AsyncPipeline
+- Hook 模型：`AsyncPipeline`
 - 类型：`AsyncPipeline<ServerInitInput, InitExtension>`
 - 使用示例：
 
@@ -764,7 +764,7 @@ export const myPlugin = (): ServerPlugin => ({
 
 - 功能：设置 Web 路由的处理函数，在中间件函数中可以拿到 Web Server 的前置中间件
 - 执行阶段：在请求到达的时候
-- Hook 模型：AsyncPipeline
+- Hook 模型：`AsyncPipeline`
 - 类型：`AsyncPipeline<WebServerStartInput, Adapter>`
 - 使用示例：
 
@@ -790,7 +790,7 @@ export const myPlugin = (): ServerPlugin => ({
 
 - 功能：设置 API 路由的处理函数，在中间件函数中可以拿到 API Server 的前置中间件
 - 执行阶段：请求到达并且 match bff basename 之后执行
-- Hook 模型：AsyncPipeline
+- Hook 模型：`AsyncPipeline`
 - 类型：`AsyncPipeline<APIServerStartInput, Adapter>`
 - 使用示例：
 
@@ -825,7 +825,7 @@ Runtime 插件主要用于开发者修改需要渲染的组件。
 
 - 功能：执行 `App.init`
 - 执行阶段：渲染（SSR/CSR）
-- Hook 模型：AsyncPipeline
+- Hook 模型：`AsyncPipeline`
 - 类型：`AsyncPipeline<{ context: RuntimeContext; }, unknown>`
 - 使用示例：
 
@@ -848,7 +848,7 @@ export const myPlugin = (): Plugin => ({
 
 - 功能：修改需要渲染的组件
 - 执行阶段：渲染（SSR/CSR）
-- Hook 模型：Pipeline
+- Hook 模型：`Pipeline`
 - 类型：`Pipeline<{ App: React.ComponentType<any>; }, React.ComponentType<any>>`
 - 使用示例：
 
@@ -886,7 +886,7 @@ export const myPlugin = (): Plugin => ({
 
 - 功能：修改需要渲染的 Element
 - 执行阶段：渲染（SSR/CSR）
-- Hook 模型：Pipeline
+- Hook 模型：`Pipeline`
 - 类型：`Pipeline<{ element: JSX.Element; props: AppProps; context: RuntimeContext }, JSX.Element>`
 - 使用示例：
 
@@ -909,7 +909,7 @@ export const myPlugin = (): Plugin => ({
 
 - 功能：定制客户端渲染流程
 - 执行阶段：在浏览器客户端渲染
-- Hook 模型：AsyncPipeline
+- Hook 模型：`AsyncPipeline`
 - 类型：`AsyncPipeline<{ App: React.ComponentType<any>; context?: RuntimeContext; rootElement: HTMLElement; }, void>`
 - 使用示例：
 
@@ -935,7 +935,7 @@ export const myPlugin = (): Plugin => ({
 
 - 功能：定制服务器端渲染流程
 - 执行阶段：SSR
-- Hook 模型：AsyncPipeline
+- Hook 模型：`AsyncPipeline`
 - 类型：`AsyncPipeline<{ App: React.ComponentType<any>; context?: RuntimeContext; }, string>`
 - 使用示例：
 


### PR DESCRIPTION
## Summary

- Add tip for framework hooks
- Add description for the config hook
- Update example for framework hooks

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77c9dc8</samp>

This pull request updates the documentation of the framework plugin hooks in Modern.js in both English and Chinese, making it more accurate, consistent, and clear. It also aligns the code examples and type imports with the latest version of the framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77c9dc8</samp>

*  Update the introduction of the hook list to reflect the different types of plugins and hooks in the Modern.js engineering system. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L8-R22), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L8-R20))
*  Wrap the hook models in backticks for consistency and readability. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L38-R44), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L130-R160), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L152-R180), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L216-R246), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L460-R502), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L709-R746), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L731-R768), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L757-R794), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L791-R828), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L814-R851), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L852-R889), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L875-R912), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L902-R938), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L38-R42), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L130-R158), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L152-R180), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L216-R244), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L392-R446), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L411-R459), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L425-R484), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L461-R502), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L711-R745), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L733-R767), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L759-R793), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L794-R828), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L817-R851), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L855-R889), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L878-R912), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L904-R938))
*  Explain the usage of the `config` hook in more detail, with an example of setting the framework configuration and the priority of the configuration merging. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L58-R94), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L58-R92))
*  Change the code block language from `sh` to `` to avoid highlighting errors. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L119-R147), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L119-R147))
*  Clarify that the `commands` hook adds new CLI commands for the commander, not the command. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L172-R204), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L172-R202))
*  Change the section title from `CLI` to `CLI Framework Hooks` to indicate that these hooks are only available for the framework, not the module. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L238-R283), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L238-R283))
*  Change the type import from `@modern-js/core` to `@modern-js/app-tools` to get accurate type hints for hooks. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L238-R283), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L263-R305), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L285-R321), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L334-R392), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L367-R426), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L460-R502), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L492-R534), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L519-R561), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L554-R596), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L580-R622), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L614-R656), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L647-R689), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L673-R715), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L238-R283), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L264-R305), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L285-R321), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L461-R502), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L493-R534), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L520-R561), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L555-R596), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L581-R622), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L615-R656), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L648-R689), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L674-R715))
*  Change the hook names and descriptions to reflect the actual execution stages and functionalities. ([link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L300-R359), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L334-R392), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L367-R426), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L392-R459), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-8cb50e8ec6ba4acd0c56382b852947c0ea46c406c9f50b206b9d7aef97b1aee4L425-R484), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L300-R347), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L320-R359), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L334-R379), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L353-R392), [link](https://github.com/web-infra-dev/modern.js/pull/4249/files?diff=unified&w=0#diff-443c18184c33647680ec9765b59c383e2f92f3a7cfe7c7f7bb9516498df20cb5L367-R426))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
