### PR TITLE
fix(doc-core): avoid internal url exposure

### DIFF
--- a/.changeset/moody-humans-turn.md
+++ b/.changeset/moody-humans-turn.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): clear the compile-time path in output bundle to avoid internal path exposure
+
+fix(doc-core): 在输出的 bundle 中清除编译时的路径以避免暴露内网路径

--- a/packages/cli/doc-core/src/node/mdx/loader.ts
+++ b/packages/cli/doc-core/src/node/mdx/loader.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { Rspack } from '@modern-js/builder-rspack-provider';
 import { createProcessor } from '@mdx-js/mdx';
 import grayMatter from 'gray-matter';
@@ -92,7 +93,7 @@ export default async function mdxLoader(
     // encode filename to be compatible with Windows
     const result = `globalThis.__RSPRESS_PAGE_META ||= {};
 globalThis.__RSPRESS_PAGE_META["${encodeURIComponent(
-      normalizePath(filepath),
+      normalizePath(path.relative(docDirectory, filepath)),
     )}"] = ${JSON.stringify(pageMeta)};
 ${compileResult}`;
     callback(null, result);

--- a/packages/cli/doc-core/src/node/route/RouteService.ts
+++ b/packages/cli/doc-core/src/node/route/RouteService.ts
@@ -117,6 +117,7 @@ export class RouteService {
       const routeInfo = {
         routePath,
         absolutePath: normalizePath(absolutePath),
+        relativePath: fileRelativePath,
         pageName: getPageKey(fileRelativePath),
         lang,
       };
@@ -236,7 +237,7 @@ ${this.getRoutes()
      *   filePath: '/Users/xxx/xxx/index.md'
      * }
      */
-    return `{ path: '${route.routePath}', element: React.createElement(${component}), filePath: '${route.absolutePath}', preload: ${preload}, lang: '${route.lang}' }`;
+    return `{ path: '${route.routePath}', element: React.createElement(${component}), filePath: '${route.relativePath}', preload: ${preload}, lang: '${route.lang}' }`;
   })
   .join(',\n')}
 ];
@@ -259,6 +260,7 @@ ${this.getRoutes()
     return {
       routePath: normalizeRoutePath(routePath, this.#defaultLang, this.#base),
       absolutePath: normalizePath(filepath),
+      relativePath: normalizePath(path.relative(this.#scanDir, filepath)),
       pageName: getPageKey(routePath),
       lang: this.#getLang(filepath),
     };

--- a/packages/cli/doc-core/src/node/runtimeModule/siteData.ts
+++ b/packages/cli/doc-core/src/node/runtimeModule/siteData.ts
@@ -43,12 +43,13 @@ function deletePriviteKey<T>(obj: T): T {
   if (typeof obj !== 'object' || obj === null) {
     return obj;
   }
-  Object.keys(obj).forEach(key => {
+  const newObj = { ...obj };
+  Object.keys(newObj).forEach(key => {
     if (key.startsWith('_')) {
-      delete obj[key];
+      delete newObj[key];
     }
   });
-  return obj;
+  return newObj;
 }
 
 export function normalizeThemeConfig(
@@ -365,26 +366,26 @@ export async function siteDataVMPlugin(context: FactoryContext) {
   }
 
   // Categorize pages, sorted by language, and write search index to file
-  const pagesByLang = deletePriviteKey<PageIndexInfo[]>(pages).reduce(
-    (acc, page) => {
-      if (!acc[page.lang]) {
-        acc[page.lang] = [];
-      }
-      if (page.frontmatter?.pageType === 'home') {
-        return acc;
-      }
-      acc[page.lang].push(page);
+  const pagesByLang = pages.reduce((acc, page) => {
+    if (!acc[page.lang]) {
+      acc[page.lang] = [];
+    }
+    if (page.frontmatter?.pageType === 'home') {
       return acc;
-    },
-    {} as Record<string, PageIndexInfo[]>,
-  );
+    }
+    acc[page.lang].push(page);
+    return acc;
+  }, {} as Record<string, PageIndexInfo[]>);
 
   const indexHashByLang = {} as Record<string, string>;
 
   // Generate search index by different languages, file name is {SEARCH_INDEX_NAME}.{lang}.{hash}.json
   await Promise.all(
     Object.keys(pagesByLang).map(async lang => {
-      const stringfiedIndex = JSON.stringify(pagesByLang[lang]);
+      // Avoid writing filepath in compile-time
+      const stringfiedIndex = JSON.stringify(
+        pagesByLang[lang].map(deletePriviteKey),
+      );
       const indexHash = createHash(stringfiedIndex);
       indexHashByLang[lang] = indexHash;
       await fs.ensureDir(TEMP_DIR);
@@ -406,12 +407,11 @@ export async function siteDataVMPlugin(context: FactoryContext) {
     icon: userConfig?.icon || '',
     themeConfig: normalizeThemeConfig(userConfig, pages),
     base: userConfig?.base || '/',
-    root: userRoot,
     lang: userConfig?.lang || '',
     logo: userConfig?.logo || '',
     search: userConfig?.search ?? { mode: 'local' },
     pages: pages.map(page => {
-      const { content, id, domain, ...rest } = page;
+      const { content, id, domain, _filepath, ...rest } = page;
       return rest;
     }),
     markdown: {

--- a/packages/cli/doc-core/src/shared/types/index.ts
+++ b/packages/cli/doc-core/src/shared/types/index.ts
@@ -17,6 +17,7 @@ export type { DocPlugin, AdditionalPage };
 export interface RouteMeta {
   routePath: string;
   absolutePath: string;
+  relativePath: string;
   pageName: string;
   lang: string;
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f676de5</samp>

This pull request fixes the issue of exposing internal paths in the output bundle of the documentation site. It replaces the `filePath` property with the `relativePath` property in the route objects and the page objects, and uses the `path` module to normalize the paths. It also updates the changelog and the type definition for the `@modern-js/doc-core` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f676de5</samp>

*  Add a markdown file to the `.changeset` folder to generate changelogs and version updates for the `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-904ddfd9fe51e4e86308d496e79ad39fb76a5aa1d9141c593de0125f042693f5R1-R7))
* Replace the absolute paths of the MDX files with the relative paths from the root or scan directory in the `mdx/loader.ts`, `RouteService.ts`, and `siteData.ts` files to avoid exposing the internal paths in the output bundle ([link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-a566ae5e894b282eb04e5dfac055648d9707f4e96293def12c6a32a1bbd40dccL95-R96), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086R120), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086L239-R240), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086R263), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL387-R388), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL409-R414))
* Add a new property `relativePath` to the `RouteMeta` interface and the `route` objects to pass the relative paths of the MDX files to the `routes` value in the `RouteService.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086R120), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-847d923c099e75b431c7eb242cf8002b18792b738d89ef2b9e7de3c9b1f62086R263), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-3b9ef78ff832598dcdf880304579f2f3fc95e1dc287ff5a94f1d0e04b162927eR20))
* Delete the properties that start with `_` from the page objects in the `siteData.ts` file to avoid exposing the internal paths in the output bundle ([link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL46-R52), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL368-R378), [link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL387-R388))
* Remove the unnecessary properties from the page objects in the `siteData.ts` file to reduce the size of the site data ([link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-7035015058e915e5353012c1d3fdc789c14735a85a6931d0a661c0693cf2ddeaL409-R414))
* Import the `path` module from Node.js in the `mdx/loader.ts` file to manipulate file paths in a cross-platform way ([link](https://github.com/web-infra-dev/modern.js/pull/4287/files?diff=unified&w=0#diff-a566ae5e894b282eb04e5dfac055648d9707f4e96293def12c6a32a1bbd40dccR1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
