### PR TITLE
feat(doc-core): expose doc container class 

### DIFF
--- a/.changeset/five-eagles-refuse.md
+++ b/.changeset/five-eagles-refuse.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+feat(doc-core): add modern-doc-container class
+
+feat(doc-core): 添加 modern-doc-container 类

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
@@ -63,7 +63,7 @@ export function DocLayout(props: DocLayoutProps) {
 
   return (
     <div
-      className={`${styles.docLayout} pt-0`}
+      className={`${styles.docLayout} modern-doc-container pt-0`}
       style={{
         ...(hideNavbar ? { marginTop: 0 } : {}),
       }}

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
@@ -63,7 +63,7 @@ export function DocLayout(props: DocLayoutProps) {
 
   return (
     <div
-      className={`${styles.docLayout} modern-doc-container pt-0`}
+      className={`${styles.docLayout} pt-0`}
       style={{
         ...(hideNavbar ? { marginTop: 0 } : {}),
       }}
@@ -76,24 +76,24 @@ export function DocLayout(props: DocLayoutProps) {
           sidebarData={sidebarData}
         />
       ) : null}
-      <div className={`${styles.content} flex flex-shrink-0`}>
-        <div className="w-full">
-          {isOverviewPage ? (
-            <Overview />
-          ) : (
-            <div className="modern-doc">
-              <TabDataContext.Provider value={{ tabData, setTabData }}>
-                <MDXProvider components={getCustomMDXComponent()}>
-                  <Content />
-                </MDXProvider>
-              </TabDataContext.Provider>
-              <div>
-                {beforeDocFooter}
-                {hasFooter && <DocFooter />}
-              </div>
+      <div
+        className={`${styles.content} modern-doc-container flex flex-shrink-0`}
+      >
+        {isOverviewPage ? (
+          <Overview />
+        ) : (
+          <div className="modern-doc">
+            <TabDataContext.Provider value={{ tabData, setTabData }}>
+              <MDXProvider components={getCustomMDXComponent()}>
+                <Content />
+              </MDXProvider>
+            </TabDataContext.Provider>
+            <div>
+              {beforeDocFooter}
+              {hasFooter && <DocFooter />}
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {hasAside ? (
           <div

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.tsx
@@ -79,21 +79,23 @@ export function DocLayout(props: DocLayoutProps) {
       <div
         className={`${styles.content} modern-doc-container flex flex-shrink-0`}
       >
-        {isOverviewPage ? (
-          <Overview />
-        ) : (
-          <div className="modern-doc">
-            <TabDataContext.Provider value={{ tabData, setTabData }}>
-              <MDXProvider components={getCustomMDXComponent()}>
-                <Content />
-              </MDXProvider>
-            </TabDataContext.Provider>
-            <div>
-              {beforeDocFooter}
-              {hasFooter && <DocFooter />}
+        <div className="w-full">
+          {isOverviewPage ? (
+            <Overview />
+          ) : (
+            <div className="modern-doc">
+              <TabDataContext.Provider value={{ tabData, setTabData }}>
+                <MDXProvider components={getCustomMDXComponent()}>
+                  <Content />
+                </MDXProvider>
+              </TabDataContext.Provider>
+              <div>
+                {beforeDocFooter}
+                {hasFooter && <DocFooter />}
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
 
         {hasAside ? (
           <div

--- a/packages/cli/doc-core/src/theme-default/logic/usePrevNextPage.ts
+++ b/packages/cli/doc-core/src/theme-default/logic/usePrevNextPage.ts
@@ -1,43 +1,30 @@
-import {
-  NormalizedSidebar,
-  NormalizedSidebarGroup,
-  SidebarItem,
-} from 'shared/types';
+import { NormalizedSidebarGroup, SidebarItem } from 'shared/types';
 import { useLocation } from 'react-router-dom';
-import { useLocaleSiteData } from './useLocaleSiteData';
+import { useSidebarData } from './useSidebarData';
 import { withBase, isEqualPath } from '@/runtime';
 
 export function usePrevNextPage() {
   const { pathname } = useLocation();
-  const localesData = useLocaleSiteData();
-  const sidebar = localesData.sidebar || {};
+  const { items } = useSidebarData();
   const flattenTitles: SidebarItem[] = [];
 
-  const walkThroughSidebar = (sidebar: NormalizedSidebar) => {
-    const walk = (sidebarItem: NormalizedSidebarGroup | SidebarItem) => {
-      if ('items' in sidebarItem) {
-        if (sidebarItem.link) {
-          flattenTitles.push({
-            text: sidebarItem.text,
-            link: sidebarItem.link,
-          });
-        }
-        sidebarItem.items.forEach(item => {
-          walk(item);
+  const walk = (sidebarItem: NormalizedSidebarGroup | SidebarItem) => {
+    if ('items' in sidebarItem) {
+      if (sidebarItem.link) {
+        flattenTitles.push({
+          text: sidebarItem.text,
+          link: sidebarItem.link,
         });
-      } else {
-        flattenTitles.push(sidebarItem);
       }
-    };
-
-    Object.values(sidebar).forEach(sidebarItem => {
-      sidebarItem.forEach(item => {
+      sidebarItem.items.forEach(item => {
         walk(item);
       });
-    });
+    } else {
+      flattenTitles.push(sidebarItem);
+    }
   };
 
-  walkThroughSidebar(sidebar);
+  items.forEach(item => walk(item));
 
   const pageIndex = flattenTitles.findIndex(item =>
     isEqualPath(withBase(item.link), pathname),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 458b464</samp>

This pull request enhances the markdown rendering and documentation of the `@modern-js/doc-core` package. It uses the `@theme` module to allow user custom mdx components, adds a class name for styling the document container, and creates a changeset file with a Chinese translation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 458b464</samp>

*  Add a changeset file to describe the features and patches for the `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4292/files?diff=unified&w=0#diff-0abb7b777566d07aafb081758953211e5fa1f857712850011bebe243e0ddb689R1-R7))
*  Import the `getCustomMDXComponent` function from the `@theme` module and remove the local import from the `docComponents` module in the `DocLayout` component ([link](https://github.com/web-infra-dev/modern.js/pull/4292/files?diff=unified&w=0#diff-04c56a17410f0a719914810a646051c5b8b6778f03884bcf9b0813dc2728a79cR4), [link](https://github.com/web-infra-dev/modern.js/pull/4292/files?diff=unified&w=0#diff-04c56a17410f0a719914810a646051c5b8b6778f03884bcf9b0813dc2728a79cL11))
*  Add a class name `modern-doc-container` to the root `div` element of the `DocLayout` component to apply some global styles and responsive behaviors ([link](https://github.com/web-infra-dev/modern.js/pull/4292/files?diff=unified&w=0#diff-04c56a17410f0a719914810a646051c5b8b6778f03884bcf9b0813dc2728a79cL66-R66))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
