### PR TITLE
fix: create request error when use node 18

### DIFF
--- a/.changeset/serious-garlics-nail.md
+++ b/.changeset/serious-garlics-nail.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/create-request': patch
+---
+
+fix: create request error when use node 18
+
+fix: 修复在 Node 18 中请求失败

--- a/packages/server/create-request/src/node.ts
+++ b/packages/server/create-request/src/node.ts
@@ -113,7 +113,7 @@ export const createRequest: RequestCreator<typeof nodeFetch> = (
         }
       }
 
-      url = `http://localhost:${port}${finalPath}`;
+      url = `http://127.0.0.1:${port}${finalPath}`;
     }
 
     const fetcher = realRequest || originFetch;

--- a/packages/server/create-request/tests/node.test.ts
+++ b/packages/server/create-request/tests/node.test.ts
@@ -9,7 +9,7 @@ import { Response } from 'node-fetch';
 import { configure, createRequest } from '../src/node';
 
 describe('configure', () => {
-  const url = 'http://localhost:8080';
+  const url = 'http://127.0.0.1:8080';
   const path = '/api';
   const method = 'GET';
   const response = {
@@ -28,7 +28,7 @@ describe('configure', () => {
   // });
 
   test('should support custom request', done => {
-    const url = 'http://localhost:9090';
+    const url = 'http://127.0.0.1:9090';
     const port = 9090;
 
     run(
@@ -54,7 +54,7 @@ describe('configure', () => {
   });
 
   test('query should support array', done => {
-    const url = 'http://localhost:9090';
+    const url = 'http://127.0.0.1:9090';
     const port = 9090;
 
     run(


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54fb690</samp>

This pull request fixes a bug in the `@modern-js/create-request` package that caused requests to fail in Node 18. It changes the URL creation logic in `packages/server/create-request/src/node.ts` and adds a changeset file to document the patch version update and the fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54fb690</samp>

* Fix request error in Node 18 for `@modern-js/create-request` package ([link](https://github.com/web-infra-dev/modern.js/pull/4421/files?diff=unified&w=0#diff-dc111a614552f04ad73f86a2c2b3cf195658a3fa29ed84d9594e1e07d86072dbL116-R116), [link](https://github.com/web-infra-dev/modern.js/pull/4421/files?diff=unified&w=0#diff-daf10af42baf4b187824fb5964917503820a82236202dabe4e554cb5b8a64f44R1-R7))
  - Replace `localhost` with `127.0.0.1` in URL creation in `createRequest` function in `packages/server/create-request/src/node.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4421/files?diff=unified&w=0#diff-dc111a614552f04ad73f86a2c2b3cf195658a3fa29ed84d9594e1e07d86072dbL116-R116))
  - Add changeset file with patch version update and fix message in English and Chinese in `.changeset/serious-garlics-nail.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4421/files?diff=unified&w=0#diff-daf10af42baf4b187824fb5964917503820a82236202dabe4e554cb5b8a64f44R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
