### PR TITLE
feat: support loader context

### DIFF
--- a/.changeset/friendly-hotels-trade.md
+++ b/.changeset/friendly-hotels-trade.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-data-loader': minor
+'@modern-js/runtime': minor
+'@modern-js/utils': minor
+---
+
+feat: support loader context
+feat: 支持 loader context

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -13,7 +13,12 @@ import {
 } from '@modern-js/utils/runtime/remix-router';
 import { transformNestedRoutes } from '@modern-js/utils/runtime/nested-routes';
 import { isPlainObject } from '@modern-js/utils/lodash';
-import { matchEntry, ServerContext } from '@modern-js/utils/runtime-node';
+import {
+  matchEntry,
+  ServerContext,
+  createRequestContext,
+  reporterCtx,
+} from '@modern-js/utils/runtime-node';
 import { CONTENT_TYPE_DEFERRED, LOADER_ID_PARAM } from '../common/constants';
 import { createDeferredReadableStream } from './response';
 
@@ -134,14 +139,20 @@ export const handleRequest = async ({
     basename,
   });
 
-  const { res, logger } = context;
+  const { res, logger, reporter } = context;
 
   const request = createLoaderRequest(context);
+  const requestContext = createRequestContext();
+  // initial requestContext
+  // 1. inject reporter
+  requestContext.set(reporterCtx, reporter);
+
   let response;
 
   try {
     response = await queryRoute(request, {
       routeId,
+      requestContext,
     });
 
     if (isResponse(response) && isRedirectResponse(response.status)) {

--- a/packages/runtime/plugin-runtime/src/router/runtime/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/index.ts
@@ -18,6 +18,10 @@ export const useRouteLoaderData: typeof useRouteData = (routeId: string) => {
   return useRouteData(realRouteId);
 };
 
+export * from './loaderContext';
+
+export type { LoaderFunction, LoaderFunctionArgs } from './types';
+
 // Note: Keep in sync with react-router-dom exports!
 export type {
   // below are react-router-dom exports
@@ -49,8 +53,6 @@ export type {
   IndexRouteProps,
   JsonFunction,
   LayoutRouteProps,
-  LoaderFunction,
-  LoaderFunctionArgs,
   Location,
   MemoryRouterProps,
   NavigateFunction,

--- a/packages/runtime/plugin-runtime/src/router/runtime/loaderContext.node.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/loaderContext.node.ts
@@ -1,0 +1,1 @@
+export { reporterCtx } from '@modern-js/utils/runtime-node';

--- a/packages/runtime/plugin-runtime/src/router/runtime/loaderContext.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/loaderContext.ts
@@ -1,0 +1,3 @@
+import type { reporterCtx as reporterCtxNode } from '@modern-js/utils/runtime-node';
+
+export const reporterCtx: typeof reporterCtxNode = null as any;

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -6,6 +6,10 @@ import {
 } from '@modern-js/utils/runtime-node/router';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { createRoutesFromElements } from '@modern-js/utils/runtime/router';
+import {
+  createRequestContext,
+  reporterCtx,
+} from '@modern-js/utils/runtime-node';
 import { RuntimeReactContext } from '../../core';
 import type { Plugin } from '../../core';
 import { SSRServerContext } from '../../ssr/serverRender/types';
@@ -105,8 +109,16 @@ export const routerPlugin = ({
           const { query } = createStaticHandler(routes, {
             basename: _basename,
           });
+
           const remixRequest = createFetchRequest(request);
-          const routerContext = await query(remixRequest);
+          const requestContext = createRequestContext();
+          // initial requestContext
+          const { reporter } = context.ssrContext!;
+          requestContext.set(reporterCtx, reporter);
+
+          const routerContext = await query(remixRequest, {
+            requestContext,
+          });
 
           if (routerContext instanceof Response) {
             // React Router would return a Response when redirects occur in loader.

--- a/packages/runtime/plugin-runtime/src/router/runtime/types.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/types.ts
@@ -1,5 +1,10 @@
-import type { RouteProps, RouteObject } from '@modern-js/utils/runtime/router';
+import type {
+  RouteProps,
+  RouteObject,
+  Params,
+} from '@modern-js/utils/runtime/router';
 import { PageRoute, NestedRoute } from '@modern-js/types';
+import type { RequestContext } from '@modern-js/utils/runtime-node';
 
 declare global {
   interface Window {
@@ -56,3 +61,19 @@ export interface RouteAssets {
     assets?: string[];
   };
 }
+
+// fork from react-router
+// due to the context is any in react-router.
+interface DataFunctionArgs<D = any> {
+  request: Request;
+  params: Params;
+  context?: D;
+}
+
+export type LoaderFunctionArgs = DataFunctionArgs<RequestContext>;
+
+declare type DataFunctionValue = Response | NonNullable<unknown> | null;
+
+export type LoaderFunction = (
+  args: LoaderFunctionArgs,
+) => Promise<DataFunctionValue> | DataFunctionValue;

--- a/packages/toolkit/types/server/utils.d.ts
+++ b/packages/toolkit/types/server/utils.d.ts
@@ -23,10 +23,10 @@ export interface ServerTiming {
   addServeTiming: (name: string, dur: number, decs?: string) => this;
 }
 
-export type Reporter = {
+export type Reporter<C = any> = {
   sessionId?: string;
   userId?: string;
-  client?: any;
+  client?: C;
 
   init: (payload: { match: any }) => void | Promise<void>;
 

--- a/packages/toolkit/utils/src/runtime-node/index.ts
+++ b/packages/toolkit/utils/src/runtime-node/index.ts
@@ -10,3 +10,4 @@ export { run, useHeaders };
 
 export { serializeJson } from './serialize';
 export * from './nestedRoutes';
+export * from './loaderContext';

--- a/packages/toolkit/utils/src/runtime-node/loaderContext/createLoaderCtx.ts
+++ b/packages/toolkit/utils/src/runtime-node/loaderContext/createLoaderCtx.ts
@@ -1,0 +1,22 @@
+export class LoaderContext<T = unknown> {
+  public symbol: symbol;
+
+  private defaultValue?: T;
+
+  constructor(defaultValue?: T) {
+    this.defaultValue = defaultValue;
+    this.symbol = Symbol('loaderContext');
+  }
+
+  getDefaultValue(): T {
+    if (!this.defaultValue) {
+      throw new Error("Can't get defaultValue before initialed");
+    }
+
+    return this.defaultValue;
+  }
+}
+
+export function createLoaderContext<T = unknown>(defaultValue?: T) {
+  return new LoaderContext(defaultValue);
+}

--- a/packages/toolkit/utils/src/runtime-node/loaderContext/createRequestCtx.ts
+++ b/packages/toolkit/utils/src/runtime-node/loaderContext/createRequestCtx.ts
@@ -1,0 +1,24 @@
+import { LoaderContext } from './createLoaderCtx';
+
+export class RequestContext {
+  private store: Map<symbol, any> = new Map();
+
+  get<T>(loaderCtx: LoaderContext<T>): T {
+    const { symbol } = loaderCtx;
+    if (this.store.get(symbol)) {
+      return this.store.get(symbol);
+    }
+
+    return loaderCtx.getDefaultValue();
+  }
+
+  set<T = unknown>(loaderCtx: LoaderContext, value: T) {
+    const { symbol } = loaderCtx;
+
+    this.store.set(symbol, value);
+  }
+}
+
+export function createRequestContext() {
+  return new RequestContext();
+}

--- a/packages/toolkit/utils/src/runtime-node/loaderContext/index.ts
+++ b/packages/toolkit/utils/src/runtime-node/loaderContext/index.ts
@@ -1,0 +1,6 @@
+import type { Reporter } from '@modern-js/types';
+import { createLoaderContext } from './createLoaderCtx';
+
+export { createRequestContext, type RequestContext } from './createRequestCtx';
+
+export const reporterCtx = createLoaderContext<Reporter>();

--- a/packages/toolkit/utils/src/runtime-node/nestedRoutes.ts
+++ b/packages/toolkit/utils/src/runtime-node/nestedRoutes.ts
@@ -4,6 +4,7 @@ export type ServerContext = Pick<
   ModernServerContext,
   | 'logger'
   | 'req'
+  | 'reporter'
   | 'res'
   | 'params'
   | 'headers'

--- a/tests/integration/ssr/fixtures/base/src/routes/context/page.loader.ts
+++ b/tests/integration/ssr/fixtures/base/src/routes/context/page.loader.ts
@@ -1,0 +1,13 @@
+import { LoaderFunctionArgs, reporterCtx } from '@modern-js/runtime/router';
+
+export interface LoaderData {
+  reporter: string;
+}
+
+export default function ({ context }: LoaderFunctionArgs) {
+  const reporter = context?.get(reporterCtx);
+
+  return {
+    reporter: typeof reporter,
+  };
+}

--- a/tests/integration/ssr/fixtures/base/src/routes/context/page.loader.ts
+++ b/tests/integration/ssr/fixtures/base/src/routes/context/page.loader.ts
@@ -8,6 +8,6 @@ export default function ({ context }: LoaderFunctionArgs) {
   const reporter = context?.get(reporterCtx);
 
   return {
-    reporter: typeof reporter,
+    reporter: `context.reporter:${typeof reporter}`,
   };
 }

--- a/tests/integration/ssr/fixtures/base/src/routes/context/page.tsx
+++ b/tests/integration/ssr/fixtures/base/src/routes/context/page.tsx
@@ -4,5 +4,5 @@ import type { LoaderData } from './page.loader';
 export default function Page() {
   const { reporter } = useLoaderData() as unknown as LoaderData;
 
-  return <div>context.reporter:{reporter}</div>;
+  return <div>{reporter}</div>;
 }

--- a/tests/integration/ssr/fixtures/base/src/routes/context/page.tsx
+++ b/tests/integration/ssr/fixtures/base/src/routes/context/page.tsx
@@ -1,0 +1,8 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+import type { LoaderData } from './page.loader';
+
+export default function Page() {
+  const { reporter } = useLoaderData() as unknown as LoaderData;
+
+  return <div>context.reporter:{reporter}</div>;
+}

--- a/tests/integration/ssr/fixtures/base/src/routes/layout.tsx
+++ b/tests/integration/ssr/fixtures/base/src/routes/layout.tsx
@@ -14,6 +14,9 @@ export default function Layout() {
         <Link to="/redirect" id="redirect-btn">
           Go Redirect
         </Link>
+        <Link to="/context" id="context-btn">
+          Go Context
+        </Link>
       </div>
       <Outlet />
     </div>

--- a/tests/integration/ssr/tests/base.test.ts
+++ b/tests/integration/ssr/tests/base.test.ts
@@ -55,6 +55,25 @@ async function checkIsPassChunkLoadingGlobal() {
   expect(content).toMatch(/chunkLoadingGlobal/);
 }
 
+async function contextLoader(page: Page, port: number) {
+  const res = await page.goto(`http://localhost:${port}/context`, {
+    waitUntil: ['networkidle0'],
+  });
+
+  const body = await res!.text();
+
+  expect(body).toMatch('context.reporter:object');
+}
+
+async function clientNavigationContextLoader(page: Page, port: number) {
+  await page.goto(`http://localhost:${port}`, {
+    waitUntil: ['networkidle0'],
+  });
+  await page.click('#context-btn');
+
+  await (expect(page) as any).toMatchTextContent('context.reporter:object');
+}
+
 describe('Traditional SSR with webpack', () => {
   let app: any;
   let appPort: number;
@@ -106,6 +125,14 @@ describe('Traditional SSR with webpack', () => {
   test('redirect in loader', async () => {
     await redirectInLoader(page, appPort);
   });
+
+  test('context loader', async () => {
+    await contextLoader(page, appPort);
+  });
+
+  test('client navigation context loader', async () => {
+    await clientNavigationContextLoader(page, appPort);
+  });
 });
 
 describe('Traditional SSR with rspack', () => {
@@ -154,5 +181,13 @@ describe('Traditional SSR with rspack', () => {
 
   test('redirect in loader', async () => {
     await redirectInLoader(page, appPort);
+  });
+
+  test('context loader', async () => {
+    await contextLoader(page, appPort);
+  });
+
+  test('client navigation context loader', async () => {
+    await clientNavigationContextLoader(page, appPort);
   });
 });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68a910e</samp>

This pull request adds support for loader context, which is a way to pass data and dependencies between loader functions and components in server-side rendering. It introduces new modules and types in `@modern-js/utils/runtime-node`, `@modern-js/runtime`, and `@modern-js/plugin-data-loader` packages, and modifies the existing code in the router runtime and the plugin data loader runtime to use them. It also adds a changeset file and a test case for the new feature.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68a910e</samp>

*  Add a changeset file to describe the features and version bumps for three packages related to loader context ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-f4967ce9032f3062eacf9c7a2c40271ede56d9cb909d918ff3f9e875fcdc217aR1-R8))
*  Export node-specific modules for creating and accessing loader context values from `@modern-js/utils/runtime-node` ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-e81571a33e3c51552dd930d2d4103bc8e3b47fa194ad59e230e1b3c412460815R13), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-11a46d3581fddcb103ddc7636d87daaddb6cc3002801509ed33cf9869cbe50d4R1-R6))
*  Define the `LoaderContext` and `RequestContext` classes and the helper functions to create them in `@modern-js/utils/runtime-node/loaderContext` ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-0377a2b3c7e8511dca93f7f4d6d5fd72dffc558d8a69e68f5fb5243ae586b2fdR1-R22), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-fc328004ba28a0f6d4427cff05f8831466b814c2ba360cce1eeae8ed45e7d2d9R1-R24))
*  Define the `reporterCtx` value as a loader context value that can store and retrieve the reporter instance from the request context ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-22e3a86387bb57e62970ead5f6e884c8387002fb28c9fc73eae655d6804919daR1), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-f16f40d59856bb987b0d244ea64b6040e9f83b01df2478cc06107c84dd2f60f2R1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-11a46d3581fddcb103ddc7636d87daaddb6cc3002801509ed33cf9869cbe50d4R1-R6))
*  Export the `LoaderFunction` and `LoaderFunctionArgs` types from `@modern-js/runtime/router` and use them to type the loader functions and their arguments ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-a2ba2aef031ad97c2b7c5dfd1a62d150661a28f360bedf74aeb67d2f800f601eR21-R24), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-c4fdad7c2445a9e1efe143f33158a41d176d4f0d3bcc3ca84fd00243f6d4e647L1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-c4fdad7c2445a9e1efe143f33158a41d176d4f0d3bcc3ca84fd00243f6d4e647R64-R79))
*  Create and pass the `requestContext` object to the `query` function in `@modern-js/plugin-data-loader` and `@modern-js/runtime` and use it to access the `reporterCtx` value in the loader functions ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL16-R21), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL137-R149), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feR155), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddR9-R12), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL108-R122))
*  Add the `reporter` property to the `ServerContext` type in `@modern-js/utils/runtime-node/nestedRoutes` and use it to set the `reporterCtx` value in the `requestContext` object ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-34f329c737c75984ea483d55e27bfb26477ea9befc19ca52811ab3319e5f32daR7), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL137-R149), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL108-R122))
*  Add a new route `/context` with a loader function and a component that demonstrate the usage of the loader context and the reporter instance ([link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-3516b5933d033ce2a12983d8bdf7fa98300d2fbbcff2636f9d17c787513f0e30R1-R13), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-9bae9f816f293bf9209632a8aee403a9ff64d978512e0c2a0ab63d75b39aef6cR1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4472/files?diff=unified&w=0#diff-a8212f9a9a07de51e90d4bd9b79d4928d6511002b1e645ac580e3e7d8971859cR17-R19))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
