### PR TITLE
fix(doc-core): use routePath for page key

### DIFF
--- a/.changeset/light-dryers-listen.md
+++ b/.changeset/light-dryers-listen.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): use routePath for page key
+
+fix(doc-core): 使用 routePath 作为页面 key

--- a/packages/cli/doc-core/src/node/route/RouteService.ts
+++ b/packages/cli/doc-core/src/node/route/RouteService.ts
@@ -259,7 +259,7 @@ ${this.getRoutes()
     return {
       routePath: normalizeRoutePath(routePath, this.#defaultLang, this.#base),
       absolutePath: normalizePath(filepath),
-      pageName: getPageKey(path.basename(filepath)),
+      pageName: getPageKey(routePath),
       lang: this.#getLang(filepath),
     };
   }

--- a/packages/cli/doc-core/theme.ts
+++ b/packages/cli/doc-core/theme.ts
@@ -1,11 +1,2 @@
-export {
-  Nav,
-  Search,
-  Tab,
-  Tabs,
-  Button,
-  Link,
-  HomeFooter,
-  getCustomMDXComponent,
-} from './dist/theme/index';
+export * from './dist/theme/index';
 export { default } from './dist/theme/index';


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at becdaee</samp>

This pull request fixes a bug in the `doc-core` package that caused the page key to be inconsistent with the route path when using different languages or base paths. It also simplifies the export statement in the `theme.ts` file of the same package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at becdaee</samp>

*  Fix page key bug in `doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4265/files?diff=unified&w=0#diff-f405ee4bbd7fd29f3eb17abdaa01e4157193d6e499ec7c274fbbecbce510cba8R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4265/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086L262-R262))
* Simplify export statement in `theme.ts` file of `doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4265/files?diff=unified&w=0#diff-071f0af901d9f37ead8f7301c4c6cffa765a3b0e1ba238808265333ca1ba107dL1-R1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
