### PR TITLE
docs(module-tools): add example for postcss-modules-dts

### DIFF
--- a/packages/document/module-doc/docs/en/guide/faq/build.mdx
+++ b/packages/document/module-doc/docs/en/guide/faq/build.mdx
@@ -234,3 +234,19 @@ import RegisterEsbuildPlugin from '@site-docs-en/components/register-esbuild-plu
 
 - First Solution: [typed-css-modules](https://github.com/Quramy/typed-css-modules)
 - Second Solution: [postcss-modules-dts](https://www.npmjs.com/package/@guanghechen/postcss-modules-dts)
+
+```ts modern.config.ts
+import { defineConfig } from '@modern-js/module-tools';
+
+export default defineConfig(async () => {
+  const { dts } =  await import("@guanghechen/postcss-modules-dts");
+  return {
+    buildConfig: {
+      style: {
+        modules: { ...dts },
+      },
+    },
+    // custom config
+  }
+});
+```

--- a/packages/document/module-doc/docs/en/guide/faq/build.mdx
+++ b/packages/document/module-doc/docs/en/guide/faq/build.mdx
@@ -235,7 +235,7 @@ import RegisterEsbuildPlugin from '@site-docs-en/components/register-esbuild-plu
 - First Solution: [typed-css-modules](https://github.com/Quramy/typed-css-modules)
 - Second Solution: [postcss-modules-dts](https://www.npmjs.com/package/@guanghechen/postcss-modules-dts)
 
-```ts modern.config.ts
+```ts title="modern.config.ts"
 import { defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig(async () => {

--- a/packages/document/module-doc/docs/zh/guide/faq/build.mdx
+++ b/packages/document/module-doc/docs/zh/guide/faq/build.mdx
@@ -235,7 +235,7 @@ import RegisterEsbuildPlugin from '@site-docs/components/register-esbuild-plugin
 - 方案一：[typed-css-modules](https://github.com/Quramy/typed-css-modules)
 - 方案二：[postcss-modules-dts](https://www.npmjs.com/package/@guanghechen/postcss-modules-dts)
 
-```ts modern.config.ts
+```ts title="modern.config.ts"
 import { defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig(async () => {

--- a/packages/document/module-doc/docs/zh/guide/faq/build.mdx
+++ b/packages/document/module-doc/docs/zh/guide/faq/build.mdx
@@ -234,3 +234,19 @@ import RegisterEsbuildPlugin from '@site-docs/components/register-esbuild-plugin
 
 - 方案一：[typed-css-modules](https://github.com/Quramy/typed-css-modules)
 - 方案二：[postcss-modules-dts](https://www.npmjs.com/package/@guanghechen/postcss-modules-dts)
+
+```ts modern.config.ts
+import { defineConfig } from '@modern-js/module-tools';
+
+export default defineConfig(async () => {
+  const { dts } =  await import("@guanghechen/postcss-modules-dts");
+  return {
+    buildConfig: {
+      style: {
+        modules: { ...dts },
+      },
+    },
+    // 你的自定义配置
+  }
+});
+```


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1efc3ef</samp>

This pull request updates the FAQ documents for the modern.js module tools in both English and Chinese. It adds a code snippet that demonstrates how to generate TypeScript declaration files for CSS modules using `@guanghechen/postcss-modules-dts`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1efc3ef</samp>

*  Add code snippets to show how to generate TypeScript declaration files for CSS modules in the FAQ document for the modern.js module tools ([link](https://github.com/web-infra-dev/modern.js/pull/4434/files?diff=unified&w=0#diff-c122c6124fcba58eb58f83f799c786ce2e75cbcf4ebf96ab934a606237d271cfR237-R252), [link](https://github.com/web-infra-dev/modern.js/pull/4434/files?diff=unified&w=0#diff-7b1519c825ec8fba968bfb21ede5f177e28c6d6e8da027ba29098e45b0c84cbcR237-R252))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
