### PR TITLE
docs(builder): fix in-house document key word replacement

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/basic/builder-config.mdx
+++ b/packages/document/builder-doc/docs/en/guide/basic/builder-config.mdx
@@ -40,14 +40,6 @@ export default {
 };
 ```
 
-Commonly used framework config files include:
-
-| Framework   | Config File        |
-| ----------- | ------------------ |
-| {MODERN_JS} | {MODERN_JS_CONFIG} |
-| EdenX       | edenx.config.ts    |
-| PIA         | pia.config.ts      |
-
 ### Using the Node API
 
 When you call the Builder through the Node API, you can pass in the Builder config through the Provider's `builderConfig` option:

--- a/packages/document/builder-doc/docs/en/guide/glossary.mdx
+++ b/packages/document/builder-doc/docs/en/guide/glossary.mdx
@@ -27,12 +27,12 @@ Currently there are two Providers:
 - `@modern-js/builder-webpack-provider`: Based on webpack.
 - `@modern-js/builder-rspack-provider`: Based on rspack.
 
-## {MODERN_JS}
+## #MODERNJS
 
-**Modern.js is an open source web engineering system from ByteDance**, which provides multiple solutions to help developers solve problems in different development scenarios.
+**#MODERNJS is an open source web engineering system from ByteDance**, which provides multiple solutions to help developers solve problems in different development scenarios.
 
-[{MODERN_JS} Repository](https://github.com/web-infra-dev/modern.js).
+[#MODERNJS Repository](https://github.com/web-infra-dev/modern.js).
 
 ## EdenX
 
-ByteDance's internal web engineering system, implemented based on {MODERN_JS}.
+ByteDance's internal web engineering system, implemented based on #MODERNJS.

--- a/packages/document/builder-doc/docs/en/guide/introduction.mdx
+++ b/packages/document/builder-doc/docs/en/guide/introduction.mdx
@@ -27,7 +27,7 @@ If you are a business developer, in most cases, you do not need to manually inst
 
 Currently, the following front-end frameworks are already using Builder:
 
-- [{MODERN_JS}](https://github.com/web-infra-dev/modern.js) Framework (Open source).
+- [#MODERNJS](https://github.com/web-infra-dev/modern.js) Framework (Open source).
 - EdenX Framework and PIA Framework inside ByteDance.
 
 ## Features

--- a/packages/document/builder-doc/docs/zh/guide/basic/builder-config.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/basic/builder-config.mdx
@@ -40,14 +40,6 @@ export default {
 };
 ```
 
-常用的框架配置文件包括：
-
-| 框架        | 配置文件           |
-| ----------- | ------------------ |
-| {MODERN_JS} | {MODERN_JS_CONFIG} |
-| EdenX       | edenx.config.ts    |
-| PIA         | pia.config.ts      |
-
 ### 通过 Node API 使用
 
 当你通过 Node API 调用 Builder 时，你可以通过 Provider 的 `builderConfig` 配置项来传入 Builder 配置：

--- a/packages/document/builder-doc/docs/zh/guide/glossary.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/glossary.mdx
@@ -27,12 +27,12 @@ Builder Provider 是 Builder 的组成部分之一，Provider 基于特定 bundl
 - `@modern-js/builder-webpack-provider`：底层基于 webpack 来实现。
 - `@modern-js/builder-rspack-provider`：底层基于 Rspack 来实现。
 
-## {MODERN_JS}
+## #MODERNJS
 
-Modern.js 是字节跳动 Web 工程体系的开源版本，它提供多个解决方案，来帮助开发者解决不同研发场景下的问题。
+#MODERNJS 是字节跳动 Web 工程体系的开源版本，它提供多个解决方案，来帮助开发者解决不同研发场景下的问题。
 
-- [{MODERN_JS} 代码仓库](https://github.com/web-infra-dev/modern.js)。
+- [#MODERNJS 代码仓库](https://github.com/web-infra-dev/modern.js)。
 
 ## EdenX
 
-字节跳动内部的 Web 工程方案，基于 {MODERN_JS} 实现。
+字节跳动内部的 Web 工程方案，基于 #MODERNJS 实现。

--- a/packages/document/builder-doc/docs/zh/guide/introduction.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/introduction.mdx
@@ -27,7 +27,7 @@ Modern.js Builder (简称 Builder) 的定位是**服务于上层框架的构建�
 
 目前已经接入 Builder 的前端框架有：
 
-- 开源的 [{MODERN_JS}](https://github.com/web-infra-dev/modern.js) 框架。
+- 开源的 [#MODERNJS](https://github.com/web-infra-dev/modern.js) 框架。
 - 字节跳动内部的 EdenX、PIA 等框架。
 
 ## 特性

--- a/packages/document/builder-doc/modern.config.ts
+++ b/packages/document/builder-doc/modern.config.ts
@@ -235,13 +235,11 @@ export default defineConfig({
       },
     },
     replaceRules: [
+       // Using "#MODERNJS" to display "Modern.js"
+       // and it will not be replaced in EdenX in the in-house document
       {
-        search: /{MODERN_JS}/g,
+        search: /#MODERNJS/g,
         replace: 'Modern.js',
-      },
-      {
-        search: /{MODERN_JS_CONFIG}/g,
-        replace: 'modern.config.ts',
       },
     ],
     builderConfig: {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3374d4</samp>

This pull request removes redundant tables and replaces placeholders in the English and Chinese guides of the builder-doc package. It also updates the `modern.config.ts` file to match the new placeholders. These changes aim to avoid confusion and duplication in the documentation of the #MODERNJS framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3374d4</samp>

*  Remove the table of commonly used framework config files from the guide of builder-config.mdx, as it is redundant with the glossary.mdx file ([link](https://github.com/web-infra-dev/modern.js/pull/4388/files?diff=unified&w=0#diff-0055efbadcaa0ad86a88096580cd8be26146f2e0adeec5a9163dd609d3b1555bL43-L50), [link](https://github.com/web-infra-dev/modern.js/pull/4388/files?diff=unified&w=0#diff-9debf2efa97f971a48bb85ce8ffd3056de4f64c1bb2064e499db8f6603a5a23eL43-L50))
* Replace the placeholder {MODERN_JS} with #MODERNJS in the guide of glossary.mdx and introduction.mdx, to avoid confusion with the actual config file name `modern.config.ts` and to prevent the replacement in the EdenX document in the in-house version ([link](https://github.com/web-infra-dev/modern.js/pull/4388/files?diff=unified&w=0#diff-a505b82ebe7d66a21efa09182702a074ac589a6af31a10289d2f4d884c535274L30-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4388/files?diff=unified&w=0#diff-057d05e7df4d1b4eb40d5856e3419a4f587f37ed8385fc5ccf1ab109cd520f69L30-R30), [link](https://github.com/web-infra-dev/modern.js/pull/4388/files?diff=unified&w=0#diff-5d64f0b9b92591711964ae24e495032ca072269230c77a6ba9d04c78d3c09dcdL30-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4388/files?diff=unified&w=0#diff-9f204318c3d73d22c4d3a6cf4f6085a3d83698917f6178bc57ca916754627dbbL30-R30))
* Update the replaceRules in the `modern.config.ts` file, to reflect the new placeholder #MODERNJS and to remove the unnecessary rule for {MODERN_JS_CONFIG} ([link](https://github.com/web-infra-dev/modern.js/pull/4388/files?diff=unified&w=0#diff-fc9e3b9be79489436a867bcdd7e7d56a5d8a90bd8c0390fdb2166410e494495fL238-R243))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
