### PR TITLE
feat(doc-plugin-typedoc): support single entry for typedoc

### DIFF
--- a/.changeset/tame-ghosts-march.md
+++ b/.changeset/tame-ghosts-march.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/doc-plugin-typedoc': patch
+---
+
+feat(doc-plugin-typedoc): support single entry for typedoc
+
+feat(doc-plugin-typedoc): typedoc 插件支持单入口

--- a/packages/cli/doc-plugin-typedoc/src/index.ts
+++ b/packages/cli/doc-plugin-typedoc/src/index.ts
@@ -3,7 +3,10 @@ import { Application, TSConfigReader } from 'typedoc';
 import type { DocPlugin } from '@modern-js/doc-core/src/shared/types/Plugin';
 import { load } from 'typedoc-plugin-markdown';
 import { API_DIR } from './constants';
-import { resolveSidebar } from './sidebar';
+import {
+  resolveSidebarForMultiEntry,
+  resolveSidebarForSingleEntry,
+} from './sidebar';
 
 export interface PluginTypeDocOptions {
   /**
@@ -67,9 +70,10 @@ export function pluginTypeDoc(options: PluginTypeDocOptions): DocPlugin {
           link: apiIndexLink,
         });
         config.themeConfig.sidebar = config.themeConfig.sidebar || {};
-        config.themeConfig.sidebar[apiIndexLink] = await resolveSidebar(
-          jsonDir,
-        );
+        config.themeConfig.sidebar[apiIndexLink] =
+          entryPoints.length > 1
+            ? await resolveSidebarForMultiEntry(jsonDir)
+            : await resolveSidebarForSingleEntry(jsonDir);
         config.themeConfig.sidebar[apiIndexLink].unshift({
           text: 'Overview',
           link: `${apiIndexLink}README`,

--- a/packages/cli/doc-plugin-typedoc/src/utils.ts
+++ b/packages/cli/doc-plugin-typedoc/src/utils.ts
@@ -1,39 +1,3 @@
-import path from 'path';
-import { ROUTE_PREFIX } from './constants';
-
 export function transformModuleName(name: string) {
   return name.replace(/\//g, '_').replace(/-/g, '_');
-}
-
-export function getModulePath(name: string) {
-  return path
-    .join(`${ROUTE_PREFIX}/modules`, `${transformModuleName(name)}`)
-    .replace(/\\/g, '/');
-}
-
-export function getClassPath(moduleName: string, className: string) {
-  return path
-    .join(
-      `${ROUTE_PREFIX}/classes`,
-      `${transformModuleName(moduleName)}.${className}`,
-    )
-    .replace(/\\/g, '/');
-}
-
-export function getInterfacePath(moduleName: string, interfaceName: string) {
-  return path
-    .join(
-      `${ROUTE_PREFIX}/interfaces`,
-      `${transformModuleName(moduleName)}.${interfaceName}`,
-    )
-    .replace(/\\/g, '/');
-}
-
-export function getFunctionPath(moduleName: string, functionName: string) {
-  return path
-    .join(
-      `${ROUTE_PREFIX}/functions`,
-      `${transformModuleName(moduleName)}.${functionName}`,
-    )
-    .replace(/\\/g, '/');
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a42532a</samp>

This pull request adds support for multiple entry points for typedoc in the `@modern-js/doc-plugin-typedoc` package. It updates the sidebar generation logic, the utility functions, and the changeset file accordingly. It also fixes some module name and link issues in the API documentation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a42532a</samp>

*  Add a changeset file to record the patch update and feature description for `@modern-js/doc-plugin-typedoc` package (.changeset/tame-ghosts-march.md)
  * Importing new functions and constant from `./sidebar` and `./constants` modules in `./index` module ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-fcb4b6345c97e9b47310c4d284ca0c58d83e62718f1dcbcc9ca6ea74fa847bf2L6-R9))
  * Adding conditional logic to use different sidebar resolution functions based on the length of `entryPoints` array in `pluginTypeDoc` function ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-fcb4b6345c97e9b47310c4d284ca0c58d83e62718f1dcbcc9ca6ea74fa847bf2L70-R76))
  * Adding new functions `resolveSidebarForSingleEntry` and `resolveSidebarForMultiEntry` in `./sidebar` module to generate sidebar groups for different cases ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-9b57277018814fdb192a48c0cc1273b8567e1af01ea8cc9143886d878e88f9d6L24-R134))
  * Removing the original `resolveSidebar` function in `./sidebar` module and replacing it with `resolveSidebarForMultiEntry` function ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-9b57277018814fdb192a48c0cc1273b8567e1af01ea8cc9143886d878e88f9d6L72-R177))
  * Importing new function and constant from `./utils` and `./constants` modules in `./sidebar` module ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-9b57277018814fdb192a48c0cc1273b8567e1af01ea8cc9143886d878e88f9d6L4-R5))
  * Using `transformModuleName` function to normalize module names in `resolveSidebarForMultiEntry` function ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-9b57277018814fdb192a48c0cc1273b8567e1af01ea8cc9143886d878e88f9d6L24-R134))
  * Using `patchLinks` function to scan and modify links in markdown files to make them relative in both sidebar resolution functions ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-9b57277018814fdb192a48c0cc1273b8567e1af01ea8cc9143886d878e88f9d6L24-R134))
*  Remove unused utility functions from `./utils` module and keep `transformModuleName` function ([link](https://github.com/web-infra-dev/modern.js/pull/4392/files?diff=unified&w=0#diff-0fb8d0f23814ce8e7f2cb5b0eccdf24934e220f02d45e53fdb8f5d40df57828bL1-R3))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
