### PR TITLE
test(builder): add more test cases

### DIFF
--- a/packages/builder/builder-webpack-provider/src/plugins/minimize.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/minimize.ts
@@ -45,6 +45,8 @@ async function applyJSMinimizer(chain: WebpackChain, config: NormalizedConfig) {
   const DEFAULT_OPTIONS: TerserPluginOptions = {
     terserOptions: {
       mangle: {
+        // not need in rspack(swc)
+        // https://github.com/swc-project/swc/discussions/3373
         safari10: true,
       },
       format: {

--- a/tests/e2e/builder/cases/basic/exports-presence/index.test.ts
+++ b/tests/e2e/builder/cases/basic/exports-presence/index.test.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import { expect } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
+
+// TODO: needs rspack exportsPresence error
+webpackOnlyTest(
+  'should throw error by default(exportsPresence error)',
+  async () => {
+    await expect(
+      build({
+        cwd: __dirname,
+        entry: {
+          index: path.resolve(__dirname, './src/index.js'),
+        },
+      }),
+    ).rejects.toThrowError();
+  },
+);

--- a/tests/e2e/builder/cases/basic/exports-presence/src/index.js
+++ b/tests/e2e/builder/cases/basic/exports-presence/src/index.js
@@ -1,0 +1,3 @@
+import { bb, aa } from './test';
+
+console.log(aa, bb);

--- a/tests/e2e/builder/cases/basic/exports-presence/src/test.js
+++ b/tests/e2e/builder/cases/basic/exports-presence/src/test.js
@@ -1,0 +1,1 @@
+export const bb = 1;

--- a/tests/e2e/builder/cases/output/ascii/index.test.ts
+++ b/tests/e2e/builder/cases/output/ascii/index.test.ts
@@ -1,0 +1,56 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build, getHrefByEntryName } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
+
+// TODO: needs rspack minifyOptions.asciiOnly
+webpackOnlyTest('output.charset default (ascii)', async ({ page }) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    runServer: true,
+  });
+
+  await page.goto(getHrefByEntryName('index', builder.port));
+  expect(await page.evaluate('window.a')).toBe('你好 world!');
+
+  const files = await builder.unwrapOutputJSON();
+
+  const [, content] = Object.entries(files).find(
+    ([name]) => name.endsWith('.js') && name.includes('static/js/index'),
+  )!;
+
+  expect(content.includes('\\u4f60\\u597d world!')).toBeTruthy();
+
+  builder.close();
+});
+
+test('output.charset (utf8)', async ({ page }) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    builderConfig: {
+      output: {
+        charset: 'utf8',
+      },
+    },
+    runServer: true,
+  });
+
+  await page.goto(getHrefByEntryName('index', builder.port));
+  expect(await page.evaluate('window.a')).toBe('你好 world!');
+
+  const files = await builder.unwrapOutputJSON();
+
+  const [, content] = Object.entries(files).find(
+    ([name]) => name.endsWith('.js') && name.includes('static/js/index'),
+  )!;
+
+  expect(content.includes('你好 world!')).toBeTruthy();
+
+  builder.close();
+});

--- a/tests/e2e/builder/cases/output/ascii/src/index.js
+++ b/tests/e2e/builder/cases/output/ascii/src/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+window.a = '你好 world!';

--- a/tests/e2e/builder/cases/web-worker/index.test.ts
+++ b/tests/e2e/builder/cases/web-worker/index.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
 
 test('should build web-worker target correctly', async () => {
   const builder = await build({
@@ -15,3 +16,21 @@ test('should build web-worker target correctly', async () => {
   expect(jsFiles.length).toEqual(1);
   expect(jsFiles[0].includes('index')).toBeTruthy();
 });
+
+// TODO: needs dynamicImportMode: 'eager',
+webpackOnlyTest(
+  'should build web-worker target with dynamicImport correctly',
+  async () => {
+    const builder = await build({
+      cwd: __dirname,
+      entry: { index: path.resolve(__dirname, './src/index2.js') },
+      target: 'web-worker',
+    });
+    const files = await builder.unwrapOutputJSON();
+    const filenames = Object.keys(files);
+    const jsFiles = filenames.filter(item => item.endsWith('.js'));
+
+    expect(jsFiles.length).toEqual(1);
+    expect(jsFiles[0].includes('index')).toBeTruthy();
+  },
+);

--- a/tests/e2e/builder/cases/web-worker/src/index2.js
+++ b/tests/e2e/builder/cases/web-worker/src/index2.js
@@ -1,0 +1,4 @@
+console.log('1');
+import('./test').then(res => {
+  console.log('res', res);
+});

--- a/tests/e2e/builder/cases/web-worker/src/test.js
+++ b/tests/e2e/builder/cases/web-worker/src/test.js
@@ -1,0 +1,1 @@
+export const bb = 'hello world';


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f00d6c8</samp>

This pull request adds new test cases and a helper function for the `builder-webpack-provider` plugin, which is a plugin that provides webpack configuration for the `modern.js` framework. The test cases cover features such as web-worker support, exports presence, and output character sets. The helper function allows skipping tests that are not applicable for `rspack`, which is a bundler based on `swc`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f00d6c8</samp>

*  Add comment to explain why `applyJSMinimizer` does not use `terser-webpack-plugin` for `rspack` ([link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-f0900604339bc45e29308a86e37b7d2de6252c91d274db00cfc834db480a73dcR48-R49))
*  Add test for `exportsPresence` feature of webpack 5, which throws an error when imports and exports do not match ([link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-4ca4ed4efe0a7090e6f413d6cd2a4f72e0e86c45967887f3cefa9605740468d5R1-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-76ae13eda06bdad8fe864474da84525ba8ceba1ce6ec8b06e6df307414cc6d32R1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-a5143c14bc382ba09a508649c5ffd3f969e32ed267e8145bd2f0c9072ad2b73eR1))
*  Add test for output character sets, which checks that the builder can output JavaScript files with `ascii` or `utf8` encoding ([link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-7fd2fee2ef4258a843c561f54d65cb3bc2d98c9540fb256f66822f5482cda845R1-R56), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-ac5fc761f7fe389296ec6d92772c40d29b0f08d245096fba9f12db227ad6d2aeR1-R2))
*  Add test for web-worker target with dynamic import, which checks that the builder can handle dynamic import in web-worker scripts ([link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-0a5bc843335e0a1b12ea1d11d640e3340d523821e5cdd693cf5b35a819c00b67R4), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-0a5bc843335e0a1b12ea1d11d640e3340d523821e5cdd693cf5b35a819c00b67R19-R36), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-85e9da1b44a0fa28ae0ed4a0aadb286bf0457caa98e2128e86e7175ea6ab7078R1-R4), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-eeb3b444a0cf5b853cc2cc2d0a32e355123e1c58a6b807b894b225fcd9164e13R1))
*  Use `webpackOnlyTest` helper function to skip tests that are not supported by `rspack` and add `TODO` comments for future implementation ([link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-4ca4ed4efe0a7090e6f413d6cd2a4f72e0e86c45967887f3cefa9605740468d5R1-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-7fd2fee2ef4258a843c561f54d65cb3bc2d98c9540fb256f66822f5482cda845R1-R56), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-0a5bc843335e0a1b12ea1d11d640e3340d523821e5cdd693cf5b35a819c00b67R4), [link](https://github.com/web-infra-dev/modern.js/pull/4393/files?diff=unified&w=0#diff-0a5bc843335e0a1b12ea1d11d640e3340d523821e5cdd693cf5b35a819c00b67R19-R36))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
