### PR TITLE
docs(doc-tools): change the title about typedoc plugin

### DIFF
--- a/packages/document/doc-tools-doc/docs/en/plugin/official-plugins/typedoc.mdx
+++ b/packages/document/doc-tools-doc/docs/en/plugin/official-plugins/typedoc.mdx
@@ -1,4 +1,4 @@
-# typedoc
+# @modern-js/doc-plugin-typedoc
 
 Integration of [TypeDoc](https://github.com/TypeStrong/typedoc)'s Modern.js Doc Plugin for Automatically Generating API Documentation for TS Modules.
 

--- a/packages/document/doc-tools-doc/docs/zh/plugin/official-plugins/typedoc.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/plugin/official-plugins/typedoc.mdx
@@ -1,4 +1,4 @@
-# typedoc
+# @modern-js/doc-plugin-typedoc
 
 集成 [TypeDoc](https://github.com/TypeStrong/typedoc) 的 Modern.js Doc 插件，用于自动生成 TS 模块的 API 文档。
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 292e2e4</samp>

Updated the titles of the English and Chinese documents for the `@modern-js/doc-plugin-typedoc` plugin to reflect the correct package name. This improves the consistency and accuracy of the documentation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 292e2e4</samp>

* Update the document titles to match the plugin package name `@modern-js/doc-plugin-typedoc` ([link](https://github.com/web-infra-dev/modern.js/pull/4298/files?diff=unified&w=0#diff-e770c2e5c7840e9d9c728f4bee511e705d788fe5c9dd548b86f4625cdef92289L1-R1), [link](https://github.com/web-infra-dev/modern.js/pull/4298/files?diff=unified&w=0#diff-9b7cfa35081017d1c1f230f566ca9207b3a8885b9536f85a064a32ea8da82765L1-R1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
