### PR TITLE
chore: remove some unsless code in builder-plugin-stylus

### DIFF
--- a/packages/builder/plugin-stylus/src/index.ts
+++ b/packages/builder/plugin-stylus/src/index.ts
@@ -46,29 +46,16 @@ export function builderPluginStylus(
           .rule(utils.CHAIN_ID.RULE.STYLUS)
           .test(STYLUS_REGEX);
 
-        if (bundlerType === 'rspack') {
-          const { applyBaseCSSRule } = await import(
-            '@modern-js/builder-rspack-provider/plugins/css'
-          );
-          await applyBaseCSSRule({
-            rule,
-            config: config as any,
-            context: api.context,
-            utils,
-            importLoaders: 2,
-          });
-        } else {
-          const { applyBaseCSSRule } = await import(
-            '@modern-js/builder-webpack-provider/plugins/css'
-          );
-          await applyBaseCSSRule({
-            rule,
-            config,
-            context: api.context,
-            utils,
-            importLoaders: 2,
-          });
-        }
+        const { applyBaseCSSRule } = await import(
+          `@modern-js/builder-${bundlerType}-provider/plugins/css`
+        );
+        await applyBaseCSSRule({
+          rule,
+          config: config as any,
+          context: api.context,
+          utils,
+          importLoaders: 2,
+        });
 
         rule
           .use(utils.CHAIN_ID.USE.STYLUS)


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46a2964</samp>

Refactor builder plugin for stylus to use template literal for importing provider function. This improves code simplicity and readability.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46a2964</samp>

*  Simplify code to import `applyBaseCSSRule` function using template literal based on `bundlerType` ([link](https://github.com/web-infra-dev/modern.js/pull/4449/files?diff=unified&w=0#diff-6b3d781c72e48d6da544ca91e2156610b231884f8b5535b4cb100b39d46a3247L49-R58))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
