### PR TITLE
fix: the issue when set more than two cookie

### DIFF
--- a/.changeset/ten-socks-pretend.md
+++ b/.changeset/ten-socks-pretend.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix: the issue when set more than two cookie
+fix: 修复设置多余两个 cookie 时的问题

--- a/packages/server/prod-server/src/libs/hook-api/base.ts
+++ b/packages/server/prod-server/src/libs/hook-api/base.ts
@@ -42,13 +42,16 @@ export class BaseResponse implements ModernResponse {
   }
 
   private setCookie(key: string, value: string, options?: any) {
-    const cookieValue = String(this.res.getHeader('set-cookie') || '');
+    const cookieValue = this.res.getHeader('set-cookie') || '';
     const fmt = Array.isArray(cookieValue)
       ? cookieValue
       : [cookieValue].filter(Boolean);
     fmt.push(cookie.serialize(key, value, options));
 
-    this.res.setHeader('set-cookie', fmt.length === 1 ? fmt[0] : fmt);
+    this.res.setHeader(
+      'set-cookie',
+      fmt.length === 1 ? fmt[0] : (fmt as string | string[]),
+    );
   }
 
   private clearCookie() {

--- a/packages/server/prod-server/tests/hook.test.ts
+++ b/packages/server/prod-server/tests/hook.test.ts
@@ -38,6 +38,12 @@ describe('test hook api', () => {
     expect(res.getHeader('set-cookie')).toMatch('name=modern');
     response.cookies.set('age', '18');
     expect(res.getHeader('set-cookie')).toEqual(['name=modern', 'age=18']);
+    response.cookies.set('foo', 'bar');
+    expect(res.getHeader('set-cookie')).toEqual([
+      'name=modern',
+      'age=18',
+      'foo=bar',
+    ]);
 
     response.cookies.clear();
     expect(res.getHeader('set-cookie')).toBeUndefined();


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b17028</samp>

Fix and test the `setCookie` method of the `BaseResponse` class in the `@modern-js/prod-server` package. This method allows setting cookies in the response object using the `response.cookies.set` method. The change also updates the changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b17028</samp>

* Fix bug in `setCookie` method of `BaseResponse` class that could cause problems when setting multiple cookies ([link](https://github.com/web-infra-dev/modern.js/pull/4444/files?diff=unified&w=0#diff-ee47aae47243d437a9b1f382b96f72f3c71a01ab0886c88c6f4f20dfe14232faL45-R45),[link](https://github.com/web-infra-dev/modern.js/pull/4444/files?diff=unified&w=0#diff-ee47aae47243d437a9b1f382b96f72f3c71a01ab0886c88c6f4f20dfe14232faL51-R54))
* Add changeset file to document patch update for `@modern-js/prod-server` package ([link](https://github.com/web-infra-dev/modern.js/pull/4444/files?diff=unified&w=0#diff-3c584a2f7c9107a6928f8c6ba70bf95ed78c43878b26d29f3adee51ecf4054baR1-R6))
* Add test case for `setCookie` method of `BaseResponse` class in `hook.test.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4444/files?diff=unified&w=0#diff-7728a85a771b30663fbc6cf8422fb247c638d272f1064158770cacf019c1457cR41-R46))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
