### PR TITLE
fix(doc-core): empty temp dir before build

### DIFF
--- a/.changeset/light-peas-invite.md
+++ b/.changeset/light-peas-invite.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: empty temp dir before build
+fix: 在构建之前清空temp目录

--- a/packages/cli/doc-core/src/node/build.ts
+++ b/packages/cli/doc-core/src/node/build.ts
@@ -11,6 +11,7 @@ import {
   HTML_START_TAG,
   BODY_START_TAG,
   PUBLIC_DIR,
+  TEMP_DIR,
 } from './constants';
 import { createModernBuilder } from './createBuilder';
 import { writeSearchIndex } from './searchIndex';
@@ -216,6 +217,10 @@ export async function build(options: BuildOptions) {
   await pluginDriver.init();
   const modifiedConfig = await pluginDriver.modifyConfig();
   await pluginDriver.beforeBuild();
+
+  // empty temp dir before build
+  await fs.emptyDir(TEMP_DIR);
+
   await bundle(appDirectory, docDirectory, modifiedConfig, pluginDriver);
   await renderPages(appDirectory, modifiedConfig, pluginDriver);
   await pluginDriver.afterBuild();

--- a/packages/cli/doc-core/src/node/dev.ts
+++ b/packages/cli/doc-core/src/node/dev.ts
@@ -1,8 +1,10 @@
 import { UserConfig } from 'shared/types';
+import fs from '@modern-js/utils/fs-extra';
 import { removeLeadingSlash } from '../shared/utils';
 import { createModernBuilder } from './createBuilder';
 import { writeSearchIndex } from './searchIndex';
 import { PluginDriver } from './PluginDriver';
+import { TEMP_DIR } from './constants';
 
 interface ServerInstance {
   close: () => Promise<void>;
@@ -24,6 +26,8 @@ export async function dev(options: DevOptions): Promise<ServerInstance> {
   try {
     const modifiedConfig = await pluginDriver.modifyConfig();
     await pluginDriver.beforeBuild();
+    // empty temp dir before build
+    await fs.emptyDir(TEMP_DIR);
     const builder = await createModernBuilder(
       docDirectory,
       modifiedConfig,


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2eb23b9</samp>

This pull request fixes a bug in the doc-core package that could cause build failures due to leftover files in the temp directory. It also adds a changeset file to document the changes and the version bumps for the affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2eb23b9</samp>

* Add a changeset file to document the fixes for the temp directory issue in the doc-core package (.changeset/light-peas-invite.md)
* Empty the temp directory before the build process in the `createModernBuilder` function ([link](https://github.com/web-infra-dev/modern.js/pull/4263/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R191-R192))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
