### PR TITLE
fix(friendly-errors-plugin): missing compiled folder after releasing

### DIFF
--- a/.changeset/kind-boats-crash.md
+++ b/.changeset/kind-boats-crash.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/friendly-errors-webpack-plugin': patch
+---
+
+fix(friendly-errors-plugin): missing compiled folder after releasing
+
+fix(friendly-errors-plugin): 发布后缺少 compiled 目录

--- a/packages/builder/friendly-errors-webpack-plugin/package.json
+++ b/packages/builder/friendly-errors-webpack-plugin/package.json
@@ -84,6 +84,7 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "compiled"
   ]
 }


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/a9d5eca2-3285-4982-920b-f304dfd05c7a)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1285abf</samp>

This pull request fixes a bug in the `@modern-js/friendly-errors-webpack-plugin` package that caused the compiled folder to be missing after publishing. It adds a changeset file to document the patch update and modifies the `package.json` file to include the compiled folder in the files array.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1285abf</samp>

*  Fix bug where compiled folder was missing from `@modern-js/friendly-errors-webpack-plugin` package ([link](https://github.com/web-infra-dev/modern.js/pull/4259/files?diff=unified&w=0#diff-7fd8c84945dcb1fa2177dd6de8db7dd47787cfd3eb89315655089582a66b042cR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4259/files?diff=unified&w=0#diff-ce4be520f70a2ce04d870a56070a41ced322352fee1ed843789c0afb1cc34cddL87-R88))
  * Add changeset file to describe patch update and provide Chinese translation ([link](https://github.com/web-infra-dev/modern.js/pull/4259/files?diff=unified&w=0#diff-7fd8c84945dcb1fa2177dd6de8db7dd47787cfd3eb89315655089582a66b042cR1-R7))
  * Include compiled folder in files array of `package.json` file ([link](https://github.com/web-infra-dev/modern.js/pull/4259/files?diff=unified&w=0#diff-ce4be520f70a2ce04d870a56070a41ced322352fee1ed843789c0afb1cc34cddL87-R88))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
