### PR TITLE
fix(builder): clone babel options to maintain isolation

### DIFF
--- a/.changeset/dull-kiwis-exist.md
+++ b/.changeset/dull-kiwis-exist.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): clone babel options to maintain isolation
+
+fix(builder): 保持 babel 选项的相互隔离

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -50,7 +50,7 @@ export const builderPluginBabel = (): BuilderPlugin => ({
           getCompiledPath,
         },
       ) => {
-        const { applyOptionsChain, isUseSSRBundle } = await import(
+        const { lodash, applyOptionsChain, isUseSSRBundle } = await import(
           '@modern-js/utils'
         );
 
@@ -171,7 +171,8 @@ export const builderPluginBabel = (): BuilderPlugin => ({
             })
             .use(CHAIN_ID.USE.BABEL)
             .loader(getCompiledPath('babel-loader'))
-            .options(babelOptions);
+            // Using cloned options to keep options separate from each other
+            .options(lodash.cloneDeep(babelOptions));
         }
 
         addCoreJsEntry({ chain, config, isServer, isServiceWorker });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b90bc8</samp>

This pull request fixes a bug in the `@modern-js/builder-webpack-provider` package that could cause babel transpilation errors. It uses `lodash` to clone the babel options for webpack and updates the changeset file accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b90bc8</samp>

*  Prevent mutation of babel options by cloning them ([link](https://github.com/web-infra-dev/modern.js/pull/4291/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL53-R53),[link](https://github.com/web-infra-dev/modern.js/pull/4291/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL174-R175))
   * Import `lodash` from `@modern-js/utils` in `babel.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4291/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL53-R53))
   * Use `lodash.cloneDeep` to copy `babelOptions` in `builderPluginBabel` ([link](https://github.com/web-infra-dev/modern.js/pull/4291/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL174-R175))
* Update changeset file for patch version bump and fix description ([link](https://github.com/web-infra-dev/modern.js/pull/4291/files?diff=unified&w=0#diff-fa903c309fa8ffe91e3ef6909685a3736dbb79b3e57f89572ec8043debda650fR1-R7))
   * Specify `@modern-js/builder-webpack-provider` as the affected package ([link](https://github.com/web-infra-dev/modern.js/pull/4291/files?diff=unified&w=0#diff-fa903c309fa8ffe91e3ef6909685a3736dbb79b3e57f89572ec8043debda650fR1-R7))
   * Write a short summary of the fix in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4291/files?diff=unified&w=0#diff-fa903c309fa8ffe91e3ef6909685a3736dbb79b3e57f89572ec8043debda650fR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
