### PR TITLE
fix: configration validate

### DIFF
--- a/.changeset/happy-coins-judge.md
+++ b/.changeset/happy-coins-judge.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/core': patch
+---
+
+fix: configration validate
+fix: 配置校验问题

--- a/packages/cli/core/src/schema/defaultSchema.ts
+++ b/packages/cli/core/src/schema/defaultSchema.ts
@@ -6,3 +6,7 @@ export const testing = {
     jest: { typeof: ['object', 'function'] },
   },
 };
+
+export const plugins = {
+  type: 'array',
+};

--- a/packages/cli/core/src/schema/patchSchema.ts
+++ b/packages/cli/core/src/schema/patchSchema.ts
@@ -1,7 +1,7 @@
 import { createDebugger, isObject } from '@modern-js/utils';
 import { cloneDeep } from '@modern-js/utils/lodash';
 import { PluginValidateSchema } from '../types';
-import { testing } from './testing';
+import { testing, plugins } from './defaultSchema';
 
 const debug = createDebugger('validate-schema');
 
@@ -10,8 +10,10 @@ export const patchSchema = (
 ) => {
   const finalSchema = cloneDeep({
     type: 'object',
+    additionalProperties: false,
     properties: {
       testing,
+      plugins,
     },
   });
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0216f73</samp>

This pull request adds support for plugins in the configuration file of the `@modern-js/core` package. It renames and updates the schema files, adds validation logic, and documents the patch updates in a changeset file.

## Details

I found the configration validate is loose.
For example, there is no error report while I use `runtime.router` in configration file, but actually I not install `@modern-js/runtime`.
So I change the initial validate schema to fix it ( may be not appropriate because lead to wider impact), is there a better way ?

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0216f73</samp>

*  Rename `testing.ts` to `defaultSchema.ts` and add `plugins` property to the default schema object ([link](https://github.com/web-infra-dev/modern.js/pull/4378/files?diff=unified&w=0#diff-638c792ea47676ec26ae28af1d6d9a9e8cc32718ca3d262c2aa26a4a3c98e578R9-R12))
*  Update import statements and `finalSchema` object in `patchSchema.ts` to reflect the renamed file and the added property ([link](https://github.com/web-infra-dev/modern.js/pull/4378/files?diff=unified&w=0#diff-e9f1ecf9741ea57e963e521cab3a83af78ee7a8d44e081170caf5db0932e8bbaL4-R4), [link](https://github.com/web-infra-dev/modern.js/pull/4378/files?diff=unified&w=0#diff-e9f1ecf9741ea57e963e521cab3a83af78ee7a8d44e081170caf5db0932e8bbaL13-R16))
*  Add changeset file to document the patch updates for the `@modern-js/core` package and the configuration validation fix ([link](https://github.com/web-infra-dev/modern.js/pull/4378/files?diff=unified&w=0#diff-3d3edea53b31ed9f31105c1f901648e9f8064f095a0dcb819c26394e0388fc30R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
