### PR TITLE
fix(doc-core): support user custom mdx components

### DIFF
--- a/.changeset/stupid-paws-attack.md
+++ b/.changeset/stupid-paws-attack.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+feat(doc-core): support user custom mdx components
+
+feat(doc-core): 支持用户自定义 mdx 组件

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { MDXProvider } from '@mdx-js/react';
+import { getCustomMDXComponent } from '@theme';
 import { Aside } from '../../components/Aside';
 import { DocFooter } from '../../components/DocFooter';
 import { useLocaleSiteData, useSidebarData } from '../../logic';
@@ -8,7 +9,6 @@ import { SideMenu } from '../../components/LocalSideBar';
 import { Overview } from '../../components/Overview';
 import { TabDataContext } from '../../logic/TabDataContext';
 import styles from './index.module.scss';
-import { getCustomMDXComponent } from './docComponents';
 import { Content, usePageData, normalizeSlash } from '@/runtime';
 
 export interface DocLayoutProps {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c9b7c2</samp>

Refactor `DocLayout` component to use `@theme` module and add support for user custom mdx components in `@modern-js/doc-core` package. This improves the flexibility and usability of the documentation system.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c9b7c2</samp>

*  Add support for user custom mdx components in `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4290/files?diff=unified&w=0#diff-0abb7b777566d07aafb081758953211e5fa1f857712850011bebe243e0ddb689R1-R7))
*  Import `getCustomMDXComponent` function from `@theme` module in `DocLayout` component ([link](https://github.com/web-infra-dev/modern.js/pull/4290/files?diff=unified&w=0#diff-04c56a17410f0a719914810a646051c5b8b6778f03884bcf9b0813dc2728a79cR4))
*  Remove unused import of `getCustomMDXComponent` function from `./docComponents` module in `DocLayout` component ([link](https://github.com/web-infra-dev/modern.js/pull/4290/files?diff=unified&w=0#diff-04c56a17410f0a719914810a646051c5b8b6778f03884bcf9b0813dc2728a79cL11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
