### PR TITLE
fix: should export bff-runtime from the plugins

### DIFF
--- a/.changeset/few-bulldogs-fold.md
+++ b/.changeset/few-bulldogs-fold.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-express': patch
+'@modern-js/plugin-koa': patch
+'@modern-js/bff-core': patch
+---
+
+fix: should export bff-runtime from the plugins
+fix: 应该从插件中导出 bff-runtime

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -35,7 +35,6 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@modern-js/bff-runtime": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "koa-compose": "^4.1.0",
     "reflect-metadata": "^0.1.13",

--- a/packages/server/plugin-express/types.d.ts
+++ b/packages/server/plugin-express/types.d.ts
@@ -53,4 +53,5 @@ declare module '@modern-js/runtime/server' {
   export type { RequestHandler };
 
   export * from '@modern-js/bff-core';
+  export * from '@modern-js/bff-runtime';
 }

--- a/packages/server/plugin-koa/types.d.ts
+++ b/packages/server/plugin-koa/types.d.ts
@@ -42,4 +42,5 @@ declare module '@modern-js/runtime/server' {
   export function hook(attacher: KoaAttacher): KoaAttacher;
 
   export * from '@modern-js/bff-core';
+  export * from '@modern-js/bff-runtime';
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4039,9 +4039,6 @@ importers:
 
   packages/server/bff-core:
     dependencies:
-      '@modern-js/bff-runtime':
-        specifier: workspace:*
-        version: link:../bff-runtime
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2036d44</samp>

This pull request fixes a bug in the express and koa plugins for modern.js that prevented the bff-runtime module from being exported. It also removes an unnecessary dependency on bff-runtime from the bff-core package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2036d44</samp>

* Fix the issue of not exporting the bff-runtime module from the express and koa plugins ([link](https://github.com/web-infra-dev/modern.js/pull/4256/files?diff=unified&w=0#diff-67117a2c442e30e25e36732bd90aed36937d3a442fcec01de3bef5079eba4457R1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4256/files?diff=unified&w=0#diff-97f0b40e0c47e3b5c43ef6d2a85be7b105307b217fd714241a06a056297065e8L38),  )
  * Remove the dependency on bff-runtime from `bff-core/package.json` ([link](https://github.com/web-infra-dev/modern.js/pull/4256/files?diff=unified&w=0#diff-97f0b40e0c47e3b5c43ef6d2a85be7b105307b217fd714241a06a056297065e8L38))
  * Provide a bilingual description of the changes in `.changeset/few-bulldogs-fold.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4256/files?diff=unified&w=0#diff-67117a2c442e30e25e36732bd90aed36937d3a442fcec01de3bef5079eba4457R1-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
