### PR TITLE
fix: packaging errors found by publint

### DIFF
--- a/.changeset/dirty-bears-attack.md
+++ b/.changeset/dirty-bears-attack.md
@@ -1,0 +1,34 @@
+---
+'@modern-js/babel-plugin-module-resolver': patch
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-plugin-image-compress': patch
+'@modern-js/node-bundle-require': patch
+'@modern-js/plugin-router-v5': patch
+'@modern-js/remark-container': patch
+'@modern-js/plugin-data-loader': patch
+'@modern-js/plugin-garfish': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/create-request': patch
+'@modern-js/plugin-storybook': patch
+'@modern-js/plugin-server': patch
+'@modern-js/plugin-worker': patch
+'@modern-js/plugin-tailwindcss': patch
+'@modern-js/app-tools': patch
+'@modern-js/builder-plugin-swc': patch
+'@modern-js/prod-server': patch
+'@modern-js/plugin-koa': patch
+'@modern-js/bff-core': patch
+'@modern-js/plugin-bff': patch
+'@modern-js/plugin-ssg': patch
+'@modern-js/plugin': patch
+'@modern-js/types': patch
+'@modern-js/utils': patch
+'@modern-js/server-core': patch
+'@modern-js/core': patch
+---
+
+fix: packaging errors found by publint
+
+fix: 修复 publint 检测到的 packaging 问题

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -29,8 +29,8 @@
       "default": "./dist/index.js"
     },
     "./plugins/*": {
-      "jsnext:source": "./src/plugins/*.ts",
       "types": "./dist/plugins/*.d.ts",
+      "jsnext:source": "./src/plugins/*.ts",
       "default": "./dist/plugins/*.js"
     }
   },

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -25,13 +25,13 @@
   "module": "./dist/index.js",
   "exports": {
     ".": {
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/index.d.ts",
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./html-webpack-plugin": {
-      "jsnext:source": "./src/exports/HtmlWebpackPlugin.ts",
       "types": "./dist/exports/HtmlWebpackPlugin.d.ts",
+      "jsnext:source": "./src/exports/HtmlWebpackPlugin.ts",
       "default": "./dist/exports/HtmlWebpackPlugin.js"
     },
     "./webpack": {
@@ -39,13 +39,13 @@
       "default": "./dist/exports/webpack.js"
     },
     "./stub": {
-      "jsnext:source": "./src/stub/index.ts",
       "types": "./dist/stub/index.d.ts",
+      "jsnext:source": "./src/stub/index.ts",
       "default": "./dist/stub/index.js"
     },
     "./plugins/*": {
-      "jsnext:source": "./src/plugins/*.ts",
       "types": "./dist/plugins/*.d.ts",
+      "jsnext:source": "./src/plugins/*.ts",
       "default": "./dist/plugins/*.js"
     },
     "./webpack/lib/ModuleFilenameHelpers.js": {

--- a/packages/builder/plugin-image-compress/package.json
+++ b/packages/builder/plugin-image-compress/package.json
@@ -34,18 +34,6 @@
     ".": {
       "jsnext:source": "./src/index.ts",
       "default": "./dist/index.js"
-    },
-    "./loader": {
-      "jsnext:source": "./src/loader.ts",
-      "types": "./dist/loader.d.ts",
-      "default": "./dist/loader.js"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "loader": [
-        "./dist/loader.d.ts"
-      ]
     }
   },
   "dependencies": {

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -24,18 +24,18 @@
       "default": "./dist/index.js"
     },
     "./loader": {
-      "jsnext:source": "./src/loader.ts",
       "types": "./dist/loader.d.ts",
+      "jsnext:source": "./src/loader.ts",
       "default": "./dist/loader.js"
     },
     "./plugin": {
-      "jsnext:source": "./src/plugin.ts",
       "types": "./dist/plugin.d.ts",
+      "jsnext:source": "./src/plugin.ts",
       "default": "./dist/plugin.js"
     },
     "./binding": {
-      "jsnext:source": "./src/binding.ts",
       "types": "./dist/binding.d.ts",
+      "jsnext:source": "./src/binding.ts",
       "default": "./dist/binding.js"
     }
   },

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -29,22 +29,23 @@
       "default": "./dist/index.js"
     },
     "./node": {
-      "jsnext:source": "./src/nodeApi.ts",
       "types": "./dist/nodeApi.d.ts",
+      "jsnext:source": "./src/nodeApi.ts",
       "default": "./dist/nodeApi.js"
     },
     "./bin": {
+      "types": "./dist/bin.d.ts",
       "jsnext:source": "./src/bin.ts",
       "default": "./dist/bin.js"
     },
     "./config": {
+      "types": "./dist/config/index.d.ts",
       "jsnext:source": "./src/config.ts",
-      "types": "./dist/config/types/index.d.ts",
       "default": "./dist/config/index.js"
     },
     "./runBin": {
-      "jsnext:source": "./src/runBin.ts",
       "types": "./dist/runBin.d.ts",
+      "jsnext:source": "./src/runBin.ts",
       "default": "./dist/runBin.js"
     },
     "./types": {

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -26,18 +26,18 @@
       "default": "./dist/cjs/cli.js"
     },
     "./cli": {
-      "jsnext:source": "./src/cli.ts",
       "types": "./dist/types/cli.d.ts",
+      "jsnext:source": "./src/cli.ts",
       "default": "./dist/cjs/cli.js"
     },
     "./server": {
-      "jsnext:source": "./src/server.ts",
       "types": "./dist/types/server.d.ts",
+      "jsnext:source": "./src/server.ts",
       "default": "./dist/cjs/server.js"
     },
     "./loader": {
-      "jsnext:source": "./src/loader.ts",
       "types": "./dist/types/loader.d.ts",
+      "jsnext:source": "./src/loader.ts",
       "default": "./dist/cjs/loader.js"
     }
   },

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -19,24 +19,24 @@
   "engines": {
     "node": ">=14.17.6"
   },
-  "jsnext:source": "./src/index.ts",
-  "types": "./src/index.ts",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "jsnext:source": "./src/runtime/index.ts",
+  "types": "./src/runtime/index.ts",
+  "main": "./dist/cjs/runtime/index.js",
+  "module": "./dist/esm/runtime/index.js",
   "exports": {
     "./loader": {
-      "jsnext:source": "./src/cli/loader.ts",
       "types": "./dist/types/cli/loader.d.ts",
+      "jsnext:source": "./src/cli/loader.ts",
       "default": "./dist/cjs/cli/loader.js"
     },
     "./server": {
-      "jsnext:source": "./src/server/index.ts",
       "types": "./dist/types/server/index.d.ts",
+      "jsnext:source": "./src/server/index.ts",
       "default": "./dist/cjs/server/index.js"
     },
     "./runtime": {
-      "jsnext:source": "./src/runtime/index.ts",
       "types": "./dist/types/runtime/index.d.ts",
+      "jsnext:source": "./src/runtime/index.ts",
       "default": "./dist/esm/runtime/index.js"
     }
   },
@@ -96,6 +96,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public",
     "provenance": true,
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/types/runtime/index.d.ts"
   }
 }

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -32,12 +32,12 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "jsnext:source": "./src/index.ts",
         "import": "./dist/esm-node/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     },
     "./cli": {
@@ -49,12 +49,12 @@
       "default": "./dist/esm/index.js"
     },
     "./types": {
-      "node": {
-        "import": "./dist/esm-node/types.js",
-        "require": "./dist/cjs/types.js",
-        "types": "./dist/types/types.d.ts"
-      },
       "types": "./dist/types/types.d.ts",
+      "node": {
+        "types": "./dist/types/types.d.ts",
+        "import": "./dist/esm-node/types.js",
+        "require": "./dist/cjs/types.js"
+      },
       "default": "./dist/esm/types.js"
     }
   },

--- a/packages/cli/plugin-storybook/package.json
+++ b/packages/cli/plugin-storybook/package.json
@@ -19,7 +19,7 @@
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/runtime/index.js",
+  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
       "node": {

--- a/packages/cli/plugin-tailwind/package.json
+++ b/packages/cli/plugin-tailwind/package.json
@@ -33,7 +33,7 @@
       "default": "./dist/cjs/cli.js"
     },
     "./runtime-design-token": {
-      "jsnext:source": "./src/design-token/index.js",
+      "jsnext:source": "./src/design-token/index.ts",
       "node": "./dist/cjs/design-token/index.js",
       "default": "./dist/esm/design-token/index.js"
     }

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -42,23 +42,23 @@
   "exports": {
     "./types": "./type.d.ts",
     ".": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/runtime/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./cli": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/cli/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./deps": {
-      "jsnext:source": "./src/deps/index.ts",
       "types": "./dist/types/deps/index.d.ts",
+      "jsnext:source": "./src/deps/index.ts",
       "default": "./dist/esm/deps/index.js"
     },
     "./runtime": {
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/types/runtime/index.d.ts",
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/esm/runtime/index.js"
     }
   },

--- a/packages/runtime/plugin-router-v5/package.json
+++ b/packages/runtime/plugin-router-v5/package.json
@@ -22,18 +22,18 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/cli/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./runtime": {
-      "jsnext:source": "./src/runtime/index.ts",
       "types": "./dist/types/runtime/index.d.ts",
+      "jsnext:source": "./src/runtime/index.ts",
       "default": "./dist/esm/runtime/index.js"
     },
     "./cli": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/cli/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     }
   },

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -25,8 +25,8 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/esm/index.js"
     },
     "./types": "./types/index.d.ts",
@@ -34,68 +34,68 @@
     "./types/router": "./types/router.d.ts",
     "./types/model": "./types/model.d.ts",
     "./loadable": {
-      "jsnext:source": "./src/exports/loadable.ts",
       "types": "./dist/types/exports/loadable.d.ts",
+      "jsnext:source": "./src/exports/loadable.ts",
       "default": "./dist/esm/exports/loadable.js"
     },
     "./head": {
-      "jsnext:source": "./src/exports/head.ts",
       "types": "./dist/types/exports/head.d.ts",
+      "jsnext:source": "./src/exports/head.ts",
       "default": "./dist/esm/exports/head.js"
     },
     "./styled": {
-      "jsnext:source": "./src/exports/styled.ts",
       "types": "./dist/types/exports/styled.d.ts",
+      "jsnext:source": "./src/exports/styled.ts",
       "default": "./dist/esm/exports/styled.js"
     },
     "./server": {
+      "types": "./dist/types/exports/server.d.ts",
       "jsnext:source": "./src/exports/server.ts",
       "node": "./dist/cjs/exports/server.js",
-      "types": "./dist/types/exports/server.d.ts",
       "default": "./dist/esm/exports/server.js"
     },
     "./document": {
+      "types": "./dist/types/document/index.d.ts",
       "jsnext:source": "./src/document/index.ts",
       "node": "./dist/cjs/document/index.js",
-      "types": "./dist/types/document/index.d.ts",
       "default": "./dist/esm/document/index.js"
     },
     "./document/cli": {
+      "types": "./dist/types/document/index.d.ts",
       "jsnext:source": "./src/document/cli/index.ts",
       "node": "./dist/cjs/document/cli/index.js",
-      "types": "./dist/types/document/index.d.ts",
       "default": "./dist/esm/document/cli/index.js"
     },
     "./ssr": {
+      "types": "./dist/types/ssr/index.d.ts",
       "jsnext:source": "./src/ssr/index.ts",
       "node": "./dist/esm/ssr/index.node.js",
       "worker": "./dist/esm/ssr/index.node.js",
-      "types": "./dist/types/ssr/index.d.ts",
       "default": "./dist/esm/ssr/index.js"
     },
     "./model": {
-      "jsnext:source": "./src/state/index.ts",
       "types": "./types/model.d.ts",
+      "jsnext:source": "./src/state/index.ts",
       "default": "./dist/esm/state/index.js"
     },
     "./cli": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/cli/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./router": {
-      "jsnext:source": "./src/router/index.ts",
       "types": "./dist/types/router/index.d.ts",
+      "jsnext:source": "./src/router/index.ts",
       "default": "./dist/esm/router/index.js"
     },
     "./router/server": {
-      "jsnext:source": "./src/router/runtime/server.ts",
       "types": "./dist/types/router/runtime/server.d.ts",
+      "jsnext:source": "./src/router/runtime/server.ts",
       "default": "./dist/esm/router/runtime/server.js"
     },
     "./loadable-bundler-plugin": {
-      "jsnext:source": "./src/ssr/cli/loadable-bundler-plugin.ts",
       "types": "./dist/types/ssr/cli/loadable-bundler-plugin.d.ts",
+      "jsnext:source": "./src/ssr/cli/loadable-bundler-plugin.ts",
       "default": "./dist/cjs/ssr/cli/loadable-bundler-plugin.js"
     }
   },

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -30,50 +30,50 @@
       "default": "./types/index.d.ts"
     },
     ".": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/cli/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./runtime": {
+      "types": "./dist/types/runtime-testing/index.d.ts",
       "jsnext:source": "./src/runtime-testing/index.ts",
       "node": {
         "import": "./dist/esm-node/runtime-testing/index.js",
         "require": "./dist/cjs/runtime-testing/index.js"
       },
-      "types": "./dist/types/runtime-testing/index.d.ts",
       "default": "./dist/esm/runtime-testing/index.js"
     },
     "./runtime-base": {
+      "types": "./dist/types/runtime-testing/base.d.ts",
       "jsnext:source": "./src/runtime-testing/base.ts",
       "node": {
         "import": "./dist/esm-node/runtime-testing/base.js",
         "require": "./dist/cjs/runtime-testing/base.js"
       },
-      "types": "./dist/types/runtime-testing/base.d.ts",
       "default": "./dist/esm/runtime-testing/base.js"
     },
     "./cli": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/cli/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./bff-cli": {
-      "jsnext:source": "./src/cli/bff/index.ts",
       "types": "./dist/types/cli/bff/index.d.ts",
+      "jsnext:source": "./src/cli/bff/index.ts",
       "default": "./dist/cjs/cli/bff/index.js"
     },
     "./base": {
-      "jsnext:source": "./src/base/index.ts",
       "types": "./dist/types/base/index.d.ts",
+      "jsnext:source": "./src/base/index.ts",
       "default": "./dist/cjs/base/index.js"
     },
     "./bff": {
+      "types": "./dist/types/runtime-testing/bff.d.ts",
       "jsnext:source": "./src/runtime-testing/bff.ts",
       "node": {
         "import": "./dist/esm-node/runtime-testing/bff.js",
         "require": "./dist/cjs/runtime-testing/bff.js"
       },
-      "types": "./dist/types/runtime-testing/bff.d.ts",
       "default": "./dist/esm/runtime-testing/bff.js"
     }
   },

--- a/packages/server/babel-plugin-module-resolver/package.json
+++ b/packages/server/babel-plugin-module-resolver/package.json
@@ -23,7 +23,7 @@
   "exports": {
     ".": {
       "node": {
-        "jsnext:source": "./src/index.js",
+        "jsnext:source": "./src/index.ts",
         "import": "./dist/esm-node/index.js",
         "require": "./dist/cjs/index.js"
       },

--- a/packages/server/babel-plugin-module-resolver/package.json
+++ b/packages/server/babel-plugin-module-resolver/package.json
@@ -23,7 +23,7 @@
   "exports": {
     ".": {
       "node": {
-        "jsnext:source": "./src/index.ts",
+        "jsnext:source": "./src/index.js",
         "import": "./dist/esm-node/index.js",
         "require": "./dist/cjs/index.js"
       },

--- a/packages/server/bff-core/package.json
+++ b/packages/server/bff-core/package.json
@@ -22,8 +22,8 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -22,12 +22,12 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "jsnext:source": "./src/index.ts",
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -16,10 +16,10 @@
     "modern.js"
   ],
   "version": "2.31.2",
-  "jsnext:source": "./src/index.ts",
-  "types": "./src/index.ts",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "jsnext:source": "./src/node.ts",
+  "types": "./src/node.ts",
+  "main": "./dist/cjs/node.js",
+  "module": "./dist/esm/node.js",
   "browser": "./dist/esm/browser.js",
   "files": [
     "dist",
@@ -27,13 +27,13 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/node.d.ts",
       "node": "./dist/esm/node.js",
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/browser.js"
     },
     "./client": {
-      "jsnext:source": "./src/browser.ts",
       "types": "./dist/types/browser.d.ts",
+      "jsnext:source": "./src/browser.ts",
       "default": "./dist/esm/browser.js"
     },
     "./modern": {
@@ -41,8 +41,8 @@
       "default": "./dist/esm-node/browser.js"
     },
     "./server": {
-      "jsnext:source": "./src/node.ts",
       "types": "./dist/types/node.d.ts",
+      "jsnext:source": "./src/node.ts",
       "default": "./dist/cjs/node.js"
     }
   },

--- a/packages/server/plugin-koa/package.json
+++ b/packages/server/plugin-koa/package.json
@@ -30,13 +30,13 @@
   "exports": {
     "./types": "./types.d.ts",
     ".": {
-      "jsnext:source": "./src/cli/index.ts",
       "types": "./dist/types/cli/index.d.ts",
+      "jsnext:source": "./src/cli/index.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./cli": {
+      "types": "./dist/types/cli/index.d.ts",
       "jsnext:source": "./src/cli/index.ts",
-      "types": "./dist/types/cli.d.ts",
       "default": "./dist/cjs/cli/index.js"
     },
     "./runtime": {
@@ -44,12 +44,12 @@
       "default": "./dist/cjs/runtime.js"
     },
     "./server": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "jsnext:source": "./src/index.ts",
         "import": "./dist/esm-node/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     }
   },

--- a/packages/server/plugin-server/package.json
+++ b/packages/server/plugin-server/package.json
@@ -21,18 +21,18 @@
   "main": "./dist/cjs/cli.js",
   "exports": {
     ".": {
-      "jsnext:source": "./src/cli.ts",
       "types": "./dist/types/cli.d.ts",
+      "jsnext:source": "./src/cli.ts",
       "default": "./dist/cjs/cli.js"
     },
     "./cli": {
-      "jsnext:source": "./src/cli.ts",
       "types": "./dist/types/cli.d.ts",
+      "jsnext:source": "./src/cli.ts",
       "default": "./dist/cjs/cli.js"
     },
     "./server": {
-      "jsnext:source": "./src/server.ts",
       "types": "./dist/types/server.d.ts",
+      "jsnext:source": "./src/server.ts",
       "default": "./dist/cjs/server.js"
     }
   },

--- a/packages/server/plugin-worker/package.json
+++ b/packages/server/plugin-worker/package.json
@@ -21,13 +21,13 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/cjs/index.js"
     },
     "./cli": {
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/cjs/index.js"
     }
   },

--- a/packages/server/prod-server/package.json
+++ b/packages/server/prod-server/package.json
@@ -22,30 +22,30 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "jsnext:source": "./src/index.ts",
         "import": "./dist/esm-node/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     },
     "./worker": {
+      "types": "./dist/types/workerServer.d.ts",
       "node": {
         "jsnext:source": "./src/workerServer.ts",
         "import": "./dist/esm-node/workerServer.js",
         "require": "./dist/cjs/workerServer.js"
       },
-      "types": "./dist/types/workerServer.d.ts",
       "default": "./dist/esm/workerServer.js"
     },
     "./renderHtml": {
+      "types": "./dist/types/renderHtml.d.ts",
       "node": {
         "jsnext:source": "./src/renderHtml.ts",
         "import": "./dist/esm-node/renderHtml.js",
         "require": "./dist/cjs/renderHtml.js"
       },
-      "types": "./dist/types/renderHtml.d.ts",
       "default": "./dist/esm/renderHtml.js"
     }
   },

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -21,27 +21,27 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "jsnext:source": "./src/index.ts",
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/cjs/index.js"
     },
     "./cli": {
-      "jsnext:source": "./src/index.ts",
       "types": "./dist/types/index.d.ts",
+      "jsnext:source": "./src/index.ts",
       "default": "./dist/cjs/index.js"
     },
     "./types": {
-      "jsnext:source": "./lib/types.d.ts",
       "types": "./lib/types.d.ts",
+      "jsnext:source": "./lib/types.d.ts",
       "default": "./lib/types.d.ts"
     },
     "./server": {
-      "jsnext:source": "./src/exports/server.ts",
       "types": "./dist/types/exports/server.d.ts",
+      "jsnext:source": "./src/exports/server.ts",
       "default": "./dist/cjs/exports/server.js"
     }
   },

--- a/packages/toolkit/node-bundle-require/package.json
+++ b/packages/toolkit/node-bundle-require/package.json
@@ -21,12 +21,12 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "jsnext:source": "./src/index.ts",
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/cjs/index.js"
     },
     "./bundle": {

--- a/packages/toolkit/plugin/package.json
+++ b/packages/toolkit/plugin/package.json
@@ -22,12 +22,12 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": {
         "jsnext:source": "./src/index.ts",
         "import": "./dist/esm-node/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     }
   },

--- a/packages/toolkit/remark-container/package.json
+++ b/packages/toolkit/remark-container/package.json
@@ -4,7 +4,7 @@
   "jsnext:source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
-  "module": "./dist/node/index.js",
+  "module": "./dist/index.js",
   "author": "yangxingyuan",
   "repository": {
     "type": "git",

--- a/packages/toolkit/types/package.json
+++ b/packages/toolkit/types/package.json
@@ -23,8 +23,8 @@
       "default": "./index.d.ts"
     },
     "./server": {
-      "jsnext:source": "./server/index.d.ts",
       "types": "./server/index.d.ts",
+      "jsnext:source": "./server/index.d.ts",
       "default": "./server/index.d.ts"
     }
   },

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -19,7 +19,7 @@
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "module": "./dist/esm/index.js",
   "_comment": "Provide ESM and CJS exports, ESM is used by runtime package, for treeshaking",
   "exports": {
     ".": {
@@ -153,7 +153,7 @@
         "default": "./dist/cjs/universal/constants.js"
       },
       "./universal/format-webpack": {
-        "types": "./dist/types/universal/format-webpack.d.ts",
+        "types": "./dist/types/universal/formatWebpack.d.ts",
         "import": "./dist/esm/universal/formatWebpack.js",
         "default": "./dist/cjs/universal/formatWebpack.js"
       },


### PR DESCRIPTION
## Summary

- https://github.com/bluwy/publint
- example:

<img width="950" alt="Screenshot 2023-08-21 at 09 35 37" src="https://github.com/web-infra-dev/modern.js/assets/7237365/80259571-6007-4a41-82cf-eda0c765e7d9">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60a969e</samp>

This pull request fixes various packaging errors and inconsistencies in the modern.js monorepo, as detected by publint. It mainly reorders, adds, or removes fields in the exports map of different packages to improve readability, maintainability, type support, and entry point resolution. It also updates some fields to point to the correct subdirectories or source files for different environments and conventions.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60a969e</samp>

*  Update package versions and changelog for fixing packaging errors ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-19e79d954199e942ca071eb9851ee7c925d14f3f9f5a047f3de01a2f0ce6194cR1-R34))
*  Swap the order of the types and jsnext:source fields in the exports map of several packages to follow the convention of putting types first ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L32-R33), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1L28-R34), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1L42-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-34ed68e35fc7b09be4c7b86093bb347bb44eb062dc6ad1961198c212ccf433caL27-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-798858f913da3d6488150ae284b7aabc6d387db02c3db2d9953bcc119991860bL32-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-ff81a1a711e2b04cc1c3f89e2cbe0f0b8075a6d8143cbf3e9d0339142ec9c6f5L29-R40), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-e096c3e0345e1b9606770a2fcc3f4ff9ac8deddb1a361935de73fa2761b9aa7cL45-R61), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-78ea1b4e93e9155f47daf4b5dd4c4e587c9fd9829efc575cef70f6f5753cf0b8L25-R36), F13L26L26, [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-a90f331e2d4e9320efe81c8af64349df4b94c4c63c247993e91f00bcfc1a8561L37-R98), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bL33-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bL43-R47), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bL52-R71), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-97f0b40e0c47e3b5c43ef6d2a85be7b105307b217fd714241a06a056297065e8L25-R26), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-f0e695380891ea8c2619daf88e49247298752b3e4a0b21ef79975c7dcb0e9eb8L44-R45), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-2a3b8ee3bca0e9f817f59425411865337140dff5f58f9f3c974ee3bd389a3548L33-R39))
*  Remove the exports map entry for the html-webpack-plugin from the `builder-plugin-image-compress` package, as it is not used by this package ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-b5d6b23b96c26eeefb50da649b47d738e36adea24f0701339bd622a69128f8d2L37-R38))
*  Update the jsnext:source, types, main and module fields of the `plugin-data-loader` and `create-request` packages to point to the runtime and node subdirectories respectively, as these packages only export the runtime and node functionality and not the cli or server parts ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-3b460c782e2166fc1f074472a38e5c65963dacdf5b16f19339e76fcadb42ad07L22-R39), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-3b460c782e2166fc1f074472a38e5c65963dacdf5b16f19339e76fcadb42ad07L99-R99), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-f0e695380891ea8c2619daf88e49247298752b3e4a0b21ef79975c7dcb0e9eb8L19-R22))
*  Update the module field of the `plugin-storybook` package to point to the runtime subdirectory, as this package only exports the runtime functionality and not the cli part ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-4ba9c298e0c9aceb8c9f170f6ad80c539f36a3ceae0575c46dfc5976b735ace4L22-R22))
*  Update the jsnext:source field of the runtime-design-token entry in the exports map of the `plugin-tailwind` package to point to the TypeScript source file instead of the JavaScript source file, as this package uses TypeScript ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-b80ac21ada8609ce79b67677d8a76e45a2a4a347b6f4797e0530cd30f3c75148L36-R36))
*  Add the types field to the exports map of the `plugin-ssg`, `server-core` and `plugin-koa` packages, to specify the type declarations for the main entry point ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-e846ee504d15ad0546aba89589fd6c87fea9c4ab12bb6ce61815770a4466ba07R35), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-72d64068cfac474c44045cd4355db420d3bd76a309883643e3af7f08638d0cafR25), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-2a3b8ee3bca0e9f817f59425411865337140dff5f58f9f3c974ee3bd389a3548R47))
*  Remove the redundant types field from the exports map of the `plugin-ssg`, `server-core`, `plugin-koa` and `plugin-testing` packages, as it is already specified in the previous entry or the main entry ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-e846ee504d15ad0546aba89589fd6c87fea9c4ab12bb6ce61815770a4466ba07L40), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-72d64068cfac474c44045cd4355db420d3bd76a309883643e3af7f08638d0cafL30), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-2a3b8ee3bca0e9f817f59425411865337140dff5f58f9f3c974ee3bd389a3548L52), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bL76))
*  Swap the order of the types and node fields in the exports map of the `plugin-ssg` and `create-request` packages, to make it consistent with other packages and follow the convention of putting types first ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-e846ee504d15ad0546aba89589fd6c87fea9c4ab12bb6ce61815770a4466ba07L52-R57), [link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-f0e695380891ea8c2619daf88e49247298752b3e4a0b21ef79975c7dcb0e9eb8L30-R36))
*  Update the jsnext:source field of the main entry in the exports map of the `babel-plugin-module-resolver` package to point to the TypeScript source file instead of the JavaScript source file, as this package uses TypeScript ([link](https://github.com/web-infra-dev/modern.js/pull/4467/files?diff=unified&w=0#diff-68919b1058e03ed865adbeced195327d5f22c54d5c36804770dfafd56e8bd9f0L26-R26))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
