### PR TITLE
fix(doc-core): not render global UI in blank page

### DIFF
--- a/.changeset/mighty-toes-carry.md
+++ b/.changeset/mighty-toes-carry.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: not render global UI in blank page
+fix: 空白页面不渲染全局 UI 组件

--- a/packages/cli/doc-core/src/theme-default/layout/Layout/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/layout/Layout/index.tsx
@@ -139,14 +139,13 @@ export const Layout: React.FC<LayoutProps> = props => {
 
       <section>{getContentLayout()}</section>
       {bottom}
-      {
+      {pageType !== 'blank' &&
         // Global UI
         globalComponents.map((Component, index) => (
           // The component order is stable
           // eslint-disable-next-line react/no-array-index-key
           <Component key={index} />
-        ))
-      }
+        ))}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db7866e</samp>

This pull request improves the documentation layout and updates the `@modern-js/doc-core` package. It hides the global UI components on blank pages and adds a changeset file with fix messages in both languages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db7866e</samp>

*  Add changeset file for patch updates of `@modern-js/doc-core` package ([link](https://github.com/web-infra-dev/modern.js/pull/4417/files?diff=unified&w=0#diff-250e5a9e9f5f7e64f6f3e394efd632a6da37301c464e74c2de63f5e6eb95a594R1-R6))
*  Prevent global UI components from rendering on blank pages in `Layout` component ([link](https://github.com/web-infra-dev/modern.js/pull/4417/files?diff=unified&w=0#diff-ad0dae9c2c9edde59e66297213d95b5b033e379f05ff677cdca9c350ca541357L142-R142))
*  Remove extra line break in `globalComponents.map` expression ([link](https://github.com/web-infra-dev/modern.js/pull/4417/files?diff=unified&w=0#diff-ad0dae9c2c9edde59e66297213d95b5b033e379f05ff677cdca9c350ca541357L148-R148))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
