### PR TITLE
chore(html): remove noscript tag in html template

### DIFF
--- a/.changeset/healthy-spies-look.md
+++ b/.changeset/healthy-spies-look.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/app-tools': patch
+---
+
+chore: remove noscript tag in html template
+chore: 移除 HTML 模板中的 noscript 标签

--- a/packages/runtime/plugin-runtime/src/document/constants.ts
+++ b/packages/runtime/plugin-runtime/src/document/constants.ts
@@ -21,8 +21,6 @@ export const DOCUMENT_SCRIPTS_PLACEHOLDER = encodeURIComponent(
 export const DOCUMENT_LINKS_PLACEHOLDER = encodeURIComponent(
   '<!-- chunk links placeholder -->',
 );
-export const DOCUMENT_NO_SCRIPTE_PLACEHOLDER =
-  encodeURIComponent('<!-- no-script -->');
 export const DOCUMENT_SCRIPT_PLACEHOLDER_START = encodeURIComponent(
   '<!-- script-start -->',
 );
@@ -42,7 +40,6 @@ export const DOCUMENT_COMMENT_PLACEHOLDER_END = encodeURIComponent(
 );
 
 export const PLACEHOLDER_REPLACER_MAP = {
-  [DOCUMENT_NO_SCRIPTE_PLACEHOLDER]: `We're sorry but react app doesn't work properly without JavaScript enabled. Please enable it to continue.`,
   [DOCUMENT_SSR_PLACEHOLDER]: HTML_SEPARATOR,
   [DOCUMENT_CHUNKSMAP_PLACEHOLDER]: HTML_CHUNKSMAP_SEPARATOR,
   [DOCUMENT_SSRDATASCRIPT_PLACEHOLDER]: HTML_SSRDATASCRIPT_SEPARATOR,

--- a/packages/solutions/app-tools/src/analyze/templates.ts
+++ b/packages/solutions/app-tools/src/analyze/templates.ts
@@ -107,9 +107,6 @@ export const html = (partials: {
 </head>
 
 <body>
-  <noscript>
-    We're sorry but react app doesn't work properly without JavaScript enabled. Please enable it to continue.
-  </noscript>
   <div id="<%= mountId %>"><!--<?- html ?>--></div>
   ${partials.body.join('\n')}
   <!--<?- chunksMap.js ?>-->


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1500e41</samp>

This pull request removes the noscript tag from the `@modern-js/runtime` and `@modern-js/app-tools` packages, as it is no longer needed to handle browsers that do not support JavaScript. It also adds a changeset file to document the changes and the version bumps for the affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1500e41</samp>

*  Remove noscript tag from HTML templates and runtime constants ([link](https://github.com/web-infra-dev/modern.js/pull/4366/files?diff=unified&w=0#diff-1a1cc0259df40308359daa495e6b88cc3bba9bdfec132dbeaded71ea428b8492L24-L25), [link](https://github.com/web-infra-dev/modern.js/pull/4366/files?diff=unified&w=0#diff-1a1cc0259df40308359daa495e6b88cc3bba9bdfec132dbeaded71ea428b8492L45), [link](https://github.com/web-infra-dev/modern.js/pull/4366/files?diff=unified&w=0#diff-dbfb9b73a9abfe46cea1f0f8a12245ca44db2fa24d49d3641c8e1ce883d3fa44L110-L112))
*  Add changeset file for `@modern-js/runtime` and `@modern-js/app-tools` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4366/files?diff=unified&w=0#diff-7b9811e13211f42e8a5cfc949dc3099f2c57aef6c064979690f91de92bf29e41R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
