### PR TITLE
feat(CLI): print solution name and version to terminal

### DIFF
--- a/.changeset/rotten-hats-collect.md
+++ b/.changeset/rotten-hats-collect.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/monorepo-tools': patch
+'@modern-js/module-tools': patch
+'@modern-js/app-tools': patch
+'@modern-js/doc-tools': patch
+'@modern-js/core': patch
+---
+
+feat(CLI): print solution name and version to terminal
+
+feat(CLI): 在控制台输入 solution 的名称和版本

--- a/.changeset/rotten-hats-collect.md
+++ b/.changeset/rotten-hats-collect.md
@@ -8,4 +8,4 @@
 
 feat(CLI): print solution name and version to terminal
 
-feat(CLI): 在控制台输入 solution 的名称和版本
+feat(CLI): 在控制台输出 solution 的名称和版本

--- a/packages/cli/core/src/runBin.ts
+++ b/packages/cli/core/src/runBin.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { minimist, lodash } from '@modern-js/utils';
+import { minimist, lodash, logger, chalk } from '@modern-js/utils';
 import { cli, CoreOptions } from '.';
 
 export const run = async (
@@ -10,6 +10,10 @@ export const run = async (
       | ((coreOptions: CoreOptions) => Promise<CoreOptions> | CoreOptions);
   } = {},
 ) => {
+  if (otherCoreOptions.initialLog) {
+    logger.info(`${chalk.green.bold(otherCoreOptions.initialLog)}`);
+  }
+
   const command = process.argv[2];
 
   if (!process.env.NODE_ENV) {

--- a/packages/cli/core/src/types/coreOptions.ts
+++ b/packages/cli/core/src/types/coreOptions.ts
@@ -6,6 +6,10 @@ export interface CoreOptions {
   cwd?: string;
   version?: string;
   configFile?: string;
+  /**
+   * The initial log message when CLI started
+   */
+  initialLog?: string;
   serverConfigFile?: string;
   packageJsonConfig?: string;
   internalPlugins?: {

--- a/packages/solutions/app-tools/bin/modern.js
+++ b/packages/solutions/app-tools/bin/modern.js
@@ -11,4 +11,5 @@ require('@modern-js/core/runBin').run({
     server: INTERNAL_SERVER_PLUGINS,
     autoLoad: INTERNAL_APP_TOOLS_RUNTIME_PLUGINS,
   },
+  initialLog: `@modern-js/app-tools v${require('../package.json').version}`,
 });

--- a/packages/solutions/doc-tools/bin/modern.js
+++ b/packages/solutions/doc-tools/bin/modern.js
@@ -5,4 +5,5 @@ require('@modern-js/core/runBin').run({
   internalPlugins: {
     cli: INTERNAL_DOC_TOOLS_PLUGINS,
   },
+  initialLog: `@modern-js/doc-tools v${require('../package.json').version}`,
 });

--- a/packages/solutions/module-tools/bin/modern.js
+++ b/packages/solutions/module-tools/bin/modern.js
@@ -5,4 +5,5 @@ require('@modern-js/core/runBin').run({
   internalPlugins: {
     cli: INTERNAL_MODULE_TOOLS_PLUGINS,
   },
+  initialLog: `@modern-js/module-tools v${require('../package.json').version}`,
 });

--- a/packages/solutions/monorepo-tools/bin/modern.js
+++ b/packages/solutions/monorepo-tools/bin/modern.js
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 
-require('@modern-js/core/runBin').run({});
+require('@modern-js/core/runBin').run({
+  initialLog: `@modern-js/monorepo-tools v${
+    require('../package.json').version
+  }`,
+});


### PR DESCRIPTION
## Summary

Print solution name and version to terminal:

1. Provide immediate feedback when running the `modern` command
2. Provide version information.

<img width="435" alt="Screenshot 2023-08-06 at 09 43 32" src="https://github.com/web-infra-dev/modern.js/assets/7237365/3bafd683-3636-4991-9902-8329e199234a">


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a3781c</samp>

This pull request adds a feature to the `cli` package that allows printing the solution name and version in the CLI output. It also updates the type definition for the `cli` options and creates a changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a3781c</samp>

*  Add `initialLog` option to customize CLI output ([link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-708f11e9c968486e9f060c8770daebc0b169d7456638c02eb85d48f7f215b5c9R13-R16),[link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-f472a5ce0e7134f1da83593d2dcb0dd9ddc59172c73af45de3ffe3235b45cc64R9-R12))
  - Import `logger` and `chalk` modules in `runBin.ts` to print formatted messages ([link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-708f11e9c968486e9f060c8770daebc0b169d7456638c02eb85d48f7f215b5c9L2-R2))
  - Check if `otherCoreOptions` has `initialLog` property in `run` function ([link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-708f11e9c968486e9f060c8770daebc0b169d7456638c02eb85d48f7f215b5c9R13-R16))
  - Print `initialLog` value with green and bold font using `logger` and `chalk` ([link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-708f11e9c968486e9f060c8770daebc0b169d7456638c02eb85d48f7f215b5c9R13-R16))
  - Define `initialLog` as an optional string property in `CoreOptions` interface in `types/coreOptions.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-f472a5ce0e7134f1da83593d2dcb0dd9ddc59172c73af45de3ffe3235b45cc64R9-R12))
* Add changeset file to document the feature ([link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-1f9c683000125bdbb4f2f4b20bec37bdcfbc473be0e2bbd3887b112535dadfcfR1-R11))
  - Create `.changeset/rotten-hats-collect.md` file with patch type and bilingual description ([link](https://github.com/web-infra-dev/modern.js/pull/4383/files?diff=unified&w=0#diff-1f9c683000125bdbb4f2f4b20bec37bdcfbc473be0e2bbd3887b112535dadfcfR1-R11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
