### PR TITLE
fix: component Style should not wrap with IIFE

### DIFF
--- a/.changeset/selfish-beans-clean.md
+++ b/.changeset/selfish-beans-clean.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: component Style render error content
+fix: component Style 渲染了错误的内容

--- a/packages/runtime/plugin-runtime/src/document/Style.tsx
+++ b/packages/runtime/plugin-runtime/src/document/Style.tsx
@@ -8,11 +8,11 @@ import {
 export function Style(props: { children?: string; content?: string }) {
   const { content, children } = props;
   const contentStr = children || content;
-  const contentIIFE = encodeURIComponent(`(${contentStr})()`);
+  const styleContent = encodeURIComponent(`${contentStr}`);
   return (
     <>
       {`${DOCUMENT_STYLE_PLACEHOLDER_START}`}
-      {`${contentIIFE}`}
+      {`${styleContent}`}
       {`${DOCUMENT_STYLE_PLACEHOLDER_END}`}
     </>
   );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2d1538</samp>

Removed IIFE wrapper from `Style` component in `plugin-runtime` package. This improves the compatibility and reliability of injecting styles into the document head.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2d1538</samp>

*  Remove IIFE wrapper from style content to prevent evaluation errors ([link](https://github.com/web-infra-dev/modern.js/pull/4469/files?diff=unified&w=0#diff-06850009932e87ece20a1884832ea388f934be46ad860e68d0cfb1f53b5c00dcL11-R15))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
