### PR TITLE
fix(swc): removeConsole not work when using SWC plugin

### DIFF
--- a/.changeset/healthy-rats-suffer.md
+++ b/.changeset/healthy-rats-suffer.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc': patch
+---
+
+fix(swc): removeConsole not work when using SWC plugin
+
+fix(swc): 修复使用 SWC 插件时 removeConsole 不生效的问题

--- a/packages/builder/plugin-swc/src/plugin.ts
+++ b/packages/builder/plugin-swc/src/plugin.ts
@@ -116,6 +116,7 @@ export const builderPluginSwc = (
             {
               jsMinify: mainConfig.jsMinify ?? mainConfig.jsc?.minify,
               cssMinify: mainConfig.cssMinify,
+              builderConfig,
             },
           ]);
       }

--- a/packages/builder/plugin-swc/src/types.ts
+++ b/packages/builder/plugin-swc/src/types.ts
@@ -8,9 +8,10 @@ import type {
 import type { lodash as _ } from '@modern-js/utils';
 
 export type {
-  TransformConfig,
   Output,
+  TransformConfig,
   JsMinifyOptions,
+  TerserCompressOptions,
 } from '@modern-js/swc-plugins';
 
 export type OuterExtensions = Omit<

--- a/tests/e2e/builder/cases/performance/performance.test.ts
+++ b/tests/e2e/builder/cases/performance/performance.test.ts
@@ -43,34 +43,6 @@ test.describe('performance configure multi', () => {
   });
 });
 
-test('removeConsole', async () => {
-  const builder = await build({
-    cwd: join(fixtures, 'removeConsole'),
-    entry: {
-      main: join(fixtures, 'removeConsole/src/index.js'),
-    },
-    builderConfig: {
-      performance: {
-        chunkSplit: {
-          strategy: 'all-in-one',
-        },
-        removeConsole: ['log', 'warn'],
-      },
-    },
-  });
-
-  const files = await builder.unwrapOutputJSON();
-
-  const [, jsFile] = Object.entries(files).find(
-    ([name, content]) => name.endsWith('.js') && content,
-  )!;
-
-  expect(jsFile.includes('test-console-debug')).toBeTruthy();
-  expect(jsFile.includes('test-console-info')).toBeFalsy();
-  expect(jsFile.includes('test-console-warn')).toBeFalsy();
-  expect(jsFile.includes('test-console-error')).toBeTruthy();
-});
-
 test('should generate vendor chunk when chunkSplit is "single-vendor"', async () => {
   const builder = await build({
     cwd: join(fixtures, 'basic'),

--- a/tests/e2e/builder/cases/performance/removeConsole.test.ts
+++ b/tests/e2e/builder/cases/performance/removeConsole.test.ts
@@ -1,0 +1,114 @@
+import { join } from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
+import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
+
+const cwd = join(__dirname, 'removeConsole');
+
+const expectConsoleType = async (
+  builder: Awaited<ReturnType<typeof build>>,
+  consoleType: Record<string, boolean>,
+) => {
+  const files = await builder.unwrapOutputJSON();
+  const mainFile = Object.keys(files).find(
+    name => name.includes('main.') && name.endsWith('.js'),
+  )!;
+  const content = files[mainFile];
+
+  Object.entries(consoleType).forEach(([key, value]) => {
+    expect(content.includes(`test-console-${key}`)).toEqual(value);
+  });
+};
+
+test('should remove specified console correctly', async () => {
+  const builder = await build({
+    cwd,
+    entry: {
+      main: join(cwd, 'src/index.js'),
+    },
+    builderConfig: {
+      performance: {
+        removeConsole: ['log', 'warn'],
+      },
+    },
+  });
+
+  await expectConsoleType(builder, {
+    log: false,
+    warn: false,
+    debug: true,
+    error: true,
+  });
+});
+
+test('should remove all console correctly', async () => {
+  const builder = await build({
+    cwd,
+    entry: {
+      main: join(cwd, 'src/index.js'),
+    },
+    builderConfig: {
+      performance: {
+        removeConsole: true,
+      },
+    },
+  });
+
+  await expectConsoleType(builder, {
+    log: false,
+    warn: false,
+    debug: false,
+    error: false,
+  });
+});
+
+webpackOnlyTest(
+  'should remove specified console correctly when using SWC plugin',
+  async () => {
+    const builder = await build({
+      cwd,
+      entry: {
+        main: join(cwd, 'src/index.js'),
+      },
+      plugins: [builderPluginSwc()],
+      builderConfig: {
+        performance: {
+          removeConsole: ['log', 'warn'],
+        },
+      },
+    });
+
+    await expectConsoleType(builder, {
+      log: false,
+      warn: false,
+      debug: true,
+      error: true,
+    });
+  },
+);
+
+webpackOnlyTest(
+  'should remove all console correctly when using SWC plugin',
+  async () => {
+    const builder = await build({
+      cwd,
+      entry: {
+        main: join(cwd, 'src/index.js'),
+      },
+      plugins: [builderPluginSwc()],
+      builderConfig: {
+        performance: {
+          removeConsole: true,
+        },
+      },
+    });
+
+    await expectConsoleType(builder, {
+      log: false,
+      warn: false,
+      debug: false,
+      error: false,
+    });
+  },
+);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b64fffe</samp>

This pull request adds support for the `removeConsole` option in the `SwcMinimizerPlugin` class, which allows users to remove console logs from the output JS code when using SWC as a transpiler and minifier. It also updates the builder plugin function, the types file, the changeset file, and the e2e tests to reflect this new feature. It removes an irrelevant test case from the performance tests and adds a new test file to test the `removeConsole` option for both webpack and SWC.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b64fffe</samp>

*  Add changeset file to document patch version update and fix message for SWC plugin package ([link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-988e1a77f908a65575ab4a6e2708ded9d957540237a18eed0f82b56923ed4836R1-R7))
*  Import `BuilderConfig` type and `webpack` function from `@modern-js/builder-webpack-provider` package to access `removeConsole` option and type `compiler` parameter ([link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-f3882b6977b3e0a928ee52cd455121924953b25f00c92d9db17e89fd7f3515b7L1-R12))
*  Add `builderConfig` option to `SwcMinimizerPlugin` constructor and pass it to `getDefaultJsMinifyOptions` method to get `removeConsole` option and apply it to SWC minify options ([link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-f3882b6977b3e0a928ee52cd455121924953b25f00c92d9db17e89fd7f3515b7L40-R68), [link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-0cf91a085824ef67c4d6a4fdbeb226b1620b511f970bf885dfd0cb465e66a863R119))
*  Export `TerserCompressOptions` type from `@modern-js/swc-plugins` package to define `compress` option for SWC minifier ([link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-d5092a2035c2200c28702f1150a981abaee074d568d3ed7649cd92fc6431b0d2L11-R14))
*  Add `getDefaultJsMinifyOptions` method to generate default JS minify options based on `removeConsole` option and set `drop_console` or `pure_funcs` accordingly ([link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-f3882b6977b3e0a928ee52cd455121924953b25f00c92d9db17e89fd7f3515b7L40-R68))
*  Remove `removeConsole` test case from `performance.test.ts` file as it is not relevant for SWC plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-f10a383cc6295cb2e964ff6b91561e6dbab5e3b470904f9fa36be52c15dde50aL46-L73))
*  Add `removeConsole.test.ts` file to test `removeConsole` option for both webpack terser plugin and SWC plugin with different values and expected console methods ([link](https://github.com/web-infra-dev/modern.js/pull/4362/files?diff=unified&w=0#diff-5ba3ab5410c60d3a93f01c3dbbd4702bbf3d0078184307346496a4267f8fc64eR1-R114))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
