### PR TITLE
feat(doc-core): support sub nav menu highlight

### DIFF
--- a/.changeset/brown-ghosts-shout.md
+++ b/.changeset/brown-ghosts-shout.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-core': patch
+---
+
+feat(doc-core): support sub nav menu highlight
+
+feat(doc-core): 支持 nav 子菜单高亮

--- a/packages/cli/doc-core/src/theme-default/components/HomeFeatures/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/HomeFeatures/index.tsx
@@ -45,10 +45,14 @@ export function HomeFeature({ frontmatter }: { frontmatter: FrontMatterMeta }) {
                 }}
               >
                 <div className="flex-center">
-                  <div className="w-12 h-12 text-3xl text-center">{icon}</div>
+                  <div className="modern-doc-home-feature-icon w-12 h-12 text-3xl text-center">
+                    {icon}
+                  </div>
                 </div>
-                <h2 className="font-bold text-center">{title}</h2>
-                <p className="leading-6 pt-2 text-sm text-text-2 font-medium">
+                <h2 className="modern-doc-home-feature-title font-bold text-center">
+                  {title}
+                </h2>
+                <p className="modern-doc-home-feature-detail leading-6 pt-2 text-sm text-text-2 font-medium">
                   {details}
                 </p>
               </article>

--- a/packages/cli/doc-core/src/theme-default/components/Nav/NavMenuGroup.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Nav/NavMenuGroup.tsx
@@ -4,12 +4,18 @@ import { Link } from '../Link';
 import Translator from '../../assets/translator.svg';
 import Down from '../../assets/down.svg';
 import { Tag } from '../Tag';
+import { withoutBase } from '@/shared/utils';
 
 export interface NavMenuGroupItem {
   text?: string | React.ReactElement;
   items: (NavItemWithLink | NavItemWithChildren)[];
   tag?: string;
+  // Design for i18n highlight.
   activeValue?: string;
+  // Currrnt pathname.
+  pathname?: string;
+  // Base path.
+  base?: string;
   // When the item is transition, we need to give a react element instead of a string.
   isTranslation?: boolean;
 }
@@ -50,10 +56,19 @@ function NormalGroupItem({ item }: { item: NavItemWithLink }) {
 }
 
 export function NavMenuGroup(item: NavMenuGroupItem) {
-  const { activeValue, isTranslation, items: groupItems } = item;
+  const {
+    activeValue,
+    isTranslation,
+    items: groupItems,
+    base = '',
+    pathname = '',
+  } = item;
   const [isOpen, setIsOpen] = useState(false);
   const renderLinkItem = (item: NavItemWithLink) => {
-    if (activeValue === item.text) {
+    const isLinkActive = new RegExp(item.activeMatch || item.link).test(
+      withoutBase(pathname, base),
+    );
+    if (activeValue === item.text || isLinkActive) {
       return <ActiveGroupItem key={item.link} item={item} />;
     }
     return <NormalGroupItem key={item.link} item={item} />;

--- a/packages/cli/doc-core/src/theme-default/components/Nav/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Nav/index.tsx
@@ -107,6 +107,8 @@ export function Nav(props: NavProps) {
             <div key={item.text} className="mx-3 last:mr-0">
               <NavMenuGroup
                 {...item}
+                base={base}
+                pathname={pathname}
                 items={'items' in item ? item.items : item}
               />
             </div>


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba68953</samp>

This pull request adds a feature to the `doc-core` package that highlights the sub nav menu items in the documentation site based on the current pathname and the active match or link property. It also updates the `NavMenuGroup` component to use a utility function and a regular expression to improve the active state detection. It includes a changeset file and a Chinese translation for the feature.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba68953</samp>

*  Add a changeset file to describe the patch version update and the feature added to the doc-core package ([link](https://github.com/web-infra-dev/modern.js/pull/4364/files?diff=unified&w=0#diff-bca97b7770702f507e10a6a1d16bef78ee5d3c8ab701c28e2f6416230fb17e04R1-R7))
*  Pass the `base` and `pathname` props from the `Nav` component to the `NavMenuGroup` component in `.theme-default/components/Nav/index.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4364/files?diff=unified&w=0#diff-2216029e0e76685016b677fdc1bc777e116d48f3ccd39775d088f9730d53a892R110-R111))
*  Import the `withoutBase` utility function from the shared utils module in `.theme-default/components/Nav/NavMenuGroup.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4364/files?diff=unified&w=0#diff-2a53b6d03372053049de656c16dadda3e6096b43264afe3083fe19f19f11b7f6R7))
*  Add the `pathname` and `base` properties to the `NavMenuGroupItem` interface in `.theme-default/components/Nav/NavMenuGroup.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4364/files?diff=unified&w=0#diff-2a53b6d03372053049de656c16dadda3e6096b43264afe3083fe19f19f11b7f6L12-R18))
*  Modify the `renderLinkItem` function to use a regular expression to test the active match or link of the item against the pathname without the base path in `.theme-default/components/Nav/NavMenuGroup.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4364/files?diff=unified&w=0#diff-2a53b6d03372053049de656c16dadda3e6096b43264afe3083fe19f19f11b7f6L53-R71))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
