### PR TITLE
fix(prod-server): the app maybe undefined, when use renderHtml

### DIFF
--- a/.changeset/dry-mice-cough.md
+++ b/.changeset/dry-mice-cough.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix(prod-server): the app maybe undefined, when use renderHtml
+fix(prod-server): 当使用 renderHtml 时，app 可能是个 undefined

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -140,7 +140,6 @@ export class ModernServer implements ModernServerInterface {
     this.staticGenerate = staticGenerate || false;
     this.runMode = runMode || RUN_MODE.FULL;
     this.metaName = appContext?.metaName;
-    // process.env.BUILD_TYPE = `${this.staticGenerate ? 'ssg' : 'ssr'}`;
   }
 
   // server prepare
@@ -156,7 +155,7 @@ export class ModernServer implements ModernServerInterface {
     const proxyHandlers = createProxyHandler(
       conf.bff?.proxy as BffProxyOptions,
     );
-    app.on('upgrade', proxyHandlers.handleUpgrade);
+    app?.on('upgrade', proxyHandlers.handleUpgrade);
     proxyHandlers.handlers.forEach(handler => {
       this.addHandler(handler);
     });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef8f929</samp>

This pull request fixes a rendering bug and adds a null check in `modernServer.ts`, and updates the changeset file for the `@modern-js/prod-server` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef8f929</samp>

*  Document patch updates and fixes for `@modern-js/prod-server` package in a changeset file (.changeset/dry-mice-cough.md) ([link](https://github.com/web-infra-dev/modern.js/pull/4446/files?diff=unified&w=0#diff-6211a45904e24d93c47c0c70c5a9b65f74a10376d8cd8d44c23162bd090aba11R1-R6))
*  Avoid overriding `process.env.BUILD_TYPE` variable set by `@modern-js/runtime` package in `modernServer.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4446/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL143))
*  Prevent error when `app` variable is undefined in `modernServer.ts` by adding a null check ([link](https://github.com/web-infra-dev/modern.js/pull/4446/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL159-R158))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
