### PR TITLE
chore(builder): use standard utils to get and make up publicPath

### DIFF
--- a/.changeset/hungry-weeks-eat.md
+++ b/.changeset/hungry-weeks-eat.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder-doc': patch
+---
+
+chore(builder): use standard utils to get and make up publicPath
+
+chore(builder): 使用标准的 utils 来读取和组装 publicPath

--- a/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
@@ -26,6 +26,8 @@ import {
   type BeforeAssetTagGenerationHtmlPluginData,
   type As,
 } from './helpers';
+import { getPublicPathFromCompiler } from '../util';
+import { withPublicPath } from '../../url';
 
 const defaultOptions = {
   type: 'async-chunks' as const,
@@ -113,17 +115,10 @@ function generateLinks(
   // Sort to ensure the output is predictable.
   const sortedFilteredFiles = filteredFiles.sort();
   const links: HtmlWebpackPlugin.HtmlTagObject[] = [];
-  const webpackPublicPath = (compilation.outputOptions.publicPath ||
-    '') as string;
-  // webpack 5 set publicPath default value 'auto'
-  const publicPath =
-    webpackPublicPath.trim() !== '' && webpackPublicPath !== 'auto'
-      ? webpackPublicPath
-      : '';
+  const publicPath = getPublicPathFromCompiler(compilation.compiler);
 
   for (const file of sortedFilteredFiles) {
-    const href = `${publicPath}${file}`;
-
+    const href = withPublicPath(file, publicPath);
     const attributes: Attributes = {
       href,
       rel: type,

--- a/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/InlineChunkHtmlPlugin.ts
@@ -11,8 +11,7 @@ import { addTrailingSlash } from '../utils';
 import type { Compiler, Compilation } from 'webpack';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { HtmlTagObject } from 'html-webpack-plugin';
-import { COMPILATION_PROCESS_STAGE } from './util';
-import { DEFAULT_ASSET_PREFIX } from '../constants';
+import { COMPILATION_PROCESS_STAGE, getPublicPathFromCompiler } from './util';
 
 export type InlineChunkHtmlPluginOptions = {
   tests: RegExp[];
@@ -193,10 +192,7 @@ export class InlineChunkHtmlPlugin {
 
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
-      const publicPath =
-        typeof compiler.options.output.publicPath === 'string'
-          ? addTrailingSlash(compiler.options.output.publicPath)
-          : DEFAULT_ASSET_PREFIX;
+      const publicPath = getPublicPathFromCompiler(compiler);
 
       const tagFunction = (tag: HtmlTagObject) =>
         this.getInlinedTag(publicPath, tag, compilation);

--- a/packages/builder/builder-shared/src/plugins/util.ts
+++ b/packages/builder/builder-shared/src/plugins/util.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { fs } from '@modern-js/utils';
 import type { Compiler } from 'webpack';
 import { DEFAULT_ASSET_PREFIX } from '../constants';
+import { addTrailingSlash } from '../utils';
 
 /** The intersection of webpack and Rspack */
 export const COMPILATION_PROCESS_STAGE = {
@@ -21,11 +22,14 @@ export const generateScriptTag = () => ({
   meta: {},
 });
 
-export const getPublicPathFromCompiler = (compiler: Compiler) =>
-  typeof compiler.options.output.publicPath === 'string'
-    ? compiler.options.output.publicPath
-    : // publicPath function is not supported yet
-      DEFAULT_ASSET_PREFIX;
+export const getPublicPathFromCompiler = (compiler: Compiler) => {
+  const { publicPath } = compiler.options.output;
+  if (typeof publicPath === 'string' && publicPath !== 'auto') {
+    return addTrailingSlash(publicPath);
+  }
+  // publicPath function is not supported yet
+  return DEFAULT_ASSET_PREFIX;
+};
 
 export const getBuilderVersion = async (): Promise<string> => {
   const pkgJson = await fs.readJSON(path.join(__dirname, '../../package.json'));

--- a/packages/document/builder-doc/docs/en/config/dev/assetPrefix.md
+++ b/packages/document/builder-doc/docs/en/config/dev/assetPrefix.md
@@ -1,7 +1,7 @@
 - **Type:** `boolean | string`
 - **Default:** `'/'`
 
-Set the URL prefix of static assets in the development environment, similar to the [output.publicPath](https://webpack.js.org/guides/public-path/) config of webpack.
+Set the URL prefix of static assets in the development environment.
 
 `assetPrefix` will affect the URLs of most of the static assets, including JavaScript files, CSS files, images, videos, etc. If an incorrect value is specified, you'll receive 404 errors while loading these resources.
 
@@ -44,3 +44,16 @@ The script URL will be:
 ```js
 <script defer src="http://example.com/assets/static/js/main.js"></script>
 ```
+
+### Differences from Native Configuration
+
+`dev.assetPrefix` corresponds to the following native configurations:
+
+- [output.publicPath](https://webpack.js.org/guides/public-path/) configuration in webpack.
+- [output.publicPath](https://www.rspack.dev/config/output.html#outputpublicpath) configuration in Rspack.
+
+The differences from the native configuration are as follows:
+
+- `dev.assetPrefix` only takes effect in the development environment.
+- `dev.assetPrefix` automatically appends a trailing `/` by default.
+- The value of `dev.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable.

--- a/packages/document/builder-doc/docs/en/config/output/assetPrefix.md
+++ b/packages/document/builder-doc/docs/en/config/output/assetPrefix.md
@@ -1,7 +1,7 @@
 - **Type:** `string`
 - **Default:** `'/'`
 
-When using CDN in the production environment, you can use this option to set the URL prefix of static assets, similar to the [output.publicPath](https://webpack.js.org/guides/public-path/) config of webpack.
+When using CDN in the production environment, you can use this option to set the URL prefix of static assets.
 
 `assetPrefix` will affect the URLs of most of the static assets, including JavaScript files, CSS files, images, videos, etc. If an incorrect value is specified, you'll receive 404 errors while loading these resources.
 
@@ -27,3 +27,16 @@ After building, you can see that the JS files are loaded from:
   src="https://cdn.example.com/assets/static/js/main.ebc4ff4f.js"
 ></script>
 ```
+
+### Differences from Native Configuration
+
+`output.assetPrefix` corresponds to the following native configurations:
+
+- [output.publicPath](https://webpack.js.org/guides/public-path/) configuration in webpack.
+- [output.publicPath](https://www.rspack.dev/config/output.html#outputpublicpath) configuration in Rspack.
+
+The differences from the native configuration are as follows:
+
+- `output.assetPrefix` only takes effect in the production environment.
+- `output.assetPrefix` automatically appends a trailing `/` by default.
+- The value of `output.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable.

--- a/packages/document/builder-doc/docs/zh/config/dev/assetPrefix.md
+++ b/packages/document/builder-doc/docs/zh/config/dev/assetPrefix.md
@@ -1,7 +1,7 @@
 - **类型：** `boolean | string`
 - **默认值：** `'/'`
 
-设置开发环境下的静态资源 URL 前缀，对应 webpack 的 [output.publicPath](https://webpack.js.org/guides/public-path/) 配置。
+设置开发环境下的静态资源 URL 前缀。
 
 `assetPrefix` 会影响构建产物中绝大部分静态资源的 URL，包括 JavaScript 文件、CSS 文件、图片、视频等。如果指定了一个错误的值，则在加载这些资源时可能会出现 404 错误。
 
@@ -44,3 +44,16 @@ export default {
 ```js
 <script defer src="http://example.com/assets/static/js/main.js"></script>
 ```
+
+### 与原生配置的区别
+
+`dev.assetPrefix` 对应以下原生配置：
+
+- webpack 的 [output.publicPath](https://webpack.js.org/guides/public-path/) 配置。
+- Rspack 的 [output.publicPath](https://www.rspack.dev/zh/config/output.html#outputpublicpath) 配置。
+
+它与原生配置的区别在于：
+
+- `dev.assetPrefix` 仅在开发环境下生效。
+- `dev.assetPrefix` 默认会自动补全尾部的 `/`。
+- `dev.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量。

--- a/packages/document/builder-doc/docs/zh/config/output/assetPrefix.md
+++ b/packages/document/builder-doc/docs/zh/config/output/assetPrefix.md
@@ -1,7 +1,7 @@
 - **类型：** `string`
 - **默认值：** `'/'`
 
-在生产环境使用 CDN 部署时，可使用该选项设置静态资源的 URL 前缀，对应 webpack 的 [output.publicPath](https://webpack.js.org/guides/public-path/) 配置。
+在生产环境使用 CDN 部署时，可使用该选项设置静态资源的 URL 前缀。
 
 `assetPrefix` 会影响构建产物中绝大部分静态资源的 URL，包括 JavaScript 文件、CSS 文件、图片、视频等。如果指定了一个错误的值，则在加载这些资源时可能会出现 404 错误。
 
@@ -27,3 +27,16 @@ export default {
   src="https://cdn.example.com/assets/static/js/main.ebc4ff4f.js"
 ></script>
 ```
+
+### 与原生配置的区别
+
+`output.assetPrefix` 对应以下原生配置：
+
+- webpack 的 [output.publicPath](https://webpack.js.org/guides/public-path/) 配置。
+- Rspack 的 [output.publicPath](https://www.rspack.dev/zh/config/output.html#outputpublicpath) 配置。
+
+它与原生配置的区别在于：
+
+- `output.assetPrefix` 仅在生产环境下生效。
+- `output.assetPrefix` 默认会自动补全尾部的 `/`。
+- `output.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量。

--- a/tests/e2e/builder/cases/performance/load-resource/index.test.ts
+++ b/tests/e2e/builder/cases/performance/load-resource/index.test.ts
@@ -12,6 +12,9 @@ test('should generate prefetch link when prefetch is defined', async () => {
       main: join(fixtures, 'src/page1/index.ts'),
     },
     builderConfig: {
+      output: {
+        assetPrefix: 'https://www.foo.com',
+      },
       performance: {
         prefetch: true,
       },
@@ -32,7 +35,7 @@ test('should generate prefetch link when prefetch is defined', async () => {
 
   expect(
     content.includes(
-      `<link href="${asyncFileName.slice(
+      `<link href="https://www.foo.com${asyncFileName.slice(
         asyncFileName.indexOf('/static/js/async/'),
       )}" rel="prefetch">`,
     ),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3fb912</samp>

This pull request refactors and improves the handling of the public path of the static assets in the `@modern-js/builder-shared` package. It also updates the documentation and the test cases for the `@modern-js/builder-doc` package to reflect the changes. The pull request adds a changeset file to prepare for publishing the updated packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3fb912</samp>

*  Simplify and unify the logic of getting and making up the public path of static assets in the `HtmlPreloadOrPrefetchPlugin` and `InlineChunkHtmlPlugin` modules by using utility functions from `./util` ([link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-90e6790de75c03bb88d02977f3ce7fe1b4c7733c7ff6e9a3dfa9557ba9bc5aa8R29-R30),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-90e6790de75c03bb88d02977f3ce7fe1b4c7733c7ff6e9a3dfa9557ba9bc5aa8L116-R121),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL14-R14),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL196-R195))
*  Handle the case where webpack 5 sets the public path default value to 'auto' by checking and appending a trailing slash to the public path in the `getPublicPathFromCompiler` utility function ([link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-8e2c05664b3b0f05dd0ced063b97c272ef2d91bccb0d9a1ac144796c1efb4498L24-R32))
*  Import the `addTrailingSlash` utility function from `../utils` to the `util` module and use it in the `getPublicPathFromCompiler` utility function ([link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-8e2c05664b3b0f05dd0ced063b97c272ef2d91bccb0d9a1ac144796c1efb4498R5))
*  Add a changeset file that describes the changes made to the `@modern-js/builder-shared` and `@modern-js/builder-doc` packages and includes a summary in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-0427707236268e13a0d10cc29baccdb556ecf7a2e520c6730a1af0091851636bR1-R8))
*  Simplify the descriptions of the `dev.assetPrefix` and `output.assetPrefix` options in the English and Chinese documentation and remove the references to the webpack `output.publicPath` config ([link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-c2863b0e5c45f178afbf38b5e834647ee8b0de44e7e02460efe0f5fe45f5e015L4-R4),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-e5a5487000138cf687ee1baae17b8a78bd96e76d84e84ad791677e212c8e99edL4-R4),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-33e119e097c7c61d3916558dc8dff5f0ff117e788094ff71bb368cf61751e3d5L4-R4),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-ac39e9487ef8ab01e8b7c8ced6874d7d56dc158c9609cb06d8ba8c6c3b33d5c2L4-R4))
*  Add new sections to the English and Chinese documentation that explain the differences between the `dev.assetPrefix` and `output.assetPrefix` options and the native configurations of webpack and Rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-c2863b0e5c45f178afbf38b5e834647ee8b0de44e7e02460efe0f5fe45f5e015R47-R59),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-e5a5487000138cf687ee1baae17b8a78bd96e76d84e84ad791677e212c8e99edR30-R42),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-33e119e097c7c61d3916558dc8dff5f0ff117e788094ff71bb368cf61751e3d5R47-R59),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-ac39e9487ef8ab01e8b7c8ced6874d7d56dc158c9609cb06d8ba8c6c3b33d5c2R30-R42))
*  Add the `output.assetPrefix` option to the test case configuration in the `load-resource` test and modify the assertion to match the expected href attribute of the link tag ([link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-a1427149267cf4370bd017ce3767ba3d7bb8fef7850282f3e432c4b63b8c6c56R15-R17),[link](https://github.com/web-infra-dev/modern.js/pull/4499/files?diff=unified&w=0#diff-a1427149267cf4370bd017ce3767ba3d7bb8fef7850282f3e432c4b63b8c6c56L35-R38))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
