### PR TITLE
docs(tailwindcss): add enabling and storybook guide

### DIFF
--- a/.changeset/spotty-donkeys-bow.md
+++ b/.changeset/spotty-donkeys-bow.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/tailwindcss-generator': patch
+---
+
+feat(tailwindcss-generator): bump tailwindcss version to v3.3
+
+feat(tailwindcss-generator): 升级 tailwindcss 版本到 v3.3

--- a/packages/document/main-doc/docs/en/configure/app/tools/tailwindcss.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/tailwindcss.mdx
@@ -19,6 +19,12 @@ const tailwind = {
 
 Used to modify the configuration of [Tailwind CSS](https://tailwindcss.com/docs/configuration).
 
+### Enabling Tailwind CSS
+
+Before using `tools.tailwindcss`, you need to enable the Tailwind CSS plugin for Modern.js.
+
+Please refer to the section [Using Tailwind CSS](/guides/basic-features/css.html#using-tailwind-css) for instructions on how to enable it.
+
 ### Function Type
 
 When `tools.tailwindcss`'s type is Function, the default tailwindcss config will be passed in as the first parameter, the config object can be modified directly, or a value can be returned as the final result.

--- a/packages/document/main-doc/docs/zh/configure/app/tools/tailwindcss.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/tailwindcss.mdx
@@ -19,6 +19,12 @@ const tailwind = {
 
 用于修改 [Tailwind CSS](https://tailwindcss.com/docs/configuration) 的配置项。
 
+### 启用 Tailwind CSS
+
+在使用 `tools.tailwindcss` 之前，你需要启用 Modern.js 的 Tailwind CSS 插件。
+
+请阅读[「使用 Tailwind CSS」](/guides/basic-features/css.html#使用-tailwind-css) 章节来了解开启方式。
+
 ### Function 类型
 
 当 `tools.tailwindcss` 为 Function 类型时，默认配置会作为第一个参数传入，你可以直接修改配置对象，也可以返回一个值作为最终结果：

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -1100,6 +1100,14 @@ const tailwind = {
 };
 ```
 
+### Enabling Tailwind CSS
+
+Before using `style.tailwindcss`, you need to enable the Tailwind CSS plugin for Module Tools.
+
+Please refer to the section [Using Tailwind CSS](/guide/best-practices/use-tailwindcss.html) for instructions on how to enable it.
+
+### Type
+
 When the value is of type `object`, it is merged with the default configuration via `Object.assign`.
 
 When the value is of type `Function`, the object returned by the function is merged with the default configuration via `Object.assign`.

--- a/packages/document/module-doc/docs/en/guide/basic/using-storybook.mdx
+++ b/packages/document/module-doc/docs/en/guide/basic/using-storybook.mdx
@@ -166,3 +166,18 @@ For the `modern build --platform` command you can see.
 - [`modern build`](/en/guide/basic/command-preview#modern-build)
 
 After the build is complete, you can see the build artifacts files in the `dist/storybook-static` directory.
+
+## Use Tailwind CSS with Storybook
+
+If you need to use Tailwind CSS in the `stories` directory, make sure that the Tailwind CSS configuration for your current project includes the `stories` directory.
+
+Taking the `tailwind.config.ts` file as an example, you need to configure the following content:
+
+```diff title="tailwind.config.ts"
+export default {
+  content: [
+    './src/**/*.{js,jsx,ts,tsx}',
++   './stories/**/*.{js,jsx,ts,tsx}',
+  ],
+};
+```

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -1100,6 +1100,14 @@ const tailwind = {
 };
 ```
 
+### 启用 Tailwind CSS
+
+在使用 `style.tailwindcss` 之前，你需要启用 Module Tools 的 Tailwind CSS 插件。
+
+请阅读[「使用 Tailwind CSS」](/guide/best-practices/use-tailwindcss.html) 章节来了解开启方式。
+
+### 类型
+
 值为 `object` 类型时，与默认配置通过 `Object.assign` 合并。
 
 值为 `Function` 类型时，函数返回的对象与默认配置通过 `Object.assign` 合并。

--- a/packages/document/module-doc/docs/zh/guide/basic/using-storybook.mdx
+++ b/packages/document/module-doc/docs/zh/guide/basic/using-storybook.mdx
@@ -62,9 +62,7 @@ export const content = 'hello world';
       "foo/*": ["./*"]
     }
   },
-  "include": [
-    "**/*"
-  ]
+  "include": ["**/*"]
 }
 ```
 
@@ -136,7 +134,6 @@ export default {
 };
 ```
 
-
 :::tip 为什么不推荐使用源码的方式?
 不仅仅是因为使用组件源码无法验证组件产物是否正确，**同时模块工程对于构建产物支持的一些配置无法完全转换为 Storybook
 内部的配置**。如果某些配置无法进行相互转换的话，就会在 Storybook 调试过程中出现不符合预期的结果。
@@ -159,7 +156,6 @@ Storybook 官方通过一个名为 `.storybook` 的文件夹来进行项目配�
 
 在未来我们会考虑这些配置是否可以允许修改，不过目前为了减少不可预知的问题暂时限制使用这些配置。
 
-
 ## 构建 Storybook 产物
 
 除了可以对组件或者普通的模块进行 Storybook 调试，还可以通过下面的命令来执行 Storybook 的构建任务。
@@ -173,3 +169,18 @@ modern build --platform storybook
 - [`modern build`](/guide/basic/command-preview#modern-build)
 
 构建完成后，可以在 `dist/storybook-static` 目录看到构建产物文件。
+
+## 结合 Tailwind CSS 使用
+
+如果你需要在 `stories` 目录下使用 Tailwind CSS，请确保当前项目的 Tailwind CSS 配置中包含了 `stories` 目录。
+
+以 `tailwind.config.ts` 文件为例，你需要配置以下内容：
+
+```diff title="tailwind.config.ts"
+export default {
+  content: [
+    './src/**/*.{js,jsx,ts,tsx}',
++   './stories/**/*.{js,jsx,ts,tsx}',
+  ],
+};
+```

--- a/packages/generator/generators/tailwindcss-generator/src/index.ts
+++ b/packages/generator/generators/tailwindcss-generator/src/index.ts
@@ -38,7 +38,7 @@ export const handleTemplateFile = async (
   }
 
   const { dependencies, peerDependencies, devDependencies } = context.config;
-  const tailwindVersion = '~3.2.4';
+  const tailwindVersion = '~3.3.3';
   if (dependencies?.tailwindcss) {
     dependencies.tailwindcss = tailwindVersion;
   }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65007ca</samp>

This pull request enhances the support and documentation of Tailwind CSS for the Modern.js framework. It updates the `@modern-js/tailwindcss-generator` package to use the latest version of `tailwindcss` and adds changeset files for the patch release. It also adds or updates sections in the English and Chinese documentation of the Module Tools and the Modern.js app to explain how to enable and use the Tailwind CSS plugin and configuration options.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65007ca</samp>

*  Add changeset file for patch update of `@modern-js/tailwindcss-generator` and feature of bumping `tailwindcss` version to v3.3 ([link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-c4af5713dfc197e6cd2263f8ec7e89dd08b9e87cba4cfe2327da2300a14c84a4R1-R7))
*  Update `tailwindVersion` variable in `handleTemplateFile` function of `@modern-js/tailwindcss-generator` to v3.3.3 ([link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-fab4fdfead981f038766d1f3f640d76de78003a18bfc67542e8366f03744395aL41-R41))
*  Add sections to English and Chinese documentation of `tools.tailwindcss` option for Modern.js app, explaining the need to enable Tailwind CSS plugin and linking to guide ([link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-a2bcb69ffc32be0c70474b45273e7348605a973eadbc9ce49ab846bb6987c4b7R22-R27), [link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-a199dd051e5150078b303745af954bbad98c64d0c92cf364ecfc010062c52ff8R22-R27))
*  Add sections to English and Chinese documentation of `style.tailwindcss` option for Module Tools, explaining the need to enable Tailwind CSS plugin and linking to guide ([link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baR1103-R1110), [link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791R1103-R1110))
*  Add sections to English and Chinese documentation of guide on using Storybook with Module Tools, explaining how to use Tailwind CSS in `stories` directory and modifying `tailwind.config.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-2fc11552e3ae202bc92c6ddb277ba2aae37e9fb818222f194624b40b86007737R169-R183), [link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-f348797041427fa8333f4474856a1f33549fae99a1b41ca8900b26230b385ea7R172-R186))
*  Format code block and remove empty lines in Chinese documentation of guide on using Storybook with Module Tools ([link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-f348797041427fa8333f4474856a1f33549fae99a1b41ca8900b26230b385ea7L65-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-f348797041427fa8333f4474856a1f33549fae99a1b41ca8900b26230b385ea7L139), [link](https://github.com/web-infra-dev/modern.js/pull/4525/files?diff=unified&w=0#diff-f348797041427fa8333f4474856a1f33549fae99a1b41ca8900b26230b385ea7L162))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
