### PR TITLE
feat: support partials in document

### DIFF
--- a/.changeset/long-tables-report.md
+++ b/.changeset/long-tables-report.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/runtime': patch
+'app-docmuent': patch
+'@modern-js/app-tools': patch
+'@modern-js/core': patch
+---
+
+feat: support partials html in Document
+feat: 支持 partials html 在 Document 中也生效

--- a/.changeset/long-tables-report.md
+++ b/.changeset/long-tables-report.md
@@ -1,6 +1,5 @@
 ---
 '@modern-js/runtime': patch
-'app-docmuent': patch
 '@modern-js/app-tools': patch
 '@modern-js/core': patch
 ---

--- a/packages/cli/core/src/types/context.ts
+++ b/packages/cli/core/src/types/context.ts
@@ -3,6 +3,7 @@ import {
   InternalPlugins,
   ServerRoute,
   HtmlTemplates,
+  HtmlPartials,
 } from '@modern-js/types';
 import { BuilderInstance } from '@modern-js/builder-shared';
 
@@ -39,4 +40,5 @@ export interface IAppContext {
   internalSrcAlias: string;
   builder?: BuilderInstance;
   bundlerType?: 'webpack' | 'rspack' | 'esbuild';
+  partialsByEntrypoint?: Record<string, HtmlPartials>;
 }

--- a/packages/runtime/plugin-runtime/src/document/Body.tsx
+++ b/packages/runtime/plugin-runtime/src/document/Body.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React, { useContext } from 'react';
 import {
+  BODY_PARTICALS_SEPARATOR,
   DOCUMENT_CHUNKSMAP_PLACEHOLDER,
   DOCUMENT_SSRDATASCRIPT_PLACEHOLDER,
 } from './constants';
@@ -14,6 +15,7 @@ export function Body(props: { children?: any }) {
     <body {...rest}>
       {hasSetRoot ? null : <DefaultRoot />}
       {children}
+      {`${BODY_PARTICALS_SEPARATOR}`}
       {`${DOCUMENT_CHUNKSMAP_PLACEHOLDER}`}
       {`${DOCUMENT_SSRDATASCRIPT_PLACEHOLDER}`}
     </body>

--- a/packages/runtime/plugin-runtime/src/document/Head.tsx
+++ b/packages/runtime/plugin-runtime/src/document/Head.tsx
@@ -3,7 +3,11 @@ import React, { useContext } from 'react';
 import { DocumentStructureContext } from './DocumentStructureContext';
 import { Scripts } from './Scripts';
 import { Links } from './Links';
-import { DOCUMENT_META_PLACEHOLDER } from './constants';
+import {
+  DOCUMENT_META_PLACEHOLDER,
+  HEAD_PARTICALS_SEPARATOR,
+  TOP_PARTICALS_SEPARATOR,
+} from './constants';
 
 export function Head(props: { children?: any }) {
   const { hasSetScripts, hasSetLinks } = useContext(DocumentStructureContext);
@@ -12,10 +16,12 @@ export function Head(props: { children?: any }) {
   return (
     <head {...rest}>
       {/* configuration by config.output.meta */}
+      {`${TOP_PARTICALS_SEPARATOR}`}
       {`${DOCUMENT_META_PLACEHOLDER}`}
       {!hasSetLinks && <Links />}
       {/* Scripts must have as default. If not, place in Head */}
       {!hasSetScripts && <Scripts />}
+      {`${HEAD_PARTICALS_SEPARATOR}`}
       {children}
     </head>
   );

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -177,7 +177,9 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
         let html = ReactDomServer.renderToStaticMarkup(HTMLElement);
 
         debug("entry %s's document jsx rendered html: %o", entryName, html);
-
+        // htmlWebpackPlugin.tags
+        const { partialsByEntrypoint } = api.useAppContext();
+        console.log('===> partialsByEntrypoint: ', partialsByEntrypoint);
         const scripts = [
           htmlWebpackPlugin.tags.headTags
             .filter((item: any) => item.tagName === 'script')

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -182,7 +182,6 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
         debug("entry %s's document jsx rendered html: %o", entryName, html);
         // htmlWebpackPlugin.tags
         const { partialsByEntrypoint } = api.useAppContext();
-        console.log('===> partialsByEntrypoint: ', partialsByEntrypoint);
         const scripts = [
           htmlWebpackPlugin.tags.headTags
             .filter((item: any) => item.tagName === 'script')

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -25,6 +25,9 @@ import {
   DOCUMENT_COMMENT_PLACEHOLDER_END,
   DOCUMENT_STYLE_PLACEHOLDER_START,
   DOCUMENT_STYLE_PLACEHOLDER_END,
+  TOP_PARTICALS_SEPARATOR,
+  HEAD_PARTICALS_SEPARATOR,
+  BODY_PARTICALS_SEPARATOR,
 } from '../constants';
 
 const debug = createDebugger('html_genarate');
@@ -186,6 +189,16 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
             .join(''),
           htmlWebpackPlugin.tags.bodyTags.toString(),
         ].join('');
+        // support partials html
+        if (partialsByEntrypoint?.[entryName]) {
+          const partialsTop = partialsByEntrypoint[entryName].top.join('\n');
+          const partialsHead = partialsByEntrypoint[entryName].head.join('\n');
+          const partialsBody = partialsByEntrypoint[entryName].body.join('\n');
+          html = html
+            .replace(TOP_PARTICALS_SEPARATOR, partialsTop)
+            .replace(HEAD_PARTICALS_SEPARATOR, partialsHead)
+            .replace(BODY_PARTICALS_SEPARATOR, partialsBody);
+        }
 
         const links = [
           htmlWebpackPlugin.tags.headTags

--- a/packages/runtime/plugin-runtime/src/document/constants.ts
+++ b/packages/runtime/plugin-runtime/src/document/constants.ts
@@ -3,6 +3,15 @@ import { HTML_CHUNKSMAP_SEPARATOR } from '@modern-js/utils/universal/constants';
 export const DOC_EXT = ['jsx', 'tsx', 'ts', 'js'];
 export const DOCUMENT_META_PLACEHOLDER = encodeURIComponent('<%= meta %>');
 export const HTML_SEPARATOR = '<!--<?- html ?>-->';
+export const HEAD_PARTICALS_SEPARATOR = encodeURIComponent(
+  '<!--<?- partials.head ?>-->',
+);
+export const BODY_PARTICALS_SEPARATOR = encodeURIComponent(
+  '<!--<?- partials.body ?>-->',
+);
+export const TOP_PARTICALS_SEPARATOR = encodeURIComponent(
+  '<!--<?- partials.top ?>-->',
+);
 
 export const HTML_SSRDATASCRIPT_SEPARATOR = '<!--<?- SSRDataScript ?>-->';
 // export const HTML_BOTTOMTPL_SEPARATOR = '<!--<?- bottomTemplate ?>-->'; // document jsx not need bottom

--- a/packages/runtime/plugin-runtime/tests/document/index.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/index.test.tsx
@@ -27,7 +27,7 @@ describe('plugin-document', () => {
     );
     const docHtml = ReactDomServer.renderToString(document);
     expect(docHtml).toEqual(
-      `<html><head>%3C%25%3D%20meta%20%25%3E<!-- -->%3C!--%20chunk%20links%20placeholder%20--%3E<!-- -->%3C!--%20chunk%20scripts%20placeholder%20--%3E</head><body><div id="root">%3C!--%3C%3F-%20html%20%3F%3E--%3E</div>%3C!--%3C%3F-%20chunksMap.js%20%3F%3E--%3E<!-- -->%3C!--%3C%3F-%20SSRDataScript%20%3F%3E--%3E</body></html>`,
+      `<html><head>%3C!--%3C%3F-%20partials.top%20%3F%3E--%3E<!-- -->%3C%25%3D%20meta%20%25%3E<!-- -->%3C!--%20chunk%20links%20placeholder%20--%3E<!-- -->%3C!--%20chunk%20scripts%20placeholder%20--%3E<!-- -->%3C!--%3C%3F-%20partials.head%20%3F%3E--%3E</head><body><div id="root">%3C!--%3C%3F-%20html%20%3F%3E--%3E</div>%3C!--%3C%3F-%20partials.body%20%3F%3E--%3E<!-- -->%3C!--%3C%3F-%20chunksMap.js%20%3F%3E--%3E<!-- -->%3C!--%3C%3F-%20SSRDataScript%20%3F%3E--%3E</body></html>`,
     );
   });
 

--- a/packages/solutions/app-tools/src/analyze/getHtmlTemplate.ts
+++ b/packages/solutions/app-tools/src/analyze/getHtmlTemplate.ts
@@ -67,6 +67,7 @@ export const getHtmlTemplate = async (
   );
 
   const htmlTemplates: HtmlTemplates = {};
+  const partialsByEntrypoint: Record<string, HtmlPartials> = {};
 
   for (const entrypoint of entrypoints) {
     const { entryName, isMainEntry } = entrypoint;
@@ -77,7 +78,6 @@ export const getHtmlTemplate = async (
       name,
       PartialPosition.INDEX,
     );
-
     if (customIndexTemplate) {
       htmlTemplates[entryName] = customIndexTemplate.file;
     } else {
@@ -113,6 +113,7 @@ export const getHtmlTemplate = async (
       fs.outputFileSync(templatePath, templates.html(partials), 'utf8');
 
       htmlTemplates[entryName] = templatePath;
+      partialsByEntrypoint[entryName] = partials;
 
       const bottomTemplate = findPartials(
         htmlDir,
@@ -124,6 +125,10 @@ export const getHtmlTemplate = async (
       }
     }
   }
-
+  // sync partialsByEntrypoint to context
+  api.setAppContext({
+    ...api.useAppContext(),
+    partialsByEntrypoint,
+  });
   return htmlTemplates;
 };

--- a/tests/integration/app-document/modern.config.ts
+++ b/tests/integration/app-document/modern.config.ts
@@ -6,6 +6,21 @@ import {
 } from '@modern-js/app-tools';
 import { routerPlugin } from '@modern-js/plugin-router-v5';
 
+const tmpTest = (): CliPlugin<AppTools> => ({
+  name: 'tmpTest',
+  setup: () => {
+    return {
+      htmlPartials({ entrypoint, partials }) {
+        partials.top.push('<script>window.abc = "hjk"</script>');
+        partials.head.push('<script>console.log("abc")</script>');
+        partials.body.push('<script>console.log(abc)</script>');
+
+        return { partials, entrypoint };
+      },
+    };
+  },
+});
+
 export default defineConfig({
   runtime: {
     router: {
@@ -28,18 +43,5 @@ export default defineConfig({
     favicon: './static/a.icon',
   },
   output: {},
-  plugins: [appTools(), routerPlugin()],
-});
-
-export const tmpTest = (): CliPlugin<AppTools> => ({
-  name: 'tmpTest',
-  setup: () => {
-    return {
-      htmlPartials({ entrypoint, partials }) {
-        partials.head.push('<script> console.log("abc")</script>');
-
-        return { partials, entrypoint };
-      },
-    };
-  },
+  plugins: [appTools(), routerPlugin(), tmpTest()],
 });

--- a/tests/integration/app-document/modern.config.ts
+++ b/tests/integration/app-document/modern.config.ts
@@ -1,4 +1,9 @@
-import { appTools, defineConfig } from '@modern-js/app-tools';
+import {
+  AppTools,
+  appTools,
+  CliPlugin,
+  defineConfig,
+} from '@modern-js/app-tools';
 import { routerPlugin } from '@modern-js/plugin-router-v5';
 
 export default defineConfig({
@@ -24,4 +29,17 @@ export default defineConfig({
   },
   output: {},
   plugins: [appTools(), routerPlugin()],
+});
+
+export const tmpTest = (): CliPlugin<AppTools> => ({
+  name: 'tmpTest',
+  setup: () => {
+    return {
+      htmlPartials({ entrypoint, partials }) {
+        partials.head.push('<script> console.log("abc")</script>');
+
+        return { partials, entrypoint };
+      },
+    };
+  },
 });

--- a/tests/integration/app-document/tests/index.test.ts
+++ b/tests/integration/app-document/tests/index.test.ts
@@ -169,4 +169,25 @@ describe('test build', () => {
 
     expect(htmlWithDoc.includes(`head class="head"`)).toBe(true);
   });
+
+  test('should injected partial html content to html', async () => {
+    const htmlWithDoc = fs.readFileSync(
+      path.join(appDir, 'dist', 'html/sub/index.html'),
+      'utf-8',
+    );
+
+    expect(
+      /<head class="head"><script>window.abc = "hjk"<\/script>/.test(
+        htmlWithDoc,
+      ),
+    ).toBe(true);
+    expect(
+      /<head.*<script>console.log\("abc"\)<\/script>.*<\/head>/.test(
+        htmlWithDoc,
+      ),
+    ).toBe(true);
+    expect(
+      /<body.*<script>console.log\(abc\)<\/script>.*<\/body>/.test(htmlWithDoc),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d26bb34</samp>

This pull request adds a new feature to the app-tools framework that allows users to inject custom html fragments into the document template for each entrypoint. It updates the types, constants, components, and functions related to the document template generation and rendering in the `@modern-js/runtime`, `@modern-js/app-tools`, and `@modern-js/core` packages. It also adds a new cli plugin and a new integration test case to demonstrate and verify the feature.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d26bb34</samp>

*  Add a changeset file to document the patch updates and the new partials html feature ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-63e0f4fd94bceb684485872130dc066e19583831ba82a7e4bf62d7012b3e5d84R1-R9))
*  Import and define the `HtmlPartials` type from `@modern-js/runtime` to `packages/cli/core/src/types/context.ts` and `packages/solutions/app-tools/src/analyze/getHtmlTemplate.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-a33f274e4ac18ae78ccf3f9628389616c4596bb4cef3ec3a3eccef4632d70857R6), [link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-47f60b67d97de34aafc3fbf622a8ba80faf70e2e70d5d44a35bb8e92b5574d0bR70))
*  Add a new property `partialsByEntrypoint` to the `IAppContext` interface to store the partials html for each entrypoint ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-a33f274e4ac18ae78ccf3f9628389616c4596bb4cef3ec3a3eccef4632d70857R43))
*  Sync the `partialsByEntrypoint` property to the app context in the `getHtmlTemplate` function using the app-tools api ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-47f60b67d97de34aafc3fbf622a8ba80faf70e2e70d5d44a35bb8e92b5574d0bL127-R132))
*  Define and import three constants to mark the placeholders for the partials html in the document template: `TOP_PARTICALS_SEPARATOR`, `HEAD_PARTICALS_SEPARATOR`, and `BODY_PARTICALS_SEPARATOR` ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-1a1cc0259df40308359daa495e6b88cc3bba9bdfec132dbeaded71ea428b8492R6-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-95c50a2c38b6e7fe3024e70c587de6ff0c1dbffaf4b46d5a4c96a1be8d4ff2b8R4), [link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-518d21577d0beb3523093dd8bf7bf6f51af83286422384761dfc8e8ba49a7c5bL6-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-0e55b04e20002e2fb2749b80f99d441529beb49561d648172696a765aa8afa67R28-R30))
*  Insert the placeholders into the `Head` and `Body` components in `packages/runtime/plugin-runtime/src/document/Head.tsx` and `packages/runtime/plugin-runtime/src/document/Body.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-518d21577d0beb3523093dd8bf7bf6f51af83286422384761dfc8e8ba49a7c5bL15-R24), [link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-95c50a2c38b6e7fe3024e70c587de6ff0c1dbffaf4b46d5a4c96a1be8d4ff2b8R18))
*  Replace the placeholders with the actual partials html in the `documentPlugin` function in `packages/runtime/plugin-runtime/src/document/cli/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-0e55b04e20002e2fb2749b80f99d441529beb49561d648172696a765aa8afa67R192-R201))
*  Add debug and console logs to the `documentPlugin` function for debugging purposes ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-0e55b04e20002e2fb2749b80f99d441529beb49561d648172696a765aa8afa67L180-R185))
*  Modify the import statement in the `tests/integration/app-document/modern.config.ts` file to import the app-tools symbols from the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-95d1b08105768981f5afa33c24979549d123d00d039045d76748af7f432efb21L1-R23))
*  Add a custom cli plugin called `tmpTest` to the config file to inject some custom scripts into the partials html for testing ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-95d1b08105768981f5afa33c24979549d123d00d039045d76748af7f432efb21L26-R46))
*  Add a new test case to the `tests/integration/app-document/tests/index.test.ts` file to verify that the partials html is correctly injected into the document template ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-e5cf6064e8f4640ca4ca4efc6bb56b44bdf3c23cf23c8e82d3ec614960de58dcR172-R192))
*  Remove an empty line in the `getHtmlTemplate` function for formatting or linting reasons ([link](https://github.com/web-infra-dev/modern.js/pull/4437/files?diff=unified&w=0#diff-47f60b67d97de34aafc3fbf622a8ba80faf70e2e70d5d44a35bb8e92b5574d0bL80))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
