### PR TITLE
fix: update server reportTimings name

### DIFF
--- a/.changeset/giant-moons-shout.md
+++ b/.changeset/giant-moons-shout.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix: update server reportTimings name
+fix: 更新 server reportTimings 名称

--- a/packages/server/prod-server/src/constants.ts
+++ b/packages/server/prod-server/src/constants.ts
@@ -31,6 +31,7 @@ export const RUN_MODE = {
 };
 
 export enum ServerReportTimings {
+  SERVER_HANDLE_REQUEST = 'server-handle-request',
   SERVER_MIDDLEWARE = 'server-middleware',
   SERVER_HOOK_AFTER_RENDER = 'server-hook-after-render',
   SERVER_HOOK_AFTER_MATCH = 'server-hook-after-match',

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -522,7 +522,7 @@ export class ModernServer implements ModernServerInterface {
 
     res.on('finish', () => {
       const cost = end();
-      reporter.reportTiming('server_handle_request', cost);
+      reporter.reportTiming(ServerReportTimings.SERVER_HANDLE_REQUEST, cost);
     });
 
     // route is api service


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7048fd</samp>

This pull request fixes a bug in the `@modern-js/prod-server` package that caused incorrect server report timings. It also introduces a new constant `SERVER_HANDLE_REQUEST` to the `RUN_MODE` enum and uses it in the `modernServer.ts` file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7048fd</samp>

*  Update `.changeset` file to indicate patch update for `@modern-js/prod-server` package and describe fix for request handling timing ([link](https://github.com/web-infra-dev/modern.js/pull/4492/files?diff=unified&w=0#diff-45b06cbb83d7ab6231ec7ba24e25f8fabb0651b24db16ae6d2368045f0d8186eR1-R6))
*  Add new constant `SERVER_HANDLE_REQUEST` to `RUN_MODE` enum in `constants.ts` file to represent server report timing name ([link](https://github.com/web-infra-dev/modern.js/pull/4492/files?diff=unified&w=0#diff-6146b90d1740b41939b8c3de96e476fe848cfe0cced341cc2c960f45ea6df06dR34))
*  Use `ServerReportTimings.SERVER_HANDLE_REQUEST` constant instead of hard-coded string in `modernServer.ts` file to measure request handling time ([link](https://github.com/web-infra-dev/modern.js/pull/4492/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL525-R525))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
