### PR TITLE
fix(doc-core): support link in header when using mdx-rs

### DIFF
--- a/.changeset/two-walls-cheat.md
+++ b/.changeset/two-walls-cheat.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): support link in header when using mdx-rs
+
+fix(doc-core): 当使用 mdx-rs 时支持在 header 中使用 link

--- a/packages/cli/doc-core/package.json
+++ b/packages/cli/doc-core/package.json
@@ -60,7 +60,7 @@
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",
     "@modern-js/doc-plugin-medium-zoom": "workspace:*",
-    "@modern-js/mdx-rs-binding": "0.2.3",
+    "@modern-js/mdx-rs-binding": "0.2.4",
     "@modern-js/remark-container": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@types/compression": "^1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,8 +941,8 @@ importers:
         specifier: workspace:*
         version: link:../doc-plugin-medium-zoom
       '@modern-js/mdx-rs-binding':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.2.4
+        version: 0.2.4
       '@modern-js/remark-container':
         specifier: workspace:*
         version: link:../../toolkit/remark-container
@@ -12178,8 +12178,8 @@ packages:
       sucrase: 3.29.0
       terser: 5.15.0
 
-  /@modern-js/mdx-rs-binding-darwin-arm64@0.2.3:
-    resolution: {integrity: sha512-fzdkz0RYZXh8IVFRjpNsUIW9SgpCuzxWo9ATANWeI/dbyepWVijqCyw9eQ2ViLRgnetcEU2uNl5ZAVtkwg611A==}
+  /@modern-js/mdx-rs-binding-darwin-arm64@0.2.4:
+    resolution: {integrity: sha512-HQXNiDV4HUkt3Coe7wiiihttkexJ9Ghd2O0ximIY+CVlS4jT+BPct44tbMKRH7gAlKWFw6YZAtBbRBVkHg3kTQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [darwin]
@@ -12187,8 +12187,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-darwin-x64@0.2.3:
-    resolution: {integrity: sha512-wjdQ9+X6YZocg6LwX6vZlxqnnl6xUkE/OCS0vllfZtddRNQBr39+9SiyhhUyAvSTam0jNnT7kUX2H72b9Lvr1w==}
+  /@modern-js/mdx-rs-binding-darwin-x64@0.2.4:
+    resolution: {integrity: sha512-6t7eiuk6J5XcBNd6ovXFM6cOllKkntpJTxcSF+QVGm6eq6ScJbwzqSIGrrOpFjEspx8K5UAzVgqBchYSon6PCw==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [darwin]
@@ -12196,8 +12196,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-linux-arm-gnueabihf@0.2.3:
-    resolution: {integrity: sha512-OQuqLYjcWL/aJMJxGTGBuV1dodCz/1BiL6Z0tLmf0LyR8zoZSN/HGFrKHmsLrT/O1RuSejY7WQf04NCRNurYJA==}
+  /@modern-js/mdx-rs-binding-linux-arm-gnueabihf@0.2.4:
+    resolution: {integrity: sha512-JHXfaoi9WQZ+lTZjMFOvM0sJAdGAwG+F0NggIjkGu90h2TVmyU1pfvCLSJyFjk3un92ZDoL+fAVDIMKI10PcHw==}
     engines: {node: '>=14.12'}
     cpu: [arm]
     os: [linux]
@@ -12205,8 +12205,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-linux-arm64-gnu@0.2.3:
-    resolution: {integrity: sha512-79VevysyLteLRMgZLtxQAP7wlN/JXR+1Evj45n1NUe9FI6H+me+Q4C6HkT1ehjnM2TooWH301sjrVSHY2m7C4g==}
+  /@modern-js/mdx-rs-binding-linux-arm64-gnu@0.2.4:
+    resolution: {integrity: sha512-1se6fjDuLT4Kj8PX3l7aI3E0/vLaAZH82EnKydSNS8Fbc2SYdk/x5X1Qc/niMi9hw2TLcx5VZOzj2NN4R2Dv6Q==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -12214,8 +12214,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-linux-arm64-musl@0.2.3:
-    resolution: {integrity: sha512-ra9B6RezPZBHNMpFnnIku3kUisrSkEAvvJwVT/eCkvF4ZZ7eRxoJFuODYF98QKXKyxjV3d/gyCFGzmzeSRy/NQ==}
+  /@modern-js/mdx-rs-binding-linux-arm64-musl@0.2.4:
+    resolution: {integrity: sha512-fHueN1I2dHRmqa3C0UFP+F9ePAnZK8FsVmTDkeQMFZ3gIrooz+bt0G8PyJIzf0pgX6srhPw48gnGVeGngOMHcQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -12223,8 +12223,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-linux-x64-gnu@0.2.3:
-    resolution: {integrity: sha512-kiuMVhjzfOObjg1pfIFTy5pQrgD5A5gzz270s6Q07FAdOuj5jzno5GN4EFZiQZjiJvoaS5P6HStUmvxgkZSIPQ==}
+  /@modern-js/mdx-rs-binding-linux-x64-gnu@0.2.4:
+    resolution: {integrity: sha512-AgxPTIcGtuInyYJpkMoVu9nXBVT2Ib96Bc7VEN/NfgLwAadG+XVpMdcjJTk7wiBtlF/5v0gFogwe/fWNW0UQmA==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -12232,8 +12232,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-linux-x64-musl@0.2.3:
-    resolution: {integrity: sha512-WwGSnBBnJTn5j+JyOzcTpzp+w3+WGjbwL6hUu+8zM8Xm0kEsAVmxcfm0sx2lANXqQdfWMaKctGjR0FgGRvjTZg==}
+  /@modern-js/mdx-rs-binding-linux-x64-musl@0.2.4:
+    resolution: {integrity: sha512-jwPAOmIVwAk1sVKESP+T/n+218LraT81l2bKBaZTDaikCAhIV4vWfbi4IbefWWh0BtXVkldchmBl/XyS4J1HBA==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -12241,8 +12241,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-win32-arm64-msvc@0.2.3:
-    resolution: {integrity: sha512-PQ7UUHSLWibzR4T5HdqI8Kj31vYqHzulezEdpbCDPc1iIpyT+Ox9bS9qzFX7bCvlhdsFPUCrbTOuTlRlJC2JJw==}
+  /@modern-js/mdx-rs-binding-win32-arm64-msvc@0.2.4:
+    resolution: {integrity: sha512-bjgRrZOPf7ahOk5r2/WCznVJD5DhIcQW6NONjHPxv5MGttZm6FdKXXAMFBXO/MtnasN9Ooroch7uh5S+ijc50Q==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [win32]
@@ -12250,8 +12250,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding-win32-x64-msvc@0.2.3:
-    resolution: {integrity: sha512-82L2lY9WqChNHOfT3b7gUbCCktXUGZG1xuqOdJeUHxMGSdRzJ6QM6rMcNEX5er48FQD+4BUFEIBuGDRJpHO0Hw==}
+  /@modern-js/mdx-rs-binding-win32-x64-msvc@0.2.4:
+    resolution: {integrity: sha512-3V37CIN2jMF/AkL3ZMwOCsF/2ukHzgJbbeRfIG8JZURNIkQQ3rU/mDFIs3hB7laZir6OtBuKNTYXVRfeDcDpaA==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [win32]
@@ -12259,19 +12259,19 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/mdx-rs-binding@0.2.3:
-    resolution: {integrity: sha512-xakeP0lYiMvYbCkWlB6RwULwp1c4LIQ0G22aStge0QxEOsbqFDS2+ZAuRiIZZPFSDd7C2N1MGItuR/zKTOp03g==}
+  /@modern-js/mdx-rs-binding@0.2.4:
+    resolution: {integrity: sha512-3kS3R64ZtoZW4IfTa6GpFfUSsi7L+S5Hrl97wiv2by3WUDiTWE8HuqY0a1wcZHbTcYBgU5YIghvHmqwY8UxgMQ==}
     engines: {node: '>= 10'}
     optionalDependencies:
-      '@modern-js/mdx-rs-binding-darwin-arm64': 0.2.3
-      '@modern-js/mdx-rs-binding-darwin-x64': 0.2.3
-      '@modern-js/mdx-rs-binding-linux-arm-gnueabihf': 0.2.3
-      '@modern-js/mdx-rs-binding-linux-arm64-gnu': 0.2.3
-      '@modern-js/mdx-rs-binding-linux-arm64-musl': 0.2.3
-      '@modern-js/mdx-rs-binding-linux-x64-gnu': 0.2.3
-      '@modern-js/mdx-rs-binding-linux-x64-musl': 0.2.3
-      '@modern-js/mdx-rs-binding-win32-arm64-msvc': 0.2.3
-      '@modern-js/mdx-rs-binding-win32-x64-msvc': 0.2.3
+      '@modern-js/mdx-rs-binding-darwin-arm64': 0.2.4
+      '@modern-js/mdx-rs-binding-darwin-x64': 0.2.4
+      '@modern-js/mdx-rs-binding-linux-arm-gnueabihf': 0.2.4
+      '@modern-js/mdx-rs-binding-linux-arm64-gnu': 0.2.4
+      '@modern-js/mdx-rs-binding-linux-arm64-musl': 0.2.4
+      '@modern-js/mdx-rs-binding-linux-x64-gnu': 0.2.4
+      '@modern-js/mdx-rs-binding-linux-x64-musl': 0.2.4
+      '@modern-js/mdx-rs-binding-win32-arm64-msvc': 0.2.4
+      '@modern-js/mdx-rs-binding-win32-x64-msvc': 0.2.4
     dev: false
 
   /@modern-js/plugin-i18n@2.18.0:


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3df129a</samp>

This pull request fixes the issue of link support in header when using mdx-rs in `@modern-js/doc-core` package. It updates the dependency of `@modern-js/mdx-rs-binding` and adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3df129a</samp>

* Update `@modern-js/doc-core` package to fix link support in header when using mdx-rs ([link](https://github.com/web-infra-dev/modern.js/pull/4300/files?diff=unified&w=0#diff-5da371f999610f7ffe240c30b852c354539c149b3a97f8055c5a305fe31c923fR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4300/files?diff=unified&w=0#diff-e9e9f549de4583f91fd9f8f888db645352c4466d076314f469f8674ff159aa51L63-R63))
  - Add a changeset file to document the patch update and provide a Chinese translation ([link](https://github.com/web-infra-dev/modern.js/pull/4300/files?diff=unified&w=0#diff-5da371f999610f7ffe240c30b852c354539c149b3a97f8055c5a305fe31c923fR1-R7))
  - Bump the dependency of `@modern-js/mdx-rs-binding` to 0.2.4 in `package.json` to use the latest mdx-rs version ([link](https://github.com/web-infra-dev/modern.js/pull/4300/files?diff=unified&w=0#diff-e9e9f549de4583f91fd9f8f888db645352c4466d076314f469f8674ff159aa51L63-R63))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
