### PR TITLE
fix(plugin-preview): add remark-gfm to support backquote in md

### DIFF
--- a/.changeset/clean-cheetahs-march.md
+++ b/.changeset/clean-cheetahs-march.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-plugin-preview': patch
+---
+
+fix: add remark-gfm to support backquote in md
+fix: 添加 remark-gfm 插件来支持 markdown 中的反引号

--- a/packages/cli/doc-plugin-preview/package.json
+++ b/packages/cli/doc-plugin-preview/package.json
@@ -39,7 +39,8 @@
     "@mdx-js/mdx": "2.2.1",
     "@modern-js/doc-core": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "qrcode.react": "^3.1.0"
+    "qrcode.react": "^3.1.0",
+    "remark-gfm": "3.0.1"
   },
   "devDependencies": {
     "@arco-design/web-react": "^2.46.0",

--- a/packages/cli/doc-plugin-preview/src/index.ts
+++ b/packages/cli/doc-plugin-preview/src/index.ts
@@ -58,8 +58,12 @@ import Demo from ${JSON.stringify(demoComponentPath)}
           const { createProcessor } = await import('@mdx-js/mdx');
           const { visit } = await import('unist-util-visit');
           const { default: fs } = await import('@modern-js/utils/fs-extra');
+          const { default: remarkGFM } = await import('remark-gfm');
           try {
-            const processor = createProcessor();
+            const processor = createProcessor({
+              format: path.extname(filepath).slice(1) as 'mdx' | 'md',
+              remarkPlugins: [remarkGFM],
+            });
             const source = await fs.readFile(filepath, 'utf-8');
             const ast = processor.parse(source);
             let index = 1;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,6 +1352,9 @@ importers:
       qrcode.react:
         specifier: ^3.1.0
         version: 3.1.0(react@18.2.0)
+      remark-gfm:
+        specifier: 3.0.1
+        version: 3.0.1
     devDependencies:
       '@arco-design/web-react':
         specifier: ^2.46.0


### PR DESCRIPTION
When we had some text like this:
```md
`Partial`<`VeStackEnvInfo`\>
```
We'll get a error.
```
'Unexpected character `` ` `` (U+0060) in name, expected a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag'
```
We add 'remark-gfm' to fix it.

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 348c2fc</samp>

Added `remark-gfm` package and plugin to enable GitHub Flavored Markdown features in the preview server for markdown files. 

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 348c2fc</samp>

*  Add `remark-gfm` dependency and plugin to enable GitHub Flavored Markdown features in preview server ([link](https://github.com/web-infra-dev/modern.js/pull/4306/files?diff=unified&w=0#diff-8f38ce4d2a9bb408339e5166994c6377d9be6244e91dd3e8a96476e4062ab55fL42-R43), [link](https://github.com/web-infra-dev/modern.js/pull/4306/files?diff=unified&w=0#diff-a8cdb5cc09b127202e6d61b57869df70121f1a4b0132d5531321a01c4ac37ecaL61-R66))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
