### PR TITLE
fix(builder): incorrect prefetch domain when assetPrefix has no protocol

### DIFF
--- a/.changeset/giant-ways-relax.md
+++ b/.changeset/giant-ways-relax.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): incorrect prefetch domain when assetPrefix has no protocol
+
+fix(builder): 修复 assetPrefix 不包含 protocol 时 prefetch 域名错误的问题

--- a/packages/builder/builder-shared/src/url.ts
+++ b/packages/builder/builder-shared/src/url.ts
@@ -1,5 +1,6 @@
 import { URL } from 'url';
 import path from 'path';
+import { urlJoin } from '@modern-js/utils';
 
 export const withPublicPath = (str: string, base: string) => {
   // The use of an absolute URL without a protocol is technically legal,
@@ -8,6 +9,10 @@ export const withPublicPath = (str: string, base: string) => {
   // e.g. str is //example.com/foo.js
   if (str.startsWith('//')) {
     return str;
+  }
+
+  if (base.startsWith('//')) {
+    return urlJoin(base, str);
   }
 
   // Only absolute url with hostname & protocol can be parsed into URL instance.

--- a/packages/builder/builder-shared/tests/url.test.ts
+++ b/packages/builder/builder-shared/tests/url.test.ts
@@ -36,5 +36,6 @@ describe('withPublicPath', () => {
       '//foo.com/bar.js',
     );
     expect(withPublicPath('//foo.com/bar.js', '/')).toBe('//foo.com/bar.js');
+    expect(withPublicPath('/bar.js', '//foo.com')).toBe('//foo.com/bar.js');
   });
 });

--- a/tests/e2e/builder/cases/performance/load-resource/index.test.ts
+++ b/tests/e2e/builder/cases/performance/load-resource/index.test.ts
@@ -42,7 +42,7 @@ test('should generate prefetch link when prefetch is defined', async () => {
   ).toBeTruthy();
 });
 
-test.only('should generate prefetch link correctly when assetPrefix do not have a protocol', async () => {
+test('should generate prefetch link correctly when assetPrefix do not have a protocol', async () => {
   const builder = await build({
     cwd: fixtures,
     entry: {

--- a/tests/e2e/builder/cases/performance/load-resource/index.test.ts
+++ b/tests/e2e/builder/cases/performance/load-resource/index.test.ts
@@ -42,6 +42,40 @@ test('should generate prefetch link when prefetch is defined', async () => {
   ).toBeTruthy();
 });
 
+test.only('should generate prefetch link correctly when assetPrefix do not have a protocol', async () => {
+  const builder = await build({
+    cwd: fixtures,
+    entry: {
+      main: join(fixtures, 'src/page1/index.ts'),
+    },
+    builderConfig: {
+      output: {
+        assetPrefix: '//www.foo.com',
+      },
+      performance: {
+        prefetch: true,
+      },
+    },
+  });
+
+  const files = await builder.unwrapOutputJSON();
+
+  const asyncFileName = Object.keys(files).find(file =>
+    file.includes('/static/js/async/'),
+  )!;
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('index.html'),
+  )!;
+
+  expect(
+    content.includes(
+      `<link href="//www.foo.com${asyncFileName.slice(
+        asyncFileName.indexOf('/static/js/async/'),
+      )}" rel="prefetch">`,
+    ),
+  ).toBeTruthy();
+});
+
 test('should generate prefetch link with filter', async () => {
   const builder = await build({
     cwd: fixtures,

--- a/tests/e2e/builder/cases/performance/load-resource/tsconfig.json
+++ b/tests/e2e/builder/cases/performance/load-resource/tsconfig.json
@@ -9,5 +9,5 @@
       "@scripts/*": ["../../../scripts/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "index.test.ts"]
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4516830</samp>

This pull request fixes a bug in the `withPublicPath` function that handles protocol-relative URLs for the `assetPrefix` option in the `@modern-js/builder-shared` package. It also adds tests and a changeset file for the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4516830</samp>

*  Add a changeset file to describe the patch version update and the fix message for the `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/4532/files?diff=unified&w=0#diff-d06f9b1ecfffbe46658421add076150ad1a6c568de3e562dba1f1bb283d97403R1-R7))
*  Import the `urlJoin` function from the `@modern-js/utils` package to handle URL segments with slashes ([link](https://github.com/web-infra-dev/modern.js/pull/4532/files?diff=unified&w=0#diff-ad14255930bb4d5c7ddf1a40506cde183fb39cb1c4c9e2bfda63b6d69d24a3b4R3))
*  Fix the `withPublicPath` function to handle the case where the `base` parameter starts with `//` and use the `urlJoin` function to join the `base` and the `str` parameters without adding a protocol ([link](https://github.com/web-infra-dev/modern.js/pull/4532/files?diff=unified&w=0#diff-ad14255930bb4d5c7ddf1a40506cde183fb39cb1c4c9e2bfda63b6d69d24a3b4R14-R17))
*  Add a test case to verify the behavior of the `withPublicPath` function when the `base` parameter starts with `//` in the `url.test.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4532/files?diff=unified&w=0#diff-309cb00a4a31269d1cb11d77950425cd1686c11ac1abe083682e98e17d5a614aR39))
*  Add an end-to-end test case to test the scenario of using the `assetPrefix` and the `prefetch` options in the builder config in the `index.test.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4532/files?diff=unified&w=0#diff-a1427149267cf4370bd017ce3767ba3d7bb8fef7850282f3e432c4b63b8c6c56R45-R78))
*  Modify the `tsconfig.json` file in the test case folder to include the `index.test.ts` file in the TypeScript compilation ([link](https://github.com/web-infra-dev/modern.js/pull/4532/files?diff=unified&w=0#diff-92fad2e803d063351a54d5b514cf8fc792bb1494d58956b8c020b8c64b8c299cL12-R12))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
