### PR TITLE
Feat: add body-parser to parse the body from request

### DIFF
--- a/.changeset/brave-penguins-grin.md
+++ b/.changeset/brave-penguins-grin.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': minor
+---
+
+feat(prod-server): add body parser
+feat(prod-server): 增加 body 解析器

--- a/packages/server/prod-server/src/libs/render/ssr.ts
+++ b/packages/server/prod-server/src/libs/render/ssr.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { IncomingMessage } from 'http';
 import {
   fs,
   mime,
@@ -45,7 +44,6 @@ export const render = async (
   const routeManifest = fs.existsSync(routesManifestUri)
     ? require(routesManifestUri)
     : undefined;
-  const body = await getRequestBody(ctx.req);
 
   const context: SSRServerContext = {
     request: {
@@ -56,7 +54,7 @@ export const render = async (
       query: ctx.query as Record<string, string>,
       url: ctx.href,
       headers: ctx.headers,
-      body,
+      body: ctx.req.body,
     },
     response: {
       setHeader: (key, value) => {
@@ -112,28 +110,3 @@ export const render = async (
     };
   }
 };
-
-/**
- * get body from request.
- * @return body -
- *  if req.method !== 'GET', it returns a string, otherwise it returns undefined
- */
-const getRequestBody = (req: IncomingMessage): Promise<string | undefined> =>
-  new Promise((resolve, reject) => {
-    if (req?.method && req.method.toLowerCase() !== 'get') {
-      let body = '';
-      req.on('data', chunk => {
-        body += chunk.toString();
-      });
-
-      req.on('end', () => {
-        resolve(body);
-      });
-
-      req.on('error', err => {
-        reject(err);
-      });
-    } else {
-      resolve(undefined);
-    }
-  });

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -46,6 +46,7 @@ import {
   noop,
   debug,
   isRedirect,
+  bodyParser,
 } from '../utils';
 import * as reader from '../libs/render/reader';
 import { createProxyHandler, BffProxyOptions } from '../libs/proxy';
@@ -503,7 +504,10 @@ export class ModernServer implements ModernServerInterface {
   /* —————————————————————— private function —————————————————————— */
   // handler route.json, include api / csr / ssr
   private async routeHandler(context: ModernServerContext) {
-    const { res } = context;
+    const { res, req } = context;
+
+    // parse request body from readable stream to assgin it to req
+    await bodyParser(req);
 
     // match routes in the route spec
     const matched = this.router.match(context.path);

--- a/packages/server/prod-server/src/type.ts
+++ b/packages/server/prod-server/src/type.ts
@@ -16,6 +16,7 @@ declare module 'http' {
   interface IncomingMessage {
     logger: Logger;
     metrics: Metrics;
+    body?: string;
   }
 }
 

--- a/packages/server/prod-server/src/utils.ts
+++ b/packages/server/prod-server/src/utils.ts
@@ -133,3 +133,32 @@ export const headersWithoutCookie = (headers: IncomingMessage['headers']) => {
 export const isRedirect = (code: number) => {
   return [301, 302, 307, 308].includes(code);
 };
+
+/**
+ * get body from request.
+ * @return body -
+ *  if req.method !== 'GET', it returns a string, otherwise it returns undefined
+ */
+const getRequestBody = (req: IncomingMessage): Promise<string | undefined> =>
+  new Promise((resolve, reject) => {
+    if (req?.method && req.method.toLowerCase() !== 'get') {
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk.toString();
+      });
+
+      req.on('end', () => {
+        resolve(body);
+      });
+
+      req.on('error', err => {
+        reject(err);
+      });
+    } else {
+      resolve(undefined);
+    }
+  });
+
+export const bodyParser = async (req: IncomingMessage) => {
+  req.body = await getRequestBody(req);
+};

--- a/packages/server/prod-server/tests/render.test.ts
+++ b/packages/server/prod-server/tests/render.test.ts
@@ -16,6 +16,7 @@ describe('test render function', () => {
         url: 'localhost:8080/foo',
         cookieMap: {},
         headers: {},
+        req: {},
       } as any,
       {
         urlPath: '/foo',
@@ -116,6 +117,7 @@ describe('test render function', () => {
         url: 'localhost:8080/foo',
         cookieMap: {},
         headers: {},
+        req: {},
         resHasHandled: () => false,
       } as any,
       route: {


### PR DESCRIPTION
## Summary

Sometime user need get request body in custom server hook, like `afterMatch`, `afterRender`, etc.
We must need load the body to context, otherwise them can't get body in somewhere.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ccd70d</samp>

Added request body parsing logic to the modern server. Extracted the `getRequestBody` function to `utils.ts` and used a middleware function `bodyParser` to assign the parsed body to the `req.body` property. Updated the `IncomingMessage` interface in `type.ts` to include the `body` property.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ccd70d</samp>

*  Refactor `getRequestBody` function to a separate utility module `utils.ts` and remove unused import of `IncomingMessage` from `http` module in `ssr.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-11c102982d4c6e9170690b8a835eabccf0e03018adbf774498acb0ce7c97047fL2), [link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-11c102982d4c6e9170690b8a835eabccf0e03018adbf774498acb0ce7c97047fL115-L139), [link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-5520c0024d9ed9695a3cadb6039396345312ecab189783d4fd1114c35db489b4R136-R164))
* Add `bodyParser` function to `utils.ts` to parse the request body from the readable stream and assign it to the `req.body` property ([link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-5520c0024d9ed9695a3cadb6039396345312ecab189783d4fd1114c35db489b4R136-R164))
* Import and use `bodyParser` function as a middleware in `modernServer.ts` to ensure the request body is parsed before passing the request to the route handler ([link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bR49), [link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL506-R511))
* Replace `body` variable by `ctx.req.body` in `render` function in `ssr.ts` to access the parsed request body from the middleware function ([link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-11c102982d4c6e9170690b8a835eabccf0e03018adbf774498acb0ce7c97047fL48), [link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-11c102982d4c6e9170690b8a835eabccf0e03018adbf774498acb0ce7c97047fL59-R57))
* Extend the `IncomingMessage` interface in `type.ts` to add the `body` property to the request object type definition ([link](https://github.com/web-infra-dev/modern.js/pull/4331/files?diff=unified&w=0#diff-43eeb40674837c6fea50840b269fbf2cc78be93bb1445caed035d0897ce76f47R19))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
