### PR TITLE
test(builder): add e2e case for history api fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@vitest/coverage-v8": "^0.33.0",
     "babel-plugin-module-resolver": "^4.1.0",
     "esbuild": "0.17.19",
+    "eslint": "^8.28.0",
     "lint-staged": "~13.1.0",
     "husky": "^8.0.0",
     "turbo": "1.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       esbuild:
         specifier: 0.17.19
         version: 0.17.19
+      eslint:
+        specifier: ^8.28.0
+        version: 8.28.0
       husky:
         specifier: ^8.0.0
         version: 8.0.1
@@ -1855,7 +1858,7 @@ importers:
         version: 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-essentials':
         specifier: 6.5.12
-        version: 6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
+        version: 6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
       '@storybook/addon-links':
         specifier: 6.5.12
         version: 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -1864,16 +1867,16 @@ importers:
         version: 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/builder-webpack5':
         specifier: 6.5.12
-        version: 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+        version: 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core':
         specifier: 6.5.12
-        version: 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
+        version: 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
       '@storybook/manager-webpack5':
         specifier: 6.5.12
-        version: 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+        version: 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/react':
         specifier: 6.5.12
-        version: 6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4)
+        version: 6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4)
       '@swc/helpers':
         specifier: 0.5.1
         version: 0.5.1
@@ -6696,6 +6699,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
+      react-router-dom:
+        specifier: ^6.8.1
+        version: 6.11.1(react-dom@18.2.0)(react@18.2.0)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -14033,7 +14039,7 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /@storybook/addon-controls@6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/addon-controls@6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-UoaamkGgAQXplr0kixkPhROdzkY+ZJQpG7VFDU6kmZsIgPRNfX/QoJFR5vV6TpDArBIjWaUUqWII+GHgPRzLgQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -14048,7 +14054,7 @@ packages:
       '@storybook/api': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/client-logger': 6.5.12
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.12
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -14067,7 +14073,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/addon-docs@6.5.12(@babel/core@7.21.8)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1):
+  /@storybook/addon-docs@6.5.12(@babel/core@7.21.8)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1):
     resolution: {integrity: sha512-T+QTkmF7QlMVfXHXEberP8CYti/XMTo9oi6VEbZLx+a2N3qY4GZl7X2g26Sf5V4Za+xnapYKBMEIiJ5SvH9weQ==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -14088,7 +14094,7 @@ packages:
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/api': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -14122,7 +14128,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/addon-essentials@6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1):
+  /@storybook/addon-essentials@6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1):
     resolution: {integrity: sha512-4AAV0/mQPSk3V0Pie1NIqqgBgScUc0VtBEXDm8BgPeuDNVhPEupnaZgVt+I3GkzzPPo6JjdCsp2L11f3bBSEjw==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -14182,16 +14188,16 @@ packages:
       '@babel/core': 7.21.8
       '@storybook/addon-actions': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-backgrounds': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/addon-controls': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/addon-docs': 6.5.12(@babel/core@7.21.8)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
+      '@storybook/addon-controls': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/addon-docs': 6.5.12(@babel/core@7.21.8)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
       '@storybook/addon-measure': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-outline': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-toolbars': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-viewport': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/api': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       core-js: 3.30.0
       react: 17.0.2
@@ -14406,7 +14412,7 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/builder-webpack4@6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/builder-webpack4@6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-TsthT5jm9ZxQPNOZJbF5AV24me3i+jjYD7gbdKdSHrOVn1r3ydX4Z8aD6+BjLCtTn3T+e8NMvUkL4dInEo1x6g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -14424,7 +14430,7 @@ packages:
       '@storybook/client-api': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/client-logger': 6.5.12
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-events': 6.5.12
       '@storybook/node-logger': 6.5.12
       '@storybook/preview-web': 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -14442,7 +14448,7 @@ packages:
       css-loader: 3.6.0(webpack@4.46.0)
       file-loader: 6.2.0(webpack@4.46.0)
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6(typescript@5.0.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@8.28.0)(typescript@5.0.4)(webpack@4.46.0)
       glob: 7.2.0
       glob-promise: 3.4.0(glob@7.2.0)
       global: 4.4.0
@@ -14475,7 +14481,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/builder-webpack5@6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/builder-webpack5@6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-jK5jWxhSbMAM/onPB6WN7xVqwZnAmzJljOG24InO/YIjW8pQof7MeAXCYBM4rYM+BbK61gkZ/RKxwlkqXBWv+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -14493,7 +14499,7 @@ packages:
       '@storybook/client-api': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/client-logger': 6.5.12
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-events': 6.5.12
       '@storybook/node-logger': 6.5.12
       '@storybook/preview-web': 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -14508,7 +14514,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.30.0
       css-loader: 5.2.7(webpack@5.88.1)
-      fork-ts-checker-webpack-plugin: 6.5.2(typescript@5.0.4)(webpack@5.88.1)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.28.0)(typescript@5.0.4)(webpack@5.88.1)
       glob: 7.2.0
       glob-promise: 3.4.0(glob@7.2.0)
       html-webpack-plugin: 5.5.3(webpack@5.88.1)
@@ -14694,7 +14700,7 @@ packages:
       webpack: 5.88.1(esbuild@0.17.19)(webpack-cli@5.1.4)
     dev: false
 
-  /@storybook/core-common@6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/core-common@6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-gG20+eYdIhwQNu6Xs805FLrOCWtkoc8Rt8gJiRt8yXzZh9EZkU4xgCRoCxrrJ03ys/gTiCFbBOfRi749uM3z4w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -14738,7 +14744,7 @@ packages:
       express: 4.18.1
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(typescript@5.0.4)(webpack@4.46.0)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.28.0)(typescript@5.0.4)(webpack@4.46.0)
       fs-extra: 9.1.0
       glob: 7.2.0
       handlebars: 4.7.7
@@ -14770,7 +14776,7 @@ packages:
     dependencies:
       core-js: 3.30.0
 
-  /@storybook/core-server@6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/core-server@6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-q1b/XKwoLUcCoCQ+8ndPD5THkEwXZYJ9ROv16i2VGUjjjAuSqpEYBq5GMGQUgxlWp1bkxtdGL2Jz+6pZfvldzA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -14787,19 +14793,19 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack4': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-client': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@4.46.0)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.12
-      '@storybook/manager-webpack4': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/manager-webpack4': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/telemetry': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/telemetry': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@types/node': 16.11.68
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
@@ -14849,7 +14855,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/core@6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1):
+  /@storybook/core@6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1):
     resolution: {integrity: sha512-+o3psAVWL+5LSwyJmEbvhgxKO1Et5uOX8ujNVt/f1fgwJBIf6BypxyPKu9YGQDRzcRssESQQZWNrZCCAZlFeuQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -14866,10 +14872,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-client': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
-      '@storybook/core-server': 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
-      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-server': 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       typescript: 5.0.4
@@ -14934,7 +14940,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/manager-webpack4@6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/manager-webpack4@6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-LH3e6qfvq2znEdxe2kaWtmdDPTnvSkufzoC9iwOgNvo3YrTGrYNyUTDegvW293TOTVfUn7j6TBcsOxIgRnt28g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -14949,7 +14955,7 @@ packages:
       '@babel/preset-react': 7.18.6(@babel/core@7.21.8)
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/core-client': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@4.46.0)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/ui': 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -14992,7 +14998,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/manager-webpack5@6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/manager-webpack5@6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-F+KgoINhfo1ArbirCc9L+EyADYD8Z4t0LyZYDVcBiZ8DlRIMIoUSye6tDsnyEm+OPloLVAcGwRMYgFhuHB70Lg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -15007,7 +15013,7 @@ packages:
       '@babel/preset-react': 7.18.6(@babel/core@7.21.8)
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/core-client': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/ui': 6.5.12(react-dom@17.0.2)(react@17.0.2)
@@ -15129,7 +15135,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/react@6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4):
+  /@storybook/react@6.5.12(@babel/core@7.21.8)(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(require-from-string@2.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-1tG8EdSfp+OZAKAWPT2UrexF4o007jEMwQFFXw1atIQrQOADzSnZ7lTYJ08o5TyJwksswtr18tH3oJJ9sG3KPw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -15162,13 +15168,13 @@ packages:
       '@babel/preset-react': 7.18.6(@babel/core@7.21.8)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.11.0)(webpack@5.88.1)
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/client-logger': 6.5.12
-      '@storybook/core': 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core': 6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(webpack@5.88.1)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/manager-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
       '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0(typescript@5.0.4)(webpack@5.88.1)
       '@storybook/semver': 7.3.2
@@ -15288,11 +15294,11 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /@storybook/telemetry@6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/telemetry@6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-mCHxx7NmQ3n7gx0nmblNlZE5ZgrjQm6B08mYeWg6Y7r4GZnqS6wZbvAwVhZZ3Gg/9fdqaBApHsdAXp0d5BrlxA==}
     dependencies:
       '@storybook/client-logger': 6.5.12
-      '@storybook/core-common': 6.5.12(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       chalk: 4.1.2
       core-js: 3.30.0
       detect-package-manager: 2.0.1
@@ -19667,7 +19673,7 @@ packages:
     resolution: {integrity: sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==}
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -23049,7 +23055,7 @@ packages:
       signal-exit: 3.0.7
     dev: false
 
-  /fork-ts-checker-webpack-plugin@4.1.6(typescript@5.0.4)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@4.1.6(eslint@8.28.0)(typescript@5.0.4)(webpack@4.46.0):
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -23065,6 +23071,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
+      eslint: 8.28.0
       micromatch: 3.1.10
       minimatch: 3.1.2
       semver: 5.7.1
@@ -23076,7 +23083,7 @@ packages:
       - supports-color
     dev: false
 
-  /fork-ts-checker-webpack-plugin@6.5.2(typescript@5.0.4)(webpack@4.46.0):
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.28.0)(typescript@5.0.4)(webpack@4.46.0):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -23096,6 +23103,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
+      eslint: 8.28.0
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.5.1
@@ -23107,7 +23115,7 @@ packages:
       webpack: 4.46.0
     dev: false
 
-  /fork-ts-checker-webpack-plugin@6.5.2(typescript@5.0.4)(webpack@5.88.1):
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.28.0)(typescript@5.0.4)(webpack@5.88.1):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -23127,6 +23135,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
+      eslint: 8.28.0
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.5.1

--- a/tests/e2e/builder/cases/dev/history-api-fallback.test.ts
+++ b/tests/e2e/builder/cases/dev/history-api-fallback.test.ts
@@ -1,0 +1,32 @@
+import { join } from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { dev } from '@scripts/shared';
+
+const cwd = join(__dirname, 'history-api-fallback');
+
+test('should provide history api fallback correctly', async ({ page }) => {
+  const builder = await dev({
+    cwd,
+    entry: {
+      main: join(cwd, 'src/index.tsx'),
+    },
+    builderConfig: {
+      tools: {
+        devServer: {
+          historyApiFallback: false,
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${builder.port}`);
+  expect(await page.innerHTML('body')).toContain('<div>home<div>');
+
+  await page.goto(`http://localhost:${builder.port}/a`);
+  expect(await page.innerHTML('body')).toContain('<div>A</div>');
+
+  await page.goto(`http://localhost:${builder.port}/b`);
+  expect(await page.innerHTML('body')).toContain('<div>B</div>');
+
+  await builder.server.close();
+});

--- a/tests/e2e/builder/cases/dev/history-api-fallback.test.ts
+++ b/tests/e2e/builder/cases/dev/history-api-fallback.test.ts
@@ -13,7 +13,7 @@ test('should provide history api fallback correctly', async ({ page }) => {
     builderConfig: {
       tools: {
         devServer: {
-          historyApiFallback: false,
+          historyApiFallback: true,
         },
       },
     },

--- a/tests/e2e/builder/cases/dev/history-api-fallback/src/App.tsx
+++ b/tests/e2e/builder/cases/dev/history-api-fallback/src/App.tsx
@@ -1,0 +1,25 @@
+import { BrowserRouter, Link, Route, Routes, Outlet } from 'react-router-dom';
+
+export const App = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <div>
+            home
+            <div>
+              <Link to="/a">A</Link>
+            </div>
+            <div>
+              <Link to="/b">B</Link>
+            </div>
+            <Outlet />
+          </div>
+        }
+      />
+      <Route path="/a" element={<div>A</div>} />
+      <Route path="/b" element={<div>B</div>} />
+    </Routes>
+  </BrowserRouter>
+);

--- a/tests/e2e/builder/cases/dev/history-api-fallback/src/index.tsx
+++ b/tests/e2e/builder/cases/dev/history-api-fallback/src/index.tsx
@@ -1,0 +1,6 @@
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container!);
+root.render(<App />);

--- a/tests/e2e/builder/cases/dev/history-api-fallback/tsconfig.json
+++ b/tests/e2e/builder/cases/dev/history-api-fallback/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -11,6 +11,7 @@
     "lodash": "^4.17.21",
     "react": "^18",
     "react-dom": "^18",
+    "react-router-dom": "^6.8.1",
     "vue": "^3.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bdad112</samp>

This pull request adds eslint as a dev dependency to the root project and a new end-to-end test case for the builder tool. The test case uses react-router-dom to test the history API fallback option of the dev server.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bdad112</samp>

*  Add eslint as a dev dependency to enable linting and code style checks ([link](https://github.com/web-infra-dev/modern.js/pull/4485/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R86))
*  Add a new end-to-end test case for the builder tool to check the history API fallback option ([link](https://github.com/web-infra-dev/modern.js/pull/4485/files?diff=unified&w=0#diff-2fd0402c175f648e7506d2d7eba1667bf8f40edd213225e15cfecccdc4560ce7R1-R32))
*  Add a new React component `App` to create a simple routing system with three routes: `/`, `/a`, and `/b` ([link](https://github.com/web-infra-dev/modern.js/pull/4485/files?diff=unified&w=0#diff-735061b4cd337467229e6aa40f280640eab877c8db1246faee3113b6b9390c61R1-R25))
   *  Use `App` as the main entry point for the test case in `src/index.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4485/files?diff=unified&w=0#diff-c29149b593df3ee31cbfda4fa0a5b692a90ca941eeb31c9221eb29c186a888bdR1-R6))
*  Add a new tsconfig.json file to configure the TypeScript compiler for the test case ([link](https://github.com/web-infra-dev/modern.js/pull/4485/files?diff=unified&w=0#diff-ba6ca3df0c0aaaacd1e9865547bfa56349545f0c60d9549ab143c8ccb9d64dedR1-R10))
*  Add react-router-dom as a dev dependency to use the library for the test case ([link](https://github.com/web-infra-dev/modern.js/pull/4485/files?diff=unified&w=0#diff-283456d349870a43f9269898463ae8e4041fd489a775c83b2aa27776d895b137R14))

## Related Issue

https://github.com/web-infra-dev/modern.js/issues/4477

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
