### PR TITLE
chore(generators): adjust build target to es2019

### DIFF
--- a/.changeset/ten-candles-try.md
+++ b/.changeset/ten-candles-try.md
@@ -1,0 +1,28 @@
+---
+'@modern-js/module-test-generator': patch
+'@modern-js/tailwindcss-generator': patch
+'@modern-js/dependence-generator': patch
+'@modern-js/changeset-generator': patch
+'@modern-js/generator-generator': patch
+'@modern-js/router-v5-generator': patch
+'@modern-js/storybook-generator': patch
+'@modern-js/monorepo-generator': patch
+'@modern-js/packages-generator': patch
+'@modern-js/upgrade-generator': patch
+'@modern-js/module-generator': patch
+'@modern-js/rspack-generator': patch
+'@modern-js/server-generator': patch
+'@modern-js/entry-generator': patch
+'@modern-js/base-generator': patch
+'@modern-js/repo-generator': patch
+'@modern-js/test-generator': patch
+'@modern-js/bff-generator': patch
+'@modern-js/doc-generator': patch
+'@modern-js/mwa-generator': patch
+'@modern-js/ssg-generator': patch
+'@modern-js/generator-plugin-plugin': patch
+---
+
+chore(generators): adjust build target to es2019
+
+chore(generators): 调整构建的 target 为 es2019

--- a/packages/generator/generators/base-generator/modern.config.js
+++ b/packages/generator/generators/base-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/bff-generator/modern.config.js
+++ b/packages/generator/generators/bff-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/changeset-generator/modern.config.js
+++ b/packages/generator/generators/changeset-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/dependence-generator/modern.config.js
+++ b/packages/generator/generators/dependence-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/doc-generator/modern.config.js
+++ b/packages/generator/generators/doc-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/entry-generator/modern.config.js
+++ b/packages/generator/generators/entry-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/generator-generator/modern.config.js
+++ b/packages/generator/generators/generator-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/generator-generator/templates/js-template/modern.config.js.handlebars
+++ b/packages/generator/generators/generator-generator/templates/js-template/modern.config.js.handlebars
@@ -2,6 +2,7 @@ import { moduleTools } from '@modern-js/module-tools';
 
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/generator-generator/templates/ts-template/modern.config.ts.handlebars
+++ b/packages/generator/generators/generator-generator/templates/ts-template/modern.config.ts.handlebars
@@ -2,6 +2,7 @@ import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/module-generator/modern.config.js
+++ b/packages/generator/generators/module-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/module-test-generator/modern.config.js
+++ b/packages/generator/generators/module-test-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/monorepo-generator/modern.config.js
+++ b/packages/generator/generators/monorepo-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/mwa-generator/modern.config.js
+++ b/packages/generator/generators/mwa-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/packages-generator/modern.config.js
+++ b/packages/generator/generators/packages-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     dts: false,
   },

--- a/packages/generator/generators/repo-generator/modern.config.js
+++ b/packages/generator/generators/repo-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/router-v5-generator/modern.config.js
+++ b/packages/generator/generators/router-v5-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/rspack-generator/modern.config.js
+++ b/packages/generator/generators/rspack-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/server-generator/modern.config.js
+++ b/packages/generator/generators/server-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/ssg-generator/modern.config.js
+++ b/packages/generator/generators/ssg-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/storybook-generator/modern.config.js
+++ b/packages/generator/generators/storybook-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/tailwindcss-generator/modern.config.js
+++ b/packages/generator/generators/tailwindcss-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/test-generator/modern.config.js
+++ b/packages/generator/generators/test-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/generators/upgrade-generator/modern.config.js
+++ b/packages/generator/generators/upgrade-generator/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/plugins/generator-plugin/modern.config.js
+++ b/packages/generator/plugins/generator-plugin/modern.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/plugins/generator-plugin/templates/modern.config.js.handlebars
+++ b/packages/generator/plugins/generator-plugin/templates/modern.config.js.handlebars
@@ -2,6 +2,7 @@ import { moduleTools } from '@modern-js/module-tools';
 
 module.exports = {
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',

--- a/packages/generator/plugins/generator-plugin/templates/modern.config.ts.handlebars
+++ b/packages/generator/plugins/generator-plugin/templates/modern.config.ts.handlebars
@@ -2,6 +2,7 @@ import { moduleTools, defineConfig } from '@modern-js/module-tools';
 
 export default defineConfig({
   buildConfig: {
+    target: 'es2019',
     autoExternal: false,
     alias: {
       chalk: '@modern-js/utils/chalk',


### PR DESCRIPTION
## Summary

Adjust build target of generator packages to `es2019` (the default target of module-tools is `es6`), which is same as other modern.js node packages.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca5b126</samp>

This pull request adds a changeset file that patches all the generator packages in the modern.js monorepo. It also adds the `target: 'es2019'` option to the `modern.config.js` or `modern.config.ts` files of each generator package and template. This option improves the performance and compatibility of the generator code by transpiling it to ES2019 syntax.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca5b126</samp>

*  Add `target: 'es2019'` option to `modern.config.js` or `modern.config.ts` files of all generator packages to transpile code to ES2019 syntax for Node.js 12+ compatibility ([link](https://github.com/web-infra-dev/modern.js/pull/4465/files?diff=unified&w=0#diff-8f5ac717e3794821c9f4b2fcae2c5f23a1a9bbeae1d2b14c514784ee36dd90b1R3)-[link](https://github.com/web-infra-dev/modern.js/pull/4465/files?diff=unified&w=0#diff-a572f6316b1795c7ae92dfb7ac77af5d9091309e12111ba3e5e03f1803a335cfR3))
*  Add `target: 'es2019'` option to template files for custom generators created by `generator-generator` package ([link](https://github.com/web-infra-dev/modern.js/pull/4465/files?diff=unified&w=0#diff-520f36ccb5651e4a0580a6278d6072ac4f231d38e81457a5d1690a5d95fc4589R5), [link](https://github.com/web-infra-dev/modern.js/pull/4465/files?diff=unified&w=0#diff-be409c78f1d7b18e084dc61a3732455b3149f8ffd4be5fff93c2468b2513cdb5R5))
*  Add changeset file to specify patch version bump and change reason for all generator packages ([link](https://github.com/web-infra-dev/modern.js/pull/4465/files?diff=unified&w=0#diff-a20fece2bf90b1ace12c48bd2c56fe99371ee04f0b6913a6ba5823c102609423R1-R28))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
