### PR TITLE
fix: if a route dont has component, should be as a no-layout route

### DIFF
--- a/.changeset/polite-comics-grin.md
+++ b/.changeset/polite-comics-grin.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/app-tools': patch
+---
+
+fix: if a route dont has component, should be as a no-layout route
+fix: 如果路由对象没有组件属性，应该被看做无布局路由

--- a/packages/runtime/plugin-runtime/src/router/runtime/types.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/types.ts
@@ -34,6 +34,10 @@ export type RouterConfig = {
     globalApp?: React.ComponentType<any>;
     routes: (NestedRoute | PageRoute)[];
   };
+  /**
+   * You should not use it
+   */
+  oldVersion?: boolean;
   serverBase?: string[];
   supportHtml5History?: boolean;
   basename?: string;

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -120,6 +120,10 @@ export const generateCode = async (
   const isV5 = isRouterV5(config);
   const getRoutes = isV5 ? getClientRoutesLegacy : getClientRoutes;
   const importsStatemets = new Map<string, ImportStatement[]>();
+  const oldVersion =
+    typeof config?.runtime.router === 'object'
+      ? Boolean(config?.runtime?.router?.oldVersion)
+      : false;
 
   await Promise.all(entrypoints.map(generateEntryCode));
 
@@ -135,7 +139,7 @@ export const generateCode = async (
       if (fileSystemRoutes) {
         let initialRoutes: (NestedRouteForCli | PageRoute)[] | RouteLegacy[] =
           [];
-        let nestedRoute: NestedRouteForCli | null = null;
+        let nestedRoutes: NestedRouteForCli | NestedRouteForCli[] | null = null;
         if (entrypoint.entry) {
           initialRoutes = getRoutes({
             entrypoint,
@@ -146,7 +150,7 @@ export const generateCode = async (
           });
         }
         if (!isV5 && entrypoint.nestedRoutesEntry) {
-          nestedRoute = await walk(
+          nestedRoutes = await walk(
             entrypoint.nestedRoutesEntry,
             entrypoint.nestedRoutesEntry,
             {
@@ -155,9 +159,15 @@ export const generateCode = async (
             },
             entrypoint.entryName,
             entrypoint.isMainEntry,
+            oldVersion,
           );
-          if (nestedRoute) {
-            (initialRoutes as Route[]).unshift(nestedRoute);
+          if (nestedRoutes) {
+            if (!Array.isArray(nestedRoutes)) {
+              nestedRoutes = [nestedRoutes];
+            }
+            for (const route of nestedRoutes) {
+              (initialRoutes as Route[]).unshift(route);
+            }
           }
         }
 

--- a/packages/solutions/app-tools/src/analyze/generateCode.ts
+++ b/packages/solutions/app-tools/src/analyze/generateCode.ts
@@ -121,8 +121,8 @@ export const generateCode = async (
   const getRoutes = isV5 ? getClientRoutesLegacy : getClientRoutes;
   const importsStatemets = new Map<string, ImportStatement[]>();
   const oldVersion =
-    typeof config?.runtime.router === 'object'
-      ? Boolean(config?.runtime?.router?.oldVersion)
+    typeof (config?.runtime.router as { oldVersion: boolean }) === 'object'
+      ? Boolean((config?.runtime.router as { oldVersion: boolean }).oldVersion)
       : false;
 
   await Promise.all(entrypoints.map(generateEntryCode));

--- a/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
@@ -70,6 +70,32 @@ const createRoute = (
   };
 };
 
+export const optimizeRoute = (
+  routeTree: NestedRouteForCli,
+): NestedRouteForCli[] => {
+  if (!routeTree.children || routeTree.children.length === 0) {
+    return [routeTree];
+  }
+
+  const { children } = routeTree;
+  if (!routeTree._component) {
+    const newRoutes = children.map(child => {
+      const routePath = `${routeTree.path ?? ''}${
+        child.path ? `/${child.path}` : ''
+      }`;
+      return { ...child, path: routePath };
+    });
+
+    if (newRoutes.length > 1) {
+      return newRoutes.flatMap(newRoute => optimizeRoute(newRoute));
+    }
+    return newRoutes;
+  } else {
+    routeTree.children = children.flatMap(optimizeRoute);
+    return [routeTree];
+  }
+};
+
 // eslint-disable-next-line complexity
 export const walk = async (
   dirname: string,
@@ -80,7 +106,8 @@ export const walk = async (
   },
   entryName: string,
   isMainEntry: boolean,
-): Promise<NestedRouteForCli | null> => {
+  oldVersion: boolean,
+): Promise<NestedRouteForCli | NestedRouteForCli[] | null> => {
   if (!(await fs.pathExists(dirname))) {
     return null;
   }
@@ -110,7 +137,7 @@ export const walk = async (
   let pageLoaderFile = '';
   let pageRoute = null;
   let splatLoaderFile = '';
-  let splatRoute = null;
+  let splatRoute: NestedRouteForCli | null = null;
   let pageConfigFile = '';
 
   const items = await fs.readdir(dirname);
@@ -129,8 +156,9 @@ export const walk = async (
         alias,
         entryName,
         isMainEntry,
+        oldVersion,
       );
-      if (childRoute) {
+      if (childRoute && !Array.isArray(childRoute)) {
         route.children?.push(childRoute);
       }
     }
@@ -237,9 +265,12 @@ export const walk = async (
     delete finalRoute.path;
   }
 
-  route.children = route.children?.filter(childRoute => childRoute);
+  // eslint-disable-next-line no-multi-assign
+  const childRoutes = (finalRoute.children = finalRoute.children?.filter(
+    childRoute => childRoute,
+  ));
 
-  if (route.children && route.children.length === 0 && !route.index) {
+  if (childRoutes && childRoutes.length === 0 && !finalRoute.index) {
     return null;
   }
 
@@ -250,12 +281,8 @@ export const walk = async (
    *    - $.tsx
    *  - layout.tsx
    */
-  if (
-    finalRoute.children &&
-    finalRoute.children.length === 1 &&
-    !finalRoute._component
-  ) {
-    const childRoute = finalRoute.children[0];
+  if (childRoutes && childRoutes.length === 1 && !finalRoute._component) {
+    const childRoute = childRoutes[0];
     if (childRoute.path === '*') {
       const path = `${finalRoute.path || ''}/${childRoute.path || ''}`;
       finalRoute = {
@@ -263,6 +290,22 @@ export const walk = async (
         path,
       };
     }
+  }
+
+  // Splat routes should be last
+  if (splatRoute) {
+    const slatRouteIndex = childRoutes?.findIndex(
+      childRoute => childRoute === splatRoute,
+    );
+    if (typeof slatRouteIndex === 'number' && slatRouteIndex !== -1) {
+      childRoutes?.splice(slatRouteIndex, 1);
+      childRoutes?.push(splatRoute);
+    }
+  }
+
+  if (isRoot && !oldVersion) {
+    const optimizedRoutes = optimizeRoute(finalRoute);
+    return optimizedRoutes;
   }
 
   return finalRoute;

--- a/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
@@ -80,19 +80,18 @@ export const optimizeRoute = (
   const { children } = routeTree;
   if (!routeTree._component) {
     const newRoutes = children.map(child => {
-      const routePath = `${routeTree.path ?? ''}${
+      const routePath = `${routeTree.path}${
         child.path ? `/${child.path}` : ''
       }`;
-      return { ...child, path: routePath };
+
+      const newRoute = { ...child, path: routePath.replace(/\/\//g, '/') };
+      return newRoute;
     });
 
-    if (newRoutes.length > 1) {
-      return newRoutes.flatMap(newRoute => optimizeRoute(newRoute));
-    }
-    return newRoutes;
+    return Array.from(new Set(newRoutes)).flatMap(optimizeRoute);
   } else {
-    routeTree.children = children.flatMap(optimizeRoute);
-    return [routeTree];
+    const optimizedChildren = routeTree.children.flatMap(optimizeRoute);
+    return [{ ...routeTree, children: optimizedChildren }];
   }
 };
 
@@ -289,17 +288,6 @@ export const walk = async (
         ...childRoute,
         path,
       };
-    }
-  }
-
-  // Splat routes should be last
-  if (splatRoute) {
-    const slatRouteIndex = childRoutes?.findIndex(
-      childRoute => childRoute === splatRoute,
-    );
-    if (typeof slatRouteIndex === 'number' && slatRouteIndex !== -1) {
-      childRoutes?.splice(slatRouteIndex, 1);
-      childRoutes?.push(splatRoute);
     }
   }
 

--- a/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
+++ b/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
@@ -1,140 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`nested routes walk 1`] = `
-{
-  "_component": "@_modern_js_src/layout.tsx",
-  "children": [
-    {
-      "_component": "@_modern_js_src/__auth/layout.tsx",
-      "children": [
-        {
-          "_component": "@_modern_js_src/__auth/__shop/layout.tsx",
-          "children": [
-            {
-              "children": [
-                {
-                  "_component": "@_modern_js_src/__auth/__shop/item/page.tsx",
-                  "children": undefined,
-                  "id": "__auth/__shop/item/page",
-                  "index": true,
-                  "type": "nested",
-                },
-              ],
-              "id": "__auth/__shop/item/layout",
-              "isRoot": false,
-              "path": "item",
-              "type": "nested",
-            },
-          ],
-          "id": "__auth/__shop/layout",
-          "isRoot": false,
-          "type": "nested",
-        },
-        {
-          "children": [
-            {
-              "_component": "@_modern_js_src/__auth/login/page.tsx",
-              "children": undefined,
-              "id": "__auth/login/page",
-              "index": true,
-              "type": "nested",
-            },
-          ],
-          "id": "__auth/login/layout",
-          "isRoot": false,
-          "path": "login",
-          "type": "nested",
-        },
-      ],
-      "config": "<ROOT>/tests/analyze/fixtures/nested-routes/__auth/layout.config.ts",
-      "id": "__auth/layout",
-      "isRoot": false,
-      "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/__auth/layout.loader.tsx",
-      "type": "nested",
-    },
-    {
-      "_component": "@_modern_js_src/user/layout.tsx",
-      "children": [
-        {
-          "children": [
-            {
-              "_component": "@_modern_js_src/user/[id]/page.tsx",
-              "children": undefined,
-              "id": "user/(id)/page",
-              "index": true,
-              "type": "nested",
-            },
-          ],
-          "id": "user/(id)/layout",
-          "isRoot": false,
-          "path": ":id",
-          "type": "nested",
-        },
-        {
-          "_component": "@_modern_js_src/user/page.tsx",
-          "children": undefined,
-          "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user/page.config.ts",
-          "id": "user/page",
-          "index": true,
-          "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/page.loader.ts",
-          "type": "nested",
-        },
-        {
-          "_component": "@_modern_js_src/user/profile/layout.tsx",
-          "children": [
-            {
-              "_component": "@_modern_js_src/user/profile/page.tsx",
-              "children": undefined,
-              "id": "user/profile/page",
-              "index": true,
-              "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/profile/page.loader.ts",
-              "type": "nested",
-            },
-          ],
-          "id": "user/profile/layout",
-          "isRoot": false,
-          "path": "profile",
-          "type": "nested",
-        },
-        {
-          "_component": "@_modern_js_src/user/$.tsx",
-          "id": "user/$",
-          "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/$.loader.ts",
-          "path": "*",
-          "type": "nested",
-        },
-      ],
-      "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user/layout.config.ts",
-      "id": "user/layout",
-      "isRoot": false,
-      "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/layout.loader.ts",
-      "path": "user",
-      "type": "nested",
-    },
-    {
-      "_component": "@_modern_js_src/user.profile.name/layout.tsx",
-      "children": [
-        {
-          "_component": "@_modern_js_src/user.profile.name/page.tsx",
-          "children": undefined,
-          "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user.profile.name/page.config.ts",
-          "id": "user.profile.name/page",
-          "index": true,
-          "type": "nested",
-        },
-      ],
-      "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user.profile.name/layout.config.ts",
-      "id": "user.profile.name/layout",
-      "isRoot": false,
-      "path": "user/profile/name",
-      "type": "nested",
-    },
-  ],
-  "config": "<ROOT>/tests/analyze/fixtures/nested-routes/layout.config.ts",
-  "id": "layout",
-  "isRoot": true,
-  "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/layout.loader.ts",
-  "path": "/",
-  "type": "nested",
-}
+[
+  {
+    "_component": "@_modern_js_src/layout.tsx",
+    "children": [
+      {
+        "_component": "@_modern_js_src/__auth/layout.tsx",
+        "children": [
+          {
+            "_component": "@_modern_js_src/__auth/__shop/layout.tsx",
+            "children": [
+              {
+                "_component": "@_modern_js_src/__auth/__shop/item/page.tsx",
+                "children": undefined,
+                "id": "__auth/__shop/item/page",
+                "index": true,
+                "path": "item",
+                "type": "nested",
+              },
+            ],
+            "id": "__auth/__shop/layout",
+            "isRoot": false,
+            "type": "nested",
+          },
+          {
+            "_component": "@_modern_js_src/__auth/login/page.tsx",
+            "children": undefined,
+            "id": "__auth/login/page",
+            "index": true,
+            "path": "login",
+            "type": "nested",
+          },
+        ],
+        "config": "<ROOT>/tests/analyze/fixtures/nested-routes/__auth/layout.config.ts",
+        "id": "__auth/layout",
+        "isRoot": false,
+        "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/__auth/layout.loader.tsx",
+        "type": "nested",
+      },
+      {
+        "_component": "@_modern_js_src/user/layout.tsx",
+        "children": [
+          {
+            "_component": "@_modern_js_src/user/$.tsx",
+            "id": "user/$",
+            "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/$.loader.ts",
+            "path": "*",
+            "type": "nested",
+          },
+          {
+            "_component": "@_modern_js_src/user/[id]/page.tsx",
+            "children": undefined,
+            "id": "user/(id)/page",
+            "index": true,
+            "path": ":id",
+            "type": "nested",
+          },
+          {
+            "_component": "@_modern_js_src/user/page.tsx",
+            "children": undefined,
+            "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user/page.config.ts",
+            "id": "user/page",
+            "index": true,
+            "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/page.loader.ts",
+            "type": "nested",
+          },
+          {
+            "_component": "@_modern_js_src/user/profile/layout.tsx",
+            "children": [
+              {
+                "_component": "@_modern_js_src/user/profile/page.tsx",
+                "children": undefined,
+                "id": "user/profile/page",
+                "index": true,
+                "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/profile/page.loader.ts",
+                "type": "nested",
+              },
+            ],
+            "id": "user/profile/layout",
+            "isRoot": false,
+            "path": "profile",
+            "type": "nested",
+          },
+        ],
+        "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user/layout.config.ts",
+        "id": "user/layout",
+        "isRoot": false,
+        "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/layout.loader.ts",
+        "path": "user",
+        "type": "nested",
+      },
+      {
+        "_component": "@_modern_js_src/user.profile.name/layout.tsx",
+        "children": [
+          {
+            "_component": "@_modern_js_src/user.profile.name/page.tsx",
+            "children": undefined,
+            "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user.profile.name/page.config.ts",
+            "id": "user.profile.name/page",
+            "index": true,
+            "type": "nested",
+          },
+        ],
+        "config": "<ROOT>/tests/analyze/fixtures/nested-routes/user.profile.name/layout.config.ts",
+        "id": "user.profile.name/layout",
+        "isRoot": false,
+        "path": "user/profile/name",
+        "type": "nested",
+      },
+    ],
+    "config": "<ROOT>/tests/analyze/fixtures/nested-routes/layout.config.ts",
+    "id": "layout",
+    "isRoot": true,
+    "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/layout.loader.ts",
+    "path": "/",
+    "type": "nested",
+  },
+]
 `;

--- a/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
+++ b/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
@@ -56,13 +56,6 @@ exports[`nested routes walk 1`] = `
       "_component": "@_modern_js_src/user/layout.tsx",
       "children": [
         {
-          "_component": "@_modern_js_src/user/$.tsx",
-          "id": "user/$",
-          "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/$.loader.ts",
-          "path": "*",
-          "type": "nested",
-        },
-        {
           "children": [
             {
               "_component": "@_modern_js_src/user/[id]/page.tsx",
@@ -101,6 +94,13 @@ exports[`nested routes walk 1`] = `
           "id": "user/profile/layout",
           "isRoot": false,
           "path": "profile",
+          "type": "nested",
+        },
+        {
+          "_component": "@_modern_js_src/user/$.tsx",
+          "id": "user/$",
+          "loader": "<ROOT>/tests/analyze/fixtures/nested-routes/user/$.loader.ts",
+          "path": "*",
           "type": "nested",
         },
       ],

--- a/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
+++ b/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
@@ -11,108 +11,168 @@ const fixtures = path.join(__dirname, 'fixtures');
 initSnapshotSerializer({ cwd: path.resolve(__dirname, '../..') });
 
 describe('nested routes', () => {
-  test('optimizeRoute', () => {
-    const route: NestedRouteForCli = {
-      id: 'a',
-      path: 'a',
-      type: 'nested',
-      children: [
+  describe('optimizeRoute', () => {
+    test('should flatten nested routes and update path, when dont has _component', () => {
+      const route: NestedRouteForCli = {
+        id: 'a',
+        path: 'a',
+        type: 'nested',
+        children: [
+          {
+            id: 'b',
+            path: 'b',
+            type: 'nested',
+            children: [
+              {
+                id: 'c',
+                type: 'nested',
+                path: 'c',
+                _component: 'componentC',
+              },
+              {
+                // pathless layout
+                id: 'e',
+                type: 'nested',
+                _component: 'componentE',
+                children: [
+                  {
+                    id: 'f',
+                    path: 'f',
+                    type: 'nested',
+                    _component: 'componentF',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'd',
+            path: 'd',
+            type: 'nested',
+            _component: 'componentD',
+          },
+          {
+            id: 'g',
+            path: 'g',
+            type: 'nested',
+            children: [
+              {
+                id: 'i',
+                path: 'h/i',
+                type: 'nested',
+                _component: 'componentH',
+              },
+              {
+                id: 'j',
+                path: '*',
+                type: 'nested',
+                _component: 'componentJ',
+              },
+            ],
+          },
+        ],
+      };
+
+      const optimizedRoutes = optimizeRoute(route);
+      expect(optimizedRoutes).toEqual([
         {
-          id: 'b',
-          path: 'b',
+          id: 'c',
+          path: 'a/b/c',
           type: 'nested',
+          _component: 'componentC',
+        },
+        {
+          id: 'e',
+          path: 'a/b',
+          type: 'nested',
+          _component: 'componentE',
           children: [
             {
-              id: 'c',
+              id: 'f',
+              path: 'f',
               type: 'nested',
-              path: 'c',
-              _component: 'componentC',
-            },
-            {
-              // pathless layout
-              id: 'e',
-              type: 'nested',
-              _component: 'componentE',
-              children: [
-                {
-                  id: 'f',
-                  path: 'f',
-                  type: 'nested',
-                  _component: 'componentF',
-                },
-              ],
+              _component: 'componentF',
             },
           ],
         },
         {
           id: 'd',
-          path: 'd',
+          path: 'a/d',
           type: 'nested',
           _component: 'componentD',
         },
         {
-          id: 'g',
-          path: 'g',
+          id: 'i',
+          path: 'a/g/h/i',
           type: 'nested',
+          _component: 'componentH',
+        },
+        {
+          id: 'j',
+          path: 'a/g/*',
+          type: 'nested',
+          _component: 'componentJ',
+        },
+      ]);
+    });
+    /**
+     * - routes
+     *  - a
+     *    - __b
+     *      - c
+     *        - page.tsx
+     *      - layout.tsx
+     */
+    test('pathless layout should be hoist', () => {
+      const route: NestedRouteForCli = {
+        id: 'a',
+        type: 'nested',
+        path: 'a',
+        children: [
+          // pathless layout
+          {
+            id: 'b',
+            type: 'nested',
+            _component: 'layoutB',
+            children: [
+              {
+                id: 'c',
+                type: 'nested',
+                path: 'c',
+                children: [
+                  {
+                    id: 'd',
+                    type: 'nested',
+                    _component: 'pageD',
+                    index: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const optimizedRoutes = optimizeRoute(route);
+
+      expect(optimizedRoutes).toEqual([
+        {
+          id: 'b',
+          path: 'a',
+          type: 'nested',
+          _component: 'layoutB',
           children: [
             {
-              id: 'i',
-              path: 'h/i',
+              id: 'd',
+              path: 'c',
+              _component: 'pageD',
               type: 'nested',
-              _component: 'componentH',
-            },
-            {
-              id: 'j',
-              path: '*',
-              type: 'nested',
-              _component: 'componentJ',
+              index: true,
             },
           ],
         },
-      ],
-    };
-
-    const optimizedRoutes = optimizeRoute(route);
-    expect(optimizedRoutes).toEqual([
-      {
-        id: 'c',
-        path: 'a/b/c',
-        type: 'nested',
-        _component: 'componentC',
-      },
-      {
-        id: 'e',
-        path: 'a/b',
-        type: 'nested',
-        _component: 'componentE',
-        children: [
-          {
-            id: 'f',
-            path: 'f',
-            type: 'nested',
-            _component: 'componentF',
-          },
-        ],
-      },
-      {
-        id: 'd',
-        path: 'a/d',
-        type: 'nested',
-        _component: 'componentD',
-      },
-      {
-        id: 'i',
-        path: 'a/g/h/i',
-        type: 'nested',
-        _component: 'componentH',
-      },
-      {
-        id: 'j',
-        path: 'a/g/*',
-        type: 'nested',
-        _component: 'componentJ',
-      },
-    ]);
+      ]);
+    });
   });
 
   test('walk', async () => {

--- a/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
+++ b/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
@@ -1,12 +1,120 @@
+/**
+ * @jest-environment node
+ */
 import path from 'path';
 import { initSnapshotSerializer } from '@scripts/jest-config/utils';
-import { walk } from '../../src/analyze/nestedRoutes';
+import { NestedRouteForCli } from '@modern-js/types';
+import { optimizeRoute, walk } from '../../src/analyze/nestedRoutes';
 
 const fixtures = path.join(__dirname, 'fixtures');
 
 initSnapshotSerializer({ cwd: path.resolve(__dirname, '../..') });
 
 describe('nested routes', () => {
+  test('optimizeRoute', () => {
+    const route: NestedRouteForCli = {
+      id: 'a',
+      path: 'a',
+      type: 'nested',
+      children: [
+        {
+          id: 'b',
+          path: 'b',
+          type: 'nested',
+          children: [
+            {
+              id: 'c',
+              type: 'nested',
+              path: 'c',
+              _component: 'componentC',
+            },
+            {
+              // pathless layout
+              id: 'e',
+              type: 'nested',
+              _component: 'componentE',
+              children: [
+                {
+                  id: 'f',
+                  path: 'f',
+                  type: 'nested',
+                  _component: 'componentF',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'd',
+          path: 'd',
+          type: 'nested',
+          _component: 'componentD',
+        },
+        {
+          id: 'g',
+          path: 'g',
+          type: 'nested',
+          children: [
+            {
+              id: 'i',
+              path: 'h/i',
+              type: 'nested',
+              _component: 'componentH',
+            },
+            {
+              id: 'j',
+              path: '*',
+              type: 'nested',
+              _component: 'componentJ',
+            },
+          ],
+        },
+      ],
+    };
+
+    const optimizedRoutes = optimizeRoute(route);
+    expect(optimizedRoutes).toEqual([
+      {
+        id: 'c',
+        path: 'a/b/c',
+        type: 'nested',
+        _component: 'componentC',
+      },
+      {
+        id: 'e',
+        path: 'a/b',
+        type: 'nested',
+        _component: 'componentE',
+        children: [
+          {
+            id: 'f',
+            path: 'f',
+            type: 'nested',
+            _component: 'componentF',
+          },
+        ],
+      },
+      {
+        id: 'd',
+        path: 'a/d',
+        type: 'nested',
+        _component: 'componentD',
+      },
+      {
+        id: 'i',
+        path: 'a/g/h/i',
+        type: 'nested',
+        _component: 'componentH',
+      },
+      {
+        id: 'j',
+        path: 'a/g/*',
+        type: 'nested',
+        _component: 'componentJ',
+      },
+    ]);
+  });
+
   test('walk', async () => {
     const routesDir = path.join(fixtures, './nested-routes');
     const route = await walk(
@@ -18,6 +126,7 @@ describe('nested routes', () => {
       },
       'main',
       true,
+      false,
     );
     expect(route).toMatchSnapshot();
   });


### PR DESCRIPTION
## Summary

Currently, if the project has a subdirectory, the wildcard routing does not work,in this case, we should make sure that wildcard routing works.

So, when the subdirectory doesn't has a route component,it should be as a no-layout route.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 030552b</samp>

This pull request improves the router logic for the `@modern-js/runtime` and `@modern-js/app-tools` packages, and adds tests and documentation for the changes. It supports both the old and the new versions of nested routes, and optimizes them when possible. It also fixes a typo in `generateCode.ts` and adds a new `oldVersion` property to the `RouterConfig` type.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 030552b</samp>

*  Add a changeset file to describe the patch updates and fixes for the router logic ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-96d0ca65230d3cd3f3021e7948801ec9d72b1842230c8d101a9b741c73952d59R1-R7))
*  Add a new property `oldVersion` to the `RouterConfig` type to indicate the router version ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-c4fdad7c2445a9e1efe143f33158a41d176d4f0d3bcc3ca84fd00243f6d4e647R37-R40))
*  Use the `oldVersion` property in the `generateCode` function to generate the router entries ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0R123-R126))
*  Rename `nestedRoute` to `nestedRoutes` and loop through it if it is an array ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L138-R142), [link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L158-R170))
*  Pass the `oldVersion` flag to the `walk` function to analyze the nested routes ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-df2331b603116d2ed09f645421f45c2fc482d1eadfad1bc1e2eb7f93d2caf5b0L149-R153), [link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdR73-R98), [link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL83-R110))
*  Add a type annotation to the `splatRoute` variable ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL113-R140))
*  Avoid adding an array as a child route by checking the type of `childRoute` ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL132-R161))
*  Replace the `route` variable with the `finalRoute` variable to use the updated properties ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL240-R273))
*  Replace the `finalRoute.children` variable with the `childRoutes` variable to use the filtered version ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL253-R285))
*  Add a new function `optimizeRoute` to flatten and simplify the nested routes when the `oldVersion` flag is false ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdR295-R310))
*  Add a comment to indicate the node environment requirement for the test file ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-b9f08e190da885b9aeebef0f55d68a4b8e57c4c46ed5deb768eb5afad999d463L1-R7))
*  Import the `NestedRouteForCli` type and add a test case for the `optimizeRoute` function ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-b9f08e190da885b9aeebef0f55d68a4b8e57c4c46ed5deb768eb5afad999d463R14-R117))
*  Pass the `oldVersion` flag as false to the `walk` function calls in the test cases ([link](https://github.com/web-infra-dev/modern.js/pull/4323/files?diff=unified&w=0#diff-b9f08e190da885b9aeebef0f55d68a4b8e57c4c46ed5deb768eb5afad999d463R129))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
