### PR TITLE
docs(module-tools): add examples and fix mistakes for dts configs

### DIFF
--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -446,6 +446,7 @@ We have done many extensions based on the original esbuild build. Therefore, whe
 
 1. Prefer to use the configuration that Modern.js Module provides. For example, esbuild does not support `target: 'es5'`, but we support this scenario internally using SWC. Setting `target: 'es5'` through esbuildOptions will result in an error.
 2. Currently, we use enhanced-resolve internally to replace esbuild's resolve algorithm, so modifying esbuild resolve-related configurations is invalid. We plan to switch back in the future.
+3. When `buildType` is `'bundleless'`, When buildType is set to 'bundleless', only certain esbuild options are effective.
 
 :::
 

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -446,7 +446,6 @@ We have done many extensions based on the original esbuild build. Therefore, whe
 
 1. Prefer to use the configuration that Modern.js Module provides. For example, esbuild does not support `target: 'es5'`, but we support this scenario internally using SWC. Setting `target: 'es5'` through esbuildOptions will result in an error.
 2. Currently, we use enhanced-resolve internally to replace esbuild's resolve algorithm, so modifying esbuild resolve-related configurations is invalid. We plan to switch back in the future.
-3. When `buildType` is `'bundleless'`, When buildType is set to 'bundleless', only certain esbuild options are effective.
 
 :::
 

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -217,7 +217,7 @@ Whether to require peerDep dependencies for external projects
 The build type, `bundle` will package your code, `bundleless` will only do the code conversion
 
 - **Type**: `'bundle' | 'bundleless'`
-- **Default**: `bundle`
+- **Default**: `'bundle'`
 
 ## copy
 
@@ -346,14 +346,36 @@ When this configuration is disabled, there is no guarantee that the type files w
 The output path of the dts file, based on [outDir](/api/config/build-config#outDir)
 
 - **Type**: `string`
-- **Default**: `. /types`
+- **Default**: `./`
+
+For example, output to the `types` directory under the `outDir`:
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      distPath: './types',
+    },
+  },
+});
+```
 
 ## dts.only
 
-Generate only dts files, not js files
+Whether to generate only type files during the build process without generating JavaScript output files.
 
 - **Type**: `boolean`
 - **Default**: `false`
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      only: true,
+    },
+  },
+});
+```
 
 ## dts.respectExternal
 
@@ -365,6 +387,16 @@ So we can avoid it with this configuration.
 - **Type**: `boolean`
 - **Default**: `true`
 
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      respectExternal: false,
+    },
+  },
+});
+```
+
 ## dts.tsconfigPath
 
 Path to the tsconfig file
@@ -372,11 +404,22 @@ Path to the tsconfig file
 - **Type**: `string`
 - **Default**: `. /tsconfig.json`
 
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      tsconfigPath: './other-tsconfig.json',
+    },
+  },
+});
+```
+
 ## esbuildOptions
 
 Used to modify the [esbuild configuration](https://esbuild.github.io/api/).
 
 - **Type**: `Function`
+- **Build Type**: `Only supported for buildType: 'bundle'`
 - **Default**: `c => c`
 
 For example, if we need to modify the file extension of the generated files:
@@ -645,17 +688,33 @@ export default {
 
 ## outDir
 
-Specifies the output directory of the build
+Specifies the output directory of the build.
 
 - **Type**: `string`
-- **Default**: `dist`
+- **Default**: `./dist`
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    outDir: './dist/esm',
+  },
+});
+```
 
 ## platform
 
 Generates code for the node environment by default, you can also specify `browser` which will generate code for the browser environment
 
 - **Type**: `'browser' | 'node'`
-- **Default**: `node`
+- **Default**: `'node'`
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    platform: 'browser',
+  },
+});
+```
 
 ## redirect
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -218,7 +218,7 @@ export default defineConfig({
 构建类型，`bundle` 会打包你的代码，`bundleless` 只做代码的转换。
 
 - 类型： `'bundle' | 'bundleless'`
-- 默认值： `bundle`
+- 默认值： `'bundle'`
 
 ## copy
 
@@ -345,15 +345,37 @@ export default defineConfig({
 
 类型文件的输出路径，基于 [outDir](/api/config/build-config#outDir) 进行输出。
 
-- 类型: `string`
-- 默认值: `./types`
+- 类型： `string`
+- 默认值： `./`
+
+比如输出到 `outDir` 下面的 `types` 目录：
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      distPath: './types',
+    },
+  },
+});
+```
 
 ## dts.only
 
-只生成类型文件，不生成 js 文件。
+是否在构建时只生成类型文件，不生成 JavaScript 产物文件。
 
 - 类型： `boolean`
 - 默认值： `false`
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      only: true,
+    },
+  },
+});
+```
 
 ## dts.respectExternal
 
@@ -364,6 +386,16 @@ export default defineConfig({
 - 类型： `boolean`
 - 默认值： `true`
 
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      respectExternal: false,
+    },
+  },
+});
+```
+
 ## dts.tsconfigPath
 
 TypeScript 配置文件的路径。
@@ -371,12 +403,23 @@ TypeScript 配置文件的路径。
 - 类型： `string`
 - 默认值： `./tsconfig.json`
 
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    dts: {
+      tsconfigPath: './other-tsconfig.json',
+    },
+  },
+});
+```
+
 ## esbuildOptions
 
 用于修改底层的 [esbuild 配置](https://esbuild.github.io/api/)。
 
-- 类型: `Function`
-- 默认值: `c => c`
+- 类型： `Function`
+- 构建类型：`仅支持 buildType: 'bundle'`
+- 默认值： `c => c`
 
 例如，我们需要修改生成文件的后缀：
 
@@ -645,17 +688,33 @@ export default defineConfig({
 
 ## outDir
 
-指定构建的输出目录
+指定构建的输出目录。
 
-- 类型: `string`
-- 默认值: `dist`
+- 类型： `string`
+- 默认值： `./dist`
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    outDir: './dist/esm',
+  },
+});
+```
 
 ## platform
 
 默认生成用于 Node.js 环境下的代码，你也可以指定为 `browser`，会生成用于浏览器环境的代码。
 
 - 类型： `'browser' | 'node'`
-- 默认值： `node`
+- 默认值： `'node'`
+
+```js modern.config.ts
+export default defineConfig({
+  buildConfig: {
+    platform: 'browser',
+  },
+});
+```
 
 ## redirect
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -418,7 +418,6 @@ export default defineConfig({
 用于修改底层的 [esbuild 配置](https://esbuild.github.io/api/)。
 
 - 类型： `Function`
-- 构建类型：`仅支持 buildType: 'bundle'`
 - 默认值： `c => c`
 
 例如，我们需要修改生成文件的后缀：
@@ -445,6 +444,7 @@ import RegisterEsbuildPlugin from '@site-docs/components/register-esbuild-plugin
 
 1. 优先使用 Modern.js Module 提供的配置，例如 esbuild 并不支持 `target: 'es5'`，但我们内部使用 SWC 支持了此场景，此时通过 `esbuildOptions` 设置`target: 'es5'`会报错。
 2. 目前我们内部使用 `enhanced-resolve` 替代了 esbuild 的 resolve 解析算法，所以修改 esbuild resolve 相关配置无效，计划在未来会切换回来。
+3. 在 `buildType` 为 `'bundleless'` 时，只有部分 esbuild 选项能够生效。
 
 :::
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -444,7 +444,6 @@ import RegisterEsbuildPlugin from '@site-docs/components/register-esbuild-plugin
 
 1. 优先使用 Modern.js Module 提供的配置，例如 esbuild 并不支持 `target: 'es5'`，但我们内部使用 SWC 支持了此场景，此时通过 `esbuildOptions` 设置`target: 'es5'`会报错。
 2. 目前我们内部使用 `enhanced-resolve` 替代了 esbuild 的 resolve 解析算法，所以修改 esbuild resolve 相关配置无效，计划在未来会切换回来。
-3. 在 `buildType` 为 `'bundleless'` 时，只有部分 esbuild 选项能够生效。
 
 :::
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36c2594</samp>

This pull request improves the documentation of the `build` config options for the `module-doc` package in both English and Chinese. It fixes errors, adds examples, and clarifies some details in the `build-config.mdx` files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 36c2594</samp>

*  Add quotation marks around the default value of `buildType` option in both English and Chinese documentation for consistency ([link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baL220-R220), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L221-R221))
*  Update the default value of `dts.distPath` option in both English and Chinese documentation to match the code behavior and add example code snippets to show how to customize the output path of the type files ([link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baL349-R379), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L348-R379))
*  Add example code snippets to show how to use `dts.only` and `dts.tsconfigPath` options in both English and Chinese documentation for clarity and illustration ([link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baR390-R399), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baR407-R416), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791R389-R398), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L374-R422))
*  Add a note to indicate that `esbuildOptions` option is only supported for `buildType: 'bundle'` in both English and Chinese documentation to avoid confusion and errors ([link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baR422), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L374-R422))
*  Update the default value of `outDir` option in both English and Chinese documentation to match the code behavior and add example code snippets to show how to customize the output directory of the build ([link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baL648-R703), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L648-R703))
*  Update the default value of `platform` option in both English and Chinese documentation for consistency and add example code snippets to show how to use the `platform` option ([link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baL658-R718), [link](https://github.com/web-infra-dev/modern.js/pull/4327/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L658-R718))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
