### PR TITLE
fix(doc-core): change modern-doc back to the original width

### DIFF
--- a/.changeset/lemon-vans-mate.md
+++ b/.changeset/lemon-vans-mate.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-core': patch
+---
+
+fix: change modern-doc back to the original width
+fix: 将 modern doc 宽度改回原来的宽度

--- a/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.scss
+++ b/packages/cli/doc-core/src/theme-default/layout/DocLayout/index.scss
@@ -62,7 +62,9 @@
   }
 
   .modern-doc {
-    padding-right: 32px;
+    width: calc(
+      1280px - var(--modern-sidebar-width) - var(--modern-aside-width)
+    );
   }
 }
 
@@ -78,5 +80,8 @@
 
   .modern-doc {
     padding-right: 64px;
+    width: calc(
+      1440px - var(--modern-sidebar-width) - var(--modern-aside-width) - 64px
+    );
   }
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61bb915</samp>

This pull request improves the responsive design of the doc theme and updates the `@modern-js/doc-core` package with a patch version and a changelog entry. It modifies the `DocLayout/index.scss` file and adds a `.changeset/lemon-vans-mate.md` file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61bb915</samp>

* Add a changeset file for patch updates of `@modern-js/doc-core` package and fix messages for changelog (.changeset/lemon-vans-mate.md)

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
