### PR TITLE
fix: typing error because the `app` is required (but actually not)

### DIFF
--- a/packages/server/prod-server/src/server/index.ts
+++ b/packages/server/prod-server/src/server/index.ts
@@ -106,21 +106,21 @@ export class Server {
     }
 
     // runner can only be used after server init
-    Object.assign(
-      this,
-      await this.runner.beforeServerInit({
+    {
+      const result = await this.runner.beforeServerInit({
         app: this.app,
         server: this.server,
-      }),
-    );
+      });
+      ({ app: this.app = this.app, server: this.server } = result);
+    }
     await this.server.onInit(this.runner, this.app);
-    Object.assign(
-      this,
-      await this.runner.afterServerInit({
+    {
+      const result = await this.runner.afterServerInit({
         app: this.app,
         server: this.server,
-      }),
-    );
+      });
+      ({ app: this.app = this.app, server: this.server } = result);
+    }
 
     return this;
   }

--- a/packages/server/prod-server/src/server/index.ts
+++ b/packages/server/prod-server/src/server/index.ts
@@ -106,18 +106,21 @@ export class Server {
     }
 
     // runner can only be used after server init
-    ({ app: this.app, server: this.server } =
+    Object.assign(
+      this,
       await this.runner.beforeServerInit({
         app: this.app,
         server: this.server,
-      }));
+      }),
+    );
     await this.server.onInit(this.runner, this.app);
-    ({ app: this.app, server: this.server } = await this.runner.afterServerInit(
-      {
+    Object.assign(
+      this,
+      await this.runner.afterServerInit({
         app: this.app,
         server: this.server,
-      },
-    ));
+      }),
+    );
 
     return this;
   }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cbd6dd7</samp>

Refactor `Server` initialization code in `index.ts` to use `Object.assign` instead of destructuring. This enables the `runner` to return additional properties for the `Server` instance.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cbd6dd7</samp>

*  Refactor server initialization to use `Object.assign` instead of destructuring assignment ([link](https://github.com/web-infra-dev/modern.js/pull/4391/files?diff=unified&w=0#diff-5cbeedfd701ea461dc9742e0bff36e00e9dd1faae4fb4dc686213499a62cb542L109-R123))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
