### PR TITLE
chore(turbo): test changes should not invalidate the build cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,18 +3,13 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [
-        "dist/**/*",
-        "compiled/config-validate/**/*",
-        "!dist/node/main.js"
-      ],
+      "outputs": ["dist/**/*", "!dist/node/main.js"],
       "inputs": [
         "src/**/*",
         "tsconfig.json",
         "package.json",
-        "modern.config.js",
-        "scripts/**/*.ts",
-        "tests/**/*"
+        "modern.config.*",
+        "scripts/**/*.ts"
       ]
     }
   }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8464835</samp>

Simplify the `build` task in `turbo.json` by removing unnecessary output and allowing different file extensions for `modern.config.*`. This improves the performance and flexibility of the modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8464835</samp>

*  Simplify the `build` task in `turbo.json` by removing unnecessary output and allowing different config file extensions ([link](https://github.com/web-infra-dev/modern.js/pull/4279/files?diff=unified&w=0#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3L6-R12))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
