### PR TITLE
feat(builder): support disable Rspack CSS sourcemap

### DIFF
--- a/.changeset/sour-kids-obey.md
+++ b/.changeset/sour-kids-obey.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+feat(builder): support disable rspack css sourcemap
+
+feat(builder): 支持禁用 rspack css sourcemap 输出

--- a/packages/builder/builder-rspack-provider/src/plugins/css.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/css.ts
@@ -212,6 +212,19 @@ export const builderPluginCss = (): BuilderPlugin => {
           config,
           context: api.context,
         });
+
+        const enableSourceMap = isUseCssSourceMap(config);
+        const enableExtractCSS = isUseCssExtract(config, utils.target);
+
+        // TODO: there is no switch to turn off experiments.css sourcemap in rspack, so we manually remove css sourcemap in builder
+        if (!enableSourceMap && enableExtractCSS) {
+          const { RemoveCssSourcemapPlugin } = await import(
+            '../rspackPlugin/removeCssSourcemapPlugin'
+          );
+          chain
+            .plugin('remove-css-sourcemap')
+            .use(RemoveCssSourcemapPlugin, [utils.HtmlPlugin]);
+        }
       });
       api.modifyRspackConfig(
         async (rspackConfig, { isProd, isServer, isWebWorker }) => {

--- a/packages/builder/builder-rspack-provider/src/rspackPlugin/removeCssSourcemapPlugin.ts
+++ b/packages/builder/builder-rspack-provider/src/rspackPlugin/removeCssSourcemapPlugin.ts
@@ -1,0 +1,32 @@
+import type { Compiler, Compilation } from '@rspack/core';
+import type HtmlPlugin from '@rspack/plugin-html';
+import { COMPILATION_PROCESS_STAGE } from '@modern-js/builder-shared';
+
+export class RemoveCssSourcemapPlugin {
+  name: string;
+
+  htmlPlugin: typeof HtmlPlugin;
+
+  constructor(htmlPlugin: typeof HtmlPlugin) {
+    this.name = 'RemoveCssSourcemapPlugin';
+    this.htmlPlugin = htmlPlugin;
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: this.name,
+          stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_SUMMARIZE,
+        },
+        () => {
+          compilation.getAssets().forEach(asset => {
+            if (asset.name.endsWith('.css.map')) {
+              compilation.deleteAsset(asset.name);
+            }
+          });
+        },
+      );
+    });
+  }
+}

--- a/packages/builder/builder-rspack-provider/src/rspackPlugin/removeCssSourcemapPlugin.ts
+++ b/packages/builder/builder-rspack-provider/src/rspackPlugin/removeCssSourcemapPlugin.ts
@@ -20,9 +20,9 @@ export class RemoveCssSourcemapPlugin {
           stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_SUMMARIZE,
         },
         () => {
-          compilation.getAssets().forEach(asset => {
-            if (asset.name.endsWith('.css.map')) {
-              compilation.deleteAsset(asset.name);
+          Object.keys(compilation.assets).forEach(name => {
+            if (name.endsWith('.css.map')) {
+              compilation.deleteAsset(name);
             }
           });
         },

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1468,6 +1468,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         },
       },
     },
+    RemoveCssSourcemapPlugin {
+      "htmlPlugin": [Function],
+      "name": "RemoveCssSourcemapPlugin",
+    },
     RspackVirtualModulePlugin {},
     InlineChunkHtmlPlugin {
       "distPath": {

--- a/packages/builder/builder-shared/src/plugins/index.ts
+++ b/packages/builder/builder-shared/src/plugins/index.ts
@@ -10,3 +10,4 @@ export { AssetsRetryPlugin } from './AssetsRetryPlugin';
 export { CheckSyntaxPlugin } from './CheckSyntaxPlugin';
 export { HtmlNetworkPerformancePlugin } from './HtmlNetworkPerformancePlugin';
 export { HTMLPreloadOrPrefetchPlugin } from './HtmlPreloadOrPrefetchPlugin';
+export { COMPILATION_PROCESS_STAGE } from './util';

--- a/packages/document/builder-doc/docs/en/config/output/disableSourceMap.md
+++ b/packages/document/builder-doc/docs/en/config/output/disableSourceMap.md
@@ -29,10 +29,6 @@ By default, Builder's Source Map generation rules are:
 - In development build, SourceMap of JS files and CSS files will be generated, which is convenient for debugging.
 - In production build, the Source Map of JS files will be generated for debugging and troubleshooting online problems; the Source Map of CSS files will not be generated.
 
-:::tip
-When using Rspack as the bundler, disable css sourcemap alone is not currently supported.
-:::
-
 If the project does not need Source Map, you can turned off it to speed up the compile speed.
 
 ```js

--- a/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -86,7 +86,6 @@ All configurations and capabilities under dev are available within rspack.
 
 Unsupported configurations and capabilities include:
 
-- [output.disableSourcemap.css](/api/config-output.html#outputdisablesourcemap)
 - [output.enableCssModuleTSDeclaration](/api/config-output.html#outputenablecssmoduletsdeclaration) (Only supported when [disableCssExtract](/api/config-output.html#outputdisablecssextract) is true)
 - [output.enableInlineScripts](/api/config-output.html#outputenableinlinescripts)
 - [output.legalComments.inline](/api/config-output.html#outputlegalcomments)

--- a/packages/document/builder-doc/docs/zh/config/output/disableSourceMap.md
+++ b/packages/document/builder-doc/docs/zh/config/output/disableSourceMap.md
@@ -29,10 +29,6 @@ Source Map 是保存源代码映射关系的信息文件，它记录了编译后
 - 在开发环境构建时，会生成 JS 文件和 CSS 文件的 SourceMap，便于进行开发调试。
 - 在生产环境构建时，会生成 JS 文件的 Source Map，用于调试和排查线上问题；不会生成 CSS 文件的 Source Map。
 
-:::tip
-在使用 Rspack 作为打包工具时，暂不支持单独禁用 css sourcemap。
-:::
-
 如果项目不需要 Source Map，可以关闭该功能，从而提升构建的速度。
 
 ```js

--- a/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -86,7 +86,6 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 
 不支持的配置项及能力包括：
 
-- [output.disableSourcemap.css](/api/config-output.html#outputdisablesourcemap)
 - [output.enableCssModuleTSDeclaration](/api/config-output.html#outputenablecssmoduletsdeclaration) (仅在 [disableCssExtract](/api/config-output.html#outputdisablecssextract) 时支持)
 - [output.enableInlineScripts](/api/config-output.html#outputenableinlinescripts)
 - [output.legalComments.inline](/api/config-output.html#outputlegalcomments)

--- a/tests/e2e/builder/cases/output/output.test.ts
+++ b/tests/e2e/builder/cases/output/output.test.ts
@@ -2,7 +2,6 @@ import { join, dirname } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { fs } from '@modern-js/utils';
 import { build } from '@scripts/shared';
-import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
@@ -58,8 +57,7 @@ test.describe('output configure multi', () => {
     expect(fs.existsSync(join(fixtures, 'rem/dist-1/aa/js'))).toBeTruthy();
   });
 
-  // todo: rspack not support disable css sourceMap individually
-  webpackOnlyTest('sourcemap', async () => {
+  test('sourcemap', async () => {
     const files = await builder.unwrapOutputJSON(false);
 
     const jsMapFiles = Object.keys(files).filter(files =>


### PR DESCRIPTION
## Summary

there is no switch to turn off experiments.css sourcemap in rspack, so we manually remove css sourcemap in builder.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ba84d4</samp>

This pull request adds a feature to the `@modern-js/builder-rspack-provider` package that allows users to disable css sourcemap output when using rspack as the bundler. It also updates the test file `output.test.ts` to support both webpack and rspack, and removes some outdated and misleading documentation from the `@modern-js/document` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ba84d4</samp>

*  Add feature to disable css sourcemap output for rspack bundler ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-d13df76be81c544a6415297b1dd37e4a7668de518384d9c1f657102cfcd2b3c5R1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-cf2a0cdc15b2ccf34cfd27ba9028db6a8e4fcfa3fc988bf6d7a374d61a337b5fR215-R227), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-a0803999006927301831f778f8c3ddade659365eb34a741bbee1050c95adacb4R1-R32), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-4aa1bceaea7909a4213851fc0b29e4b4f7ce3d0c49e6f356a2186ff9ec423d81R13))
  * Create a changeset file to document the patch updates for `@modern-js/builder-rspack-provider` and `@modern-js/builder-shared` packages and the feature description in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-d13df76be81c544a6415297b1dd37e4a7668de518384d9c1f657102cfcd2b3c5R1-R8))
  * Add a conditional block of code in `css.ts` to import and apply a custom plugin `RemoveCssSourcemapPlugin` when the user configures to disable css sourcemap and enable css extract in the builder config ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-cf2a0cdc15b2ccf34cfd27ba9028db6a8e4fcfa3fc988bf6d7a374d61a337b5fR215-R227))
  * Add a new file `removeCssSourcemapPlugin.ts` to define the custom plugin class that hooks into the compilation process and deletes any asset that ends with `.css.map` ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-a0803999006927301831f778f8c3ddade659365eb34a741bbee1050c95adacb4R1-R32))
  * Export a constant `COMPILATION_PROCESS_STAGE` from `@modern-js/builder-shared` to define the different stages of the webpack compilation process and use it in the custom plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-4aa1bceaea7909a4213851fc0b29e4b4f7ce3d0c49e6f356a2186ff9ec423d81R13))
* Remove outdated and misleading tip sections and links from the documentation files for `@modern-js/document` package ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-ea7c941a27dd4d6550c8d2e4aa6e86cd363e3cae35844cb2b031ce9dad6f45b4L32-L35), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L89), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-9812cddd0f57ae3e49ada7fee29719220d76ca5155c54bcad035abcd061fe4e9L32-L35), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L89))
  * Remove the tip section that stated that rspack does not support disabling css sourcemap alone from the English and Chinese versions of `disableSourceMap.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-ea7c941a27dd4d6550c8d2e4aa6e86cd363e3cae35844cb2b031ce9dad6f45b4L32-L35), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-9812cddd0f57ae3e49ada7fee29719220d76ca5155c54bcad035abcd061fe4e9L32-L35))
  * Remove the link to the `output.disableSourcemap.css` option from the English and Chinese versions of `rspack-start.mdx`, as the option is not relevant for rspack users ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-914057dea134889c31535df0ce07bab3b24e410174c7667d2ca98f2e7fef8118L89), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-f8cbd3f0d3d051c8b2816d35026eb70aed638a236d5ded5ac7ce1d145db54a62L89))
* Enable the test case for sourcemap output to run with both webpack and rspack in the test file `output.test.ts` for `@modern-js/e2e` package ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL5), [link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL61-R60))
  * Remove the import statement for the `webpackOnlyTest` function, which was used to skip some tests that were not compatible with rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL5))
  * Replace the `webpackOnlyTest` function call with a regular `test` function call to run the test case with both bundlers ([link](https://github.com/web-infra-dev/modern.js/pull/4413/files?diff=unified&w=0#diff-caab91bb74e3f84f88b5dd31234717f95b592e779b0b36f64c4894abe63724dbL61-R60))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
