### PR TITLE
fix(module-doc): remove auto margin for overview to adaper new layout

### DIFF
--- a/.changeset/blue-plants-check.md
+++ b/.changeset/blue-plants-check.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-doc': patch
+---
+
+fix: remove auto margin for overview to adaper new layout
+fix: 移除概述组件的自动边距,以适应新的布局

--- a/packages/module/plugin-module-doc/static/global-components/Overview.tsx
+++ b/packages/module/plugin-module-doc/static/global-components/Overview.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@modern-js/doc-core/theme';
-import IconRight from './IconRight.svg';
+import IconRight from './right.svg';
 import styles from './Overview.module.scss';
 
 type List = {
@@ -25,7 +25,7 @@ export default ({ list }: { list?: List[] }) => {
   const gridClass = getGridClass(moduleList.length);
   return (
     <div>
-      <div className="overflow-hidden m-auto flex flex-wrap max-w-6xl">
+      <div className="overflow-hidden flex flex-wrap max-w-6xl">
         {moduleList.map(({ text, link, icon, arrow }) => {
           return (
             <div

--- a/tests/integration/module-doc/modern.config.ts
+++ b/tests/integration/module-doc/modern.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
         Button: './src/button.tsx',
       },
       languages: ['zh', 'en'],
-      previewMode: 'web',
+      previewMode: 'mobile',
       apiParseTool: 'react-docgen-typescript',
     }),
   ],


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b0ee92</samp>

This pull request improves the module doc plugin and its documentation site. It fixes some UI issues, adds a changeset file, and changes a test configuration option.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9b0ee92</samp>

* Add a changeset file to document the patch updates for the `@modern-js/plugin-module-doc` package ([link](https://github.com/web-infra-dev/modern.js/pull/4432/files?diff=unified&w=0#diff-535de45d15fafac3161122a329f31e986354d2d898c587a955e51270dce46e98R1-R6))
* Fix the import path for the `IconRight` component in `Overview.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4432/files?diff=unified&w=0#diff-b9d9b1eb35bd39767301e158bce4bdfd2eec740e8d811ec2e6b05e394b64d572L2-R2))
* Remove the auto margin for the overview component in `Overview.tsx` to adapt to the new layout ([link](https://github.com/web-infra-dev/modern.js/pull/4432/files?diff=unified&w=0#diff-b9d9b1eb35bd39767301e158bce4bdfd2eec740e8d811ec2e6b05e394b64d572L28-R28))
* Change the `previewMode` option for the module doc plugin in `modern.config.ts` to test the mobile responsiveness ([link](https://github.com/web-infra-dev/modern.js/pull/4432/files?diff=unified&w=0#diff-afe57c5f775e4181dd2dde5dd96374935eda74a53d74a615ce67a04ab79de3dfL13-R13))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
