### PR TITLE
feat: using Node.js v18 LTS by default

### DIFF
--- a/.changeset/silver-trainers-punch.md
+++ b/.changeset/silver-trainers-punch.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/base-generator': patch
+---
+
+feat(generator): using Node.js v18 LTS by default
+
+feat(generator): 默认使用 Node.js v18 LTS

--- a/.github/workflows/build-builder-website.yml
+++ b/.github/workflows/build-builder-website.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/build-doc-website.yml
+++ b/.github/workflows/build-doc-website.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/build-main-website.yml
+++ b/.github/workflows/build-main-website.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/build-module-website.yml
+++ b/.github/workflows/build-module-website.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest] # ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [windows-latest] # windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/lint-Linux.yml
+++ b/.github/workflows/lint-Linux.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest] # ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 16
+      - name: Setup Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
           cache: 'pnpm'
 
       - name: Turbo Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 16
+      - name: Setup Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
           cache: 'pnpm'
 
       - name: Install npm v9
@@ -88,10 +88,10 @@ jobs:
       - name: Install Pnpm
         run: corepack enable
 
-      - name: Setup Node.js 16
+      - name: Setup Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
           cache: 'pnpm'
 
       - name: Install npm v9

--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [windows-latest] # windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/test-garfish-e2e.yml
+++ b/.github/workflows/test-garfish-e2e.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [macos-latest] # macos-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/vitest-Windows.yml
+++ b/.github/workflows/vitest-Windows.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [windows-latest] # windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/vitest-macOS.yml
+++ b/.github/workflows/vitest-macOS.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [macos-latest] # macos-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/packages/document/builder-doc/docs/en/guide/optimization/build-performance.mdx
+++ b/packages/document/builder-doc/docs/en/guide/optimization/build-performance.mdx
@@ -20,7 +20,7 @@ Especially for devices with Apple M1/M2 chips, it is recommended to use Node 18.
 
 Node >= 16 provides Apple Silicon binaries by default, so the performance on M1/M2 models will be greatly improved than Node 14. According to our tests, **After switching from Node 14 to Node >= 16, the compilation speed can be improved by more than 100%**.
 
-You can switch to Node 19 by following steps:
+You can switch to Node 18 by following steps:
 
 ```bash
 # Install Node v18

--- a/packages/document/builder-doc/docs/en/guide/optimization/build-performance.mdx
+++ b/packages/document/builder-doc/docs/en/guide/optimization/build-performance.mdx
@@ -16,21 +16,21 @@ The following are some general optimization strategies, which can speed up the d
 
 In general, updating Node.js to the latest [LTS release](https://github.com/nodejs/release#release-schedule) will help improve build performance.
 
-Especially for devices with Apple M1/M2 chips, it is recommended to use Node 16 or Node 18.
+Especially for devices with Apple M1/M2 chips, it is recommended to use Node 18.
 
-Node 16 provides Apple Silicon binaries by default, so the performance on M1/M2 models will be greatly improved than Node 14. According to our tests, **After switching from Node 14 to Node 16, the compilation speed can be improved by more than 100%**.
+Node >= 16 provides Apple Silicon binaries by default, so the performance on M1/M2 models will be greatly improved than Node 14. According to our tests, **After switching from Node 14 to Node >= 16, the compilation speed can be improved by more than 100%**.
 
-You can switch to Node 16 by following steps:
+You can switch to Node 19 by following steps:
 
 ```bash
-# Install Node.js v16
-nvm install 16
+# Install Node v18
+nvm install 18
 
-# switch to Node 16
-nvm use 16
+# switch to Node 18
+nvm use 18
 
-# Set Node 16 as the default version
-nvm default 16
+# Set Node 18 as the default version
+nvm default 18
 
 # View Node version
 node -v

--- a/packages/document/builder-doc/docs/en/shared/nodeVersion.md
+++ b/packages/document/builder-doc/docs/en/shared/nodeVersion.md
@@ -1,25 +1,24 @@
-Before getting started, you will need to install [Node.js](https://nodejs.org/), and ensure that your Node.js version is higher than 14.17.6. **We recommend using the LTS version of Node.js 16.**
+Before getting started, you will need to install [Node.js](https://nodejs.org/), and ensure that your Node.js version is higher than 14.17.6. **We recommend using the LTS version of Node.js 18.**
 
 You can check the currently used Node.js version with the following command:
 
 ```bash
 node -v
-# v16.19.1
 ```
 
 If you do not have Node.js installed in your current environment, or the installed version is lower than 14.17.6, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install the required version.
 
-Here is an example of how to install the Node.js 16 LTS version via nvm:
+Here is an example of how to install the Node.js 18 LTS version via nvm:
 
 ```bash
-# Install the long-term support version of Node.js 16
-nvm install 16 --lts
+# Install the long-term support version of Node.js 18
+nvm install 18 --lts
 
-# Make the newly installed Node.js 16 as the default version
-nvm alias default 16
+# Make the newly installed Node.js 18 as the default version
+nvm alias default 18
 
-# Switch to the newly installed Node.js 16
-nvm use 16
+# Switch to the newly installed Node.js 18
+nvm use 18
 ```
 
 :::tip nvm and fnm

--- a/packages/document/builder-doc/docs/zh/guide/optimization/build-performance.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/optimization/build-performance.mdx
@@ -16,21 +16,21 @@ Modern.js Builder 默认对构建性能进行了充分优化，但是随着业�
 
 通常来说，将 Node.js 更新到最新的 [LTS 版本](https://github.com/nodejs/release#release-schedule)，有助于提升构建性能。
 
-尤其是对于 Apple M1/M2 芯片的机型，推荐使用 Node 16 或 Node 18 进行构建。
+尤其是对于 Apple M1/M2 芯片的机型，推荐使用 Node 18 进行构建。
 
-Node 16 默认提供了 Apple Silicon binaries，因此在 M1/M2 机型上性能会比 Node 14 有大幅度提升。根据我们的测试，**从 Node 14 切换到 Node 16 后，编译速度可以提升 100% 以上**。
+Node >= 16 默认提供了 Apple Silicon binaries，因此在 M1/M2 机型上性能会比 Node 14 有大幅度提升。根据我们的测试，**从 Node 14 切换到 Node >= 16 后，编译速度可以提升 100% 以上**。
 
-你可以通过以下步骤来切换到 Node 16：
+你可以通过以下步骤来切换到 Node 18：
 
 ```bash
-# 安装 Node.js v16
-nvm install 16
+# 安装 Node v18
+nvm install 18
 
-# 切换到 Node 16
-nvm use 16
+# 切换到 Node 18
+nvm use 18
 
-# 将 Node 16 设置为默认版本
-nvm default 16
+# 将 Node 18 设置为默认版本
+nvm default 18
 
 # 查看 Node 版本
 node -v

--- a/packages/document/builder-doc/docs/zh/shared/nodeVersion.md
+++ b/packages/document/builder-doc/docs/zh/shared/nodeVersion.md
@@ -1,29 +1,28 @@
-在开始使用前，你需要安装 [Node.js](https://nodejs.org/)，并保证 Node.js 版本不低于 14.17.6，**我们推荐使用 Node.js 16 的 LTS 版本**。
+在开始使用前，你需要安装 [Node.js](https://nodejs.org/)，并保证 Node.js 版本不低于 14.17.6，**我们推荐使用 Node.js 18 的 LTS 版本**。
 
 你可以通过以下命令检查当前使用的 Node.js 版本：
 
 ```bash
 node -v
-# v16.19.1
 ```
 
 如果你当前的环境中尚未安装 Node.js，或是安装的版本低于 14.17.6，可以通过 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https://github.com/Schniz/fnm) 安装需要的版本。
 
-下面是通过 nvm 安装 Node.js 16 LTS 版本的例子：
+下面是通过 nvm 安装 Node.js 18 LTS 版本的例子：
 
 ```bash
-# 安装 Node.js 16 的长期支持版本
-nvm install 16 --lts
+# 安装 Node.js 18 的长期支持版本
+nvm install 18 --lts
 
-# 将刚安装的 Node.js 16 设置为默认版本
-nvm alias default 16
+# 将刚安装的 Node.js 18 设置为默认版本
+nvm alias default 18
 
-# 切换到刚安装的 Node.js 16
-nvm use 16
+# 切换到刚安装的 Node.js 18
+nvm use 18
 ```
 
 :::tip nvm 和 fnm
 nvm 和 fnm 都是 Node.js 版本管理工具。相对来说，nvm 较为成熟和稳定，而 fnm 是使用 Rust 实现的，比 nvm 提供了更好的性能。
 :::
 
-此外，在安装 nvm 或 fnm 后，然后只要仓库根目录下有内容为 `lts/gallium` 的 `.nvmrc` 文件，进入这个仓库时就会自动安装或切换到正确的 Node.js 版本。
+此外，在安装 nvm 或 fnm 后，然后只要仓库根目录下有内容为 `lts/hydrogen` 的 `.nvmrc` 文件，进入这个仓库时就会自动安装或切换到正确的 Node.js 版本。

--- a/packages/document/main-doc/docs/en/community/contributing-guide.mdx
+++ b/packages/document/main-doc/docs/en/community/contributing-guide.mdx
@@ -17,26 +17,25 @@ own GitHub account and then [clone](https://help.github.com/articles/cloning-a-r
 
 ### Install Node.js
 
-We recommend using Node.js 16 or 18. You can check your currently used Node.js version with the following command:
+We recommend using Node.js 18. You can check your currently used Node.js version with the following command:
 
 ```bash
 node -v
-#v16.18.0
 ```
 
 If you do not have Node.js installed in your current environment, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install it.
 
-Here is an example of how to install the Node.js 16 LTS version via nvm:
+Here is an example of how to install the Node.js 18 LTS version via nvm:
 
 ```bash
-# Install the LTS version of Node.js 16
-nvm install 16 --lts
+# Install the LTS version of Node.js 18
+nvm install 18 --lts
 
-# Make the newly installed Node.js 16 as the default version
-nvm alias default 16
+# Make the newly installed Node.js 18 as the default version
+nvm alias default 18
 
-# Switch to the newly installed Node.js 16
-nvm use 16
+# Switch to the newly installed Node.js 18
+nvm use 18
 ```
 
 ### Install pnpm

--- a/packages/document/main-doc/docs/en/guides/troubleshooting/dependencies.mdx
+++ b/packages/document/main-doc/docs/en/guides/troubleshooting/dependencies.mdx
@@ -46,7 +46,7 @@ The engine "node" is incompatible with this module.
 Expected version ">=14.17.6". Got "12.20.1"
 ```
 
-When using Modern.js, it is recommended to use the latest version of [Node.js 14.x](https://nodejs.org/download/release/latest-v14.x/) or [Node.js 16.x](https://nodejs.org/download/release/latest-v16.x/).
+When using Modern.js, it is recommended to use the latest version of [Node.js 18.x](https://nodejs.org/download/release/latest-v18.x/).
 
 If the Node.js version of the current environment is lower than the above requirement, you can use tools such as [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to switch versions.
 

--- a/packages/document/main-doc/docs/zh/community/contributing-guide.mdx
+++ b/packages/document/main-doc/docs/zh/community/contributing-guide.mdx
@@ -16,26 +16,25 @@ sidebar_position: 3
 
 ### 安装 Node.js
 
-我们推荐使用 Node.js 16 或 18。你可以通过以下命令查看当前使用的 Node.js 版本：
+我们推荐使用 Node.js 18。你可以通过以下命令查看当前使用的 Node.js 版本：
 
 ```bash
 node -v
-#v16.18.0
 ```
 
 如果你当前环境没有安装 Node.js，可以使用 [nvm](https://github.com/nvm-sh/nvm)或者 [fnm](https://github.com/Schniz/fnm) 来安装它。
 
-以下是如何通过 nvm 安装 Node.js 16 LTS 版本的示例：
+以下是如何通过 nvm 安装 Node.js 18 LTS 版本的示例：
 
 ```bash
-# 安装 Node.js 16 的 LTS 版本
-nvm install 16 --lts
+# 安装 Node.js 18 的 LTS 版本
+nvm install 18 --lts
 
-# 将新安装的 Node.js 16 设为默认版本
-nvm alias default 16
+# 将新安装的 Node.js 18 设为默认版本
+nvm alias default 18
 
-# 切换到新安装的 Node.js 16
-nvm use 16
+# 切换到新安装的 Node.js 18
+nvm use 18
 ```
 
 ### 安装 pnpm

--- a/packages/document/main-doc/docs/zh/guides/troubleshooting/dependencies.mdx
+++ b/packages/document/main-doc/docs/zh/guides/troubleshooting/dependencies.mdx
@@ -46,7 +46,7 @@ The engine "node" is incompatible with this module.
 Expected version ">=14.17.6". Got "12.20.1"
 ```
 
-使用 Modern.js 时，建议使用 [Node.js 14.x](https://nodejs.org/download/release/latest-v14.x/) 或 [Node.js 16.x](https://nodejs.org/download/release/latest-v16.x/) 的最新版本。
+使用 Modern.js 时，建议使用 [Node.js 18.x](https://nodejs.org/download/release/latest-v18.x/) 的最新版本。
 
 如果当前环境的 Node.js 版本低于上述要求的版本，则可以使用 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https://github.com/Schniz/fnm) 等工具进行版本切换。
 

--- a/packages/document/module-doc/docs/en/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/en/guide/intro/getting-started.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 ## 3 minute demo
 
-Want to experience Module Tools in action? The only prerequisite you need is [Node.js LTS](https://github.com/nodejs/Release) and make sure your Node version is **>= 14.18.0**.We recommend using the LTS version of Node.js 16.
+Want to experience Module Tools in action? The only prerequisite you need is [Node.js LTS](https://github.com/nodejs/Release) and make sure your Node version is **>= 14.18.0**.We recommend using the LTS version of Node.js 18.
 
 ### Create new project
 

--- a/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
+++ b/packages/document/module-doc/docs/zh/guide/intro/getting-started.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 ## 三分钟快速上手
 
-想要实际体验 Module Tools？首先需要安装 [Node.js LTS](https://github.com/nodejs/Release)，并确保 Node 版本大于等于 **14.18.0**。我们推荐使用 Node.js 16 的 LTS 版本。
+想要实际体验 Module Tools？首先需要安装 [Node.js LTS](https://github.com/nodejs/Release)，并确保 Node 版本大于等于 **14.18.0**。我们推荐使用 Node.js 18 的 LTS 版本。
 
 ### 创建新项目
 

--- a/packages/generator/generators/base-generator/templates/base-templates/.nvmrc
+++ b/packages/generator/generators/base-generator/templates/base-templates/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/packages/toolkit/e2e/package.json
+++ b/packages/toolkit/e2e/package.json
@@ -48,7 +48,6 @@
     "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/connect": "^3.4.35",
-    "@types/got": "^9.6.12",
     "@types/node": "^14",
     "@types/serve-static": "^1.13.10",
     "got": "^11.8.3",

--- a/packages/toolkit/e2e/tests/server/index.test.ts
+++ b/packages/toolkit/e2e/tests/server/index.test.ts
@@ -5,10 +5,10 @@ import { runStaticServer } from '../../src/server';
 
 describe('runStaticServer', () => {
   it('should run static server', async () => {
-    const { port } = await runStaticServer(__dirname);
+    const { hostname, port } = await runStaticServer(__dirname);
     expect(port).toBeGreaterThan(0);
     expect(readFileSync(__filename, 'utf-8')).toEqual(
-      await got(`http://localhost:${port}/index.test.ts`).text(),
+      await got(`http://${hostname}:${port}/index.test.ts`).text(),
     );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5820,9 +5820,6 @@ importers:
       '@types/connect':
         specifier: ^3.4.35
         version: 3.4.35
-      '@types/got':
-        specifier: ^9.6.12
-        version: 9.6.12
       '@types/node':
         specifier: ^14
         version: 14.18.35
@@ -16068,14 +16065,6 @@ packages:
       '@types/node': 18.11.17
     dev: true
 
-  /@types/got@9.6.12:
-    resolution: {integrity: sha512-X4pj/HGHbXVLqTpKjA2ahI4rV/nNBc9mGO2I/0CgAra+F2dKgMXnENv2SRpemScBzBAI4vMelIVYViQxlSE6xA==}
-    dependencies:
-      '@types/node': 18.11.17
-      '@types/tough-cookie': 4.0.2
-      form-data: 2.5.1
-    dev: true
-
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
@@ -19055,7 +19044,7 @@ packages:
       keyv: 4.3.2
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
-      responselike: 2.0.0
+      responselike: 2.0.1
 
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -23237,15 +23226,6 @@ packages:
       webpack: 5.88.1(esbuild@0.17.19)(webpack-cli@5.1.4)
     dev: false
 
-  /form-data@2.5.1:
-    resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
-    engines: {node: '>= 0.12'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: true
-
   /form-data@3.0.1:
     resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
     engines: {node: '>= 6'}
@@ -23812,7 +23792,7 @@ packages:
       http2-wrapper: 1.0.3
       lowercase-keys: 2.0.0
       p-cancelable: 2.1.1
-      responselike: 2.0.0
+      responselike: 2.0.1
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -32702,8 +32682,8 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
 
-  /responselike@2.0.0:
-    resolution: {integrity: sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==}
+  /responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
     dependencies:
       lowercase-keys: 2.0.0
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ebb4a6</samp>

This pull request updates the Node.js version used by the `@modern-js/base-generator` package and the GitHub workflows to Node.js v18 LTS. This is done to support a new feature that uses Node.js v18 LTS by default for generating projects. The pull request also updates the changeset file, the `.nvmrc` file, and the documentation file to reflect the Node.js version change.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ebb4a6</samp>

*  Add a changeset file to describe the patch update and feature of using Node.js v18 LTS by default for the `@modern-js/base-generator` package ([link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-bf05faced82dfb0b9f53c0e2e871da213a8e1536854364261dc690e859f70c49R1-R7))
*  Update the Node.js version from 16 to 18 in various GitHub workflow files for building, testing, linting, releasing, and checking the changeset files, to improve the performance and compatibility with Apple Silicon devices and the latest Node.js version ([link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-40a842b346ec6ff70d2f79317de32d7e7bafb097d15ead27a0f53ec4ac607779L25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-004b488c64fbed36faeda4c1de3be7e8eeff905490579a643bfbb68992a908a7L27-R27), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-cf28b3e23b6222306734a144a456cbc5456a44373b52b4250414255ff7c6197eL26-R26), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-7594f6b69428d941d1ef72442e20bb0bfedc29fb40d51b9395e163b80f103a77L25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-6a81f4e59f26bd7c1958ebdc4a37c41b6876ff18d502763cede2658aaf3fe193L16-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL19-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-0140bd37d64c64518fe24fe1d94ea665cfae9e6da21a3ff99117c6b4f2076b91L19-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-8f7277e8806c84c3b5e6f4633856152294f87ba832563e4dbe928e4d2c202172L25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-16a64a20883492ca4054e74874bd1b1b2e551bb2d4729678a263a8df16b44efdL34-R37), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L42-R45), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L91-R94), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-2fd49069a90d672fd2b786ac43bff42e2e8886388951a79de3e77aadb955e881L25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-5df3b6d84caad924e3ba63aab4356432d2cfd20a3992e7e09fe9e5e8a0880f04L14-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-9cfe6beef0da4c00254521340043e1fda926023e4fd1f0c25e94a8cf05badba0L14-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-17ea3e6a3c1c6e583d7856e9275dacb15942c642da0f1347ffcb5a20c71c159eL25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-22cca89afb99b829ee69f606d54e47fc56b3c7e434c0e3100ea84ff9127ad91dL16-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-95573ba90321fd797ed824c00761a003620560275f96809b2fc42830a0810e4bL25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-2b0ce61f3b7eda161f53533338b36bc7751fe70d0dc54fc174a1972e5e7a6c11L25-R25))
*  Update the Node.js version from `lts/gallium` to `lts/hydrogen` in the `.nvmrc` file, to use the latest Node.js version for local development and testing ([link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-2c8effdf840690ccb88c7e21e56148978c6adb2c6926530c58ff0e47a9588b44L1-R1))
*  Update the Node.js version recommendation and commands in the optimization guide of the builder doc package, to inform the users of the benefits and steps of using the latest Node.js version for building the documentation website ([link](https://github.com/web-infra-dev/modern.js/pull/4398/files?diff=unified&w=0#diff-dab5198bfdb6057b3475532111f016c66fd1cb0935842e87062d82fcd19012d4L19-R33))

## Related Issue

- close https://github.com/web-infra-dev/modern.js/issues/4390

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
