### PR TITLE
docs(module-tools): add intro for core npm package and postcss config

### DIFF
--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -945,12 +945,38 @@ export default {
 
 ## style.postcss
 
-- plugins
-- processOptions
+Used to configure options for PostCSS. The provided values will be merged with the default configuration using `Object.assign`. Note that `Object.assign` performs a shallow copy, so it will completely override the built-in `plugins` array.
 
-See [PostCSS](https://github.com/postcss/postcss#options) for detailed configuration
+For detailed configuration, please refer to [PostCSS](https://github.com/postcss/postcss#options).
 
-**Basic usage：**
+- **Type**:
+
+```ts
+type PostcssOptions = {
+  processOptions?: ProcessOptions;
+  plugins?: AcceptedPlugin[];
+};
+```
+
+- **Default**:
+
+```ts
+const defaultConfig = {
+  plugins: [
+    // The following plugins are enabled by default
+    require('postcss-flexbugs-fixes'),
+    require('postcss-media-minmax'),
+    require('postcss-nesting'),
+    // The following plugins are only enabled when the target is `es5`
+    require('postcss-custom-properties'),
+    require('postcss-initial'),
+    require('postcss-page-break'),
+    require('postcss-font-variant'),
+  ],
+};
+```
+
+- **Example**:
 
 ```js modern.config.ts
 export default defineConfig({
@@ -1080,6 +1106,7 @@ const tailwind = {
   ],
 };
 ```
+
 </details>
 
 When the value is of type `object`, it is merged with the default configuration via `Object.assign`.

--- a/packages/document/module-doc/docs/en/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/en/guide/intro/getting-started.md
@@ -73,6 +73,25 @@ Finally, add the command `"build": "modern build"` to the project's `package.jso
 
 If your project has a `src/index.(js|jsx)` file or both `src/index.(ts|tsx)` and `tsconfig.json` files, then congratulations you can run the `npm run build` command directly to build your project with Module Tools.
 
+### Core npm Package
+
+`@modern-js/module-tools` is the core npm package of Module Tools, providing the following capabilities:
+
+- It offers commonly used CLI commands such as `modern dev`, `modern build`, and more.
+- It integrates Modern.js Core, providing capabilities for configuration parsing, plugin loading, and more.
+- It integrates esbuild and SWC, providing build capabilities.
+- It integrates some commonly used plugins, such as `plugin-lint`, `plugin-changeset`, and others.
+
+`@modern-js/module-tools` is implemented based on the plugin system of Modern.js. Essentially, it is a plugin. Therefore, you need to register `moduleTools` in the `plugins` field of the configuration file:
+
+```ts modern.config.ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+
+export default defineConfig({
+  plugins: [moduleTools()],
+});
+```
+
 ### View official example
 
 **If you want to see the complete project using the modular engineering scheme, you can execute the following command**.

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -945,12 +945,38 @@ export default defineConfig({
 
 ## style.postcss
 
-- plugins
-- processOptions
+用于配置 PostCSS 的选项，传入的值会与默认配置通过 `Object.assign` 合并。注意 `Object.assign` 是浅拷贝，因此会完全覆盖内置的 plugins 数组。
 
-详细配置查看 [PostCSS](https://github.com/postcss/postcss#options)。
+详细配置请查看 [PostCSS](https://github.com/postcss/postcss#options)。
 
-**基础使用：**
+- 类型：
+
+```ts
+type PostcssOptions = {
+  processOptions?: ProcessOptions;
+  plugins?: AcceptedPlugin[];
+};
+```
+
+- 默认值：
+
+```ts
+const defaultConfig = {
+  plugins: [
+    // 以下插件默认启用
+    require('postcss-flexbugs-fixes'),
+    require('postcss-media-minmax'),
+    require('postcss-nesting'),
+    // 以下插件仅在 target 为 `es5` 时启用
+    require('postcss-custom-properties'),
+    require('postcss-initial'),
+    require('postcss-page-break'),
+    require('postcss-font-variant'),
+  ],
+};
+```
+
+- 示例：
 
 ```js modern.config.ts
 export default defineConfig({
@@ -1082,6 +1108,7 @@ const tailwind = {
   ],
 };
 ```
+
 </details>
 
 值为 `object` 类型时，与默认配置通过 `Object.assign` 合并。

--- a/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
@@ -70,6 +70,25 @@ export default defineConfig({
 
 如果你的项目存在 `src/index.(js|jsx)` 文件或者同时存在 `src/index.(ts|tsx)` 和 `tsconfig.json` 文件，那么恭喜你可以运行直接运行 `npm run build` 来使用 Module Tools 构建你的项目了。
 
+### 核心 npm 包
+
+`@modern-js/module-tools` 是 Module Tools 的核心 npm 包，主要提供以下能力：
+
+- 提供 `modern dev`, `modern build` 等常用的 CLI 命令。
+- 集成 Modern.js Core，提供配置解析、插件加载等能力。
+- 集成 esbuild 和 SWC，提供构建能力。
+- 集成一些最为常用的插件，比如 `plugin-lint`、`plugin-changeset` 等。
+
+`@modern-js/module-tools` 是基于 Modern.js 的插件体系实现的，本质上是一个插件，因此你需要在配置文件的 `plugins` 字段中注册 `moduleTools`：
+
+```ts modern.config.ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+
+export default defineConfig({
+  plugins: [moduleTools()],
+});
+```
+
 ### 查看官方示例
 
 **如果你想要看看使用了模块工程方案的完整项目，可以执行以下命令**：


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1b218d</samp>

This pull request updates and improves the documentation of Module Tools, a set of tools for building modern JavaScript applications. It adds more details and examples for the `style.postcss` option in the build configuration file, and introduces the core npm package `@modern-js/module-tools` in the getting started guide, in both English and Chinese.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1b218d</samp>

*  Update and translate the documentation of the `style.postcss` option in the build configuration file ([link](https://github.com/web-infra-dev/modern.js/pull/4375/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baL948-R980), [link](https://github.com/web-infra-dev/modern.js/pull/4375/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L948-R980)). Add details about the type, default value, and merging behavior of the option, and link to the PostCSS documentation. Format the code blocks with language tags.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
