### PR TITLE
test: run integration test in Node 18

### DIFF
--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest] # ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [windows-latest] # windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/packages/builder/builder/src/plugins/tsChecker.ts
+++ b/packages/builder/builder/src/plugins/tsChecker.ts
@@ -93,9 +93,9 @@ export const builderPluginTsChecker = (): DefaultBuilderPlugin => {
           api.context.bundlerType === 'rspack' &&
           chain.get('mode') === 'production'
         ) {
-          logger.info('ts-checker running...');
+          logger.info('ts checker running...');
           logger.info(
-            'ts-checker is running slowly and will block builds until it is complete, please be patient and wait.',
+            'ts checker is running slowly and will block builds until it is complete, please be patient and wait.',
           );
         }
 

--- a/tests/e2e/builder/cases/asset-fallback/index.test.ts
+++ b/tests/e2e/builder/cases/asset-fallback/index.test.ts
@@ -12,7 +12,6 @@ test('should handle unknown modules with fallback rule', async () => {
       },
     },
   });
-
   const files = await builder.unwrapOutputJSON();
 
   const result = Object.keys(files).find(file => file.endsWith('.xxx'));

--- a/tests/e2e/builder/cases/asset-fallback/index.test.ts
+++ b/tests/e2e/builder/cases/asset-fallback/index.test.ts
@@ -12,6 +12,7 @@ test('should handle unknown modules with fallback rule', async () => {
       },
     },
   });
+
   const files = await builder.unwrapOutputJSON();
 
   const result = Object.keys(files).find(file => file.endsWith('.xxx'));


### PR DESCRIPTION
## Summary

- Linux passed: https://github.com/web-infra-dev/modern.js/actions/runs/5845199820
- Windows passed: https://github.com/web-infra-dev/modern.js/actions/runs/5845200007

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc6aa29</samp>

The pull request updates the node-version to 18.x for the integration-test-Linux workflow and fixes a typo in the ts checker plugin. These changes aim to improve the testing and quality of the modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bc6aa29</samp>

*  Rename and update integration-test-Windows workflow file to integration-test-Linux and test compatibility with node 18.x ([link](https://github.com/web-infra-dev/modern.js/pull/4426/files?diff=unified&w=0#diff-0140bd37d64c64518fe24fe1d94ea665cfae9e6da21a3ff99117c6b4f2076b91L19-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4426/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL19-R19))
*  Fix typo and use consistent naming for ts checker plugin in log messages of `builderPluginTsChecker` function in `tsChecker.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4426/files?diff=unified&w=0#diff-e894d618992ca3ef64b2f399f4275b6723da055ccb84fc13c8d8c9409a43f5e8L96-R98))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
