### PR TITLE
fix: should not flat routes when the layout has loading or error

### DIFF
--- a/.changeset/silly-mirrors-jam.md
+++ b/.changeset/silly-mirrors-jam.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: should not flat routes when the layout has loading or error
+fix: 当 layout 中存在 loading 或者 error 时，不应该 flat routes

--- a/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
@@ -78,7 +78,7 @@ export const optimizeRoute = (
   }
 
   const { children } = routeTree;
-  if (!routeTree._component) {
+  if (!routeTree._component && !routeTree.error && !routeTree.loading) {
     const newRoutes = children.map(child => {
       const routePath = `${routeTree.path}${
         child.path ? `/${child.path}` : ''


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9093702</samp>

This pull request updates the `@modern-js/app-tools` package to fix a bug that caused the error or loading components to be missing in nested routes. It also adds a changeset file to document the patch version update and the fix messages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9093702</samp>

* Add a markdown file to document the patch version update for `@modern-js/app-tools` and the fixes for the error and loading components ([link](https://github.com/web-infra-dev/modern.js/pull/4349/files?diff=unified&w=0#diff-af457fddadd2435887ff98a4fa36c33c5f9345e64bba381244c3c40764ed1a9aR1-R6))
* Prevent flattening the error or loading components when the layout has no component in the `optimizeRoute` function in `nestedRoutes.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4349/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL81-R81))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
