### PR TITLE
feat(doc-core): support builder plugins

### DIFF
--- a/.changeset/four-eggs-admire.md
+++ b/.changeset/four-eggs-admire.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+feat(doc-core): support builder plugins in doc-tools
+
+feat(doc-core): 支持 builder plugins 配置

--- a/.changeset/four-eggs-admire.md
+++ b/.changeset/four-eggs-admire.md
@@ -2,6 +2,6 @@
 '@modern-js/doc-core': patch
 ---
 
-feat(doc-core): support builder plugins in doc-tools
+feat(doc-core): support builder plugins
 
 feat(doc-core): 支持 builder plugins 配置

--- a/packages/cli/doc-core/src/node/createBuilder.ts
+++ b/packages/cli/doc-core/src/node/createBuilder.ts
@@ -187,6 +187,7 @@ export async function createModernBuilder(
 ): Promise<BuilderInstance<BuilderRspackProvider>> {
   const cwd = process.cwd();
   const userRoot = path.resolve(rootDir || config.doc?.root || cwd);
+  const builderPlugins = config.doc.builderPlugins ?? [];
   // We use a temp dir to store runtime files, so we can separate client and server build
   // and we should empty temp dir before build
   await fs.emptyDir(TEMP_DIR);
@@ -240,6 +241,7 @@ export async function createModernBuilder(
       routeService,
       pluginDriver,
     }),
+    ...builderPlugins,
   ]);
 
   return builder;

--- a/packages/cli/doc-core/src/shared/types/index.ts
+++ b/packages/cli/doc-core/src/shared/types/index.ts
@@ -3,7 +3,7 @@ import type { BuilderConfig } from '@modern-js/builder-rspack-provider';
 import type { PluginConfig } from '@modern-js/core';
 import _ from '@modern-js/utils/lodash';
 import type { PluggableList } from 'unified';
-import { BuilderPlugin } from '@modern-js/builder';
+import type { BuilderPlugin } from '@modern-js/builder';
 import type {
   Config as DefaultThemeConfig,
   NormalizedConfig as NormalizedDefaultThemeConfig,

--- a/packages/cli/doc-core/src/shared/types/index.ts
+++ b/packages/cli/doc-core/src/shared/types/index.ts
@@ -3,6 +3,7 @@ import type { BuilderConfig } from '@modern-js/builder-rspack-provider';
 import type { PluginConfig } from '@modern-js/core';
 import _ from '@modern-js/utils/lodash';
 import type { PluggableList } from 'unified';
+import { BuilderPlugin } from '@modern-js/builder';
 import type {
   Config as DefaultThemeConfig,
   NormalizedConfig as NormalizedDefaultThemeConfig,
@@ -135,6 +136,10 @@ export interface DocConfig<ThemeConfig = DefaultThemeConfig> {
     | {
         selector?: string;
       };
+  /**
+   * Add some extra builder plugins
+   */
+  builderPlugins?: BuilderPlugin[];
 }
 
 export type BaseRuntimePageInfo = Omit<

--- a/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
@@ -22,6 +22,28 @@ export default defineConfig({
 });
 ```
 
+## builderPlugins
+
+- Type: `Array`
+
+Used to customize the plugins of Modern.js Builder. For example:
+
+```ts title="modern.config.ts"
+import { docTools, defineConfig } from '@modern-js/doc-tools';
+import { builderPluginSemi } from '@edenx/builder-plugin-semi';
+
+export default defineConfig({
+  doc: {
+    builderPlugins: [
+      builderPluginSemi({
+        theme: '@ies/semi-theme-xxxx',
+      }),
+    ],
+  },
+  plugins: [docTools()],
+});
+```
+
 ### Default Config
 
 If you need to see the default `builderConfig`, you can add the `DEBUG=builder` parameter when running the `modern dev` or `modern build` command:

--- a/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config/config-build.mdx
@@ -24,21 +24,17 @@ export default defineConfig({
 
 ## builderPlugins
 
-- Type: `Array`
+- Type: `BuilderPlugin[]`
 
-Used to customize the plugins of Modern.js Builder. For example:
+Used to customize the [plugins of Modern.js Builder](https://modernjs.dev/builder/en/plugins/introduction.html). For example:
 
 ```ts title="modern.config.ts"
 import { docTools, defineConfig } from '@modern-js/doc-tools';
-import { builderPluginSemi } from '@edenx/builder-plugin-semi';
+import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';
 
 export default defineConfig({
   doc: {
-    builderPlugins: [
-      builderPluginSemi({
-        theme: '@ies/semi-theme-xxxx',
-      }),
-    ],
+    builderPlugins: [builderPluginStylus()],
   },
   plugins: [docTools()],
 });

--- a/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
@@ -22,6 +22,28 @@ export default defineConfig({
 });
 ```
 
+## builderPlugins
+
+- Type: `Array`
+
+用于加入 Modern.js Builder 的插件，比如：
+
+```ts title="modern.config.ts"
+import { docTools, defineConfig } from '@modern-js/doc-tools';
+import { builderPluginSemi } from '@edenx/builder-plugin-semi';
+
+export default defineConfig({
+  doc: {
+    builderPlugins: [
+      builderPluginSemi({
+        theme: '@ies/semi-theme-xxxx',
+      }),
+    ],
+  },
+  plugins: [docTools()],
+});
+```
+
 ### 默认配置
 
 如果你需要查看默认的 `builderConfig`，可以在执行 `modern dev` 或 `modern build` 命令时，添加 `DEBUG=builder` 参数：

--- a/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config/config-build.mdx
@@ -24,21 +24,17 @@ export default defineConfig({
 
 ## builderPlugins
 
-- Type: `Array`
+- Type: `BuilderPlugin[]`
 
-用于加入 Modern.js Builder 的插件，比如：
+用于加入 [Modern.js Builder 的插件](https://modernjs.dev/builder/plugins/introduction.html)，比如：
 
 ```ts title="modern.config.ts"
 import { docTools, defineConfig } from '@modern-js/doc-tools';
-import { builderPluginSemi } from '@edenx/builder-plugin-semi';
+import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';
 
 export default defineConfig({
   doc: {
-    builderPlugins: [
-      builderPluginSemi({
-        theme: '@ies/semi-theme-xxxx',
-      }),
-    ],
+    builderPlugins: [builderPluginStylus()],
   },
   plugins: [docTools()],
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f86861c</samp>

This pull request adds a new feature to the `doc-tools` package that allows users to customize the Modern.js Builder plugins in the doc config. It updates the `doc-core` package to read and apply the `builderPlugins` option, and the `doc-tools-doc` package to document the option in both English and Chinese. It also adds a changeset file to track the patch update of the `doc-core` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f86861c</samp>

*  Add `builderPlugins` option to doc config to support custom builder plugins in doc-tools ([link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R190), [link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R244), [link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-3b9ef78ff832598dcdf880304579f2f3fc95e1dc287ff5a94f1d0e04b162927eR6), [link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-3b9ef78ff832598dcdf880304579f2f3fc95e1dc287ff5a94f1d0e04b162927eR139-R142), [link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-bc40f81a971eaf041649c609ba3438007393fdfccc00b9eba5b432adcdd80c95R25-R46), [link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-5bff610c93c6503d010f0dd3c8b5941a3c2fff2d14f0b925b640eb82d95da5b8R25-R46))
  * Import `BuilderPlugin` type from `@modern-js/builder` in `types` module of `doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-3b9ef78ff832598dcdf880304579f2f3fc95e1dc287ff5a94f1d0e04b162927eR6))
  * Declare `builderPlugins` property in `DocConfig` interface with JSDoc comment ([link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-3b9ef78ff832598dcdf880304579f2f3fc95e1dc287ff5a94f1d0e04b162927eR139-R142))
  * Read `builderPlugins` option from doc config and spread it into plugins array in `createModernBuilder` function of `doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R190), [link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-ad5dc5ecd92556b2af670bda79efdeddd5fc360383070f6453fb07308b6f9554R244))
  * Document `builderPlugins` option in English and Chinese versions of doc-tools API in `doc-tools-doc` package ([link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-bc40f81a971eaf041649c609ba3438007393fdfccc00b9eba5b432adcdd80c95R25-R46), [link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-5bff610c93c6503d010f0dd3c8b5941a3c2fff2d14f0b925b640eb82d95da5b8R25-R46))
* Create changeset file to document patch update of `@modern-js/doc-core` package and new feature of `builderPlugins` option with Chinese translation ([link](https://github.com/web-infra-dev/modern.js/pull/4343/files?diff=unified&w=0#diff-5547c063e32bc85161c3b9d097c01f2ff1a7b57b0f6fc2665ad7e1d5f2d854d2R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
