### PR TITLE
fix: should passthrough the requestCreator

### DIFF
--- a/.changeset/lemon-bags-relax.md
+++ b/.changeset/lemon-bags-relax.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-bff': patch
+---
+
+fix: should passthrough the requestCreator
+fix: 应该传 requestCreator

--- a/.changeset/tall-mails-cross.md
+++ b/.changeset/tall-mails-cross.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-bff': patch
+---
+
+fix: should passthrough the requestCreator
+fix: 应该透传 requestCreator

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -83,6 +83,7 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
                   existLambda,
                   port,
                   target: name,
+                  requestCreator: bff?.requestCreator,
                   httpMethodDecider,
                 });
             },

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -33,7 +33,6 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
                 },
                 fetcher: { type: 'string' },
                 proxy: { type: 'object' },
-                requestCreator: { type: 'string' },
               },
             },
           },
@@ -83,7 +82,8 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
                   existLambda,
                   port,
                   target: name,
-                  requestCreator: bff?.requestCreator,
+                  // Internal field
+                  requestCreator: (bff as any)?.requestCreator,
                   httpMethodDecider,
                 });
             },

--- a/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/plugin-bff/tests/__snapshots__/cli.test.ts.snap
@@ -56,9 +56,6 @@ exports[`bff cli plugin schema 1`] = `
           "proxy": {
             "type": "object",
           },
-          "requestCreator": {
-            "type": "string",
-          },
         },
         "type": "object",
       },

--- a/packages/server/core/src/types/config/bff.ts
+++ b/packages/server/core/src/types/config/bff.ts
@@ -6,7 +6,6 @@ export interface BffUserConfig {
   proxy?: Record<string, Options>;
   httpMethodDecider?: HttpMethodDecider;
   enableHandleWeb?: boolean;
-  requestCreator?: string;
 }
 
 export type BffNormalizedConfig = BffUserConfig;

--- a/packages/server/core/src/types/config/bff.ts
+++ b/packages/server/core/src/types/config/bff.ts
@@ -6,6 +6,7 @@ export interface BffUserConfig {
   proxy?: Record<string, Options>;
   httpMethodDecider?: HttpMethodDecider;
   enableHandleWeb?: boolean;
+  requestCreator?: string;
 }
 
 export type BffNormalizedConfig = BffUserConfig;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7ed5aa</samp>

This pull request adds a new `requestCreator` option to the `@modern-js/plugin-bff` package that allows users to customize the request object for the bff server. It updates the code and the types in the `cli.ts` and `bff.ts` files and adds a changeset file to document the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7ed5aa</samp>

*  Add `requestCreator` option to bff server config and pass it to server core ([link](https://github.com/web-infra-dev/modern.js/pull/4513/files?diff=unified&w=0#diff-ddb13338fa5e4286f0affca3a481539c4265f010c94db3bb4beb2c5ba9202033R86), [link](https://github.com/web-infra-dev/modern.js/pull/4513/files?diff=unified&w=0#diff-bd1a2d740043d75bb02d9f830fa1caaa64f13ea1fba0af976340dbe256f04810R9), [link](https://github.com/web-infra-dev/modern.js/pull/4513/files?diff=unified&w=0#diff-30479e1c38e072e050b933f0ad2d2a9e349de4033a5c56b598db9c0e9f90be5cR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
