### PR TITLE
fix(builder): temporarily disable asciiOnly in rspack

### DIFF
--- a/.changeset/tame-shrimps-smile.md
+++ b/.changeset/tame-shrimps-smile.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+hotfix(builder): temporarily disable asciiOnly in rspack
+
+hotfix(builder): rspack 场景下临时关闭 asciiOnly 能力

--- a/packages/builder/builder-rspack-provider/src/plugins/minimize.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/minimize.ts
@@ -37,7 +37,8 @@ export async function applyJSMinimizer(
       break;
   }
 
-  options.asciiOnly = config.output.charset === 'ascii';
+  // TODO: need fix
+  // options.asciiOnly = config.output.charset === 'ascii';
 
   setConfig(rspackConfig, 'builtins.minifyOptions', options);
 }

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -768,7 +768,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "process.env.NODE_ENV": "\\"production\\"",
     },
     "minifyOptions": {
-      "asciiOnly": true,
       "extractComments": true,
     },
     "pluginImport": [

--- a/packages/builder/builder-rspack-provider/tests/plugins/minimize.test.ts
+++ b/packages/builder/builder-rspack-provider/tests/plugins/minimize.test.ts
@@ -33,10 +33,11 @@ describe('plugins/minimize', () => {
 
     expect(bundlerConfigs[0].optimization?.minimize).toEqual(true);
 
-    expect(bundlerConfigs[0].builtins?.minifyOptions).toEqual({
-      asciiOnly: true,
-      extractComments: true,
-    });
+    expect(bundlerConfigs[0].builtins?.minifyOptions).toMatchInlineSnapshot(`
+      {
+        "extractComments": true,
+      }
+    `);
 
     process.env.NODE_ENV = 'test';
   });
@@ -78,11 +79,12 @@ describe('plugins/minimize', () => {
       origin: { bundlerConfigs },
     } = await builder.inspectConfig();
 
-    expect(bundlerConfigs[0].builtins?.minifyOptions).toEqual({
-      asciiOnly: true,
-      extractComments: true,
-      dropConsole: true,
-    });
+    expect(bundlerConfigs[0].builtins?.minifyOptions).toMatchInlineSnapshot(`
+      {
+        "dropConsole": true,
+        "extractComments": true,
+      }
+    `);
 
     process.env.NODE_ENV = 'test';
   });
@@ -103,11 +105,15 @@ describe('plugins/minimize', () => {
       origin: { bundlerConfigs },
     } = await builder.inspectConfig();
 
-    expect(bundlerConfigs[0].builtins?.minifyOptions).toEqual({
-      asciiOnly: true,
-      pureFuncs: ['console.log', 'console.warn'],
-      extractComments: true,
-    });
+    expect(bundlerConfigs[0].builtins?.minifyOptions).toMatchInlineSnapshot(`
+      {
+        "extractComments": true,
+        "pureFuncs": [
+          "console.log",
+          "console.warn",
+        ],
+      }
+    `);
 
     process.env.NODE_ENV = 'test';
   });

--- a/tests/e2e/builder/cases/output/ascii/index.test.ts
+++ b/tests/e2e/builder/cases/output/ascii/index.test.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
 
-test('output.charset default (ascii)', async ({ page }) => {
+webpackOnlyTest('output.charset default (ascii)', async ({ page }) => {
   const builder = await build({
     cwd: __dirname,
     entry: {

--- a/tests/e2e/builder/cases/output/ascii/src/index.js
+++ b/tests/e2e/builder/cases/output/ascii/src/index.js
@@ -1,2 +1,13 @@
 // eslint-disable-next-line no-undef
 window.a = '你好 world!';
+
+// eslint-disable-next-line no-undef
+window.b = {
+  Д: 'A',
+  Å: 'A',
+  Ð: 'D',
+  Þ: 'o',
+  å: 'a',
+  ð: 'd',
+  þ: 'o',
+};


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab3ef92</samp>

This pull request fixes a bug in the `rspack` bundler that caused issues with non-ASCII characters in the output files. It disables the `asciiOnly` option in the `minimize` plugin and updates the unit and end-to-end tests accordingly. It also adds a changeset file to document the patch version update and the hotfix message for the `@modern-js/builder-rspack-provider` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab3ef92</samp>

*  Disable `asciiOnly` option in `rspack` bundler due to issues and add hotfix message ([link](https://github.com/web-infra-dev/modern.js/pull/4459/files?diff=unified&w=0#diff-b31c1031275cfcc97d0c2511b4c98a2d091c82dc1e5c811b036f4b9458f21d01R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4459/files?diff=unified&w=0#diff-00652a3b9cfcf087a07f68d8d17fcba9f6529ef9ad06eff43a5d63bb7be474f3L40-R41))
*  Update unit tests for `applyJSMinimizer` function to use snapshot matchers and remove `asciiOnly` property from expected objects ([link](https://github.com/web-infra-dev/modern.js/pull/4459/files?diff=unified&w=0#diff-996b6ead70a814bcbf609de19b0dd583899f30f5558e5c0bc8f6dd641145f79dL36-R40), [link](https://github.com/web-infra-dev/modern.js/pull/4459/files?diff=unified&w=0#diff-996b6ead70a814bcbf609de19b0dd583899f30f5558e5c0bc8f6dd641145f79dL81-R87), [link](https://github.com/web-infra-dev/modern.js/pull/4459/files?diff=unified&w=0#diff-996b6ead70a814bcbf609de19b0dd583899f30f5558e5c0bc8f6dd641145f79dL106-R116))
*  Skip end-to-end test for `output.charset` option if bundler is not `webpack` and add code to test non-ASCII characters in output file ([link](https://github.com/web-infra-dev/modern.js/pull/4459/files?diff=unified&w=0#diff-7fd2fee2ef4258a843c561f54d65cb3bc2d98c9540fb256f66822f5482cda845L4-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4459/files?diff=unified&w=0#diff-ac5fc761f7fe389296ec6d92772c40d29b0f08d245096fba9f12db227ad6d2aeR3-R13))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
