### PR TITLE
fix(doc-core): redirect to incorrect language page

### DIFF
--- a/.changeset/mighty-schools-juggle.md
+++ b/.changeset/mighty-schools-juggle.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): redirect to incorrect language page
+
+fix(doc-core): 重定向不存在的语言页面

--- a/packages/cli/doc-core/src/theme-default/components/Nav/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Nav/index.tsx
@@ -74,7 +74,7 @@ export function Nav(props: NavProps) {
   const [isMobile, setIsMobile] = useState(false);
   const localeLanguages = Object.values(siteData.themeConfig.locales || {});
   const hasMultiLanguage = localeLanguages.length > 1;
-  const socialLinks = siteData?.themeConfig?.socialLinks || [];
+  const socialLinks = siteData.themeConfig.socialLinks || [];
   const hasSocialLinks = socialLinks.length > 0;
   const defaultLang = siteData.lang || 'zh';
   const { lang } = page;

--- a/packages/cli/doc-core/src/theme-default/layout/Layout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/Layout/index.tsx
@@ -54,6 +54,8 @@ export const Layout: React.FC<LayoutProps> = props => {
   // Priority: front matter title > h1 title
   let title = (frontmatter?.title as string) ?? articleTitle;
   const mainTitle = siteData.title || localesData.title;
+  const localeLanguages = Object.values(siteData.themeConfig.locales || {});
+  const langs = localeLanguages.map(item => item.lang) || [];
 
   if (title && pageType === 'doc') {
     // append main title as a suffix
@@ -102,7 +104,9 @@ export const Layout: React.FC<LayoutProps> = props => {
       localStorage.setItem(FIRST_VISIT_KEY, '1');
     }
     const targetLang = window.navigator.language.split('-')[0];
-
+    if (!langs.includes(targetLang)) {
+      return;
+    }
     if (targetLang !== currentLang) {
       if (targetLang === defaultLang) {
         // Redirect to the default language


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93e48de</samp>

This pull request fixes a bug in the language redirection logic for the CLI documentation and removes some redundant code. It also updates the doc-core package version and adds a changeset file with a Chinese translation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93e48de</samp>

*  Prevent redirecting to non-existent language page based on browser language in doc-core package ([link](https://github.com/web-infra-dev/modern.js/pull/4271/files?diff=unified&w=0#diff-ad0dae9c2c9edde59e66297213d95b5b033e379f05ff677cdca9c350ca541357R57-R58), [link](https://github.com/web-infra-dev/modern.js/pull/4271/files?diff=unified&w=0#diff-ad0dae9c2c9edde59e66297213d95b5b033e379f05ff677cdca9c350ca541357L105-R109), [link](https://github.com/web-infra-dev/modern.js/pull/4271/files?diff=unified&w=0#diff-916993979efc1b886ee17243523b91178df671af1967af2b1aaabfbc9fffed4bR1-R7))
* Remove unnecessary optional chaining operator from accessing `socialLinks` property of `themeConfig` object in `Nav` component ([link](https://github.com/web-infra-dev/modern.js/pull/4271/files?diff=unified&w=0#diff-2216029e0e76685016b677fdc1bc777e116d48f3ccd39775d088f9730d53a892L77-R77))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
