### PR TITLE
fix(module-tools): set platform to browser when build umd output

### DIFF
--- a/.changeset/great-wasps-enjoy.md
+++ b/.changeset/great-wasps-enjoy.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): set platform to browser when build umd output
+
+fix(module-tools): 构建 umd 时默认将 platform 设置为 browser

--- a/packages/document/module-doc/docs/en/api/config/build-preset.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-preset.mdx
@@ -100,6 +100,7 @@ export const buildConfig = [
   {
     format: 'umd',
     target: 'es6',
+    platform: 'browser',
     buildType: 'bundle',
     outDir: './dist/umd',
   },
@@ -183,6 +184,7 @@ export const buildConfig = [
   {
     format: 'umd',
     target: 'es6',
+    platform: 'browser',
     buildType: 'bundle',
     outDir: './dist/umd',
   },

--- a/packages/document/module-doc/docs/zh/api/config/build-preset.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-preset.mdx
@@ -100,6 +100,7 @@ export const buildConfig = [
   {
     format: 'umd',
     target: 'es6',
+    platform: 'browser',
     buildType: 'bundle',
     outDir: './dist/umd',
   },
@@ -183,6 +184,7 @@ export const buildConfig = [
   {
     format: 'umd',
     target: 'es6',
+    platform: 'browser',
     buildType: 'bundle',
     outDir: './dist/umd',
   },

--- a/packages/solutions/module-tools/src/constants/buildPresets.ts
+++ b/packages/solutions/module-tools/src/constants/buildPresets.ts
@@ -64,6 +64,7 @@ export const npmLibraryWithUmdPresetConfig: PartialBaseBuildConfig[] = [
   {
     format: 'umd',
     target: 'es6',
+    platform: 'browser',
     buildType: 'bundle',
     outDir: './dist/umd',
     dts: false,
@@ -112,6 +113,7 @@ export const npmComponentWithUmdPresetConfig: PartialBaseBuildConfig[] = [
   {
     format: 'umd',
     target: 'es6',
+    platform: 'browser',
     buildType: 'bundle',
     outDir: './dist/umd',
     dts: false,


### PR DESCRIPTION
## Summary

The umd artifacts are usually used in browser, so we need to set `platform` to `browser` by default.

If the `platform` is `node`, it will generate invalid output when importing `axios` or some other packages.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 071ea6e</samp>

This pull request adds a new `platform: 'browser'` option to the `buildPresets` configuration for the `@modern-js/module-tools` package. This option enables users to generate umd bundles that are compatible with the browser environment. The pull request also updates the documentation and the changeset for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 071ea6e</samp>

*  Add `platform: 'browser'` option to `umd` and `umd-min` presets for `@modern-js/module-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4321/files?diff=unified&w=0#diff-dbddc8676f8ba0ba6bb2c43d38d4bc1be9fdce24296c1f858233aeeda9db88d3R67), [link](https://github.com/web-infra-dev/modern.js/pull/4321/files?diff=unified&w=0#diff-dbddc8676f8ba0ba6bb2c43d38d4bc1be9fdce24296c1f858233aeeda9db88d3R116))
*  Update English and Chinese documentation of `buildPresets` configuration to include `platform: 'browser'` option ([link](https://github.com/web-infra-dev/modern.js/pull/4321/files?diff=unified&w=0#diff-6f25134dafe78f6eda81d3b2d23b25c6f4c1bc2e62b236ff6b2bb81628f9b306R103), [link](https://github.com/web-infra-dev/modern.js/pull/4321/files?diff=unified&w=0#diff-6f25134dafe78f6eda81d3b2d23b25c6f4c1bc2e62b236ff6b2bb81628f9b306R187), [link](https://github.com/web-infra-dev/modern.js/pull/4321/files?diff=unified&w=0#diff-17436bf8ef1a0a400b70106680bca5ce6b0bf0036f93a7568eb2c463b589396aR103), [link](https://github.com/web-infra-dev/modern.js/pull/4321/files?diff=unified&w=0#diff-17436bf8ef1a0a400b70106680bca5ce6b0bf0036f93a7568eb2c463b589396aR187))
*  Add changeset file for patch update of `@modern-js/module-tools` package with fix message ([link](https://github.com/web-infra-dev/modern.js/pull/4321/files?diff=unified&w=0#diff-52560d09bf5b82454e546b4d6b7e371362a101f83485a3b1cd6b81758f72cf57R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
