### PR TITLE
fix: should update asset when only html exists

### DIFF
--- a/.changeset/mean-mayflies-invent.md
+++ b/.changeset/mean-mayflies-invent.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: should update asset when only html exists
+fix: 只有当 html 存在时，才更新资源

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -272,49 +272,54 @@ export class RouterPlugin {
 
             const nonceAttr = nonce ? `nonce="${nonce}"` : '';
 
-            if (enableInlineRouteManifests) {
-              compilation.updateAsset(
-                htmlName,
-                new RawSource(
-                  oldHtml
-                    .source()
-                    .toString()
-                    .replace(
-                      placeholder,
-                      `<script ${nonceAttr}>${injectedContent}</script>`,
-                    ),
-                ),
-                // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
-                undefined as any,
-              );
-            } else {
-              const scriptPath = `${staticJsDir}/${ROUTE_MANIFEST_HOLDER}-${entryName}${
-                disableFilenameHash
-                  ? '.js'
-                  : `.${generateContentHash(injectedContent)}.js`
-              }`;
+            if (oldHtml) {
+              if (enableInlineRouteManifests) {
+                compilation.updateAsset(
+                  htmlName,
+                  new RawSource(
+                    oldHtml
+                      .source()
+                      .toString()
+                      .replace(
+                        placeholder,
+                        `<script ${nonceAttr}>${injectedContent}</script>`,
+                      ),
+                  ),
+                  // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
+                  undefined as any,
+                );
+              } else {
+                const scriptPath = `${staticJsDir}/${ROUTE_MANIFEST_HOLDER}-${entryName}${
+                  disableFilenameHash
+                    ? '.js'
+                    : `.${generateContentHash(injectedContent)}.js`
+                }`;
 
-              const scriptUrl = `${publicPath}${scriptPath}`;
+                const scriptUrl = `${publicPath}${scriptPath}`;
 
-              const scriptLoadingAttr =
-                // eslint-disable-next-line no-nested-ternary
-                scriptLoading === 'defer'
-                  ? scriptLoading
-                  : scriptLoading === 'module'
-                  ? `type="module"`
-                  : '';
+                const scriptLoadingAttr =
+                  // eslint-disable-next-line no-nested-ternary
+                  scriptLoading === 'defer'
+                    ? scriptLoading
+                    : scriptLoading === 'module'
+                    ? `type="module"`
+                    : '';
 
-              const script = `<script ${scriptLoadingAttr} ${nonceAttr} src="${scriptUrl}"></script>`;
+                const script = `<script ${scriptLoadingAttr} ${nonceAttr} src="${scriptUrl}"></script>`;
 
-              compilation.updateAsset(
-                htmlName,
-                new RawSource(
-                  oldHtml.source().toString().replace(placeholder, script),
-                ),
-                // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
-                undefined as any,
-              );
-              compilation.emitAsset(scriptPath, new RawSource(injectedContent));
+                compilation.updateAsset(
+                  htmlName,
+                  new RawSource(
+                    oldHtml.source().toString().replace(placeholder, script),
+                  ),
+                  // FIXME: The arguments third of updatgeAsset is a optional function in webpack.
+                  undefined as any,
+                );
+                compilation.emitAsset(
+                  scriptPath,
+                  new RawSource(injectedContent),
+                );
+              }
             }
           }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e14fabd</samp>

This pull request fixes a bug in the `@modern-js/app-tools` package that caused the asset not to update when only html existed. It adds a changeset file to document the patch updates and a condition to the `RouterPlugin` class to avoid errors when the html file is missing or empty.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e14fabd</samp>

*  Fix a bug that prevented asset update when only html existed ([link](https://github.com/web-infra-dev/modern.js/pull/4476/files?diff=unified&w=0#diff-3818c5b0cced9f6c5182bfd8c9d39710a95a4cb04c4349c1502890deadfdacf9R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4476/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L275-R322))
   * Add a changeset file to document the patch updates for the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4476/files?diff=unified&w=0#diff-3818c5b0cced9f6c5182bfd8c9d39710a95a4cb04c4349c1502890deadfdacf9R1-R6))
   * Add a condition to check if `oldHtml` is truthy before calling `updateAsset` and `emitAsset` on the `compilation` object in the `RouterPlugin` class ([link](https://github.com/web-infra-dev/modern.js/pull/4476/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L275-R322))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
