### PR TITLE
test(CI): exclude generators when running Vitest CI

### DIFF
--- a/.github/workflows/vitest-Windows.yml
+++ b/.github/workflows/vitest-Windows.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build packages
         if: ${{steps.docs-change.outputs.DOCS_CHANGE != 'docs only change'}}
-        run: pnpm build:skip-dts
+        run: pnpm build:vitest
 
       - name: Test
         if: ${{steps.docs-change.outputs.DOCS_CHANGE != 'docs only change'}}

--- a/.github/workflows/vitest-macOS.yml
+++ b/.github/workflows/vitest-macOS.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build packages
         if: ${{steps.docs-change.outputs.DOCS_CHANGE != 'docs only change'}}
-        run: pnpm build:skip-dts
+        run: pnpm build:vitest
 
       - name: Test
         if: ${{steps.docs-change.outputs.DOCS_CHANGE != 'docs only change'}}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:e2e": "cd tests && npm run test",
     "fast-lint": "sh -x ./scripts/fast-lint.sh",
     "lint:package-json": "cd ./scripts/lint-package-json && pnpm start",
-    "build:skip-dts": "cross-env SKIP_DTS=true pnpm --filter {packages/**} run build",
+    "build:vitest": "cross-env SKIP_DTS=true pnpm --filter \"./packages/!(generator)/**\" run build",
     "prepare": "turbo run build --filter {packages/**} --cache-dir=.turbo --no-daemon && husky install",
     "lint": "npm run fast-lint",
     "change": "modern change",


### PR DESCRIPTION
## Summary

Exclude generators when running Vitest CI, this change can make Vitest CI faster.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
