### PR TITLE
fix(app-tools): tools.tsChecker default value mismatch with doc

### DIFF
--- a/.changeset/five-snails-speak.md
+++ b/.changeset/five-snails-speak.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/builder': patch
+---
+
+fix(app-tools): tools.tsChecker default value mismatch with doc
+
+fix(app-tools): tools.tsChecker 默认值与文档不匹配

--- a/packages/builder/builder/src/plugins/tsChecker.ts
+++ b/packages/builder/builder/src/plugins/tsChecker.ts
@@ -1,4 +1,5 @@
 import { DefaultBuilderPlugin } from '@modern-js/builder-shared';
+import { merge as deepMerge } from '@modern-js/utils/lodash';
 import type { BuilderPluginAPI as WebpackBuilderPluginAPI } from '@modern-js/builder-webpack-provider';
 
 export const builderPluginTsChecker = (): DefaultBuilderPlugin => {
@@ -83,10 +84,11 @@ export const builderPluginTsChecker = (): DefaultBuilderPlugin => {
               },
             },
           },
-          typeof config.tools.tsChecker === 'object'
-            ? config.tools.tsChecker
-            : {},
+          config.tools.tsChecker,
+          undefined,
+          deepMerge,
         );
+
         if (
           api.context.bundlerType === 'rspack' &&
           chain.get('mode') === 'production'

--- a/packages/document/builder-doc/docs/en/config/tools/tsChecker.md
+++ b/packages/document/builder-doc/docs/en/config/tools/tsChecker.md
@@ -33,8 +33,32 @@ By default, the [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/f
 
 ### Object Type
 
-When this value is an Object, it is merged with the default config via Object.assign.
+When the value of `tsChecker` is of type Object, it will be deeply merged with the default configuration.
+
+```ts
+export default {
+  tools: {
+    tsChecker: {
+      issue: {
+        exclude: [{ file: '**/some-folder/**/*.ts' }],
+      },
+    },
+  },
+};
+```
 
 ### Function Type
 
-When the value is a Function, the default config is passed in as the first parameter. You can modify the config object directly, or return an object as the final config.
+When the value of `tsChecker` is of type Function, the default configuration will be passed as the first argument. You can directly modify the configuration object or return an object as the final configuration.
+
+```ts
+export default {
+  tools: {
+    tsChecker(options) {
+      (options?.issue?.exclude as unknown[]).push({
+        file: '**/some-folder/**/*.ts',
+      });
+    },
+  },
+};
+```

--- a/packages/document/builder-doc/docs/zh/config/tools/tsChecker.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/tsChecker.md
@@ -33,8 +33,32 @@ const defaultOptions = {
 
 ### Object 类型
 
-当此值为 Object 类型时，与默认配置通过 Object.assign 合并。
+当 `tsChecker` 的值为 Object 类型时，会与默认配置进行深层合并。
+
+```ts
+export default {
+  tools: {
+    tsChecker: {
+      issue: {
+        exclude: [{ file: '**/some-folder/**/*.ts' }],
+      },
+    },
+  },
+};
+```
 
 ### Function 类型
 
-当此值为 Function 类型时，默认配置作为第一个参数传入，你可以直接修改配置对象，也可以返回一个对象作为最终配置。
+当 `tsChecker` 的值为 Function 类型时，默认配置会作为第一个参数传入，你可以直接修改配置对象，也可以返回一个对象作为最终配置。
+
+```ts
+export default {
+  tools: {
+    tsChecker(options) {
+      (options?.issue?.exclude as unknown[]).push({
+        file: '**/some-folder/**/*.ts',
+      });
+    },
+  },
+};
+```

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -65,12 +65,21 @@ export function createDefaultConfig(
     port: 8080,
   };
 
+  const defaultTsCheckerConfig = {
+    tsChecker: {
+      issue: {
+        include: [{ file: '**/src/**/*' }],
+      },
+    },
+  };
+
   const tools =
     bundler === 'webpack'
       ? {
           ...defaultBuilderConfig.tools,
+          ...defaultTsCheckerConfig,
         }
-      : undefined;
+      : defaultTsCheckerConfig;
 
   return {
     source,

--- a/packages/solutions/app-tools/src/config/initialize/inits.ts
+++ b/packages/solutions/app-tools/src/config/initialize/inits.ts
@@ -138,18 +138,7 @@ export function initSourceConfig(
 }
 
 export function initToolsConfig(config: AppNormalizedConfig<'webpack'>) {
-  const defaultTsChecker = {
-    issue: {
-      include: [{ file: '**/src/**/*' }],
-      exclude: [
-        { file: '**/*.(spec|test).ts' },
-        { file: '**/node_modules/**/*' },
-      ],
-    },
-  };
-
-  const { tsChecker, tsLoader } = config.tools;
-  config.tools.tsChecker = applyOptionsChain(defaultTsChecker, tsChecker);
+  const { tsLoader } = config.tools;
   tsLoader &&
     (config.tools.tsLoader = (tsLoaderConfig, utils) => {
       applyOptionsChain(


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ae785c</samp>

This pull request enhances the `tsChecker` plugin for the builder by allowing deep merging of configuration objects. It also updates the documentation and the default config for the `tsChecker` plugin in both English and Chinese. It removes some redundant code in the `initToolsConfig` function.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ae785c</samp>

*  Add a changeset file to specify the packages to be patched and the commit message ([link](https://github.com/web-infra-dev/modern.js/pull/4339/files?diff=unified&w=0#diff-f8e43f6632c9573ff9d9f5252ceec835b35ee42fd71096e7aa029c9b0091c6f5R1-R8))
*  Import and use `deepMerge` function from `@modern-js/utils/lodash` to merge `tsChecker` configuration objects in `tsChecker.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4339/files?diff=unified&w=0#diff-e894d618992ca3ef64b2f399f4275b6723da055ccb84fc13c8d8c9409a43f5e8R2),[link](https://github.com/web-infra-dev/modern.js/pull/4339/files?diff=unified&w=0#diff-e894d618992ca3ef64b2f399f4275b6723da055ccb84fc13c8d8c9409a43f5e8L86-R91))
*  Update English and Chinese documentation for `tsChecker` configuration in `tsChecker.md` files to reflect deep merging behavior and add code examples ([link](https://github.com/web-infra-dev/modern.js/pull/4339/files?diff=unified&w=0#diff-d5116ce70c3e6f57c94801a556de2cb7d622da639374a7c44963c3857597e6f4L36-R64),[link](https://github.com/web-infra-dev/modern.js/pull/4339/files?diff=unified&w=0#diff-654545af3757ec637d9f19971ea848302171126c0c943448133d40498e4dcec8L36-R64))
*  Add default `tsChecker` configuration to `tools` property of default config object in `default.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4339/files?diff=unified&w=0#diff-0260062e8ac455ff921325fc939e6a99cdd4380798613d44f211d3d768621578L68-R82))
*  Remove redundant initialization of `tsChecker` configuration in `initToolsConfig` function in `inits.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4339/files?diff=unified&w=0#diff-5f5feae03755ce69fc8a4f660481085a7197b6d61c99b51b4838344658e3b523L141-R141))

## Related Issue

- https://github.com/web-infra-dev/modern.js/issues/4295

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
