### PR TITLE
feat(generator): exclude node_modules by default in tsconfig.json

### DIFF
--- a/.changeset/cool-coats-search.md
+++ b/.changeset/cool-coats-search.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/module-test-generator': patch
+'@modern-js/storybook-generator': patch
+'@modern-js/module-generator': patch
+'@modern-js/mwa-generator': patch
+---
+
+feat(generator): exclude node_modules by default in tsconfig.json
+
+feat(generator): 默认在 tsconfig.json 中排除 node_modules

--- a/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
@@ -7,5 +7,6 @@
     },
     "isolatedModules": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/node_modules"]
 }

--- a/packages/generator/generators/module-test-generator/templates/ts/tests/tsconfig.json.handlebars
+++ b/packages/generator/generators/module-test-generator/templates/ts/tests/tsconfig.json.handlebars
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "baseUrl": "../"
   },
-  "include": ["**/*", "../src"]
+  "include": ["**/*", "../src"],
+  "exclude": ["**/node_modules"]
 }

--- a/packages/generator/generators/mwa-generator/templates/ts-template/tsconfig.json
+++ b/packages/generator/generators/mwa-generator/templates/ts-template/tsconfig.json
@@ -9,5 +9,6 @@
       "@shared/*": ["./shared/*"]
     }
   },
-  "include": ["src", "shared", "config", "modern.config.ts"]
+  "include": ["src", "shared", "config", "modern.config.ts"],
+  "exclude": ["**/node_modules"]
 }

--- a/packages/generator/generators/storybook-generator/templates/ts-template/tsconfig.json
+++ b/packages/generator/generators/storybook-generator/templates/ts-template/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "baseUrl": "../"
   },
-  "include": ["**/*"]
+  "include": ["**/*"],
+  "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## Summary

This change follows the [TypeScript official performance guideline](https://github.com/microsoft/TypeScript/wiki/Performance#configuring-tsconfigjson-or-jsconfigjson).

### Specifying Files

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/1aff33d7-10dc-4865-826e-e98b693e177c)

### Misconfigured include and exclude

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/8df39562-66cc-44ad-b0a0-3882831c6048)


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
