### PR TITLE
fix(builder): checkSyntax failed when first script is JSON

### DIFF
--- a/.changeset/green-bees-fail.md
+++ b/.changeset/green-bees-fail.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): checkSyntax failed when first script is JSON
+
+fix(builder): 修复首个 script 是 JSON 时 checkSyntax 错误的问题

--- a/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/generateHtmlScripts.ts
+++ b/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/generateHtmlScripts.ts
@@ -8,7 +8,7 @@ export async function generateHtmlScripts(filepath: string) {
 
 export function getHtmlScripts(html: string) {
   const inlineScripts: string[] = [];
-  let currentScript: string | null = '';
+  let currentScript: string | null = null;
 
   const parser = new Parser({
     onopentag(name, attrs) {

--- a/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
+++ b/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
@@ -40,7 +40,7 @@ describe('getHtmlScripts', () => {
     `);
   });
 
-  test('should not extract external scripts', async () => {
+  test('should not extract external scripts and JSON scripts', async () => {
     expect(
       getHtmlScripts(`<html>
     <head>

--- a/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
+++ b/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { getHtmlScripts } from '../../src/plugins/CheckSyntaxPlugin/helpers/generateHtmlScripts';
 
 describe('getHtmlScripts', () => {
-  test('should extract single inline script correctly', async () => {
+  test('should extract inline scripts correctly', async () => {
     expect(
       getHtmlScripts(`<html>
     <head>
@@ -38,5 +38,20 @@ describe('getHtmlScripts', () => {
       It has a line break.\\");",
       ]
     `);
+  });
+
+  test('should not extract external scripts', async () => {
+    expect(
+      getHtmlScripts(`<html>
+    <head>
+      <title>Title</title>
+    </head>
+    <body>
+      <h1>Hello, World!</h1>
+      <script type="application/json">{"foo":"bar"}</script>
+      <script src="external.js"></script>
+    </body>
+  </html>`),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14101e5</samp>

Fixed a bug in the `CheckSyntaxPlugin` that caused syntax errors when the first script in an HTML file was a JSON script. Added a test case and a changeset file for the `@modern-js/builder-shared` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 14101e5</samp>

*  Add a changeset file to describe the patch version update and the bug fix for the `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/4324/files?diff=unified&w=0#diff-072a6e5ecf6900bc75077ee7274e87332a3b239636bce97fb847b418677f96e8R1-R7))
*  Fix the bug in the `getHtmlScripts` function that caused the `CheckSyntaxPlugin` to fail when the first script in the HTML file was a JSON script ([link](https://github.com/web-infra-dev/modern.js/pull/4324/files?diff=unified&w=0#diff-3e042074c15c6ba290354a4598df11304329aebabce4206758af8a97798a7b49L11-R11))
*  Update and add test cases for the `getHtmlScripts` function in the `CheckSyntaxPlugin.test.ts` file to verify the bug fix and the multiple inline script extraction ([link](https://github.com/web-infra-dev/modern.js/pull/4324/files?diff=unified&w=0#diff-8e07cc58775721e483bb461e2dcadd9db7e0f178257f8540c32a3f910803af47L5-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4324/files?diff=unified&w=0#diff-8e07cc58775721e483bb461e2dcadd9db7e0f178257f8540c32a3f910803af47R42-R56))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
