### PR TITLE
fix: not set partials html receive extra placeholder

### DIFF
--- a/.changeset/chilled-walls-sort.md
+++ b/.changeset/chilled-walls-sort.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: html has placeholder when not set partials
+fix: html 在没有设置 partials 的时候,会多出占位符

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -189,15 +189,24 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
           htmlWebpackPlugin.tags.bodyTags.toString(),
         ].join('');
         // support partials html
+        const partialsContent = {
+          partialsTop: '',
+          partialsHead: '',
+          partialsBody: '',
+        };
         if (partialsByEntrypoint?.[entryName]) {
-          const partialsTop = partialsByEntrypoint[entryName].top.join('\n');
-          const partialsHead = partialsByEntrypoint[entryName].head.join('\n');
-          const partialsBody = partialsByEntrypoint[entryName].body.join('\n');
-          html = html
-            .replace(TOP_PARTICALS_SEPARATOR, partialsTop)
-            .replace(HEAD_PARTICALS_SEPARATOR, partialsHead)
-            .replace(BODY_PARTICALS_SEPARATOR, partialsBody);
+          partialsContent.partialsTop =
+            partialsByEntrypoint[entryName].top.join('\n');
+          partialsContent.partialsHead =
+            partialsByEntrypoint[entryName].head.join('\n');
+          partialsContent.partialsBody =
+            partialsByEntrypoint[entryName].body.join('\n');
         }
+
+        html = html
+          .replace(TOP_PARTICALS_SEPARATOR, partialsContent.partialsTop)
+          .replace(HEAD_PARTICALS_SEPARATOR, partialsContent.partialsHead)
+          .replace(BODY_PARTICALS_SEPARATOR, partialsContent.partialsBody);
 
         const links = [
           htmlWebpackPlugin.tags.headTags

--- a/tests/integration/app-document/modern.config.ts
+++ b/tests/integration/app-document/modern.config.ts
@@ -1,5 +1,28 @@
-import { appTools, defineConfig } from '@modern-js/app-tools';
+import {
+  AppTools,
+  appTools,
+  CliPlugin,
+  defineConfig,
+} from '@modern-js/app-tools';
 import { routerPlugin } from '@modern-js/plugin-router-v5';
+
+export const tmpTest = (): CliPlugin<AppTools> => ({
+  name: 'tmpTest',
+  setup: () => {
+    return {
+      htmlPartials({ entrypoint, partials }) {
+        console.log('===> e.name: ', entrypoint.entryName);
+        if (entrypoint.entryName === 'sub') {
+          partials.top.push('<script>window.abc = "hjk"</script>');
+          partials.head.push('<script>console.log("abc")</script>');
+          partials.body.push('<script>console.log(abc)</script>');
+        }
+
+        return { partials, entrypoint };
+      },
+    };
+  },
+});
 
 export default defineConfig({
   runtime: {
@@ -23,5 +46,5 @@ export default defineConfig({
     favicon: './static/a.icon',
   },
   output: {},
-  plugins: [appTools(), routerPlugin()],
+  plugins: [appTools(), routerPlugin(), tmpTest()],
 });

--- a/tests/integration/app-document/modern.config.ts
+++ b/tests/integration/app-document/modern.config.ts
@@ -11,7 +11,6 @@ export const tmpTest = (): CliPlugin<AppTools> => ({
   setup: () => {
     return {
       htmlPartials({ entrypoint, partials }) {
-        console.log('===> e.name: ', entrypoint.entryName);
         if (entrypoint.entryName === 'sub') {
           partials.top.push('<script>window.abc = "hjk"</script>');
           partials.head.push('<script>console.log("abc")</script>');

--- a/tests/integration/app-document/modern.config.ts
+++ b/tests/integration/app-document/modern.config.ts
@@ -1,25 +1,5 @@
-import {
-  AppTools,
-  appTools,
-  CliPlugin,
-  defineConfig,
-} from '@modern-js/app-tools';
+import { appTools, defineConfig } from '@modern-js/app-tools';
 import { routerPlugin } from '@modern-js/plugin-router-v5';
-
-const tmpTest = (): CliPlugin<AppTools> => ({
-  name: 'tmpTest',
-  setup: () => {
-    return {
-      htmlPartials({ entrypoint, partials }) {
-        partials.top.push('<script>window.abc = "hjk"</script>');
-        partials.head.push('<script>console.log("abc")</script>');
-        partials.body.push('<script>console.log(abc)</script>');
-
-        return { partials, entrypoint };
-      },
-    };
-  },
-});
 
 export default defineConfig({
   runtime: {
@@ -43,5 +23,5 @@ export default defineConfig({
     favicon: './static/a.icon',
   },
   output: {},
-  plugins: [appTools(), routerPlugin(), tmpTest()],
+  plugins: [appTools(), routerPlugin()],
 });

--- a/tests/integration/app-document/src/differentProperities/pages/index.tsx
+++ b/tests/integration/app-document/src/differentProperities/pages/index.tsx
@@ -1,0 +1,10 @@
+import { Link } from '@modern-js/runtime/router-v5';
+
+const App = () => (
+  <>
+    <Link to={'/a'}>去 A</Link>
+    <Link to={'/b'}>去 B</Link>
+  </>
+);
+
+export default App;

--- a/tests/integration/app-document/tests/index.test.ts
+++ b/tests/integration/app-document/tests/index.test.ts
@@ -170,6 +170,15 @@ describe('test build', () => {
     expect(htmlWithDoc.includes(`head class="head"`)).toBe(true);
   });
 
+  test('when not set partial html should normal', async () => {
+    const normalHtml = fs.readFileSync(
+      path.join(appDir, 'dist', 'html/differentProperities/index.html'),
+      'utf-8',
+    );
+    const partialPlaceholder = encodeURIComponent('<!--<?- partials.top ?>-->');
+    expect(new RegExp(partialPlaceholder).test(normalHtml)).toBe(false);
+  });
+
   test('should injected partial html content to html', async () => {
     const htmlWithDoc = fs.readFileSync(
       path.join(appDir, 'dist', 'html/sub/index.html'),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25ec6f4</samp>

This pull request updates the `@modern-js/runtime` package to fix the html placeholder issue and improve the code readability of the `documentPlugin` function. It also adds a changeset file to document the patch updates.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25ec6f4</samp>

* Add a changeset file for patch updates of `@modern-js/runtime` package and fix messages for html placeholder issue (.changeset/chilled-walls-sort.md)
* Refactor `documentPlugin` function to use an object for partials content and fix html placeholder issue ([link](https://github.com/web-infra-dev/modern.js/pull/4520/files?diff=unified&w=0#diff-0e55b04e20002e2fb2749b80f99d441529beb49561d648172696a765aa8afa67L192-R210))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
