### PR TITLE
fix(doc-core): links in sidemenu now can be opened in a new tab

### DIFF
--- a/.changeset/loud-cobras-change.md
+++ b/.changeset/loud-cobras-change.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix(doc-core): links cannot be opened in a new tab

--- a/packages/cli/doc-core/src/theme-default/components/Link/index.tsx
+++ b/packages/cli/doc-core/src/theme-default/components/Link/index.tsx
@@ -26,6 +26,16 @@ export function Link(props: LinkProps) {
   const handleNavigate = async (
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
   ) => {
+    // early return to allow "open in new tab"
+    if (
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.metaKey || // apple
+      e.button === 1 // middle click
+    ) {
+      return;
+    }
+
     e.preventDefault();
     if (!process.env.__SSR__) {
       const matchedRoutes = matchRoutes(


### PR DESCRIPTION
…d in a new tab

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3414ae2</samp>

This pull request fixes a bug in the `@modern-js/doc-core` package that prevented opening links in the sidemenu in a new tab. It also updates the changelog for the package to reflect the patch version bump.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3414ae2</samp>

*  Allow opening sidemenu links in new tab with keyboard or middle click in `@modern-js/doc-core` default theme ([link](https://github.com/web-infra-dev/modern.js/pull/4428/files?diff=unified&w=0#diff-16c428f58d25ce3fc56d0795b8f55ee4e1a565b6be155d1c6534b0918ef08933R29-R38))
* Update changelog for `@modern-js/doc-core` package with patch version and bug fix summary ([link](https://github.com/web-infra-dev/modern.js/pull/4428/files?diff=unified&w=0#diff-eafe917c088299e95d75d0d238110893a4d981e9d15ffe6b8a9b283437165ec4R1-R5))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
