### PR TITLE
feat: report time for server loader

### DIFF
--- a/.changeset/warm-mayflies-carry.md
+++ b/.changeset/warm-mayflies-carry.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-data-loader': patch
+'@modern-js/runtime': patch
+'@modern-js/utils': patch
+---
+
+feat: report time for server loader
+feat: 上报 server loader 执行的时间

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -197,7 +197,7 @@ export const handleRequest = async ({
   }
 
   const cost = end();
-  reporter.reportTiming(LOADER_REPORTER_NAME, cost);
+  reporter.reportTiming(`${LOADER_REPORTER_NAME}-navigation`, cost);
 
   await sendLoaderResponse(res, response);
 };

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -19,6 +19,8 @@ import {
   createRequestContext,
   reporterCtx,
 } from '@modern-js/utils/runtime-node';
+import { time } from '@modern-js/utils/universal/time';
+import { LOADER_REPORTER_NAME } from '@modern-js/utils/universal/constants';
 import { CONTENT_TYPE_DEFERRED, LOADER_ID_PARAM } from '../common/constants';
 import { createDeferredReadableStream } from './response';
 
@@ -134,13 +136,14 @@ export const handleRequest = async ({
   }
 
   const basename = entry.urlPath;
-  const routes = transformNestedRoutes(routesConfig);
+  const end = time();
+  const { res, logger, reporter } = context;
+  const routes = transformNestedRoutes(routesConfig, reporter);
   const { queryRoute } = createStaticHandler(routes, {
     basename,
   });
-
-  const { res, logger, reporter } = context;
-
+  const cost = end();
+  reporter.reportTiming(LOADER_REPORTER_NAME, cost);
   const request = createLoaderRequest(context);
   const requestContext = createRequestContext();
   // initial requestContext

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -142,8 +142,6 @@ export const handleRequest = async ({
   const { queryRoute } = createStaticHandler(routes, {
     basename,
   });
-  const cost = end();
-  reporter.reportTiming(LOADER_REPORTER_NAME, cost);
   const request = createLoaderRequest(context);
   const requestContext = createRequestContext();
   // initial requestContext
@@ -197,6 +195,9 @@ export const handleRequest = async ({
       },
     });
   }
+
+  const cost = end();
+  reporter.reportTiming(LOADER_REPORTER_NAME, cost);
 
   await sendLoaderResponse(res, response);
 };

--- a/packages/cli/plugin-data-loader/tests/server.test.ts
+++ b/packages/cli/plugin-data-loader/tests/server.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable node/prefer-global/url */
 import { IncomingMessage, ServerResponse } from 'http';
 import qs from 'querystring';
@@ -58,6 +59,20 @@ describe('handleRequest', () => {
       get query() {
         const str = this.querystring;
         return qs.parse(str);
+      },
+      logger: {
+        info() {},
+        warn() {},
+        error() {},
+        debug() {},
+        log() {},
+      },
+      reporter: {
+        init() {},
+        reportTiming() {},
+        reportError() {},
+        reportInfo() {},
+        reportWarn() {},
       },
     };
     return context;

--- a/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Route, isRouteErrorResponse } from '@modern-js/utils/runtime/router';
-import {
-  type NestedRoute,
-  type PageRoute,
-  type SSRMode,
+import type {
+  Reporter,
+  NestedRoute,
+  PageRoute,
+  SSRMode,
 } from '@modern-js/types';
 import {
   ErrorResponse,
@@ -21,10 +22,12 @@ export function getRouteComponents(
     globalApp,
     ssrMode,
     props,
+    reporter,
   }: {
     globalApp?: React.ComponentType<any>;
     ssrMode?: SSRMode;
     props?: Record<string, any>;
+    reporter: Reporter;
   },
 ) {
   const Layout = ({ Component, ...props }: any) => {
@@ -42,6 +45,7 @@ export function getRouteComponents(
         DeferredDataComponent:
           ssrMode === 'stream' ? DeferredDataScripts : undefined,
         props,
+        reporter,
       });
       routeElements.push(routeElement);
     } else {
@@ -63,10 +67,12 @@ export function renderRoutes({
   routesConfig,
   props,
   ssrMode,
+  reporter,
 }: {
   routesConfig: RouterConfig['routesConfig'];
   props?: Record<string, any>;
   ssrMode?: SSRMode;
+  reporter: Reporter;
 }) {
   if (!routesConfig) {
     return null;
@@ -79,6 +85,7 @@ export function renderRoutes({
     globalApp,
     ssrMode,
     props,
+    reporter,
   });
   return routeElements;
 }

--- a/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
@@ -27,7 +27,7 @@ export function getRouteComponents(
     globalApp?: React.ComponentType<any>;
     ssrMode?: SSRMode;
     props?: Record<string, any>;
-    reporter: Reporter;
+    reporter?: Reporter;
   },
 ) {
   const Layout = ({ Component, ...props }: any) => {
@@ -72,7 +72,7 @@ export function renderRoutes({
   routesConfig: RouterConfig['routesConfig'];
   props?: Record<string, any>;
   ssrMode?: SSRMode;
-  reporter: Reporter;
+  reporter?: Reporter;
 }) {
   if (!routesConfig) {
     return null;

--- a/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
+++ b/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
@@ -117,7 +117,10 @@ export const renderNestedRoute = (
   }
 
   const childElements = children?.map(childRoute => {
-    return renderNestedRoute(childRoute, { parent: nestedRoute });
+    return renderNestedRoute(childRoute, {
+      parent: nestedRoute,
+      reporter,
+    });
   });
 
   const routeElement = index ? (
@@ -141,7 +144,7 @@ function createLoader(route: NestedRoute, reporter?: Reporter): LoaderFunction {
       const end = time();
       const res = await loader(args);
       const cost = end();
-      if (!document && reporter) {
+      if (typeof document === 'undefined' && reporter) {
         reporter?.reportTiming(`${LOADER_REPORTER_NAME}-${route.id}`, cost);
       }
       return res;

--- a/packages/toolkit/utils/src/universal/constants.ts
+++ b/packages/toolkit/utils/src/universal/constants.ts
@@ -12,3 +12,8 @@ export const HMR_SOCK_PATH = '/webpack-hmr';
  * html placeholder
  */
 export const HTML_CHUNKSMAP_SEPARATOR = '<!--<?- chunksMap.js ?>-->';
+
+/**
+ * reporter name for server loader
+ */
+export const LOADER_REPORTER_NAME = `server-loader`;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf5aa2c</samp>

This pull request adds a feature to measure and report the execution time of the server loader function for server side rendering in the `@modern-js` framework. It modifies the `@modern-js/plugin-data-loader`, `@modern-js/runtime`, and `@modern-js/utils` packages to use the `time`, `reporter`, and `serverTiming` modules from `@modern-js/utils/universal`. It also adds a changeset file and a constant for the reporter name.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf5aa2c</samp>

*  Add a changeset file to describe the changes to three packages: `@modern-js/plugin-data-loader`, `@modern-js/runtime`, and `@modern-js/utils` ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-2e31f4b2e732bf185edc3244b154d819a2990c86d6357b9dfe50c11fd9a4d376R1-R8))
*  Import `time` and `LOADER_REPORTER_NAME` modules from `@modern-js/utils/universal` in `@modern-js/plugin-data-loader` and `@modern-js/runtime` packages to measure and report the execution time of the server loader function ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feR22-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddR13-R14))
*  Modify the `handleRequest` function in `@modern-js/plugin-data-loader` to start a timer and get the `reporter` from the `context` object ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL137-R146))
*  Modify the `routerPlugin` function in `@modern-js/runtime` to create a request context with the `reporter`, pass the `reporter` to the `query` function, and stop the timer and report the cost of the `query` function using the `reporter` and the `serverTiming` ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddR95-R97), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddR108), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-8d3a53101845b3af2464dec57d3c2a80c81e87d5d558e50edc05f672a23830ddL114-R127))
*  Import the `Reporter` type from `@modern-js/types` in `@modern-js/runtime` and `@modern-js/utils` packages to define the interface of the reporter object ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L3-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L5-R5))
*  Modify the `getRouteComponents` and `renderRoutes` functions in `@modern-js/runtime` to pass the `reporter` to the `renderRoutes` and `transformNestedRoutes` functions ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L24-R30), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32R48), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L66-R75), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32R88))
*  Modify the `transformNestedRoutes` and `renderNestedRoute` functions in `@modern-js/utils` to pass the `reporter` to the `renderNestedRoute` and `createLoader` functions ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L14-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1R42), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L40-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L46-R54))
*  Modify the `createLoader` function in `@modern-js/utils` to wrap the original loader function with a timer and a reporter ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L126-R147))
*  Add the `LOADER_REPORTER_NAME` constant to the `constants.ts` file in `@modern-js/utils` to identify the reporter name for the server loader ([link](https://github.com/web-infra-dev/modern.js/pull/4494/files?diff=unified&w=0#diff-3772d8cf6948f6d8d61b47bacc8c3b4b059de0d8dde76c45cc020a0aadc6fda2R15-R19))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
