### PR TITLE
fix: disable buildCache in parallel test scenario

### DIFF
--- a/tests/integration/app-document/modern-rem.config.ts
+++ b/tests/integration/app-document/modern-rem.config.ts
@@ -30,5 +30,8 @@ export default defineConfig({
       inlineRuntime: false,
     },
   },
+  performance: {
+    buildCache: false,
+  },
   plugins: [appTools(), routerPlugin()],
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e294700</samp>

Disable build cache for app-document integration tests. This change avoids potential cache-related errors when testing the @modern-js/app-document plugin.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e294700</samp>

* Disable build cache for app-document example to avoid cache-related errors in integration tests ([link](https://github.com/web-infra-dev/modern.js/pull/4304/files?diff=unified&w=0#diff-f4ec6b3949ed43dce7c89a9f46fbd0094ce38279ff0bf1b0d160396c14c9c9c7R33-R35))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
