### PR TITLE
chore: when the page component exists, keep the layout component

### DIFF
--- a/.changeset/four-bikes-deliver.md
+++ b/.changeset/four-bikes-deliver.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+chore: When the page component exists, keep the layout component
+chore: 当 page 组件存在时，保留 layout 组件

--- a/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
@@ -78,12 +78,14 @@ export const optimizeRoute = (
   }
 
   const { children } = routeTree;
+  const hasPage = children.some(child => child.index);
   if (
     !routeTree._component &&
     !routeTree.error &&
     !routeTree.loading &&
     !routeTree.config &&
-    !routeTree.clientData
+    !routeTree.clientData &&
+    !hasPage
   ) {
     const newRoutes = children.map(child => {
       const routePath = `${routeTree.path ? routeTree.path : ''}${
@@ -103,7 +105,6 @@ export const optimizeRoute = (
       }
       return newRoute;
     });
-
     return Array.from(new Set(newRoutes)).flatMap(optimizeRoute);
   } else {
     const optimizedChildren = routeTree.children.flatMap(optimizeRoute);

--- a/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
+++ b/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
@@ -12,9 +12,17 @@ exports[`nested routes walk 1`] = `
             "_component": "@_modern_js_src/__auth/__shop/layout.tsx",
             "children": [
               {
-                "_component": "@_modern_js_src/__auth/__shop/item/page.tsx",
-                "children": undefined,
-                "id": "__auth/__shop/item/page",
+                "children": [
+                  {
+                    "_component": "@_modern_js_src/__auth/__shop/item/page.tsx",
+                    "children": undefined,
+                    "id": "__auth/__shop/item/page",
+                    "index": true,
+                    "type": "nested",
+                  },
+                ],
+                "id": "__auth/__shop/item/layout",
+                "isRoot": false,
                 "path": "item",
                 "type": "nested",
               },
@@ -24,9 +32,17 @@ exports[`nested routes walk 1`] = `
             "type": "nested",
           },
           {
-            "_component": "@_modern_js_src/__auth/login/page.tsx",
-            "children": undefined,
-            "id": "__auth/login/page",
+            "children": [
+              {
+                "_component": "@_modern_js_src/__auth/login/page.tsx",
+                "children": undefined,
+                "id": "__auth/login/page",
+                "index": true,
+                "type": "nested",
+              },
+            ],
+            "id": "__auth/login/layout",
+            "isRoot": false,
             "path": "login",
             "type": "nested",
           },
@@ -48,9 +64,17 @@ exports[`nested routes walk 1`] = `
             "type": "nested",
           },
           {
-            "_component": "@_modern_js_src/user/[id]/page.tsx",
-            "children": undefined,
-            "id": "user/(id)/page",
+            "children": [
+              {
+                "_component": "@_modern_js_src/user/[id]/page.tsx",
+                "children": undefined,
+                "id": "user/(id)/page",
+                "index": true,
+                "type": "nested",
+              },
+            ],
+            "id": "user/(id)/layout",
+            "isRoot": false,
             "path": ":id",
             "type": "nested",
           },

--- a/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
+++ b/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
@@ -163,10 +163,17 @@ describe('nested routes', () => {
           _component: 'layoutB',
           children: [
             {
-              id: 'd',
-              path: 'c',
-              _component: 'pageD',
+              id: 'c',
               type: 'nested',
+              path: 'c',
+              children: [
+                {
+                  id: 'd',
+                  type: 'nested',
+                  _component: 'pageD',
+                  index: true,
+                },
+              ],
             },
           ],
         },

--- a/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
+++ b/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
@@ -7,6 +7,7 @@ import {
   createRoutesFromElements,
   LoaderFunction,
   LoaderFunctionArgs,
+  Outlet,
   Route,
   RouteProps,
 } from 'react-router-dom';
@@ -99,6 +100,8 @@ export const renderNestedRoute = (
     // and it should inherit the loading of the parent component to make the loading of the parent layout component take effect.
     // It also means when layout component is undefined, loading component in then same dir should not working.
     nestedRoute.loading = parent?.loading;
+    // If the component is undefined, it must be a layout component.
+    routeProps.element = <Outlet />;
   }
 
   if (element) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b869f2e</samp>

This pull request enhances the support for nested routes with layout and page components in `@modern-js/app-tools`. It fixes some bugs in `nestedRoutes.ts` and adds a new feature in `nestedRoutes.tsx` using the `Outlet` component. It also updates the changeset file for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b869f2e</samp>

*  Add a changeset file for patching `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4484/files?diff=unified&w=0#diff-4d1a330a6bf28a4b29b039dcc74b21943e75c758b8211a128dccd87bf8b32112R1-R6))
*  Preserve layout component when page component exists in nested routes ([link](https://github.com/web-infra-dev/modern.js/pull/4484/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdR81), [link](https://github.com/web-infra-dev/modern.js/pull/4484/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL86-R88), [link](https://github.com/web-infra-dev/modern.js/pull/4484/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1R10), [link](https://github.com/web-infra-dev/modern.js/pull/4484/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1R103-R104))
*  Remove an empty line from `nestedRoutes.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4484/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL106))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
