### PR TITLE
feat(doc-plugin-preview): improve preview

### DIFF
--- a/.changeset/olive-singers-deny.md
+++ b/.changeset/olive-singers-deny.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/doc-plugin-preview': patch
+---
+
+feat: support refresh iframe and refactor DemoBlock to support dark mode
+feat: 支持刷新 iframe 并且重构 DemoBlock 组件支持暗黑模式

--- a/packages/cli/doc-plugin-preview/src/virtual-demo.tsx
+++ b/packages/cli/doc-plugin-preview/src/virtual-demo.tsx
@@ -17,13 +17,16 @@ export default function Demo(props: { iframePosition: string }) {
     const renderDemos = demos
       .flat()
       .filter(item => new RegExp(`${normalizedId}_\\d+`).test(item.id));
-    const componentList = renderDemos.map(demo => demo.component);
-    return componentList.length > 0 ? (
+    return renderDemos.length > 0 ? (
       <NoSSR>
         <div className="preview-container">
           <div className="preview-nav">{renderDemos[0].title}</div>
-          {componentList.map(component => {
-            return <div>{createElement(component)}</div>;
+          {renderDemos.map(renderDemo => {
+            return (
+              <div key={renderDemo.id}>
+                {createElement(renderDemo.component)}
+              </div>
+            );
           })}
         </div>
       </NoSSR>

--- a/packages/cli/doc-plugin-preview/static/global-components/Container.scss
+++ b/packages/cli/doc-plugin-preview/static/global-components/Container.scss
@@ -21,6 +21,7 @@
       border-radius: 50%;
       border: 1px solid transparent;
       background-color: var(--modern-c-bg-soft);
+      margin-left: 14px;
 
       &:hover {
         background-color: var(--modern-preview-button-hover-bg);
@@ -36,7 +37,6 @@
       display: flex;
       justify-content: flex-end;
       width: 100%;
-      border-top: 1px solid #e6e6e6;
       padding: 6px;
     }
 
@@ -62,7 +62,9 @@
   }
 
   &-qrcode {
-    background-color: #f7f8fa;
+    background-color: #fff;
+    width: 120px;
+    height: 120px;
     position: absolute;
     top: -132px;
     right: -46px;
@@ -94,6 +96,7 @@
     display: flex;
     flex-direction: column;
     iframe {
+      border-bottom: 1px solid #e6e6e6;
       width: 360px;
       height: 100%;
       flex: auto;

--- a/packages/cli/doc-plugin-preview/static/global-components/Container.tsx
+++ b/packages/cli/doc-plugin-preview/static/global-components/Container.tsx
@@ -1,23 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { QRCodeSVG } from 'qrcode.react';
+import { useCallback, useState } from 'react';
 import { withBase, useLang, NoSSR } from '@modern-js/doc-core/runtime';
+import MobileOperation from './common/mobile-operation';
 import IconCode from './svg/code.svg';
-import IconLaunch from './svg/launch.svg';
-import IconQrcode from './svg/qrcode.svg';
 import './Container.scss';
-
-const locales = {
-  zh: {
-    expand: '展开代码',
-    collapse: '收起代码',
-    open: '在新页面打开',
-  },
-  en: {
-    expand: 'Expand Code',
-    collapse: 'Collapse Code',
-    open: 'Open in new page',
-  },
-};
 
 type ContainerProps = {
   children: React.ReactNode[];
@@ -28,10 +13,7 @@ type ContainerProps = {
 const Container: React.FC<ContainerProps> = props => {
   const { children, isMobile, url } = props;
   const [showCode, setShowCode] = useState(false);
-  const [showQRCode, setShowQRCode] = useState(false);
   const lang = useLang();
-  const triggerRef = useRef(null);
-  const t = lang === 'zh' ? locales.zh : locales.en;
 
   const getPageUrl = () => {
     if (typeof window !== 'undefined') {
@@ -46,57 +28,11 @@ const Container: React.FC<ContainerProps> = props => {
     }
     setShowCode(!showCode);
   };
-  const toggleQRCode = (e: any) => {
-    if (!showQRCode) {
-      e.target.blur();
-    }
-    setShowQRCode(!showQRCode);
-  };
-  const openNewPage = (e: any) => {
-    if (!showCode) {
-      e.target.blur();
-    }
-    window.open(getPageUrl());
-  };
 
-  const contains = function (root: HTMLElement | null, ele: any) {
-    if (!root) {
-      return false;
-    }
-    if (root.contains) {
-      return root.contains(ele);
-    }
-    let node = ele;
-    while (node) {
-      if (node === root) {
-        return true;
-      }
-      node = node.parentNode;
-    }
-    return false;
-  };
-
-  const onClickOutside = useCallback(
-    (e: MouseEvent) => {
-      console.log(
-        !contains(triggerRef.current, e.target),
-        triggerRef.current,
-        e.target,
-      );
-      if (!contains(triggerRef.current, e.target)) {
-        setShowQRCode(false);
-      }
-    },
-    [triggerRef],
-  );
-
-  useEffect(() => {
-    if (showQRCode) {
-      document.addEventListener('mousedown', onClickOutside, false);
-    } else {
-      document.removeEventListener('mousedown', onClickOutside, false);
-    }
-  }, [showQRCode]);
+  const [iframeKey, setIframeKey] = useState(0);
+  const refresh = useCallback(() => {
+    setIframeKey(Math.random());
+  }, []);
 
   return (
     <NoSSR>
@@ -105,26 +41,8 @@ const Container: React.FC<ContainerProps> = props => {
           <div className="modern-preview-wrapper flex">
             <div className="modern-preview-code">{children?.[0]}</div>
             <div className="modern-preview-device">
-              <iframe src={getPageUrl()}></iframe>
-              <div className="modern-preview-operations mobile">
-                <div className="relative" ref={triggerRef}>
-                  {showQRCode && (
-                    <div className="modern-preview-qrcode">
-                      <QRCodeSVG value={getPageUrl()} size={96} />
-                    </div>
-                  )}
-                  <button style={{ marginLeft: '8px' }} onClick={toggleQRCode}>
-                    <IconQrcode />
-                  </button>
-                </div>
-                <button
-                  onClick={openNewPage}
-                  aria-label={t.open}
-                  style={{ marginLeft: '8px' }}
-                >
-                  <IconLaunch />
-                </button>
-              </div>
+              <iframe src={getPageUrl()} key={iframeKey}></iframe>
+              <MobileOperation url={url} refresh={refresh} />
             </div>
           </div>
         ) : (
@@ -141,8 +59,8 @@ const Container: React.FC<ContainerProps> = props => {
               <div className="modern-preview-operations web">
                 <button
                   onClick={toggleCode}
-                  aria-label={t.collapse}
-                  className={showCode ? 'button-expanded' : ''}
+                  aria-label={lang === 'zh' ? '收起代码' : ''}
+                  className={showCode ? 'button-expanded' : 'Collapse Code'}
                 >
                   <IconCode />
                 </button>

--- a/packages/cli/doc-plugin-preview/static/global-components/DemoBlock.scss
+++ b/packages/cli/doc-plugin-preview/static/global-components/DemoBlock.scss
@@ -1,9 +1,14 @@
-.demo-block {
+:root {
+  --modern-demo-block-bg: #f7f8fA;
+}
+
+.dark {
+  --modern-demo-block-bg: #1a1a1a
+}
+
+.modern-demo-block {
   padding-bottom: 12px;
-  background-color: #f7f8fA;
-  &:last-of-type {
-    padding-bottom: 44px;
-  }
+  background-color: var(--modern-demo-block-bg);
   &-title {
     padding: 12px 12px 8px;
     color: #697b8c;

--- a/packages/cli/doc-plugin-preview/static/global-components/DemoBlock.tsx
+++ b/packages/cli/doc-plugin-preview/static/global-components/DemoBlock.tsx
@@ -2,25 +2,15 @@ import './DemoBlock.scss';
 
 interface Props {
   title: string;
-  padding?: string;
-  background?: string;
   children?: React.ReactNode;
 }
 
 export default (props: Props) => {
-  const { title, padding = '12px 12px', background = '#fff', children } = props;
+  const { title, children } = props;
   return (
-    <div className="demo-block">
-      <div className="demo-block-title">{title}</div>
-      <div
-        className="demo-block-main"
-        style={{
-          padding,
-          background,
-        }}
-      >
-        {children}
-      </div>
+    <div className="modern-demo-block">
+      <div className="modern-demo-block-title">{title}</div>
+      <div className="modern-demo-block-main">{children}</div>
     </div>
   );
 };

--- a/packages/cli/doc-plugin-preview/static/global-components/Device.scss
+++ b/packages/cli/doc-plugin-preview/static/global-components/Device.scss
@@ -10,8 +10,14 @@
   max-height: calc(100vh - var(--modern-preview-padding) * 2 - var(--modern-nav-height));
   width: 360px;
   pointer-events: auto;
-  border-radius: var(--modern-device-border-radius);
-  border: var(--modern-device-border)
+  border-radius: var(--modern-device-border-radius) var(--modern-device-border-radius) 0 0;
+  border: var(--modern-device-border);
+}
+
+.fixed-operation {
+  border: var(--modern-device-border);
+  border-top: 0;
+  border-radius: 0 0 var(--modern-device-border-radius) var(--modern-device-border-radius);
 }
 
 :root {

--- a/packages/cli/doc-plugin-preview/static/global-components/Device.tsx
+++ b/packages/cli/doc-plugin-preview/static/global-components/Device.tsx
@@ -1,7 +1,7 @@
 import { usePageData, withBase } from '@modern-js/doc-core/runtime';
 import { demos } from 'virtual-meta';
-import { useEffect, useState } from 'react';
-
+import { useCallback, useEffect, useState } from 'react';
+import MobileOperation from './common/mobile-operation';
 import './Device.scss';
 
 export default () => {
@@ -22,11 +22,16 @@ export default () => {
   };
   const { page } = usePageData();
   const pageName = getPageKey(page._relativePath);
+  const url = `~demo/${pageName}`;
   const haveDemos =
     demos.flat().filter(item => new RegExp(`${pageName}_\\d+`).test(item.id))
       .length > 0;
   const [asideWidth, setAsideWidth] = useState('0px');
   const [innerWidth, setInnerWidth] = useState(window.innerWidth);
+  const [iframeKey, setIframeKey] = useState(0);
+  const refresh = useCallback(() => {
+    setIframeKey(Math.random());
+  }, []);
 
   // get default value from root
   // listen resize and re-render
@@ -74,9 +79,15 @@ export default () => {
   return haveDemos ? (
     <div className="fixed-device">
       <iframe
-        src={getPageUrl(`~demo/${pageName}`)}
+        src={getPageUrl(url)}
         className="fixed-iframe"
+        key={iframeKey}
       ></iframe>
+      <MobileOperation
+        url={url}
+        className="fixed-operation"
+        refresh={refresh}
+      />
     </div>
   ) : null;
 };

--- a/packages/cli/doc-plugin-preview/static/global-components/common/mobile-operation.tsx
+++ b/packages/cli/doc-plugin-preview/static/global-components/common/mobile-operation.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { withBase, useLang } from '@modern-js/doc-core/runtime';
+import IconLaunch from '../svg/launch.svg';
+import IconQrcode from '../svg/qrcode.svg';
+import IconRefresh from '../svg/refresh.svg';
+
+const locales = {
+  zh: {
+    refresh: '刷新页面',
+    open: '在新页面打开',
+  },
+  en: {
+    refresh: 'refresh',
+    open: 'Open in new page',
+  },
+};
+
+export default (props: {
+  url: string;
+  className?: string;
+  refresh: () => void;
+}) => {
+  const [showQRCode, setShowQRCode] = useState(false);
+  const { url, className = '', refresh } = props;
+  const lang = useLang();
+  const triggerRef = useRef(null);
+  const t = lang === 'zh' ? locales.zh : locales.en;
+
+  const getPageUrl = () => {
+    if (typeof window !== 'undefined') {
+      return window.location.origin + withBase(url);
+    }
+    // Do nothing in ssr
+    return '';
+  };
+  const toggleQRCode = (e: any) => {
+    if (!showQRCode) {
+      e.target.blur();
+    }
+    setShowQRCode(!showQRCode);
+  };
+  const openNewPage = () => {
+    window.open(getPageUrl());
+  };
+
+  const contains = function (root: HTMLElement | null, ele: any) {
+    if (!root) {
+      return false;
+    }
+    if (root.contains) {
+      return root.contains(ele);
+    }
+    let node = ele;
+    while (node) {
+      if (node === root) {
+        return true;
+      }
+      node = node.parentNode;
+    }
+    return false;
+  };
+
+  const onClickOutside = useCallback(
+    (e: MouseEvent) => {
+      console.log(
+        !contains(triggerRef.current, e.target),
+        triggerRef.current,
+        e.target,
+      );
+      if (!contains(triggerRef.current, e.target)) {
+        setShowQRCode(false);
+      }
+    },
+    [triggerRef],
+  );
+
+  useEffect(() => {
+    if (showQRCode) {
+      document.addEventListener('mousedown', onClickOutside, false);
+    } else {
+      document.removeEventListener('mousedown', onClickOutside, false);
+    }
+  }, [showQRCode]);
+
+  return (
+    <div className={`modern-preview-operations mobile ${className}`}>
+      <button onClick={refresh} aria-label={t.refresh}>
+        <IconRefresh />
+      </button>
+      <div className="relative" ref={triggerRef}>
+        {showQRCode && (
+          <div className="modern-preview-qrcode">
+            <QRCodeSVG value={getPageUrl()} size={96} />
+          </div>
+        )}
+        <button onClick={toggleQRCode}>
+          <IconQrcode />
+        </button>
+      </div>
+      <button onClick={openNewPage} aria-label={t.open}>
+        <IconLaunch />
+      </button>
+    </div>
+  );
+};

--- a/packages/cli/doc-plugin-preview/static/global-components/svg/refresh.svg
+++ b/packages/cli/doc-plugin-preview/static/global-components/svg/refresh.svg
@@ -1,0 +1,3 @@
+<svg width="1em" height="1em" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="4">
+<path d="M38.837 18C36.4634 12.1363 30.7148 8 24 8C15.1634 8 8 15.1634 8 24C8 32.8366 15.1634 40 24 40C31.4554 40 37.7198 34.9009 39.4959 28M40 8V18H30" stroke-linecap="butt"></path>
+</svg>


### PR DESCRIPTION
1. support refresh iframe 2. refactor DemoBlock

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6f6c77</samp>

This pull request improves the `@modern-js/doc-plugin-preview` package by adding new features and refactoring some components. It adds a refresh button and a QR code scanner to the device frame, a QR code popup and operation buttons to the mobile preview, and a CSS variable for the demo block background color. It also extracts the QR code and operation logic to a new `MobileOperation` component, simplifies the props and class names of the `DemoBlock` component, and adjusts the margins and borders of the preview container. It updates the `.changeset` folder with the patch level and feature descriptions.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f6f6c77</samp>

*  Add a markdown file for the `@changesets/cli` tool to generate changelogs and version updates for the `@modern-js/doc-plugin-preview` package ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-1eef339d4545afb72e3fb15dec5804a45d24a68637cd5d4b3b32c8d677580059R1-R6))
*  Refactor the QR code logic and the operation buttons for the mobile preview to a reusable `MobileOperation` component and import it in `Container.tsx` and `Device.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-37a82eb407a41dc78f74e099b616439f92e77c9849b3c453779aa10693a6841bR1-R106), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aL1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aL49-R36), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aL108-R45), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-8f016bbd246d49d9ecdd522378b649c111f4cf066b03ac234bc896f8db975a2bL3-R4), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-8f016bbd246d49d9ecdd522378b649c111f4cf066b03ac234bc896f8db975a2bL77-R90))
*  Add a state variable and a function for refreshing the iframe in the preview container and the device frame components and pass them as props to the `MobileOperation` component ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aL31-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aL49-R36), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-8f016bbd246d49d9ecdd522378b649c111f4cf066b03ac234bc896f8db975a2bR31-R34))
*  Simplify the props interface and the return value of the `DemoBlock` component and use a CSS variable for the background color ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-2f2ecac48cc6d0fa31fa8e96c64aec0eaaee6a528364cb03486ad693719702b2L5-R13), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-a181de68712c976953f89b40577e71cb59ebb201a19779f1fc67cae4cdafcb72L1-R11))
*  Modify the aria-label prop of the toggleCode button in the preview container component to use the correct language based on the `lang` variable ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-a2f11c2241df9ec2ace81890ef06dd7866e1ea516db82ebfd5af0082c7ed383aL144-R63))
*  Modify the border-radius property of the device frame in the fixed mode and add a new class for the operation buttons in the fixed mode ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-ad5bce51e16ed4767ac7b282071134a090a9d761089ca8ea3b344b9d4d5a8596L13-R22))
*  Add a left margin to the code block and a bottom border to the operation buttons in the preview container component and remove the top border from the device frame ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-213f57f8f4612d1c68ded5ff7cd653164ecffd874156f0263ac8cc9a6c331665R24), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-213f57f8f4612d1c68ded5ff7cd653164ecffd874156f0263ac8cc9a6c331665L39), [link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-213f57f8f4612d1c68ded5ff7cd653164ecffd874156f0263ac8cc9a6c331665R99))
*  Modify the background color and the size of the QR code popup in the preview container component ([link](https://github.com/web-infra-dev/modern.js/pull/4435/files?diff=unified&w=0#diff-213f57f8f4612d1c68ded5ff7cd653164ecffd874156f0263ac8cc9a6c331665L65-R67))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
