### PR TITLE
test(builder):  not open real browser when running test

### DIFF
--- a/packages/builder/builder-shared/tests/openBrowser.test.ts
+++ b/packages/builder/builder-shared/tests/openBrowser.test.ts
@@ -7,6 +7,11 @@ describe('openBrowser', () => {
       default: () => Promise.resolve(),
     };
   });
+  vi.mock('child_process', () => {
+    return {
+      execSync: () => '',
+    };
+  });
   it('should open an Microsoft Edge browser if you have', async () => {
     vi.stubEnv('BROWSER', 'Microsoft Edge');
     expect(await openBrowser('https://modernjs.dev/')).toBeTypeOf('boolean');


### PR DESCRIPTION
## Summary

Fix the following Dialog when running vitest:

<img width="680" alt="Screenshot 2023-08-10 at 14 54 13" src="https://github.com/web-infra-dev/modern.js/assets/7237365/8b14a4a0-8b93-4214-a4f8-7bafb3886133">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc855f3</samp>

Mock `child_process` module in `openBrowser.test.ts` to improve test reliability. This prevents the test from running any real commands that could affect the test environment or the browser.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc855f3</samp>

* Mock `child_process` module to avoid executing commands in tests ([link](https://github.com/web-infra-dev/modern.js/pull/4412/files?diff=unified&w=0#diff-0aeec1d9bd74a444ed9cce3286e224cf8aa1946a16e44c962256ea958650bfbdR10-R14))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
