### PR TITLE
test: fix source code testing for vitest cases

### DIFF
--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -176,7 +176,7 @@ exports[`webpackConfig > should not have any pluginImport in Babel 1`] = `
           "configFile": false,
           "plugins": [
             [
-              "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
             ],
             [
               "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -276,7 +276,7 @@ exports[`webpackConfig > should not have any pluginImport in Babel 1`] = `
           "configFile": false,
           "plugins": [
             [
-              "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
             ],
             [
               "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -395,7 +395,7 @@ exports[`webpackConfig > should not set default pluginImport for Babel 1`] = `
               "antd",
             ],
             [
-              "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
             ],
             [
               "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -504,7 +504,7 @@ exports[`webpackConfig > should not set default pluginImport for Babel 1`] = `
               "antd",
             ],
             [
-              "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
             ],
             [
               "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -645,7 +645,7 @@ exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
               "foo",
             ],
             [
-              "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
             ],
             [
               "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -753,7 +753,7 @@ exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
               "foo",
             ],
             [
-              "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+              "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
             ],
             [
               "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -34,7 +34,7 @@ exports[`plugins/babel > should add rule to compile Data URI when enable source.
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -134,7 +134,7 @@ exports[`plugins/babel > should add rule to compile Data URI when enable source.
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -248,7 +248,7 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -343,7 +343,7 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -455,7 +455,7 @@ exports[`plugins/babel > should apply exclude condition when using source.exclud
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -555,7 +555,7 @@ exports[`plugins/babel > should apply exclude condition when using source.exclud
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -677,7 +677,7 @@ exports[`plugins/babel > should override targets of babel-preset-env when using 
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -775,7 +775,7 @@ exports[`plugins/babel > should override targets of babel-preset-env when using 
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -887,7 +887,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -987,7 +987,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -1105,7 +1105,7 @@ exports[`plugins/babel > should set include/exclude 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -1205,7 +1205,7 @@ exports[`plugins/babel > should set include/exclude 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -510,7 +510,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -649,7 +649,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -1442,7 +1442,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -1587,7 +1587,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -2331,7 +2331,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -2474,7 +2474,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -3127,7 +3127,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",
@@ -3272,7 +3272,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "@arco-design/web-react/icon",
                 ],
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-lodash/index.js",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
@@ -25,7 +25,7 @@ exports[`plugins/react > should work with babel-loader 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -140,7 +140,7 @@ exports[`plugins/react > should work with babel-loader 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/esm-node/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",

--- a/packages/builder/friendly-errors-webpack-plugin/tests/pathReplacements.ts
+++ b/packages/builder/friendly-errors-webpack-plugin/tests/pathReplacements.ts
@@ -1,4 +1,4 @@
-import { applyMatcherReplacement } from '@modern-js/utils';
+import { applyMatcherReplacement } from '@scripts/vitest-config';
 import { snapshotSerializer } from './setup';
 import { ErrorTransformer } from '@/shared/types';
 

--- a/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -70,7 +70,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -176,7 +176,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -350,7 +350,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -454,7 +454,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",

--- a/packages/builder/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -68,7 +68,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -174,7 +174,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -346,7 +346,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",
@@ -452,7 +452,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
               "configFile": false,
               "plugins": [
                 [
-                  "<WORKSPACE>/packages/cli/babel-preset-app/dist/cjs/babelPluginLockCorejsVersion",
+                  "<WORKSPACE>/packages/cli/babel-preset-app/src/babelPluginLockCorejsVersion",
                 ],
                 [
                   "<WORKSPACE>/packages/cli/babel-preset-base/compiled/babel-plugin-dynamic-import-node/index.js",

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -18,9 +18,11 @@
   "module": "./dist/index.js",
   "exports": {
     ".": {
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./playwright": {
+      "jsnext:source": "./src/exports/playwright.ts",
       "default": "./dist/exports/playwright.js"
     },
     "./fixtures/*": {

--- a/packages/toolkit/utils/src/cli/index.ts
+++ b/packages/toolkit/utils/src/cli/index.ts
@@ -12,7 +12,6 @@ export * from './logger';
 export * from './monorepo';
 export * from './package';
 export * from './path';
-export * from './pathSerializer';
 export * from './port';
 export * from './prettyInstructions';
 export * from './require';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6025,9 +6025,6 @@ importers:
       '@modern-js/tsconfig':
         specifier: workspace:*
         version: link:../../packages/review/tsconfig
-      '@modern-js/utils':
-        specifier: workspace:*
-        version: link:../../packages/toolkit/utils
       '@types/lodash':
         specifier: ^4.14.195
         version: 4.14.195

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6028,6 +6028,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../packages/toolkit/utils
+      '@types/lodash':
+        specifier: ^4.14.195
+        version: 4.14.195
       '@types/node':
         specifier: ^14
         version: 14.18.35
@@ -6040,12 +6043,18 @@ importers:
       globby:
         specifier: ^11.0.4
         version: 11.1.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       p-map:
         specifier: ^4.0.0
         version: 4.0.0
       typescript:
         specifier: ^5
         version: 5.0.4
+      upath:
+        specifier: 2.0.1
+        version: 2.0.1
 
   tests:
     devDependencies:
@@ -33423,7 +33432,6 @@ packages:
   /upath@2.0.1:
     resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
     engines: {node: '>=4'}
-    dev: true
 
   /update-browserslist-db@1.0.10(browserslist@4.21.4):
     resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6043,9 +6043,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      p-map:
-        specifier: ^4.0.0
-        version: 4.0.0
       typescript:
         specifier: ^5
         version: 5.0.4

--- a/scripts/vitest-config/package.json
+++ b/scripts/vitest-config/package.json
@@ -12,12 +12,14 @@
   },
   "dependencies": {
     "@modern-js/tsconfig": "workspace:*",
-    "@modern-js/utils": "workspace:*",
     "@types/node": "^14",
+    "@types/lodash": "^4.14.195",
     "execa": "^5.1.1",
+    "lodash": "^4.17.21",
     "fs-extra": "^10",
     "globby": "^11.0.4",
     "p-map": "^4.0.0",
+    "upath": "2.0.1",
     "typescript": "^5"
   }
 }

--- a/scripts/vitest-config/package.json
+++ b/scripts/vitest-config/package.json
@@ -18,7 +18,6 @@
     "lodash": "^4.17.21",
     "fs-extra": "^10",
     "globby": "^11.0.4",
-    "p-map": "^4.0.0",
     "upath": "2.0.1",
     "typescript": "^5"
   }

--- a/scripts/vitest-config/src/index.ts
+++ b/scripts/vitest-config/src/index.ts
@@ -1,6 +1,7 @@
+import _ from 'lodash';
 import { defineConfig, UserConfigExport } from 'vitest/config';
-import _ from '@modern-js/utils/lodash';
 import { createSnapshotSerializer } from './utils';
+import { applyMatcherReplacement } from './pathSerializer';
 
 export const testPreset = defineConfig({
   test: {
@@ -13,9 +14,12 @@ export const testPreset = defineConfig({
     include: ['src/**/*.test.[jt]s?(x)', 'tests/**/*.test.[jt]s?(x)'],
     restoreMocks: true,
   },
+  resolve: {
+    conditions: ['jsnext:source'],
+  },
 });
 
 export const withTestPreset = (config: UserConfigExport) =>
   _.merge(testPreset, config);
 
-export { defineConfig, createSnapshotSerializer };
+export { defineConfig, createSnapshotSerializer, applyMatcherReplacement };

--- a/scripts/vitest-config/src/path.ts
+++ b/scripts/vitest-config/src/path.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
-import { nanoid, upath } from '../compiled';
+import _ from 'lodash';
+import upath from 'upath';
 
 export const isPathString = (test: string): boolean =>
   path.posix.basename(test) !== test || path.win32.basename(test) !== test;
@@ -16,13 +17,39 @@ export const normalizeToPosixPath = (p: string | undefined) =>
     .normalizeSafe(path.normalize(p || ''))
     .replace(/^([a-zA-Z]+):/, (_, m: string) => `/${m.toLowerCase()}`);
 
-export const getTemplatePath = (prefix?: string) => {
-  const tmpRoot = fs.realpathSync(os.tmpdir());
-  const parts = [tmpRoot];
-  prefix && parts.push(prefix);
-  parts.push(nanoid());
-  return path.resolve(...parts);
-};
+/**
+ * Compile path string to RegExp.
+ * @note Only support posix path.
+ */
+export function compilePathMatcherRegExp(match: string | RegExp) {
+  if (typeof match !== 'string') {
+    return match;
+  }
+  const escaped = _.escapeRegExp(match);
+  return new RegExp(`(?<=\\W|^)${escaped}(?=\\W|$)`);
+}
+
+/** @internal @see {@link upwardPaths} */
+export const _joinPathParts = (
+  _part: unknown,
+  i: number,
+  parts: _.List<string>,
+) =>
+  _(parts)
+    .filter(part => !['/', '\\'].includes(part))
+    .tap(parts => parts.unshift(''))
+    .slice(0, i + 2)
+    .join('/');
+
+export function upwardPaths(start: string): string[] {
+  return _(start)
+    .split(/[/\\]/)
+    .filter(Boolean)
+    .map(_joinPathParts)
+    .reverse()
+    .push('/')
+    .value();
+}
 
 export function getRealTemporaryDirectory() {
   let ret: string | null = null;
@@ -36,14 +63,3 @@ export function getRealTemporaryDirectory() {
 export function splitPathString(str: string) {
   return str.split(/[\\/]/);
 }
-
-export const removeLeadingSlash = (s: string): string => s.replace(/^\/+/, '');
-
-export const removeTailSlash = (s: string): string => s.replace(/\/+$/, '');
-
-export const removeSlash = (s: string): string =>
-  removeLeadingSlash(removeTailSlash(s));
-
-export const cutNameByHyphen = (s: string) => {
-  return s.split(/[-_]/)[0];
-};

--- a/scripts/vitest-config/src/pathSerializer.ts
+++ b/scripts/vitest-config/src/pathSerializer.ts
@@ -1,6 +1,6 @@
 // Todo: only @scripts/vitest-config used
 import os from 'os';
-import _ from '../../compiled/lodash';
+import _ from 'lodash';
 import {
   compilePathMatcherRegExp,
   normalizeToPosixPath,

--- a/scripts/vitest-config/src/utils.ts
+++ b/scripts/vitest-config/src/utils.ts
@@ -1,12 +1,11 @@
 import assert from 'assert';
+import path from 'path';
 import {
   applyMatcherReplacement,
   createDefaultPathMatchers,
-  isPathString,
-  normalizeToPosixPath,
   PathMatcher,
-  findMonorepoRoot,
-} from '@modern-js/utils';
+} from './pathSerializer';
+import { isPathString, normalizeToPosixPath } from './path';
 
 export const debug: typeof console.log = (...args) => {
   process.env.DEBUG_MODERNJS_VITEST && console.log(...args);
@@ -21,7 +20,7 @@ export interface SnapshotSerializerOptions {
 export function createSnapshotSerializer(options?: SnapshotSerializerOptions) {
   const {
     cwd = process.cwd(),
-    workspace = findMonorepoRoot(cwd),
+    workspace = path.join(__dirname, '../../..'),
     replace: customMatchers = [],
   } = options || {};
   assert(cwd, 'cwd is required');
@@ -41,6 +40,7 @@ export function createSnapshotSerializer(options?: SnapshotSerializerOptions) {
     );
 
   return {
+    pathMatchers,
     // match path-format string
     test: (val: unknown) => typeof val === 'string' && isPathString(val),
     print: (val: unknown) => {

--- a/scripts/vitest-config/tests/path.test.ts
+++ b/scripts/vitest-config/tests/path.test.ts
@@ -1,4 +1,9 @@
-import { compilePathMatcherRegExp, upwardPaths, _joinPathParts } from '../src';
+import { describe, expect, it } from 'vitest';
+import {
+  compilePathMatcherRegExp,
+  upwardPaths,
+  _joinPathParts,
+} from '../src/path';
 
 describe('upwardPaths', () => {
   it('should get upward paths', () => {

--- a/scripts/vitest-config/tests/pathSerializer.test.ts
+++ b/scripts/vitest-config/tests/pathSerializer.test.ts
@@ -1,8 +1,9 @@
+import { describe, expect, it } from 'vitest';
 import {
   applyMatcherReplacement,
   applyPathMatcher,
   matchUpwardPathsAsUnknown,
-} from '../src';
+} from '../src/pathSerializer';
 
 describe('matchUpwardPathsAsUnknown', () => {
   it('should match upward paths', () => {

--- a/scripts/vitest-config/vitestRunAll.js
+++ b/scripts/vitest-config/vitestRunAll.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const fs = require('fs-extra');
 const pMap = require('p-map');
 const execa = require('execa');
 const globby = require('globby');
@@ -18,15 +17,6 @@ const restArgv = process.argv.slice(2);
 
   try {
     const filters = ['@scripts/vitest-config'];
-
-    directories.forEach(dir => {
-      const pkgJson = path.join(dir, 'package.json');
-      if (fs.existsSync(pkgJson)) {
-        const { name } = fs.readJSONSync(pkgJson);
-        filters.push(name);
-      }
-    });
-
     const filterCmd = filters
       .map(item => `--filter-prod "${item}"...`)
       .join(' ');
@@ -36,7 +26,6 @@ const restArgv = process.argv.slice(2);
     await execa(buildCmd, {
       shell: SHELL,
       stdio: 'inherit',
-      env: { SKIP_DTS: 'true' },
     });
 
     await pMap(

--- a/scripts/vitest-config/vitestRunAll.js
+++ b/scripts/vitest-config/vitestRunAll.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const pMap = require('p-map');
 const execa = require('execa');
 const globby = require('globby');
 
@@ -28,14 +27,14 @@ const restArgv = process.argv.slice(2);
       stdio: 'inherit',
     });
 
-    await pMap(
-      directories,
-      async cwd => {
-        const args = ['run', 'test', ...restArgv];
-        await execa('pnpm', args, { shell: SHELL, stdio: 'inherit', cwd });
-      },
-      { concurrency: 2 },
-    );
+    for (let i = 0; i < directories.length; i++) {
+      const args = ['run', 'test', ...restArgv];
+      await execa('pnpm', args, {
+        shell: SHELL,
+        stdio: 'inherit',
+        cwd: directories[i],
+      });
+    }
   } catch (err) {
     console.error(err);
     // eslint-disable-next-line no-process-exit


### PR DESCRIPTION
## Summary

The source code testing was broken after upgrading to vitest v0.33.0:

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/b00f3f9f-e3df-41dc-bdcf-cf9a72e9a3da)

I've found that this limitation only affects the `vitest.config.ts` and its dependencies, so we can refactor `@script/vitest-config` and remove the `@modern-js/utils` dependency, then the source code testing will work again.

This PR also removed the `p-map` logic, as parallel testing would occasionally fail on Window CI.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 397ac46</samp>

This pull request refactors the path-related utilities and the vitest configuration for the `web-infra-dev/modern.js` repository. It moves some modules from `packages/toolkit/utils` to `scripts/vitest-config`, a new package that provides a test preset for vitest, a testing framework. It also updates the imports, exports, dependencies, and tests of the affected files to use the new package and modules.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 397ac46</samp>

*  Move `applyMatcherReplacement` function and related utilities to a new package `scripts/vitest-config` that provides a test preset for vitest ([link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-523c6ec9a9b62de319bce78f1279488ab21c2b9793c9eabc79e0c1955bd45ba0L1-R1), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-8aac5478574eea52dc8b594f0c725ec404014b84577cc13a778193db47d455d9L15), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-f981da3eb5ebbaa20f23267609c16cd3b593daec343fe1ccdca2e918ee42bf09L4-R4), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-f981da3eb5ebbaa20f23267609c16cd3b593daec343fe1ccdca2e918ee42bf09L27-L60), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-1e7586475934ec39cb3e5cd4f6db5b647ae88b0f04bcc6667fb2877a837014b9L15-R22), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-68fafc94759583f1e8143fad750c38688eb941c1daf059975e379da21a78bbc1L1-R4), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-68fafc94759583f1e8143fad750c38688eb941c1daf059975e379da21a78bbc1L21-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-edca296bf8b810cb040b0d615cbaf2074cb0610a0bbd894c34ee7d9c671266d3L3-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-daa1854c07630041ab396da49ac979a6f6cf5cece828633b7d2ce4cc92967f8cL2-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-daa1854c07630041ab396da49ac979a6f6cf5cece828633b7d2ce4cc92967f8cL24-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-daa1854c07630041ab396da49ac979a6f6cf5cece828633b7d2ce4cc92967f8cR43))
*  Add `resolve` option to `testPreset` object to specify the `jsnext:source` condition for resolving modules ([link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-68fafc94759583f1e8143fad750c38688eb941c1daf059975e379da21a78bbc1R17-R19))
*  Add code for `isPathString`, `isRelativePath`, `normalizeOutputPath`, `normalizeToPosixPath`, `compilePathMatcherRegExp`, `upwardPaths`, `_joinPathParts`, `getRealTemporaryDirectory`, and `splitPathString` to `scripts/vitest-config/src/path.ts` as utility functions for handling paths ([link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-af9f2b283e9c439da6f907729746b5252915bc35035d3c9c9f2dbc34ce93516aR1-R65))
*  Add `pathMatchers` argument to `createSnapshotSerializer` function to allow customizing the path replacements for snapshots ([link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-daa1854c07630041ab396da49ac979a6f6cf5cece828633b7d2ce4cc92967f8cR43))
*  Update imports in `scripts/vitest-config/tests/path.test.ts` and `scripts/vitest-config/tests/pathSerializer.test.ts` to use `vitest` and the correct modules from `scripts/vitest-config/src` ([link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-b0241985b767f828e8fcad98283991b6249c8496df037f559b38a205a242e909L1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-d99b841f01efe45ed364eb277cf7619185b0124776025c1845067b389fcbdeb6L1-R6))
*  Remove unnecessary and error-prone code from `scripts/vitest-config/vitestRunAll.js` ([link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-38bd2bd794ec43d088714a436d30bed0f16a9cf1cdfdc92deed7e38bc18e1f70L2), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-38bd2bd794ec43d088714a436d30bed0f16a9cf1cdfdc92deed7e38bc18e1f70L21-L29), [link](https://github.com/web-infra-dev/modern.js/pull/4330/files?diff=unified&w=0#diff-38bd2bd794ec43d088714a436d30bed0f16a9cf1cdfdc92deed7e38bc18e1f70L39))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
