### PR TITLE
docs: modify the correct NoSSR import mode

### DIFF
--- a/.changeset/polite-islands-leave.md
+++ b/.changeset/polite-islands-leave.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/main-doc': patch
+---
+
+fix(main-doc): modify the correct NoSSR import mode
+
+fix(main-doc): 修复NoSSR组件引入找不到

--- a/packages/document/main-doc/docs/en/apis/app/runtime/ssr/no-ssr.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/ssr/no-ssr.mdx
@@ -8,7 +8,7 @@ The content wrapped by NoSSR will not be rendered at the server, nor will it be 
 ## Usage
 
 ```tsx
-import { NoSSR } from '@modern-js/runtime';
+import { NoSSR } from '@modern-js/runtime/ssr';
 
 export default () => <NoSSR>...</NoSSR>;
 ```
@@ -18,7 +18,7 @@ export default () => <NoSSR>...</NoSSR>;
 In the following code, the `Time` component is used to display the current time. Since the time obtained by server-side rendering and client side hydrate are diff, React will throw an exception. For this case, you can use `NoSSR` to optimize:
 
 ```tsx
-import { NoSSR } from '@modern-js/runtime';
+import { NoSSR } from '@modern-js/runtime/ssr';
 
 function Time() {
   return (

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/ssr/no-ssr.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/ssr/no-ssr.mdx
@@ -8,7 +8,7 @@ title: NoSSR
 ## 使用姿势
 
 ```tsx
-import { NoSSR } from '@modern-js/runtime';
+import { NoSSR } from '@modern-js/runtime/ssr';
 
 export default () => <NoSSR>...</NoSSR>;
 ```
@@ -18,7 +18,7 @@ export default () => <NoSSR>...</NoSSR>;
 下列代码中，`Time` 组件用于展示当前的时间，由于服务端渲染和客户端 hydrate 时获取到的时间是不一致的，React 就会抛出异常。针对这种情况可以使用 `NoSSR` 进行优化：
 
 ```tsx
-import { NoSSR } from '@modern-js/runtime';
+import { NoSSR } from '@modern-js/runtime/ssr';
 
 function Time() {
   return (


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef91970</samp>

This pull request fixes the documentation and example code for the `NoSSR` component in both English and Chinese, and prepares a major release for the `@modern-js/main-doc` package. The fix ensures that users can correctly import and use the component for server-side rendering.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef91970</samp>

*  Bump the major version of `@modern-js/main-doc` and explain the fix for the `NoSSR` component import path in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4448/files?diff=unified&w=0#diff-7e8ac321982d6243586899e283d433d049f1e82155902a3faf9d160c26b1f6b7R1-R7))
*  Fix the import path of the `NoSSR` component from `@modern-js/runtime/ssr` in the documentation and example code for both English and Chinese languages ([link](https://github.com/web-infra-dev/modern.js/pull/4448/files?diff=unified&w=0#diff-b4cec90eeb77023f8d03d278082f6a6da06de8ec5e3ecf1e1c4152fcb5f2ba46L11-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4448/files?diff=unified&w=0#diff-b4cec90eeb77023f8d03d278082f6a6da06de8ec5e3ecf1e1c4152fcb5f2ba46L21-R21), [link](https://github.com/web-infra-dev/modern.js/pull/4448/files?diff=unified&w=0#diff-d0fc5433f2645ef952edb6982ce359800badb8ccea9e6c13ff04bcac37116bc0L11-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4448/files?diff=unified&w=0#diff-d0fc5433f2645ef952edb6982ce359800badb8ccea9e6c13ff04bcac37116bc0L21-R21))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
