### PR TITLE
feat: memo creating router

### DIFF
--- a/.changeset/grumpy-maps-stare.md
+++ b/.changeset/grumpy-maps-stare.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: memo creating router
+feat: 缓存 router 创建

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import {
   createBrowserRouter,
   createHashRouter,
@@ -77,20 +77,7 @@ export const routerPlugin = ({
           }
 
           const getRouteApp = () => {
-            return (props => {
-              beforeCreateRouter = false;
-              routes = createRoutes
-                ? createRoutes()
-                : createRoutesFromElements(
-                    renderRoutes({
-                      routesConfig: finalRouteConfig,
-                      props,
-                    }),
-                  );
-
-              const runner = (api as any).useHookRunners();
-              routes = runner.modifyRoutes(routes);
-
+            const useCreateRouter = (props: any) => {
               const baseUrl =
                 window._SERVER_DATA?.router.baseUrl ||
                 select(location.pathname);
@@ -98,51 +85,77 @@ export const routerPlugin = ({
                 baseUrl === '/' ? urlJoin(baseUrl, basename) : baseUrl;
 
               let hydrationData = window._ROUTER_DATA;
-              if (hydrationData?.errors) {
-                hydrationData = {
-                  ...hydrationData,
-                  errors: deserializeErrors(hydrationData.errors),
-                };
-              }
-
-              const router = supportHtml5History
-                ? createBrowserRouter(routes, {
-                    basename: _basename,
-                    hydrationData,
-                  })
-                : createHashRouter(routes, {
-                    basename: _basename,
-                    hydrationData,
-                  });
-
               const runtimeContext = useContext(RuntimeReactContext);
-              if (!runtimeContext.remixRouter) {
+
+              const { unstable_getBlockNavState: getBlockNavState } =
+                runtimeContext;
+
+              return useMemo(() => {
+                if (hydrationData?.errors) {
+                  hydrationData = {
+                    ...hydrationData,
+                    errors: deserializeErrors(hydrationData.errors),
+                  };
+                }
+
+                routes = createRoutes
+                  ? createRoutes()
+                  : createRoutesFromElements(
+                      renderRoutes({
+                        routesConfig: finalRouteConfig,
+                        props,
+                      }),
+                    );
+
+                const runner = (api as any).useHookRunners();
+                routes = runner.modifyRoutes(routes);
+
+                const router = supportHtml5History
+                  ? createBrowserRouter(routes, {
+                      basename: _basename,
+                      hydrationData,
+                    })
+                  : createHashRouter(routes, {
+                      basename: _basename,
+                      hydrationData,
+                    });
+
+                const originSubscribe = router.subscribe;
+
+                router.subscribe = (listener: RouterSubscriber) => {
+                  const wrapedListener: RouterSubscriber = (...args) => {
+                    const blockRoute = getBlockNavState
+                      ? getBlockNavState()
+                      : false;
+
+                    if (blockRoute) {
+                      return;
+                    }
+                    // eslint-disable-next-line consistent-return
+                    return listener(...args);
+                  };
+                  return originSubscribe(wrapedListener);
+                };
+
                 Object.defineProperty(runtimeContext, 'remixRouter', {
                   get() {
                     return router;
                   },
                 });
-              }
 
-              const originSubscribe = router.subscribe;
+                return router;
+              }, [
+                finalRouteConfig,
+                props,
+                _basename,
+                hydrationData,
+                getBlockNavState,
+              ]);
+            };
 
-              router.subscribe = (listener: RouterSubscriber) => {
-                const wrapedListener: RouterSubscriber = (...args) => {
-                  const getBlockNavState =
-                    runtimeContext.unstable_getBlockNavState;
-
-                  const blockRoute = getBlockNavState
-                    ? getBlockNavState()
-                    : false;
-
-                  if (blockRoute) {
-                    return;
-                  }
-                  // eslint-disable-next-line consistent-return
-                  return listener(...args);
-                };
-                return originSubscribe(wrapedListener);
-              };
+            return (props => {
+              beforeCreateRouter = false;
+              const router = useCreateRouter(props);
 
               return (
                 <App {...props}>


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2b8427</samp>

This pull request improves the performance and usability of the `@modern-js/runtime` package by optimizing the router creation and subscription logic. It also adds a changeset file to document the patch update and the features added. The changes affect the `router/runtime/plugin.tsx` file and the `.changeset/grumpy-maps-stare.md` file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e2b8427</samp>

*  Add a changeset file to document the patch update and the features added to the `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-63af3545f7ac0ded1341477da5b651282aa4cf0507f898d06db5ce7bfbc91f9dR1-R6))
*  Extract a custom hook `useCreateRouter` from the `routerPlugin` value in `router/runtime/plugin.tsx` to memoize and cache the router creation based on the props and the runtime context ([link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L80-R80), [link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L101-R139))
*  Move the logic of creating and modifying the routes, deserializing the errors, and creating the browser or hash router inside the `useCreateRouter` hook ([link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L101-R139))
*  Wrap the router subscribe method with a check for the block navigation state to prevent unwanted location updates ([link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L101-R139))
*  Return the router from the `useCreateRouter` hook and define the `remixRouter` property on the runtime context with a getter that returns the router ([link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L125-R159))
*  Render the `App` component with the props and the router as children and remove the redundant code from the `getRouteApp` function ([link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L125-R159))
*  Import the `useMemo` hook from React in `router/runtime/plugin.tsx` to use it in the `useCreateRouter` hook ([link](https://github.com/web-infra-dev/modern.js/pull/4451/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6L1-R1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
