### PR TITLE
fix(app-tools): inject nonce attr to route manifest script

### DIFF
--- a/.changeset/pretty-bees-serve.md
+++ b/.changeset/pretty-bees-serve.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): inject nonce attr to route manifest script
+
+fix(app-tools): 向 route manifest 脚本注入 nonce 属性

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -135,7 +135,7 @@ function applyRouterPlugin<B extends Bundler>(
           normalizedConfig.output.enableInlineRouteManifests,
         staticJsDir: normalizedConfig.output?.distPath?.js,
         disableFilenameHash: normalizedConfig.output?.disableFilenameHash,
-        scriptLoading: normalizedConfig.html.scriptLoading,
+        scriptLoading: normalizedConfig.html?.scriptLoading,
         nonce: normalizedConfig.security?.nonce,
       },
     ]);

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -136,6 +136,7 @@ function applyRouterPlugin<B extends Bundler>(
         staticJsDir: normalizedConfig.output?.distPath?.js,
         disableFilenameHash: normalizedConfig.output?.disableFilenameHash,
         scriptLoading: normalizedConfig.html.scriptLoading,
+        nonce: normalizedConfig.security.nonce,
       },
     ]);
   }

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -136,7 +136,7 @@ function applyRouterPlugin<B extends Bundler>(
         staticJsDir: normalizedConfig.output?.distPath?.js,
         disableFilenameHash: normalizedConfig.output?.disableFilenameHash,
         scriptLoading: normalizedConfig.html.scriptLoading,
-        nonce: normalizedConfig.security.nonce,
+        nonce: normalizedConfig.security?.nonce,
       },
     ]);
   }

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -27,6 +27,7 @@ type Options = {
   enableInlineRouteManifests: boolean;
   disableFilenameHash?: boolean;
   scriptLoading?: ScriptLoading;
+  nonce?: string;
 };
 
 const generateContentHash = (content: string) => {
@@ -44,18 +45,22 @@ export class RouterPlugin {
 
   private scriptLoading?: ScriptLoading;
 
+  private nonce?: string;
+
   constructor({
     staticJsDir = 'static/js',
     HtmlBundlerPlugin,
     enableInlineRouteManifests,
     disableFilenameHash = false,
     scriptLoading = 'defer',
+    nonce,
   }: Options) {
     this.HtmlBundlerPlugin = HtmlBundlerPlugin;
     this.enableInlineRouteManifests = enableInlineRouteManifests;
     this.staticJsDir = staticJsDir;
     this.disableFilenameHash = disableFilenameHash;
     this.scriptLoading = scriptLoading;
+    this.nonce = nonce;
   }
 
   private isTargetNodeOrWebWorker(target: Compiler['options']['target']) {
@@ -262,7 +267,11 @@ export class RouterPlugin {
               disableFilenameHash,
               staticJsDir,
               scriptLoading,
+              nonce,
             } = this;
+
+            const nonceAttr = nonce ? `nonce="${nonce}"` : '';
+
             if (enableInlineRouteManifests) {
               compilation.updateAsset(
                 htmlName,
@@ -272,7 +281,7 @@ export class RouterPlugin {
                     .toString()
                     .replace(
                       placeholder,
-                      `<script>${injectedContent}</script>`,
+                      `<script ${nonceAttr}>${injectedContent}</script>`,
                     ),
                 ),
                 // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
@@ -287,14 +296,15 @@ export class RouterPlugin {
 
               const scriptUrl = `${publicPath}${scriptPath}`;
 
-              const script = `<script ${
+              const scriptLoadingAttr =
                 // eslint-disable-next-line no-nested-ternary
                 scriptLoading === 'defer'
                   ? scriptLoading
                   : scriptLoading === 'module'
                   ? `type="module"`
-                  : ''
-              } src="${scriptUrl}"></script>`;
+                  : '';
+
+              const script = `<script ${scriptLoadingAttr} ${nonceAttr} src="${scriptUrl}"${nonceAttr}></script>`;
 
               compilation.updateAsset(
                 htmlName,

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -304,7 +304,7 @@ export class RouterPlugin {
                   ? `type="module"`
                   : '';
 
-              const script = `<script ${scriptLoadingAttr} ${nonceAttr} src="${scriptUrl}"${nonceAttr}></script>`;
+              const script = `<script ${scriptLoadingAttr} ${nonceAttr} src="${scriptUrl}"></script>`;
 
               compilation.updateAsset(
                 htmlName,

--- a/packages/solutions/app-tools/src/types/config/index.ts
+++ b/packages/solutions/app-tools/src/types/config/index.ts
@@ -22,7 +22,11 @@ import type {
   RsHtmlUserConfig,
   SharedHtmlConfig,
 } from './html';
-import type { RsSecurityConfig, SecurityUserConfig } from './security';
+import type {
+  RsSecurityConfig,
+  SecurityUserConfig,
+  SharedSecurityConfig,
+} from './security';
 import type { DeployUserConfig } from './deploy';
 import type { ExperimentsUserConfig } from './experiments';
 import type {
@@ -56,6 +60,7 @@ export type SharedUserConfig = {
   runtimeByEntries?: RuntimeByEntriesUserConfig;
   html?: SharedHtmlConfig;
   tools?: SharedToolsConfig;
+  security?: SharedSecurityConfig;
   testing?: TestingUserConfig;
   builderPlugins?: BuilderPlugin[];
   performance?: SharedPerformanceConfig;

--- a/packages/solutions/app-tools/src/types/config/security.ts
+++ b/packages/solutions/app-tools/src/types/config/security.ts
@@ -1,3 +1,4 @@
+import type { SharedSecurityConfig } from '@modern-js/builder-shared';
 import type {
   WebpackBuilderConfig,
   RspackBuilderConfig,
@@ -15,3 +16,5 @@ export type RsSecurityConfig = UnwrapBuilderConfig<
 >;
 
 export type SecurityUserConfig = BuilderSecurityConfig;
+
+export type { SharedSecurityConfig };

--- a/tests/integration/nonce/tests/index.test.ts
+++ b/tests/integration/nonce/tests/index.test.ts
@@ -43,8 +43,6 @@ describe('test nonce', () => {
         }),
     );
 
-    console.log('scriptArr', scriptArr);
-
     const nonceArr = scriptArr.filter(nonce => nonce === 'test-nonce');
     expect(nonceArr.length).toBe(scriptArr.length);
   });

--- a/tests/integration/nonce/tests/index.test.ts
+++ b/tests/integration/nonce/tests/index.test.ts
@@ -43,6 +43,8 @@ describe('test nonce', () => {
         }),
     );
 
+    console.log('scriptArr', scriptArr);
+
     const nonceArr = scriptArr.filter(nonce => nonce === 'test-nonce');
     expect(nonceArr.length).toBe(scriptArr.length);
   });


### PR DESCRIPTION
## Summary

Fix integration test: https://github.com/web-infra-dev/modern.js/actions/runs/5869177588/job/15913618122#step:11:4686

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e6b061</samp>

This pull request adds a security feature to the `@modern-js/app-tools` package, which allows specifying a nonce attribute for the script tags injected by the `RouterPlugin` for server-side rendering. It updates the types, config, and bundler plugins to support the `nonce` option, and adds a changeset and a test for the feature. It also refactors some script tag generation logic.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e6b061</samp>

*  Add a changeset file to document the patch update for the `@modern-js/app-tools` package and the fix for injecting the nonce attribute to the route manifest script ([link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-0e189664a9b1afcda07f72fdb686f88906131f358bbd2df7d8ae083810b98172R1-R7))
*  Add the `security` option to the `SharedUserConfig` type and import the `SharedSecurityConfig` type from the `@modern-js/builder-shared` package in the `config/index.ts` and `config/security.ts` files ([link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-4c105a4a2d686e814e1b69b06352da11a65f7b2f63f17dac1df09b9374956ab2L25-R29), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-4c105a4a2d686e814e1b69b06352da11a65f7b2f63f17dac1df09b9374956ab2R63), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-89c1b7422cc2ea0b9a603eb0c6ffe9d29d8112431b669106ab75e62b69beecfcR1), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-89c1b7422cc2ea0b9a603eb0c6ffe9d29d8112431b669106ab75e62b69beecfcR19-R20))
*  Pass the `nonce` option from the normalized config to the `applyRouterPlugin` function in the `adapterSSR.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-d019db18fbb5169d98250c217097e90337f356e26121269d691b402495334186R139))
*  Add the `nonce` option to the `Options` type, the `RouterPlugin` class, and the constructor of the `RouterPlugin` in the `RouterPlugin.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3R30), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3R48-R49), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3R56), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3R63))
*  Use the `nonce` option value to construct the nonce attribute string for the script tags generated by the `RouterPlugin` in the `RouterPlugin.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L265-R274), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L275-R284), [link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L296-R308))
*  Add a console log statement to the integration test for the nonce feature in the `index.test.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4445/files?diff=unified&w=0#diff-6b63f6ce880f239b4e457038d539ed3753d3c950d933548603bbb933ba883071R46-R47))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
