### PR TITLE
fix: inline the route manifests into the html

### DIFF
--- a/.changeset/bright-ears-sneeze.md
+++ b/.changeset/bright-ears-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: inline the route manifests into the html
+fix: 内联路由信息到 html 中

--- a/packages/document/main-doc/docs/en/configure/app/output/enable-inline-route-manifests.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/enable-inline-route-manifests.mdx
@@ -1,0 +1,10 @@
+---
+sidebar_label: enableInlineRouteManifests
+---
+
+# output.enableInlineRouteManifests
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+When using convention-based routing, the framework injects routing information into the client for optimization purposes. By default, routing information is injected into the html, but when this is configured to `false`, routing information is injected into a separate JS file.

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-route-manifests.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-route-manifests.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_label: enableInlineRouteManifests
+---
+
+# output.enableInlineRouteManifests
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+当使用约定式路由时，框架为了做一些优化，会向客户端中注入路由信息，默认情况下路由信息会注入到 html 中，
+当该配置为 `false` 时，路由信息会注入到一个单独的 JS 文件中。
+
+Example:
+
+```ts
+export default {
+  output: {
+    enableInlineRouteManifests: false,
+  },
+}
+```

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-route-manifests.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-route-manifests.mdx
@@ -4,8 +4,8 @@ sidebar_label: enableInlineRouteManifests
 
 # output.enableInlineRouteManifests
 
-- **Type:** `boolean`
-- **Default:** `true`
+- **类型:** `boolean`
+- **默认值:** `true`
 
 当使用约定式路由时，框架为了做一些优化，会向客户端中注入路由信息，默认情况下路由信息会注入到 html 中，
 当该配置为 `false` 时，路由信息会注入到一个单独的 JS 文件中。

--- a/packages/server/core/src/types/config/output.ts
+++ b/packages/server/core/src/types/config/output.ts
@@ -10,6 +10,7 @@ export interface OutputUserConfig {
     media?: string;
     server?: string;
   };
+  enableInlineRouteManifests?: boolean;
   path?: string;
   assetPrefix?: string;
   polyfill?: 'entry' | 'usage' | 'ua' | 'off';

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -135,6 +135,7 @@ function applyRouterPlugin<B extends Bundler>(
         enableInlineRouteManifests:
           normalizedConfig.output.enableInlineRouteManifests,
         staticJsDir: normalizedConfig.output?.distPath?.js,
+        disableFilenameHash: normalizedConfig.output?.disableFilenameHash,
       },
     ]);
   }

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -132,6 +132,9 @@ function applyRouterPlugin<B extends Bundler>(
     chain.plugin('route-plugin').use(RouterPlugin, [
       {
         HtmlBundlerPlugin,
+        enableInlineRouteManifests:
+          normalizedConfig.output.enableInlineRouteManifests,
+        staticJsDir: normalizedConfig.output?.distPath?.js,
       },
     ]);
   }

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -7,6 +7,7 @@ import {
 } from '@modern-js/builder-shared';
 import { isSSR, fs } from '@modern-js/utils';
 import { ChainIdentifier } from '@modern-js/utils/chain-id';
+import type HtmlWebpackPlugin from '@modern-js/builder-webpack-provider/html-webpack-plugin';
 import type {
   AppNormalizedConfig,
   Bundler,
@@ -43,7 +44,7 @@ export const builderPluginAdapterSSR = <B extends Bundler>(
         const builderConfig = api.getNormalizedConfig();
         const { normalizedConfig } = options;
 
-        applyRouterPlugin(chain, options);
+        applyRouterPlugin(chain, options, HtmlBundlerPlugin);
         if (isSSR(normalizedConfig)) {
           await applySSRLoaderEntry(chain, options, isServer);
           applySSRDataLoader(chain, options);
@@ -114,6 +115,7 @@ function applyAsyncChunkHtmlPlugin({
 function applyRouterPlugin<B extends Bundler>(
   chain: BundlerChain,
   options: Readonly<BuilderOptions<B>>,
+  HtmlBundlerPlugin: typeof HtmlWebpackPlugin,
 ) {
   const { appContext, normalizedConfig } = options;
   const { entrypoints } = appContext;
@@ -127,7 +129,11 @@ function applyRouterPlugin<B extends Bundler>(
 
   // for ssr mode
   if (existNestedRoutes || routerManifest || workerSSR) {
-    chain.plugin('route-plugin').use(RouterPlugin);
+    chain.plugin('route-plugin').use(RouterPlugin, [
+      {
+        HtmlBundlerPlugin,
+      },
+    ]);
   }
 }
 

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -127,7 +127,6 @@ function applyRouterPlugin<B extends Bundler>(
   const routerManifest = Boolean(routerConfig?.manifest);
   const workerSSR = Boolean(normalizedConfig.deploy.worker?.ssr);
 
-  // for ssr mode
   if (existNestedRoutes || routerManifest || workerSSR) {
     chain.plugin('route-plugin').use(RouterPlugin, [
       {
@@ -136,6 +135,7 @@ function applyRouterPlugin<B extends Bundler>(
           normalizedConfig.output.enableInlineRouteManifests,
         staticJsDir: normalizedConfig.output?.distPath?.js,
         disableFilenameHash: normalizedConfig.output?.disableFilenameHash,
+        scriptLoading: normalizedConfig.html.scriptLoading,
       },
     ]);
   }

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -286,10 +286,16 @@ export class RouterPlugin {
               }`;
 
               const scriptUrl = `${publicPath}${scriptPath}`;
-              const script =
-                scriptLoading === 'defer' || this.scriptLoading === 'module'
-                  ? `<script ${scriptLoading} src="${scriptUrl}"></script>`
-                  : `<script src="${scriptUrl}"></script>`;
+
+              const script = `<script ${
+                // eslint-disable-next-line no-nested-ternary
+                scriptLoading === 'defer'
+                  ? scriptLoading
+                  : scriptLoading === 'module'
+                  ? `type="module"`
+                  : ''
+              } src="${scriptUrl}"></script>`;
+
               compilation.updateAsset(
                 htmlName,
                 new RawSource(

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -3,7 +3,7 @@ import { ROUTE_MANIFEST_FILE } from '@modern-js/utils';
 import { ROUTE_MANIFEST } from '@modern-js/utils/universal/constants';
 import type { webpack } from '@modern-js/builder-webpack-provider';
 import type { Rspack } from '@modern-js/builder-rspack-provider';
-import HtmlWebpackPlugin from '@modern-js/builder-webpack-provider/html-webpack-plugin';
+import type HtmlWebpackPlugin from '@modern-js/builder-webpack-provider/html-webpack-plugin';
 
 const PLUGIN_NAME = 'ModernjsRoutePlugin';
 
@@ -19,7 +19,17 @@ type Compiler = webpack.Compiler | Rspack.Compiler;
 type Compilation = webpack.Compilation | Rspack.Compilation;
 type Chunks = webpack.StatsChunk[];
 
+type Options = {
+  HtmlBundlerPlugin: typeof HtmlWebpackPlugin;
+};
+
 export class RouterPlugin {
+  private HtmlBundlerPlugin: typeof HtmlWebpackPlugin;
+
+  constructor(options: Options) {
+    this.HtmlBundlerPlugin = options.HtmlBundlerPlugin;
+  }
+
   private isTargetNodeOrWebWorker(target: Compiler['options']['target']) {
     if (
       target === 'node' ||
@@ -76,7 +86,7 @@ export class RouterPlugin {
     const chunksToHtmlName = new Map();
 
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, compilation => {
-      HtmlWebpackPlugin.getHooks(
+      this.HtmlBundlerPlugin.getHooks(
         compilation as webpack.Compilation,
       ).beforeEmit.tapAsync('RouterManifestPlugin', (data, callback) => {
         const { outputName } = data;

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -19,6 +19,7 @@ export function createDefaultConfig(
   const output: AppUserConfig['output'] = {
     ...defaultBuilderConfig.output,
     disableNodePolyfill: true,
+    enableInlineRouteManifests: true,
   };
 
   const source: AppUserConfig['source'] & {

--- a/packages/solutions/app-tools/src/schema/index.ts
+++ b/packages/solutions/app-tools/src/schema/index.ts
@@ -46,6 +46,7 @@ const bff = {
 const output = {
   ssg: { typeof: ['boolean', 'object', 'function'] },
   disableNodePolyfill: { type: 'boolean' },
+  enableInlineRouteManifests: { type: 'boolean' },
 };
 const dev = {};
 const server = {

--- a/packages/solutions/app-tools/src/types/config/output.ts
+++ b/packages/solutions/app-tools/src/types/config/output.ts
@@ -19,6 +19,7 @@ export interface SharedOutputConfig extends BuilderSharedOutputConfig {
   ssg?: SSGConfig;
   splitRouteChunks?: boolean;
   disableNodePolyfill?: boolean;
+  enableInlineRouteManifests?: boolean;
   tempDir?: string;
 }
 

--- a/packages/solutions/app-tools/src/types/legacyConfig/output.ts
+++ b/packages/solutions/app-tools/src/types/legacyConfig/output.ts
@@ -26,7 +26,6 @@ export type OutputLegacyUserConfig = {
   disableCssExtract?: boolean;
   enableCssModuleTSDeclaration?: boolean;
   disableMinimize?: boolean;
-  disableInlineRouteManifests?: boolean;
   enableInlineStyles?: boolean;
   enableInlineScripts?: boolean;
   disableSourceMap?: boolean;

--- a/packages/solutions/app-tools/src/types/legacyConfig/output.ts
+++ b/packages/solutions/app-tools/src/types/legacyConfig/output.ts
@@ -26,6 +26,7 @@ export type OutputLegacyUserConfig = {
   disableCssExtract?: boolean;
   enableCssModuleTSDeclaration?: boolean;
   disableMinimize?: boolean;
+  disableInlineRouteManifests?: boolean;
   enableInlineStyles?: boolean;
   enableInlineScripts?: boolean;
   disableSourceMap?: boolean;

--- a/tests/integration/routes/tests/index.test.ts
+++ b/tests/integration/routes/tests/index.test.ts
@@ -335,9 +335,9 @@ const supportLoadChunksParallelly = async () => {
   const distDir = path.join(appDir, './dist');
   const manifestFile = path.join(distDir, ROUTE_MANIFEST_FILE);
   expect(await fs.pathExists(manifestFile)).toBeTruthy();
-  const threeBundleFile = path.join(distDir, 'static/js/three.js');
-  const thressBundleContent = await fs.readFile(threeBundleFile);
-  expect(thressBundleContent.includes(ROUTE_MANIFEST)).toBeTruthy();
+  const threeHtmlPath = path.join(distDir, 'html/three/index.html');
+  const threeHtml = await fs.readFile(threeHtmlPath);
+  expect(threeHtml.includes(ROUTE_MANIFEST)).toBeTruthy();
 };
 
 const supportHandleConfig = async (page: Page, appPort: number) => {
@@ -460,26 +460,19 @@ const supportCatchAll = async (
 const getStaticJSDir = (appDir: string) =>
   path.join(appDir, './dist/static/js');
 
+const getHtmlDir = (appDir: string) => path.join(appDir, './dist/html');
+
 const getEntryFile = async (staticJSDir: string) => {
   const files = await fs.readdir(staticJSDir);
   return files.find(file => /^three(\.\w+)?\.js$/.test(file));
 };
 
-const getEntryContent = async (staticJSDir: string, entryFile: string) => {
-  const entryContent = (
-    await fs.readFile(path.join(staticJSDir, entryFile))
-  ).toString();
-  return entryContent;
-};
-
 const testRouterPlugin = async (appDir: string) => {
-  const staticJSDir = getStaticJSDir(appDir);
-  const entryFile = await getEntryFile(staticJSDir);
-  expect(entryFile).toBeDefined();
-
-  const entryContent = await getEntryContent(staticJSDir, entryFile!);
-  expect(entryContent.includes(entryFile!)).toBe(true);
-  expect(!entryContent.includes('four.')).toBe(true);
+  const htmlDir = getHtmlDir(appDir);
+  const threeHtmlPath = path.join(htmlDir, 'three', 'index.html');
+  const threeHtml = await fs.readFile(threeHtmlPath);
+  expect(threeHtml.includes('three.')).toBe(true);
+  expect(!threeHtml.includes('four.')).toBe(true);
 };
 
 const hasHashCorrectly = async (appDir: string) => {
@@ -487,7 +480,9 @@ const hasHashCorrectly = async (appDir: string) => {
   const entryFile = await getEntryFile(staticJSDir);
   expect(entryFile).toBeDefined();
 
-  const entryContent = await getEntryContent(staticJSDir, entryFile!);
+  const htmlDir = getHtmlDir(appDir);
+  const threeHtmlPath = path.join(htmlDir, 'three', 'index.html');
+  const threeHtml = (await fs.readFile(threeHtmlPath)).toString();
 
   const threeUserFiles = await fs.readdir(
     path.join(staticJSDir, 'async/three_user'),
@@ -499,7 +494,7 @@ const hasHashCorrectly = async (appDir: string) => {
   const matched = testFile!.match(/page\.(\w+)\.js$/);
   expect(matched).toBeDefined();
   const hash = matched![1];
-  expect(entryContent.includes(`"${hash}"`)).toBe(true);
+  expect(threeHtml.includes(hash)).toBe(true);
 };
 
 describe('dev', () => {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3266cd1</samp>

This pull request fixes the route manifest injection feature for the `@modern-js/app-tools` package by using the `HtmlWebpackPlugin` to inject the manifest into the html files instead of the bundle files. It also updates the test cases and the changeset file accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3266cd1</samp>

*  Add a changeset file to document the patch version update and the fix messages for the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-8ca4553cb61336a2267b3b6ecd0b129ff43dddb0ca0cca106996e313219bb4c6R1-R6))
*  Use `HtmlWebpackPlugin` from `@modern-js/builder-webpack-provider` to inject the route manifest into the html files instead of the entry chunk files in the `RouterPlugin` class ([link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L77-R96), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L279-R235))
*  Remove unused and redundant imports and comments in the `RouterPlugin` class ([link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L67-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L269))
*  Update the test cases for the `RouterPlugin` and the `PatchRouterManifestWebpackPlugin` to check the html files instead of the main bundle files for the route manifest and the chunk ids ([link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-9c0f1b870238c4da70b10cfdc1f150960ec9f0a2675f042f83c86e33080041d6R4), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-9c0f1b870238c4da70b10cfdc1f150960ec9f0a2675f042f83c86e33080041d6L25-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-9c0f1b870238c4da70b10cfdc1f150960ec9f0a2675f042f83c86e33080041d6L126-R146), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-9c0f1b870238c4da70b10cfdc1f150960ec9f0a2675f042f83c86e33080041d6L142-R161))
*  Update the integration test cases for the `supportLoadChunksParallelly` and the `hasHashCorrectly` features to check the html files instead of the bundle files for the route manifest and the hash value ([link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L338-R340), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L468-R475), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L490-R485), [link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L502-R497))
*  Add a helper function to get the html directory path in the integration test file ([link](https://github.com/web-infra-dev/modern.js/pull/4441/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444R463-R464))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
