### PR TITLE
chore: add globalUIComponents doc

### DIFF
--- a/packages/document/doc-tools-doc/docs/en/api/config/config-basic.mdx
+++ b/packages/document/doc-tools-doc/docs/en/api/config/config-basic.mdx
@@ -223,3 +223,26 @@ export async function onSearch(query: string) {
   console.log(query);
 }
 ```
+
+## globalUIComponents
+
+- Type: `string[]`
+- Default: `[]`
+
+You can register global UI components through the `globalUIComponents` parameter, for example:
+
+```ts title="modern.config.ts"
+import { docTools, defineConfig } from '@modern-js/doc-tools';
+import path from 'path';
+
+export default defineConfig({
+  doc: {
+    globalUIComponents: [path.join(__dirname, 'components', 'MyComponent.tsx')],
+  },
+  plugins: [docTools()],
+});
+```
+
+import GlobalUIComponents from '../../fragments/global-ui-components.mdx';
+
+<GlobalUIComponents />

--- a/packages/document/doc-tools-doc/docs/en/fragments/global-ui-components.mdx
+++ b/packages/document/doc-tools-doc/docs/en/fragments/global-ui-components.mdx
@@ -1,0 +1,41 @@
+When you register global components, the framework will automatically render these React components in the theme without manually importing and using them.
+
+Through global components, you can complete many custom functions, such as:
+
+```tsx title="comp-ui.tsx"
+import React from 'react';
+
+// Need a default export
+export default function PluginUI() {
+  return <div>这是一个全局的布局组件</div>;
+}
+```
+
+In this way, the content of the component will be rendered in the theme page, such as adding **BackToTop** button.
+
+In the meanwhile, you can also use the global component to register some side effects, such as:
+
+```tsx title="comp-side-effect.tsx"
+import { useEffect } from 'react';
+import { useLocation } from '@modern-js/doc-tools/runtime';
+
+// Need a default export
+export default function PluginSideEffect() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    // Executed when the component renders for the first time
+  }, []);
+
+  useEffect(() => {
+    // Executed when the route changes
+  }, [pathname]);
+  return null;
+}
+```
+
+This way, side effects of components are executed in the theme page. For example, some of the following scenarios require side effects:
+
+- Redirect for certain page routes.
+- Bind click event on the img tag of the page to implement the image zoom function.
+- When the route changes, the PV data of different pages are reported.
+- ......

--- a/packages/document/doc-tools-doc/docs/en/fragments/global-ui-components.mdx
+++ b/packages/document/doc-tools-doc/docs/en/fragments/global-ui-components.mdx
@@ -2,12 +2,12 @@ When you register global components, the framework will automatically render the
 
 Through global components, you can complete many custom functions, such as:
 
-```tsx title="comp-ui.tsx"
+```tsx title="compUi.tsx"
 import React from 'react';
 
 // Need a default export
 export default function PluginUI() {
-  return <div>这是一个全局的布局组件</div>;
+  return <div>This is a global layout component</div>;
 }
 ```
 
@@ -15,7 +15,7 @@ In this way, the content of the component will be rendered in the theme page, su
 
 In the meanwhile, you can also use the global component to register some side effects, such as:
 
-```tsx title="comp-side-effect.tsx"
+```tsx title="compSideEffect.tsx"
 import { useEffect } from 'react';
 import { useLocation } from '@modern-js/doc-tools/runtime';
 

--- a/packages/document/doc-tools-doc/docs/en/plugin/system/plugin-api.mdx
+++ b/packages/document/doc-tools-doc/docs/en/plugin/system/plugin-api.mdx
@@ -56,49 +56,9 @@ export function pluginForDoc(): DocPlugin {
 }
 ```
 
-When you register global components, the framework will automatically render these React components in the theme without manually importing and using them.
+import GlobalUIComponents from '../../fragments/global-ui-components.mdx';
 
-Through global components, you can complete many custom functions, such as:
-
-#### Add global UI components
-
-```tsx title="comp-ui.tsx"
-import React from 'react';
-
-// Need a default export
-export default function PluginUI() {
-  return <div>这是一个全局的布局组件</div>;
-}
-```
-
-In this way, the content of the component will be rendered in the theme page, such as adding **BackToTop** button.
-
-#### Register global side effects
-
-```tsx title="comp-side-effect.tsx"
-import { useEffect } from 'react';
-import { useLocation } from '@modern-js/doc-tools/runtime';
-
-// Need a default export
-export default function PluginSideEffect() {
-  const { pathname } = useLocation();
-  useEffect(() => {
-    // Executed when the component renders for the first time
-  }, []);
-
-  useEffect(() => {
-    // Executed when the route changes
-  }, [pathname]);
-  return null;
-}
-```
-
-This way, side effects of components are executed in the theme page. For example, some of the following scenarios require side effects:
-
-- Redirect for certain page routes.
-- Bind click event on the img tag of the page to implement the image zoom function.
-- When the route changes, the PV data of different pages are reported.
-- ......
+<GlobalUIComponents />
 
 ### builderConfig
 

--- a/packages/document/doc-tools-doc/docs/zh/api/config/config-basic.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/api/config/config-basic.mdx
@@ -223,3 +223,26 @@ export async function onSearch(query: string) {
   console.log(query);
 }
 ```
+
+## globalUIComponents
+
+- Type: `string[]`
+- Default: `[]`
+
+你可以通过 `globalUIComponents` 参数来增加全局 UI 组件，比如：
+
+```ts title="modern.config.ts"
+import { docTools, defineConfig } from '@modern-js/doc-tools';
+import path from 'path';
+
+export default defineConfig({
+  doc: {
+    globalUIComponents: [path.join(__dirname, 'components', 'MyComponent.tsx')],
+  },
+  plugins: [docTools()],
+});
+```
+
+import GlobalUIComponents from '../../fragments/global-ui-components.mdx';
+
+<GlobalUIComponents />

--- a/packages/document/doc-tools-doc/docs/zh/fragments/global-ui-components.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/fragments/global-ui-components.mdx
@@ -1,0 +1,41 @@
+当你注册了全局组件之后，框架会自动将这些 React 组件在主题中进行渲染，而不用你手动引入。
+
+通过全局组件，你可以完成诸多自定义的功能，比如:
+
+```tsx title="comp-ui.tsx"
+import React from 'react';
+
+// 需要默认导出一个组件
+export default function PluginUI() {
+  return <div>这是一个全局的布局组件</div>;
+}
+```
+
+这样，在主题页面中会渲染组件的内容，比如添加**回到顶部按钮**。
+
+同时，你也可以通过全局组件来注册全局副作用。比如：
+
+```tsx title="comp-side-effect.tsx"
+import { useEffect } from 'react';
+import { useLocation } from '@modern-js/doc-tools/runtime';
+
+// 需要默认导出一个组件
+export default function PluginSideEffect() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    // 组件初次渲染时执行
+  }, []);
+
+  useEffect(() => {
+    // 路由变化时执行
+  }, [pathname]);
+  return null;
+}
+```
+
+这样，在主题页面中会执行组件的副作用。比如以下的一些需要副作用的场景:
+
+- 针对某些页面路由进行重定向操作。
+- 对页面的 img 标签进行事件监听，实现图片放大功能。
+- 路由变化时，上报不同页面的 PV 数据。
+- ......

--- a/packages/document/doc-tools-doc/docs/zh/fragments/global-ui-components.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/fragments/global-ui-components.mdx
@@ -2,7 +2,7 @@
 
 通过全局组件，你可以完成诸多自定义的功能，比如:
 
-```tsx title="comp-ui.tsx"
+```tsx title="compUi.tsx"
 import React from 'react';
 
 // 需要默认导出一个组件
@@ -15,7 +15,7 @@ export default function PluginUI() {
 
 同时，你也可以通过全局组件来注册全局副作用。比如：
 
-```tsx title="comp-side-effect.tsx"
+```tsx title="compSideEffect.tsx"
 import { useEffect } from 'react';
 import { useLocation } from '@modern-js/doc-tools/runtime';
 

--- a/packages/document/doc-tools-doc/docs/zh/plugin/system/plugin-api.mdx
+++ b/packages/document/doc-tools-doc/docs/zh/plugin/system/plugin-api.mdx
@@ -57,49 +57,9 @@ export function pluginForDoc(): DocPlugin {
 }
 ```
 
-当你注册了全局组件之后，框架会自动将这些 React 组件在主题中进行渲染，而不用你手动引入。
+import GlobalUIComponents from '../../fragments/global-ui-components.mdx';
 
-通过全局组件，你可以完成诸多自定义的功能，比如:
-
-#### 添加全局的 UI 组件
-
-```tsx title="comp-ui.tsx"
-import React from 'react';
-
-// 需要默认导出一个组件
-export default function PluginUI() {
-  return <div>这是一个全局的布局组件</div>;
-}
-```
-
-这样，在主题页面中会渲染组件的内容，比如添加**回到顶部按钮**。
-
-#### 注册全局副作用
-
-```tsx title="comp-side-effect.tsx"
-import { useEffect } from 'react';
-import { useLocation } from '@modern-js/doc-tools/runtime';
-
-// 需要默认导出一个组件
-export default function PluginSideEffect() {
-  const { pathname } = useLocation();
-  useEffect(() => {
-    // 组件初次渲染时执行
-  }, []);
-
-  useEffect(() => {
-    // 路由变化时执行
-  }, [pathname]);
-  return null;
-}
-```
-
-这样，在主题页面中会执行组件的副作用。比如以下的一些需要副作用的场景:
-
-- 针对某些页面路由进行重定向操作。
-- 对页面的 img 标签进行事件监听，实现图片放大功能。
-- 路由变化时，上报不同页面的 PV 数据。
-- ......
+<GlobalUIComponents />
 
 ### builderConfig
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e58af67</samp>

This pull request updates the documentation of the doc-tools framework to introduce the globalUIComponents parameter for registering global UI components. It adds a new section and a fragment file to both the English and Chinese versions of the `config-basic.mdx` file, and removes the duplicate content from the `plugin-api.mdx` file. It also fixes the heading level of the `builderConfig` section in the `plugin-api.mdx` file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e58af67</samp>

*  Add a new section to the English and Chinese documentation of the `config-basic.mdx` file, explaining the usage and examples of the `globalUIComponents` parameter for registering global UI components in the doc-tools framework ([link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2R226-R248), [link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dR226-R248))
* Import and render a new fragment file called `global-ui-components.mdx` in both languages, containing more details about the global UI components feature, such as how to add global UI components, how to register global side effects, and some scenarios that require side effects ([link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-9494fc2d65a677728c812eba20b85e929762ffe255159e5cde6875fc65f38ec2R226-R248), [link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-4b4b5a712e6d76a810271be29d649df34ee0f6574ae8fb395e2d7197c6efea88R1-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-856ec42f5b0e04bb26e13229e8077164925e507ab10e3a994ecc8587b4d4a38dR226-R248), [link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-e5370b885ca0e93e7b2dc6922e3a4aaec9ea633406773758834f477bae64c320R1-R41))
* Remove the redundant content about the global UI components feature from the `plugin-api.mdx` file in both languages, and adjust the heading level of the `builderConfig` section to match the previous sections ([link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-1b9eeb5ff6e52af72efa99123654d70d702df475e9abbd814f6afb2e093d6550L59-R62), [link](https://github.com/web-infra-dev/modern.js/pull/4423/files?diff=unified&w=0#diff-2f742b8b3f2803b8eb5ea2ffb2888b0a619e4502f6e8b0a549105fd3106c1444L60-R63))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
