### PR TITLE
docs(ssr): fix codes in serverless pre-render doc

### DIFF
--- a/packages/document/main-doc/docs/en/guides/advanced-features/ssr.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/ssr.mdx
@@ -159,10 +159,10 @@ Using SPR in Modern.js is very simple. Just add the PreRender component to your 
 
 Here is a simulated component that uses the useLoaderData API. The request in the Data Loader takes 2 seconds to consume.
 
-```jsx
+```tsx title="page.loader.ts"
 import { useLoaderData } from '@modern-js/runtime/router';
 
-export const loader = async () => {
+export default async () => {
   await new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve(null);
@@ -173,6 +173,10 @@ export const loader = async () => {
     message: 'Hello Modern.js',
   };
 };
+```
+
+```tsx title="page.tsx"
+import { useLoaderData } from '@modern-js/runtime/router';
 
 export default () => {
   const data = useLoaderData();

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/ssr.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/ssr.mdx
@@ -149,8 +149,6 @@ SPR 利用预渲染与缓存技术，为 SSR 页面提供静态 Web 的响应性
 这里模拟一个使用 `useLoaderData` API 的组件，Data Loader 中的请求需要消耗 2s 时间。
 
 ```tsx title="page.loader.ts"
-import { useLoaderData } from '@modern-js/runtime/router';
-
 export default async () => {
   await new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -165,6 +163,8 @@ export default async () => {
 ```
 
 ```tsx title="page.tsx"
+import { useLoaderData } from '@modern-js/runtime/router';
+
 export default () => {
   const data = useLoaderData();
   return <div>{data?.message}</div>;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bf17ed</samp>

This pull request updates the SSR documentation in both English and Chinese for modern.js. It improves the readability and accuracy of the code examples in `ssr.mdx` files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bf17ed</samp>

*  Add title attribute to loader function code block in English SSR document ([link](https://github.com/web-infra-dev/modern.js/pull/4273/files?diff=unified&w=0#diff-330ac39a323be9cad02c25d9ca808b23c9a705fa6e05ad03ef7aa8fd3a8166d8L162-R165))
*  Split loader function and component code blocks in English SSR document for clarity ([link](https://github.com/web-infra-dev/modern.js/pull/4273/files?diff=unified&w=0#diff-330ac39a323be9cad02c25d9ca808b23c9a705fa6e05ad03ef7aa8fd3a8166d8L176-R180))
*  Remove duplicate import statement for useLoaderData hook in Chinese SSR document ([link](https://github.com/web-infra-dev/modern.js/pull/4273/files?diff=unified&w=0#diff-676a4cee77af7d5251c78fe69b877e1bc5eb6dd3163152ef456bf83743288863L152-L153))
*  Add import statement for useLoaderData hook in Chinese SSR document for consistency ([link](https://github.com/web-infra-dev/modern.js/pull/4273/files?diff=unified&w=0#diff-676a4cee77af7d5251c78fe69b877e1bc5eb6dd3163152ef456bf83743288863R166-R167))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
