### PR TITLE
fix(CI): build scripts for libuild in windows

### DIFF
--- a/.changeset/old-cycles-burn.md
+++ b/.changeset/old-cycles-burn.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/libuild': patch
+---
+
+ci: fix build scripts for libuild in windows
+ci: 修复在windows下的libuild构建脚本

--- a/packages/libuild/libuild-core/scripts/build.ts
+++ b/packages/libuild/libuild-core/scripts/build.ts
@@ -86,7 +86,7 @@ async function run() {
 
           let realPath = require.resolve('enhanced-resolve', { paths: [baseName] });
           if (subPath) {
-            realPath = realPath.replace(/(\/lib\/.*)$/, `${subPath}.js`);
+            realPath = realPath.replace(/([\\\/]lib[\\\/].*)$/, `${subPath}.js`);
           }
           return {
             path: realPath,


### PR DESCRIPTION
fix https://github.com/web-infra-dev/modern.js/actions/runs/5761730053/job/15620123275

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d7b677</samp>

This pull request fixes the Windows compatibility of the `libuild` package and adds a changeset file for it. The changeset file documents the patch version bump and the bug fix for the `enhanced-resolve` module resolution.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7d7b677</samp>

*  Fix build scripts for libuild in Windows by using a generic regex for enhanced-resolve module path ([link](https://github.com/web-infra-dev/modern.js/pull/4379/files?diff=unified&w=0#diff-2787a998ae8c77cdadd7e91af0fb936badf8be4827d70a51c2bac0406b0b9a1fL89-R89))
*  Add changeset file for `@modern-js/libuild` package with patch version bump and bilingual message ([link](https://github.com/web-infra-dev/modern.js/pull/4379/files?diff=unified&w=0#diff-d4d9fc0a178a166e284692f3a341b727b424ecf1b2e9041f08c15734b45145aaR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
