### PR TITLE
fix: server timing not use metaName at some case

### DIFF
--- a/.changeset/brown-stingrays-build.md
+++ b/.changeset/brown-stingrays-build.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix about server timing not use metaName at some case

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -703,7 +703,7 @@ export class ModernServer implements ModernServerInterface {
     req.metrics = req.metrics || this.metrics;
     let context: ModernServerContext;
     try {
-      context = this.createContext(req, res);
+      context = this.createContext(req, res, { metaName: this.metaName });
     } catch (e) {
       this.logger.error(e as Error);
       res.statusCode = 500;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c66229e</samp>

This pull request fixes a bug in the `@modern-js/prod-server` package that could cause errors or unexpected behaviors when serving modern JavaScript applications. It passes the `metaName` option to the `createContext` method of the `ModernServer` class and updates the changelog accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c66229e</samp>

*  Fix a bug in `@modern-js/prod-server` package that caused errors or unexpected behaviors when using custom meta tag name for application manifest ([link](https://github.com/web-infra-dev/modern.js/pull/4483/files?diff=unified&w=0#diff-fafab65e2992cc393ca59f5e03baa7424598b203e07a150acfec82e7bd35e9caR1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4483/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL706-R706))
  * Update the changelog with a patch version and a description of the bug fix ([link](https://github.com/web-infra-dev/modern.js/pull/4483/files?diff=unified&w=0#diff-fafab65e2992cc393ca59f5e03baa7424598b203e07a150acfec82e7bd35e9caR1-R5))
  * Pass the `metaName` option from the `ModernServer` constructor to the `createContext` method in `modernServer.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4483/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL706-R706))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
