### PR TITLE
test: rename & skip integration tests of devtools

### DIFF
--- a/tests/integration/devtools/tests/index.test.ts
+++ b/tests/integration/devtools/tests/index.test.ts
@@ -15,8 +15,8 @@ function existsSync(filePath: string) {
   return fs.existsSync(path.join(appDir, 'dist', filePath));
 }
 
-describe('alias set build', () => {
-  test(`should get right alias build!`, async () => {
+describe.skip('devtools build', () => {
+  test(`should get right devtools build!`, async () => {
     const buildRes = await modernBuild(appDir);
     expect(buildRes.code === 0).toBe(true);
     expect(existsSync('route.json')).toBe(true);
@@ -24,7 +24,7 @@ describe('alias set build', () => {
   });
 });
 
-describe('alias set dev', () => {
+describe.skip('devtools dev', () => {
   test(`should render page correctly`, async () => {
     const appPort = await getPort();
     const app = await launchApp(


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f34e759</samp>

Skipped some integration tests for `alias` feature due to a build bug.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f34e759</samp>

*  Skip two test suites for the alias feature due to a bug that causes build and dev failures ([link](https://github.com/web-infra-dev/modern.js/pull/4384/files?diff=unified&w=0#diff-a8931c45e87ccd3e72fd75f9e47744457058cbbda26a0a4d8b7bc06033b2c080L18-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4384/files?diff=unified&w=0#diff-a8931c45e87ccd3e72fd75f9e47744457058cbbda26a0a4d8b7bc06033b2c080L27-R27)) in `tests/integration/devtools/tests/index.test.ts`

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
