### PR TITLE
fix(module-doc): support module sidebar when user don't have zh or en dir in root

### DIFF
--- a/.changeset/large-scissors-sniff.md
+++ b/.changeset/large-scissors-sniff.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+fix: support module sidebar when user don't have zh or en dir in root
+fix: 当用户没有 zh 或者 en 目录时，仍然支持 module sidebar

--- a/packages/cli/doc-core/src/node/createBuilder.ts
+++ b/packages/cli/doc-core/src/node/createBuilder.ts
@@ -188,6 +188,8 @@ export async function createModernBuilder(
   const cwd = process.cwd();
   const userRoot = path.resolve(rootDir || config.doc?.root || cwd);
   // We use a temp dir to store runtime files, so we can separate client and server build
+  // and we should empty temp dir before build
+  await fs.emptyDir(TEMP_DIR);
   const runtimeTempDir = path.join(TEMP_DIR, 'runtime');
   await fs.ensureDir(runtimeTempDir);
   const routeService = await initRouteService({

--- a/packages/module/plugin-module-doc/src/features/lanchDoc.ts
+++ b/packages/module/plugin-module-doc/src/features/lanchDoc.ts
@@ -24,7 +24,22 @@ export async function launchDoc({
   const DEFAULT_LANG = languages[0];
   const { dev, build } = await import('@modern-js/doc-core');
 
-  const base = join(root, DEFAULT_LANG);
+  // Compatible with older, poorer designs.
+  // If user don't have 'zh' or 'en' dir, we will use root instead.
+  const defaultBase = join(root, DEFAULT_LANG);
+  const defaultLocales = [
+    {
+      lang: 'zh',
+      label: '简体中文',
+    },
+    {
+      lang: 'en',
+      label: 'English',
+    },
+  ];
+  const base = (await fs.readdir(defaultBase)).length > 0 ? defaultBase : root;
+  const locales = languages.length === 2 ? defaultLocales : undefined;
+
   const getAutoSidebar = async (): Promise<Sidebar> => {
     const traverse = async (cwd: string): Promise<SidebarGroup['items']> => {
       // FIXME: win32
@@ -93,19 +108,7 @@ export async function launchDoc({
       ],
     };
   };
-  const locales =
-    languages.length === 2
-      ? [
-          {
-            lang: 'zh',
-            label: '简体中文',
-          },
-          {
-            lang: 'en',
-            label: 'English',
-          },
-        ]
-      : undefined;
+
   const modernDocConfig = mergeModuleDocConfig<UserConfig>(
     {
       doc: {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f01731</samp>

This pull request fixes some issues with the `plugin-module-doc` package and improves its compatibility with different language directories. It also adds a changeset file to document the fixes and a line of code to clean the temporary directory before building the documentation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f01731</samp>

*  Add a changeset file to document the fixes for the plugin-module-doc package ([link](https://github.com/web-infra-dev/modern.js/pull/4285/files?diff=unified&w=0#diff-e772098cbda895acd5967cd32fa3c0cde506f1d413dfcfa5f782710d39ccf797R1-R6))
*  Empty the temporary directory before building the documentation in the doc-core package ([link](https://github.com/web-infra-dev/modern.js/pull/4285/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R191-R192))
*  Support the module sidebar feature when the user does not have a zh or en directory in the root of their project in the plugin-module-doc package ([link](https://github.com/web-infra-dev/modern.js/pull/4285/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L27-R42))
*  Remove redundant locales variable declaration and unnecessary blank lines from the launchDoc function in `plugin-module-doc/src/features/lanchDoc.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4285/files?diff=unified&w=0#diff-f124dfe03b780dd75a5a97595b1e2087bb699538d58b8d1ec4f7fd1a9d06c0e9L96-R111))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
