### PR TITLE
fix(plugin-garfish): phantom dependencies of react

### DIFF
--- a/.changeset/fix-plugin-garfish.md
+++ b/.changeset/fix-plugin-garfish.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix(plugin-garfish): add react and react-dom as peerDependencies to prevent phantom dependencies
+
+fix(plugin-garfish): 增加 react 和 react-dom 为 peerDependencies 来防止幻影依赖

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -81,7 +81,9 @@
     "@swc/helpers": "0.5.1"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.32.1"
+    "@modern-js/runtime": "workspace:^2.32.1",
+    "react": ">=17",
+    "react-dom": ">=17"
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",


### PR DESCRIPTION
closes #4505 
I add peerDependencies, as does `@garfish/bridge-react`
 https://github.com/web-infra-dev/garfish/blob/695df5e5eb5f0f37c4a5e901243f9f321542e44b/packages/bridge-react/package.json#L43C1-L46C5
```json
"peerDependencies": {
    "react": ">=16",
    "react-dom": ">=16"
}
```

