### PR TITLE
refactor(builder-plugin-swc): move lockCorejsVersion to plugin option, no affecting binding

### DIFF
--- a/.changeset/great-bears-study.md
+++ b/.changeset/great-bears-study.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc': patch
+---
+
+refactor(builder-plugin-swc): move lockCorejsVersion to plugin option, no affecting binding
+
+refactor(builder-plugin-swc): 移动 lockCorejsVersion 配置到 plugin 配置中，不影响binding

--- a/packages/builder/plugin-swc/src/binding.ts
+++ b/packages/builder/plugin-swc/src/binding.ts
@@ -1,6 +1,5 @@
 import { Compiler as RawCompiler, Output } from '@modern-js/swc-plugins';
 import { TransformConfig } from './types';
-import { CORE_JS_DIR_PATH, SWC_HELPERS_DIR_PATH } from './constants';
 
 export {
   minify,
@@ -9,28 +8,10 @@ export {
   minifyCssSync,
 } from '@modern-js/swc-plugins';
 
-export function applyExtensionsConfig(opt: TransformConfig): TransformConfig {
-  // set lockCoreVersion config
-  const config = {
-    ...opt,
-    extensions: {
-      ...opt.extensions,
-      lockCorejsVersion: {
-        ...(opt.extensions?.lockCorejsVersion || {}),
-        corejs: CORE_JS_DIR_PATH,
-        swcHelpers: SWC_HELPERS_DIR_PATH,
-      },
-    },
-  };
-
-  return config;
-}
-
 export class Compiler extends RawCompiler {
   config: TransformConfig;
 
-  constructor(config: TransformConfig) {
-    const finalConfig = applyExtensionsConfig(config);
+  constructor(finalConfig: TransformConfig) {
     super(finalConfig);
     this.config = finalConfig;
   }

--- a/packages/builder/plugin-swc/src/utils.ts
+++ b/packages/builder/plugin-swc/src/utils.ts
@@ -20,6 +20,7 @@ import {
   PluginSwcOptions,
   TransformConfig,
 } from './types';
+import { CORE_JS_DIR_PATH, SWC_HELPERS_DIR_PATH } from './constants';
 
 /**
  * Determin react runtime mode based on react version
@@ -214,6 +215,11 @@ export async function applyPluginConfig(
       ids: ['lodash', 'lodash-es'],
     };
   }
+
+  extensions.lockCorejsVersion ??= {
+    corejs: CORE_JS_DIR_PATH,
+    swcHelpers: SWC_HELPERS_DIR_PATH,
+  };
 
   /**
    * SWC can't use latestDecorator in TypeScript file for now

--- a/packages/builder/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/builder/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -35,6 +35,10 @@ exports[`plugins/swc > should apply source.include and source.exclude correctly 
                 ],
               },
               "extensions": {
+                "lockCorejsVersion": {
+                  "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                  "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+                },
                 "lodash": {
                   "cwd": "<ROOT>",
                   "ids": [
@@ -94,6 +98,10 @@ exports[`plugins/swc > should apply source.include and source.exclude correctly 
                 ],
               },
               "extensions": {
+                "lockCorejsVersion": {
+                  "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                  "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+                },
                 "lodash": {
                   "cwd": "<ROOT>",
                   "ids": [
@@ -156,6 +164,10 @@ exports[`plugins/swc > should disable react refresh when dev.hmr is false 1`] = 
               ],
             },
             "extensions": {
+              "lockCorejsVersion": {
+                "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+              },
               "lodash": {
                 "cwd": "<ROOT>",
                 "ids": [
@@ -219,6 +231,10 @@ exports[`plugins/swc > should disable react refresh when target is not web 1`] =
               ],
             },
             "extensions": {
+              "lockCorejsVersion": {
+                "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+              },
               "lodash": {
                 "cwd": "<ROOT>",
                 "ids": [
@@ -278,6 +294,10 @@ exports[`plugins/swc > should disable react refresh when target is not web 2`] =
               ],
             },
             "extensions": {
+              "lockCorejsVersion": {
+                "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+              },
               "lodash": {
                 "cwd": "<ROOT>",
                 "ids": [
@@ -339,6 +359,10 @@ exports[`plugins/swc > should disable react refresh when target is not web 3`] =
               ],
             },
             "extensions": {
+              "lockCorejsVersion": {
+                "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+              },
               "lodash": {
                 "cwd": "<ROOT>",
                 "ids": [
@@ -400,6 +424,10 @@ exports[`plugins/swc > should disable react refresh when target is not web 4`] =
               ],
             },
             "extensions": {
+              "lockCorejsVersion": {
+                "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+              },
               "lodash": {
                 "cwd": "<ROOT>",
                 "ids": [
@@ -461,6 +489,10 @@ exports[`plugins/swc > should disable react refresh when target is not web 5`] =
               ],
             },
             "extensions": {
+              "lockCorejsVersion": {
+                "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+              },
               "lodash": {
                 "cwd": "<ROOT>",
                 "ids": [
@@ -565,6 +597,10 @@ exports[`plugins/swc > should set multiple swc-loader 1`] = `
             ],
           },
           "extensions": {
+            "lockCorejsVersion": {
+              "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+              "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+            },
             "lodash": {
               "cwd": "<ROOT>",
               "ids": [
@@ -625,6 +661,10 @@ exports[`plugins/swc > should set multiple swc-loader 1`] = `
             ],
           },
           "extensions": {
+            "lockCorejsVersion": {
+              "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+              "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+            },
             "lodash": {
               "cwd": "<ROOT>",
               "ids": [
@@ -680,6 +720,10 @@ exports[`plugins/swc > should set multiple swc-loader 1`] = `
             ],
           },
           "extensions": {
+            "lockCorejsVersion": {
+              "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+              "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+            },
             "lodash": {
               "cwd": "<ROOT>",
               "ids": [
@@ -769,6 +813,10 @@ exports[`plugins/swc > should set swc-loader 1`] = `
                 ],
               },
               "extensions": {
+                "lockCorejsVersion": {
+                  "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                  "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+                },
                 "lodash": {
                   "cwd": "<ROOT>",
                   "ids": [
@@ -828,6 +876,10 @@ exports[`plugins/swc > should set swc-loader 1`] = `
                 ],
               },
               "extensions": {
+                "lockCorejsVersion": {
+                  "corejs": "<WORKSPACE>/node_modules/<PNPM_INNER>/core-js",
+                  "swcHelpers": "<WORKSPACE>/node_modules/<PNPM_INNER>/@swc/helpers",
+                },
                 "lodash": {
                   "cwd": "<ROOT>",
                   "ids": [


### PR DESCRIPTION
## Summary

lockCorejsVersion should not enable by default when user uses loader instead of plugin

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f683929</samp>

This pull request adds a feature to the `plugin-swc` package that allows locking the core-js version when using the preset-env plugin. It also refactors and cleans up some code in `binding.ts` and `utils.ts`, and updates the `.changeset` directory with a change description.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f683929</samp>

*  Add a changeset file to generate changelogs and version updates ([link](https://github.com/web-infra-dev/modern.js/pull/4453/files?diff=unified&w=0#diff-3a5207b258dd6dee8dda5c2bce7781aa36bb88d2334737fbe638593ab8d819f3R1-R7))
  - Removing an unused import statement ([link](https://github.com/web-infra-dev/modern.js/pull/4453/files?diff=unified&w=0#diff-b8648765a0d2d3ce485b31d5e9252d88d5478af128ecb436d24a82a727000856L3))
  - Moving the `lockCorejsVersion` option to the plugin config ([link](https://github.com/web-infra-dev/modern.js/pull/4453/files?diff=unified&w=0#diff-b8648765a0d2d3ce485b31d5e9252d88d5478af128ecb436d24a82a727000856L12-R14))
  - Importing the constants for the core-js and swc-helpers paths ([link](https://github.com/web-infra-dev/modern.js/pull/4453/files?diff=unified&w=0#diff-7e7493837494e3c87f9cdb9c34a14e2355f4a5882cccad8b5de3322727df7ab3R23))
  - Formatting the `extensions` property for readability ([link](https://github.com/web-infra-dev/modern.js/pull/4453/files?diff=unified&w=0#diff-7e7493837494e3c87f9cdb9c34a14e2355f4a5882cccad8b5de3322727df7ab3L154-R157))
  - Setting the `lockCorejsVersion` option based on the plugin config or the constants ([link](https://github.com/web-infra-dev/modern.js/pull/4453/files?diff=unified&w=0#diff-7e7493837494e3c87f9cdb9c34a14e2355f4a5882cccad8b5de3322727df7ab3R221-R225))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [] I have updated the documentation.
- [ ] I have added tests to cover my changes.
