### PR TITLE
fix: collect ssr serverTiming name & remove reporter.uesrId injected.

### DIFF
--- a/.changeset/purple-squids-attend.md
+++ b/.changeset/purple-squids-attend.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(plugin-runtime): ssr reporter some problems
+fix(plugin-runtime): ssr reporter 小问题

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/constants.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/constants.ts
@@ -1,0 +1,5 @@
+export enum ServerTimingNames {
+  SSR_RENDER_TOTAL = 'ssr-render-total',
+  SSR_PREFETCH = 'ssr-prefetch',
+  SSR_RENDER_HTML = 'ssr-render-html',
+}

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
@@ -19,6 +19,7 @@ import {
   attributesToString,
 } from '../utils';
 import { SSRReporter, createSSRReporter } from '../reporter';
+import { ServerTimingNames } from '../constants';
 import { SSRServerContext, RenderResult } from './type';
 import { Fragment, toFragments } from './template';
 import { reduce } from './reduce';
@@ -55,7 +56,6 @@ const buildTemplateData = (
       },
       reporter: {
         sessionId: reporter.sessionId,
-        userId: reporter.userId,
       },
     },
     renderLevel,
@@ -178,7 +178,10 @@ export default class Entry {
       this.logger.debug(`App Prefetch cost = %d ms`, prefetchCost);
       this.metrics.emitTimer('app.prefetch.cost', prefetchCost);
       this.reporter.reportTime('app_prefetch_cost', prefetchCost);
-      this.severTiming.addServeTiming('ssr-pretch', prefetchCost);
+      this.severTiming.addServeTiming(
+        ServerTimingNames.SSR_PREFETCH,
+        prefetchCost,
+      );
     } catch (e) {
       this.result.renderLevel = RenderLevel.CLIENT_RENDER;
       this.logger.error('App Prefetch Render', e as Error);
@@ -218,7 +221,7 @@ export default class Entry {
       this.logger.debug('App Render To HTML cost = %d ms', cost);
       this.metrics.emitTimer('app.render.html.cost', cost);
       this.reporter.reportTime('app_render_html_cost', cost);
-      this.severTiming.addServeTiming('ssr-render-html', cost);
+      this.severTiming.addServeTiming(ServerTimingNames.SSR_RENDER_HTML, cost);
       this.result.renderLevel = RenderLevel.SERVER_RENDER;
     } catch (e) {
       this.logger.error('App Render To HTML', e as Error);

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/index.ts
@@ -2,6 +2,7 @@ import { run } from '@modern-js/utils/runtime-node';
 import { time } from '@modern-js/utils/universal/time';
 import { ServerRenderOptions } from '../types';
 import { PreRender } from '../../react/prerender';
+import { ServerTimingNames } from '../constants';
 import SSREntry from './entry';
 
 export const render = ({
@@ -26,7 +27,7 @@ export const render = ({
     entry.logger.info('App Render Total cost = %d ms', cost);
     entry.metrics.emitTimer('app.render.cost', cost);
     entry.reporter.reportTime('app_render_cost', cost);
-    entry.severTiming.addServeTiming('ssr-render-total', cost);
+    entry.severTiming.addServeTiming(ServerTimingNames.SSR_RENDER_TOTAL, cost);
 
     const cacheConfig = PreRender.config();
     if (cacheConfig) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c34c299</samp>

This pull request refactors the server-side rendering code in the `plugin-runtime` package to use an enum for the server timing names, and removes an unnecessary property from the template data. This improves the code quality, performance, and privacy. It also adds a changeset file to document the patch version update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c34c299</samp>

*  Add a changeset file to describe the patch version update and the fixes for the plugin-runtime package ([link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-0a505ff7fb9482c66c3813cb59fd61eaec47df0530d1a8567ef7f709795bb7f9R1-R6))
*  Add an enum for the server timing metrics used in the server-side rendering process and import it to the relevant files ([link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-fa7d8d28db1fc2a1e49493845aedf9cd564bd7c5a1f2b1b4b48685f36fcb683aR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR22), [link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-57fccd878d7aa5b0589b6ce04ee36b219f78d7e22ac6ad57602f7670a905993bR5))
*  Replace the hard-coded strings for the server timing metrics with the enum values in the server-side rendering logic and export ([link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL181-R184), [link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL221-R224), [link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-57fccd878d7aa5b0589b6ce04ee36b219f78d7e22ac6ad57602f7670a905993bL29-R30))
*  Remove the userId property from the template data passed to the reporter for privacy reasons ([link](https://github.com/web-infra-dev/modern.js/pull/4352/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL58))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
