### PR TITLE
fix(plugin-vue): add features flags config to remove warning

### DIFF
--- a/.changeset/chilly-deers-brake.md
+++ b/.changeset/chilly-deers-brake.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-vue': patch
+---
+
+fix(plugin-vue): add features flags config to remove warning
+
+fix(plugin-vue): 增加 features flags 配置并移除 warning

--- a/packages/builder/plugin-vue/src/index.ts
+++ b/packages/builder/plugin-vue/src/index.ts
@@ -30,6 +30,13 @@ export function builderPluginVue(
           output: {
             disableSvgr: true,
           },
+          source: {
+            define: {
+              // https://link.vuejs.org/feature-flags
+              __VUE_OPTIONS_API__: true,
+              __VUE_PROD_DEVTOOLS__: false,
+            },
+          },
           tools: {
             babel(_, { addPlugins }) {
               addPlugins([

--- a/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -554,3 +554,42 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
   },
 }
 `;
+
+exports[`plugins/vue > should define feature flags correctly 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "test": /\\\\\\.vue\\$/,
+        "use": [
+          {
+            "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/vue-loader/dist/index.js",
+            "options": {
+              "compilerOptions": {
+                "preserveWhitespace": false,
+              },
+              "experimentalInlineMatchResource": false,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "plugins": [
+    Plugin {},
+    DefinePlugin {
+      "definitions": {
+        "__VUE_OPTIONS_API__": true,
+        "__VUE_PROD_DEVTOOLS__": false,
+        "process.env.ASSET_PREFIX": "\\"\\"",
+        "process.env.NODE_ENV": "\\"test\\"",
+      },
+    },
+  ],
+  "resolve": {
+    "extensions": [
+      ".vue",
+    ],
+  },
+}
+`;

--- a/packages/builder/plugin-vue/tests/index.test.ts
+++ b/packages/builder/plugin-vue/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import { createStubBuilder } from '@modern-js/builder-webpack-provider/stub';
 import { builderPluginBabel } from '@modern-js/builder-webpack-provider/plugins/babel';
+import { builderPluginDefine } from '@modern-js/builder-webpack-provider/plugins/define';
 import { builderPluginVue } from '../src';
 
 describe('plugins/vue', () => {
@@ -50,6 +51,14 @@ describe('plugins/vue', () => {
     });
     const config = await builder.unwrapWebpackConfig();
 
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should define feature flags correctly', async () => {
+    const builder = await createStubBuilder({
+      plugins: [builderPluginVue(), builderPluginDefine()],
+    });
+    const config = await builder.unwrapWebpackConfig();
     expect(config).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Fix the Vue runtime warning:

<img width="1225" alt="Screenshot 2023-08-10 at 15 15 37" src="https://github.com/web-infra-dev/modern.js/assets/7237365/3879028d-2810-4af8-9d37-95a5eb080f02">

Details: https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 546865a</samp>

This pull request adds a new option to the `builderPluginVue` function to enable feature flags for the Vue plugin. It also updates the test case and the changeset file for the `@modern-js/builder-plugin-vue` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 546865a</samp>

* Add a changeset file to document the patch update of the `@modern-js/builder-plugin-vue` package ([link](https://github.com/web-infra-dev/modern.js/pull/4414/files?diff=unified&w=0#diff-516e4b111ecd8643495815687377bcbd07e125c1fbd52588e0c49dab0064d76fR1-R7))
* Add a `source.define` option to the `builderPluginVue` function to inject global constants into the Vue source code ([link](https://github.com/web-infra-dev/modern.js/pull/4414/files?diff=unified&w=0#diff-0a40dae09a36847b55ebbebdc5a12905a73d1783e1b340dc87ec039ac6d8f368R33-R39))
* Test the `builderPluginVue` function with the `builderPluginDefine` function in `index.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4414/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR4), [link](https://github.com/web-infra-dev/modern.js/pull/4414/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR56-R63))
* Import the `builderPluginDefine` function from the `@modern-js/builder-webpack-provider` package in `index.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4414/files?diff=unified&w=0#diff-7d4169fe26bb6b8aa58ae8a014607c729fdc27a8c5c8f53f6b4122fe89e02babR4))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
