### PR TITLE
fix(builder): omit unused keys from builder config passed by user

### DIFF
--- a/.changeset/calm-laws-repair.md
+++ b/.changeset/calm-laws-repair.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): omit unused keys from builder config passed by user
+
+fix(builder): 移除用户传入的 builder config 中多余的 key

--- a/packages/builder/builder-rspack-provider/src/provider.ts
+++ b/packages/builder/builder-rspack-provider/src/provider.ts
@@ -1,5 +1,6 @@
 import {
   startProdServer,
+  pickBuilderConfig,
   createPublicContext,
   type BuilderProvider,
 } from '@modern-js/builder-shared';
@@ -23,10 +24,12 @@ export type BuilderRspackProvider = BuilderProvider<
 >;
 
 export function builderRspackProvider({
-  builderConfig,
+  builderConfig: originalBuilderConfig,
 }: {
   builderConfig: BuilderConfig;
 }): BuilderRspackProvider {
+  const builderConfig = pickBuilderConfig(originalBuilderConfig);
+
   return async ({ pluginStore, builderOptions, plugins }) => {
     const context = await createContext(builderOptions, builderConfig);
     const pluginAPI = getPluginAPI({ context, pluginStore });

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -21,6 +21,7 @@ import type {
   BuilderTarget,
   BundlerChainRule,
   SharedHtmlConfig,
+  SharedBuilderConfig,
   InspectConfigOptions,
   CreateBuilderOptions,
   NormalizedSharedDevConfig,
@@ -31,6 +32,7 @@ import type {
   NormalizedSharedPerformanceConfig,
   NormalizedSharedToolsConfig,
 } from './types';
+import { pick } from './pick';
 import { logger } from './logger';
 import { join } from 'path';
 
@@ -388,4 +390,23 @@ export const getDefaultStyledComponentsConfig = (
     displayName: true,
     transpileTemplateLiterals: true,
   };
+};
+
+/**
+ * Omit unused keys from builder config passed by user
+ */
+export const pickBuilderConfig = (
+  builderConfig: SharedBuilderConfig,
+): SharedBuilderConfig => {
+  const keys: Array<keyof SharedBuilderConfig> = [
+    'dev',
+    'html',
+    'tools',
+    'source',
+    'output',
+    'security',
+    'performance',
+    'experiments',
+  ];
+  return pick(builderConfig, keys);
 };

--- a/packages/builder/builder-shared/tests/config.test.ts
+++ b/packages/builder/builder-shared/tests/config.test.ts
@@ -1,6 +1,11 @@
 import { expect, it, describe } from 'vitest';
 import webpack from 'webpack';
-import { getExtensions, stringifyConfig, getMetaTags } from '../src/config';
+import {
+  getExtensions,
+  stringifyConfig,
+  getMetaTags,
+  pickBuilderConfig,
+} from '../src/config';
 
 it('should get default extensions correctly', async () => {
   expect(getExtensions()).toEqual(['.js', '.jsx', '.mjs', '.json']);
@@ -111,5 +116,40 @@ describe('stringifyConfig', () => {
 
     const entry1 = await getMetaTags('entry1', builderConfig);
     expect(entry1).toMatchSnapshot();
+  });
+});
+
+describe('pickBuilderConfig', () => {
+  it('should pick correct keys from builder config', () => {
+    const builderConfig = {
+      dev: {},
+      html: {},
+      tools: {},
+      source: {},
+      output: {},
+      security: {},
+      performance: {},
+      experiments: {},
+      extraKey: 'extraValue',
+    };
+
+    const result = pickBuilderConfig(builderConfig);
+
+    expect(result).toEqual({
+      dev: {},
+      html: {},
+      tools: {},
+      source: {},
+      output: {},
+      security: {},
+      performance: {},
+      experiments: {},
+    });
+  });
+
+  it('should return empty object when builder config is empty', () => {
+    const builderConfig = {};
+    const result = pickBuilderConfig(builderConfig);
+    expect(result).toEqual({});
   });
 });

--- a/packages/builder/builder-webpack-provider/src/provider.ts
+++ b/packages/builder/builder-webpack-provider/src/provider.ts
@@ -1,5 +1,6 @@
 import {
   startProdServer,
+  pickBuilderConfig,
   createPublicContext,
   type BuilderProvider,
 } from '@modern-js/builder-shared';
@@ -18,10 +19,12 @@ export type BuilderWebpackProvider = BuilderProvider<
 >;
 
 export function builderWebpackProvider({
-  builderConfig,
+  builderConfig: originalBuilderConfig,
 }: {
   builderConfig: BuilderConfig;
 }): BuilderWebpackProvider {
+  const builderConfig = pickBuilderConfig(originalBuilderConfig);
+
   return async ({ pluginStore, builderOptions, plugins }) => {
     const context = await createContext(builderOptions, builderConfig);
     const pluginAPI = getPluginAPI({ context, pluginStore });


### PR DESCRIPTION
## Summary

Fix the inspected `builder.config.js` which contains a lot of framework configuration:

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/a611e863-cd8f-4a1c-b6ff-02fa4859fa19)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc1fc7d</samp>

This pull request fixes the issue of passing unused keys to the builder config object for different providers. It introduces a shared function `pickBuilderConfig` and a common type `SharedBuilderConfig` to simplify and validate the config object. It also updates the tests and the changeset for the affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc1fc7d</samp>

*  Add a changeset file to describe the patch updates for three packages and the fix for omitting unused keys from the builder config ([link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-949582bc70b1c57c3b07180eb7377350f3a36f34decd6f1a5ef6f24c5928e2e3R1-R9))
*  Export the `SharedBuilderConfig` type that defines the common properties of the builder config object ([link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eR24))
*  Define and export the `pickBuilderConfig` function that uses the `pick` utility to filter out the unused keys from the builder config object ([link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eR35), [link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eR394-R412))
*  Import and use the `pickBuilderConfig` function in the `@modern-js/builder-rspack-provider` and `@modern-js/builder-webpack-provider` packages to pass only the relevant keys to the `createContext` function ([link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-8a726c59be2574234656971f190f0e9148482e3630dacecdb0cef0a441b07435R3), [link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-8a726c59be2574234656971f190f0e9148482e3630dacecdb0cef0a441b07435L26-R32), [link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-00efd56ec502c6806c8470bb5d47e440ab509e7d3e4f22771abc1d857fccce60R3), [link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-00efd56ec502c6806c8470bb5d47e440ab509e7d3e4f22771abc1d857fccce60L21-R27))
*  Add and run two test cases for the `pickBuilderConfig` function in the `@modern-js/builder-shared/tests/config.test.ts` file to check its functionality and behavior ([link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-1919ce277aa3e85ec73acb6b6fc7bbe38b892b7380469518644cd6ba04e23d60L3-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4425/files?diff=unified&w=0#diff-1919ce277aa3e85ec73acb6b6fc7bbe38b892b7380469518644cd6ba04e23d60R121-R155))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
