### PR TITLE
chore(builder): move performance config default value to shared

### DIFF
--- a/.changeset/forty-items-wonder.md
+++ b/.changeset/forty-items-wonder.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+chore(builder): move performance config default value to shared
+
+chore(builder): 移动 performance 默认配置到 shared 中

--- a/packages/builder/builder-shared/src/config.ts
+++ b/packages/builder/builder-shared/src/config.ts
@@ -76,10 +76,12 @@ export const getDefaultToolsConfig = (): NormalizedSharedToolsConfig => ({
 
 export const getDefaultPerformanceConfig =
   (): NormalizedSharedPerformanceConfig => ({
+    profile: false,
     buildCache: true,
     printFileSize: true,
     removeConsole: false,
     transformLodash: true,
+    removeMomentLocale: false,
     chunkSplit: {
       strategy: 'split-by-experience',
     },

--- a/packages/builder/builder-webpack-provider/src/config/defaults.ts
+++ b/packages/builder/builder-webpack-provider/src/config/defaults.ts
@@ -33,11 +33,7 @@ export const createDefaultConfig = (): BuilderConfig => ({
     lazyCompilation: false,
     sourceBuild: false,
   },
-  performance: {
-    ...getDefaultPerformanceConfig(),
-    profile: false,
-    removeMomentLocale: false,
-  },
+  performance: getDefaultPerformanceConfig(),
 });
 
 export const withDefaultConfig = (config: BuilderConfig) =>


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6861c45</samp>

This pull request adds a `profile` option to the performance configuration of the webpack build, and updates the `@modern-js/builder-webpack-provider` and `@modern-js/builder-shared` packages accordingly. It also creates a `.changeset` file to document the changes and prepare for a patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6861c45</samp>

*  Add a markdown file to generate changelogs and version updates for two packages ([link](https://github.com/web-infra-dev/modern.js/pull/4464/files?diff=unified&w=0#diff-27ae04e815df9822a02716f5450a1f9974bcf9ddad2d9232d695d3a6b7baa29fR1-R8))
*  Add a `profile` option to the default performance configuration for webpack builds ([link](https://github.com/web-infra-dev/modern.js/pull/4464/files?diff=unified&w=0#diff-23b69a2bcb6d1c3fb1f194334df85d94505881ebcd162da6b33dcdc860efd63eL79-R84))
*  Simplify the default webpack configuration by removing redundant options ([link](https://github.com/web-infra-dev/modern.js/pull/4464/files?diff=unified&w=0#diff-509b786377fa5b943ac874136d340205543b916068fa1ac34947861673f54e27L36-R36))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
