### PR TITLE
fix: fix redefining the remixRouter

### DIFF
--- a/.changeset/great-shrimps-lay.md
+++ b/.changeset/great-shrimps-lay.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: fix redefining the remixRouter issue
+fix: 修复 remixRouter 重定义问题

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -141,6 +141,7 @@ export const routerPlugin = ({
                   get() {
                     return router;
                   },
+                  configurable: true,
                 });
 
                 return router;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32a949a</samp>

This pull request fixes a compatibility issue between `@modern-js/runtime` and `@remix-run/react` by making the `remixRouter` global variable configurable. It also adds a changeset file to document the patch update for the `@modern-js/runtime` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32a949a</samp>

* Allow `remixRouter` global variable to be redefined by other plugins or modules ([link](https://github.com/web-infra-dev/modern.js/pull/4456/files?diff=unified&w=0#diff-5a481a09516eabe813ec9e1009ae820ad90959f997c130b9c127ec0bd0009db6R144))
* Add changeset file for `@modern-js/runtime` package with patch version bump and changelog messages ([link](https://github.com/web-infra-dev/modern.js/pull/4456/files?diff=unified&w=0#diff-8908d49611c48be009e2255fd6a5937a159612fb6bc73eb6cfc0d605aa937191R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
