### PR TITLE
fix(@modern-js/utils): add missing url in devServer console

### DIFF
--- a/.changeset/wet-ears-drop.md
+++ b/.changeset/wet-ears-drop.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/utils': patch
+---
+
+fix(@modern-js/utils): add missing url in devServer console
+fix(@modern-js/utils): 修复 devServer console 中丢失的 url

--- a/packages/toolkit/utils/src/cli/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/cli/prettyInstructions.ts
@@ -108,7 +108,7 @@ export const prettyInstructions = (appContext: any, config: any) => {
     const maxNameLength = Math.max(...routes.map(r => r.entryName.length));
 
     urls.forEach(({ label, url }) => {
-      message += `  ${chalk.bold(`> ${label}`)}\n`;
+      message += `  ${chalk.bold(`> ${label}`)}${chalk.cyanBright(url)}\n`;
       routes.forEach(({ entryName, urlPath, isSSR }) => {
         if (!checkedEntries.includes(entryName)) {
           return;

--- a/packages/toolkit/utils/src/cli/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/cli/prettyInstructions.ts
@@ -108,7 +108,9 @@ export const prettyInstructions = (appContext: any, config: any) => {
     const maxNameLength = Math.max(...routes.map(r => r.entryName.length));
 
     urls.forEach(({ label, url }) => {
-      message += `  ${chalk.bold(`> ${label}`)}${chalk.cyanBright(url)}\n`;
+      message += `  ${chalk.bold(`> ${label}`)}${
+        routes.length === 0 ? chalk.cyanBright(url) : ''
+      }\n`;
       routes.forEach(({ entryName, urlPath, isSSR }) => {
         if (!checkedEntries.includes(entryName)) {
           return;

--- a/packages/toolkit/utils/tests/__snapshots__/prettyInstructions.test.ts.snap
+++ b/packages/toolkit/utils/tests/__snapshots__/prettyInstructions.test.ts.snap
@@ -18,6 +18,18 @@ exports[`prettyInstructions basic usage 1`] = `
 "
 `;
 
+exports[`prettyInstructions custom entry 1`] = `
+"App running at:
+
+  > Local:  http://localhost:8080
+  > Network:  http://11.11.111.11:8080
+  > Network:  http://10.100.100.100:8080
+
+  λ (Server) server-side renders at runtime
+  ○ (Static) client-side renders as static HTML
+"
+`;
+
 exports[`prettyInstructions should print host correctly 1`] = `
 "App running at:
 

--- a/packages/toolkit/utils/tests/prettyInstructions.test.ts
+++ b/packages/toolkit/utils/tests/prettyInstructions.test.ts
@@ -172,4 +172,16 @@ describe('prettyInstructions', () => {
 
     expect(message).toMatchSnapshot();
   });
+
+  test('custom entry', () => {
+    const mockAppContext = {
+      entrypoints: [],
+      serverRoutes: [],
+      port: 8080,
+      apiOnly: false,
+    };
+
+    const message = prettyInstructions(mockAppContext, {});
+    expect(message).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f62722</samp>

This pull request fixes a bug in the devServer console output and updates the `@modern-js/utils` package with a changeset file. It also adds a test case for the `prettyInstructions` function in `packages/toolkit/utils`.

## Details

![image](https://github.com/web-infra-dev/modern.js/assets/16858738/0dd2cd5f-2f6f-4d6a-851e-5247dcea2a89)


<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f62722</samp>

* Add a changeset file for patch updates of `@modern-js/utils` package (.changeset/wet-ears-drop.md)
* Fix missing url in devServer console output by adding url to each label with `chalk.cyanBright` color ([link](https://github.com/web-infra-dev/modern.js/pull/4335/files?diff=unified&w=0#diff-e626d746b4e67834724a3c1c9cba4699911b3f8cfe2044411b5cba3ff00fd3cbL111-R111))
* Add test case for `prettyInstructions` function when no entrypoint or server route defined ([link](https://github.com/web-infra-dev/modern.js/pull/4335/files?diff=unified&w=0#diff-d73a01fadab58ff34e705eebd3a2162847b77ff7d3d6746c333523f2e2159728R175-R186))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
