### PR TITLE
docs(router): add xxx.config.ts doc

### DIFF
--- a/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/routes.mdx
@@ -147,6 +147,29 @@ In summary, if there is a `layout.tsx` file under the sub-route's file directory
 
 All routes should end with the `<Page>` component. If the developer introduces the `<Outlet>` component in the `page.tsx` file, there will be no effect.
 
+#### Config
+
+Each `Layout` or `Page` file can define its own `config` file, such as `page.config.ts`. In this file, we have an conventinal on a named export called `handle`, which you can define any properties:
+
+```ts title="routes/blog/page.config.ts"
+export const handle = {
+  breadcrumbName: 'profile'
+}
+```
+
+These properties as defined are available via the [`useMatches`](https://reactrouter.com/en/main/hooks/use-matches) hook:
+
+```ts title="routes/layout.ts"
+export default () => {
+  const matches = useMatches;
+  const breadcrumbs = matches.map(matchedRoute => matchedRoute?.handle?.breadcrumbName);
+  return (
+    <Breadcrumb names={breadcrumbs}>
+    </Breadcrumb>
+  )
+}
+```
+
 ### Dynamic Routing
 
 Routes generated from file directories named with `[]` will be handled as dynamic routes. For example, the following file directory:
@@ -204,7 +227,18 @@ For example, the following directory structure:
     └── page.tsx
 ```
 
-When accessing any path that does not match, the `routes/$.tsx` component will be rendered. Similarly, you can use [useParams](/apis/app/runtime/router/router#useparams) in `$.tsx` to capture the remaining parts of the URL.
+When accessing any path that does not match(For example `/blog/a`), the `routes/$.tsx` component will be rendered, because there is `layout.tsx` here, the rendered UI is as follows.
+```tsx
+<RootLayout>
+  <BlogLayout>
+    <$></$>
+  </BlogLayout>
+</RootLayout>
+```
+
+If you want access to `/blog` to also match the `blog/$.tsx` file, you need to delete the `blog/layout.tsx` file in the same directory and make sure that there are no other subroutes under `blog`.
+
+As same, you can use [useParams](/apis/app/runtime/router/router#useparams) in `$.tsx` to capture the remaining parts of the URL.
 
 ```ts title="$.tsx"
 import { useParams } from '@modern-js/runtime/router';

--- a/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/routes.mdx
@@ -150,6 +150,31 @@ export default () => {
 
 所有的路由，理论上都应该由 `<Page>` 组件结束。在 `page.tsx` 文件内，如果开发者引入 `<Outlet>` 组件，不会有任何效果。
 
+#### Config
+
+每个 `Layout` 或 `Page` 文件都可以定义一个自己的 `config` 文件，如 `page.config.ts`，该文件中我们约定了一个具名导出 `handle`，
+这个字段中你可以定义任意属性：
+
+```ts title="routes/page.config.ts"
+export const handle = {
+  breadcrumbName: 'profile'
+}
+```
+
+定义的这些属性可以通过 [`useMatches`](https://reactrouter.com/en/main/hooks/use-matches) hook 获取：
+
+```ts title="routes/layout.ts"
+export default () => {
+  const matches = useMatches;
+  const breadcrumbs = matches.map(matchedRoute => matchedRoute?.handle?.breadcrumbName);
+  return (
+    <Breadcrumb names={breadcrumbs}>
+    </Breadcrumb>
+  )
+}
+```
+
+
 ### 动态路由
 
 通过 `[]` 命名的文件目录，生成的路由会作为动态路由。例如以下文件目录：
@@ -201,13 +226,25 @@ export default () => {
 
 ```bash
 └── routes
-    ├── $.tsx
     ├── blog
-    │   └── page.tsx
+    │   ├── $.tsx
+    │   └── layout.tsx
+    └── layout.tsx
     └── page.tsx
 ```
 
-当访问任何匹配不到的路径时，都会渲染 `routes/$.tsx` 组件，同样，`$.tsx` 中可以使用 [useParams](/apis/app/runtime/router/router#useparams) 捕获 url 的剩余部分。
+当访问任何匹配不到的路径时(如 `/blog/a`)，都会渲染 `routes/$.tsx` 组件，因为这里有 `layout.tsx`，渲染的 UI 如下：
+```tsx
+<RootLayout>
+  <BlogLayout>
+    <$></$>
+  </BlogLayout>
+</RootLayout>
+```
+
+如果希望访问 `/blog` 时，也匹配到 `blog/$.tsx` 文件，需要删除同目录下的 `blog/layout.tsx` 文件，同时保证 `blog` 下面没有其他子路由。
+
+同样，`$.tsx` 中可以使用 [useParams](/apis/app/runtime/router/router#useparams) 捕获 url 的剩余部分。
 
 ```ts title="$.tsx"
 import { useParams } from '@modern-js/runtime/router';
@@ -216,7 +253,8 @@ const params = useParams();
 params['*']; // => 'aaa/bbb'
 ```
 
-`$.tsx` 可以加入到 `routes` 目录下的任意目录中，一个常见的使用示例是添加 `routes/$.tsx` 文件去定制任意层级的 404 页面。
+`$.tsx` 可以加入到 `routes` 目录下的任意目录中，一个常见的使用示例是添加 `routes/$.tsx` 文件去定制任意层级的 404 内容。
+
 
 ### 无路径布局
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 040937a</samp>

This pull request enhances the documentation of the `routes.mdx` guide for both English and Chinese readers. It introduces the new feature of route-level configuration and clarifies the usage of the `$.tsx` file. It also synchronizes the Chinese version with the latest English version and improves the translation quality.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 040937a</samp>

*  Add a new section to the routes.mdx documentation in both English and Chinese, explaining how to use the `config` file and the `handle` export to customize the properties of each route, such as the breadcrumb name ([link](https://github.com/web-infra-dev/modern.js/pull/4296/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134R150-R172), [link](https://github.com/web-infra-dev/modern.js/pull/4296/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2R153-R177))
*  Clarify the behavior of the `$.tsx` file when there are nested layouts and subroutes, and give an example of how to render the UI with the `$.tsx` file, in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4296/files?diff=unified&w=0#diff-d241f975611226b5855634d8b23b1eea196b7f7657e4ae1ca82ff7ee8ce4a134L207-R242), [link](https://github.com/web-infra-dev/modern.js/pull/4296/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L204-R248))
*  Change the wording of the 404 example in the Chinese documentation of routes.mdx, from "页面" (page) to "内容" (content), to avoid confusion with the `Page` component ([link](https://github.com/web-infra-dev/modern.js/pull/4296/files?diff=unified&w=0#diff-00505071a8d949d0c52469c79e789619ec5e076f90f34b350af62959fe5aaea2L219-R258))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
