### PR TITLE
feat(builder): support project references for source code build mode

### DIFF
--- a/.changeset/wise-yaks-love.md
+++ b/.changeset/wise-yaks-love.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder': minor
+---
+
+feat(builder): source code build feature support project reference by adding tsCheck configuration
+feat(builder): 源码构建增加 tsCheck 配置支持 project reference 的情况

--- a/tests/integration/source-code-build/app/modern.config.ts
+++ b/tests/integration/source-code-build/app/modern.config.ts
@@ -4,9 +4,6 @@ export default defineConfig({
   runtime: {
     state: true,
   },
-  output: {
-    disableTsChecker: true,
-  },
   plugins: [
     appTools({
       bundler:

--- a/tests/integration/source-code-build/components/package.json
+++ b/tests/integration/source-code-build/components/package.json
@@ -21,7 +21,7 @@
         "./dist/types/index.d.ts"
       ],
       "card": [
-        "./dist/types/card/index.ts"
+        "./dist/types/card/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9438c1f</samp>

This pull request adds support for source code build mode for TypeScript projects with project references in the `@modern-js/builder` package. It also updates the integration tests and the changeset file for this feature.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9438c1f</samp>

*  Add a changeset file to document the changes for the `@changesets/cli` tool ([link](https://github.com/web-infra-dev/modern.js/pull/4286/files?diff=unified&w=0#diff-6cf6d0610c6009a735393ffd136677c2331331db3c56e07404852c246bdecc1bR1-R6))
*  Import a type definition from `@modern-js/builder-webpack-provider` to access the webpack builder plugin configuration ([link](https://github.com/web-infra-dev/modern.js/pull/4286/files?diff=unified&w=0#diff-e894d618992ca3ef64b2f399f4275b6723da055ccb84fc13c8d8c9409a43f5e8R2))
*  Add a variable `enableSourceBuild` to check if the `experiments.sourceBuild` option is enabled in the builder configuration ([link](https://github.com/web-infra-dev/modern.js/pull/4286/files?diff=unified&w=0#diff-e894d618992ca3ef64b2f399f4275b6723da055ccb84fc13c8d8c9409a43f5e8R48-R52))
*  Add a conditional object to the `ForkTsCheckerWebpackPlugin` options to enable type checking for project references in source build mode ([link](https://github.com/web-infra-dev/modern.js/pull/4286/files?diff=unified&w=0#diff-e894d618992ca3ef64b2f399f4275b6723da055ccb84fc13c8d8c9409a43f5e8R61-R68))
*  Remove the `output.disableTsChecker` option from the `app` package configuration in the integration test for source code build, as it is no longer needed ([link](https://github.com/web-infra-dev/modern.js/pull/4286/files?diff=unified&w=0#diff-0f45805098e87aa19a1053e82cc534f1bc506d28b7f20706cd60cf08038f88dcL7-L9))
*  Fix a typo in the `card` entry point of the `components` package in the integration test for source code build, to point to the `.d.ts` file instead of the `.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4286/files?diff=unified&w=0#diff-973cc6dbda9e51c378857f61583d8fea2ebd5a4a879dd0e2c3f3baa627446d3bL24-R24))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
