### PR TITLE
feat(builder): add an error tip for source.include

### DIFF
--- a/.changeset/smart-seals-hide.md
+++ b/.changeset/smart-seals-hide.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/utils': patch
+---
+
+feat(builder): add an error tip for source.include
+
+feat(builder): 增加 source.include 常见问题的提示日志

--- a/packages/builder/builder-shared/src/format.ts
+++ b/packages/builder/builder-shared/src/format.ts
@@ -7,7 +7,7 @@ export function formatStats(stats: Stats | MultiStats, showWarnings = true) {
     preset: 'errors-warnings',
   });
 
-  const { errors, warnings } = formatWebpackMessages(statsData);
+  const { errors, warnings } = formatWebpackMessages(statsData, chalk);
 
   if (errors.length) {
     const errorMsgs = `${errors.join('\n\n')}\n`;

--- a/packages/toolkit/utils/src/universal/formatWebpack.ts
+++ b/packages/toolkit/utils/src/universal/formatWebpack.ts
@@ -87,8 +87,59 @@ function formatMessage(stats: webpack.StatsError | string) {
   return message.trim();
 }
 
+type ErrorHelper = {
+  validator: (message: string) => boolean | void;
+  formatter: (message: string) => string;
+};
+
+const noop = (message: string) => message;
+const defaultColor = {
+  gray: noop,
+  cyan: noop,
+  green: noop,
+  yellow: noop,
+  underline: noop,
+};
+
+export function addErrorTips(errors: string[], color = defaultColor) {
+  const errorHelpers: ErrorHelper[] = [
+    {
+      validator(message) {
+        return (
+          (message.includes('You may need an appropriate loader') ||
+            message.includes('You may need an additional loader')) &&
+          message.includes('.ts')
+        );
+      },
+      formatter(message) {
+        return `${message}\n\n${color.yellow(
+          `If it is a TypeScript file, you can use "source.include" config to compile it. see ${color.underline(
+            'https://modernjs.dev/builder/en/api/config-source.html#sourceinclude',
+          )}`,
+        )}
+
+${color.green(`${color.gray('// config file')}
+export default {
+  source: {
+    include: [
+      ${color.gray('// add some include rules')}
+    ]
+  }
+}`)}
+        `;
+      },
+    },
+  ];
+
+  return errors.map(error => {
+    const helper = errorHelpers.find(item => item.validator(error));
+    return helper ? helper.formatter(error) : error;
+  });
+}
+
 function formatWebpackMessages(
   json?: Pick<StatsCompilation, 'errors' | 'warnings'>,
+  color = defaultColor,
 ): {
   errors: string[];
   warnings: string[];
@@ -99,6 +150,7 @@ function formatWebpackMessages(
   const result = {
     errors: formattedErrors || [],
     warnings: formattedWarnings || [],
+    errorTips: [],
   };
 
   if (result.errors?.some(isLikelyASyntaxError)) {
@@ -110,6 +162,8 @@ function formatWebpackMessages(
   if (result.errors.length > 1) {
     result.errors.length = 1;
   }
+
+  result.errors = addErrorTips(result.errors, color);
 
   return result;
 }

--- a/packages/toolkit/utils/tests/universal/__snapshots__/formatWebpack.test.ts.snap
+++ b/packages/toolkit/utils/tests/universal/__snapshots__/formatWebpack.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`addErrorTips Should format "You may need an appropriate loader" for TypeScript files 1`] = `
+[
+  "File: ./node_modules/foo/index.ts
+Module parse failed: Unexpected token (1:14)
+You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
+> export const a: string = 1;
+
+
+If it is a TypeScript file, you can use "source.include" config to compile it. see https://modernjs.dev/builder/en/api/config-source.html#sourceinclude
+
+// config file
+export default {
+  source: {
+    include: [
+      // add some include rules
+    ]
+  }
+}
+        ",
+]
+`;
+
+exports[`addErrorTips Should not format "You may need an appropriate loader" for non-TypeScript files 1`] = `
+[
+  "File: ./node_modules/foo/index.foo
+Module parse failed: Unexpected token (1:14)
+You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
+> export const a: string = 1;
+",
+]
+`;

--- a/packages/toolkit/utils/tests/universal/formatWebpack.test.ts
+++ b/packages/toolkit/utils/tests/universal/formatWebpack.test.ts
@@ -1,0 +1,27 @@
+import { addErrorTips } from '../../src/universal/formatWebpack';
+
+describe('addErrorTips', () => {
+  test('Should format "You may need an appropriate loader" for TypeScript files', () => {
+    expect(
+      addErrorTips([
+        `File: ./node_modules/foo/index.ts
+Module parse failed: Unexpected token (1:14)
+You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
+> export const a: string = 1;
+`,
+      ]),
+    ).toMatchSnapshot();
+  });
+
+  test('Should not format "You may need an appropriate loader" for non-TypeScript files', () => {
+    expect(
+      addErrorTips([
+        `File: ./node_modules/foo/index.foo
+Module parse failed: Unexpected token (1:14)
+You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
+> export const a: string = 1;
+`,
+      ]),
+    ).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary

### Original Error

<img width="1178" alt="Screenshot 2023-07-24 at 18 55 33" src="https://github.com/web-infra-dev/modern.js/assets/7237365/1d098390-ed3b-4d79-b6e1-aab2ef3843f9">

### Formatted Error

<img width="1179" alt="Screenshot 2023-07-24 at 18 55 46" src="https://github.com/web-infra-dev/modern.js/assets/7237365/1a5988b3-c585-44bf-b270-b2c42008fa90">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63bccbc</samp>

This pull request adds a new feature to the `@modern-js/utils` and `@modern-js/builder-shared` packages to improve the error reporting of webpack compilation. It enhances the error messages with tips or suggestions for common problems, and colorizes the output for better readability. It also adds a changeset file and a test file to document and verify the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63bccbc</samp>

*  Add a changeset file to document the features and versioning impact of the changes ([link](https://github.com/web-infra-dev/modern.js/pull/4288/files?diff=unified&w=0#diff-7054930c91939abb049beadbfeb66cb6a938c896563bd82b04845779e487cf1aR1-R8))
*  Pass the `chalk` module to the `formatWebpackMessages` function in the `@modern-js/builder-shared` package to colorize the output messages ([link](https://github.com/web-infra-dev/modern.js/pull/4288/files?diff=unified&w=0#diff-8dc6e5e9db15efc7918d82c179534ebfbdea20648c3d828819694b84de3e6a28L10-R10))
*  Add a new function `addErrorTips` and a new type `ErrorHelper` to the `@modern-js/utils` package to enhance the error messages with tips or suggestions ([link](https://github.com/web-infra-dev/modern.js/pull/4288/files?diff=unified&w=0#diff-933d8dde0e7dd1bfbfb7e55cca82f6c84b5e545a89b280f03252991db64193f0L90-R142))
*  Modify the `formatWebpackMessages` function in the `@modern-js/utils` package to accept a `color` parameter and to use the `addErrorTips` function to format the errors ([link](https://github.com/web-infra-dev/modern.js/pull/4288/files?diff=unified&w=0#diff-933d8dde0e7dd1bfbfb7e55cca82f6c84b5e545a89b280f03252991db64193f0L90-R142), [link](https://github.com/web-infra-dev/modern.js/pull/4288/files?diff=unified&w=0#diff-933d8dde0e7dd1bfbfb7e55cca82f6c84b5e545a89b280f03252991db64193f0R166-R167))
*  Add a new property `errorTips` to the result object returned by the `formatWebpackMessages` function in the `@modern-js/utils` package to contain the formatted error tips ([link](https://github.com/web-infra-dev/modern.js/pull/4288/files?diff=unified&w=0#diff-933d8dde0e7dd1bfbfb7e55cca82f6c84b5e545a89b280f03252991db64193f0R153))
*  Add a new test file `formatWebpack.test.ts` to the `@modern-js/utils` package to test the `addErrorTips` function with different scenarios and snapshots ([link](https://github.com/web-infra-dev/modern.js/pull/4288/files?diff=unified&w=0#diff-77972bbd6a0715f3551041649f2cd10b64fb7c87a02e6bd4faac7b9cd6860edfR1-R27))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
