### PR TITLE
feat(module-generator): remove jsnext:source and add `declaration:true`

### DIFF
--- a/.changeset/ten-papayas-crash.md
+++ b/.changeset/ten-papayas-crash.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-generator': patch
+---
+
+feat(module-generator): remove jsnext:source and add `declaration:true`
+feat(module-generator): 移除 jsnext:source 并且增加 `declaration:true`

--- a/packages/generator/generators/module-generator/templates/base-template/package.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/base-template/package.json.handlebars
@@ -5,7 +5,6 @@
   "main": "./src/index.{{ language }}",
   {{/unless}}
   {{#if isPublic}}
-  "jsnext:source": "./src/index.{{ language }}",
   {{#if isTs}}
   "types": "./dist/types/index.d.ts",
   {{/if}}

--- a/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
@@ -1,5 +1,6 @@
 {
   "extends": "@modern-js/tsconfig/base",
+  "declaration": true,
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57c2adc</samp>

This pull request updates the `@modern-js/module-generator` package to remove the unused `jsnext:source` field and add the `declaration` field to the module templates. This improves the compatibility and usability of the generated modules.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 57c2adc</samp>

* Remove `jsnext:source` field from module generator templates ([link](https://github.com/web-infra-dev/modern.js/pull/4326/files?diff=unified&w=0#diff-100315a28805094a770f73f353981c90a3d1a8b1a1260cfcbe1e659c616f2c78L8))
* Add `declaration` field to TypeScript module generator template ([link](https://github.com/web-infra-dev/modern.js/pull/4326/files?diff=unified&w=0#diff-a082369268bcf3a4214502bbd1f252021dcff571dcf5e0cf237ad41ee8472399R3))
* Update changeset file for `@modern-js/module-generator` package ([link](https://github.com/web-infra-dev/modern.js/pull/4326/files?diff=unified&w=0#diff-541072f4817b2b8d2d8ab77034ed4eb4f4e683c989a5299c561569e05a8b5f64R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
