### PR TITLE
fix(builder): fix withPublicPath may missing subpath

### DIFF
--- a/.changeset/few-olives-remain.md
+++ b/.changeset/few-olives-remain.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): fix withPublicPath may missing subpath
+
+fix(builder):  修复 withPublicPath 方法可能会丢失子路径的问题

--- a/packages/builder/builder-shared/src/url.ts
+++ b/packages/builder/builder-shared/src/url.ts
@@ -1,5 +1,4 @@
 import { URL } from 'url';
-import path from 'path';
 import { urlJoin } from '@modern-js/utils';
 
 export const withPublicPath = (str: string, base: string) => {
@@ -11,28 +10,11 @@ export const withPublicPath = (str: string, base: string) => {
     return str;
   }
 
-  if (base.startsWith('//')) {
-    return urlJoin(base, str);
-  }
-
   // Only absolute url with hostname & protocol can be parsed into URL instance.
   // e.g. str is https://example.com/foo.js
   try {
     return new URL(str).toString();
   } catch {}
 
-  // Or it should be a relative path.
-  // Let's join the publicPath.
-  // e.g. str is ./foo.js
-  try {
-    // `base` is a url with hostname & protocol.
-    // e.g. base is https://example.com/static
-    const url = new URL(base);
-    url.pathname = path.posix.resolve(url.pathname, str);
-    return url.toString();
-  } catch {
-    // without hostname & protocol.
-    // e.g. base is /
-    return path.posix.resolve(base, str);
-  }
+  return urlJoin(base, str);
 };

--- a/packages/builder/builder-shared/tests/url.test.ts
+++ b/packages/builder/builder-shared/tests/url.test.ts
@@ -9,15 +9,15 @@ describe('withPublicPath', () => {
       'https://www.example.com/static/foo/bar.js',
     );
     expect(withPublicPath('foo/bar.js', '/')).toBe('/foo/bar.js');
-    expect(withPublicPath('./foo/bar.js', PUBLIC_PATH)).toBe(
+    expect(withPublicPath('/foo/bar.js', PUBLIC_PATH)).toBe(
       'https://www.example.com/static/foo/bar.js',
     );
-    expect(withPublicPath('./foo/bar.js', '/')).toBe('/foo/bar.js');
+    expect(withPublicPath('/foo/bar.js', '/')).toBe('/foo/bar.js');
   });
 
   it('should handle absolute url', () => {
     expect(withPublicPath('/foo/bar.js', PUBLIC_PATH)).toBe(
-      'https://www.example.com/foo/bar.js',
+      'https://www.example.com/static/foo/bar.js',
     );
     expect(withPublicPath('/foo/bar.js', '/')).toBe('/foo/bar.js');
   });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec63460</samp>

This pull request fixes and simplifies the `withPublicPath` function in the `@modern-js/builder-shared` package, updates the corresponding test cases, and adds a changeset file for the patch update. This improves the URL handling and documentation of the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec63460</samp>

*  Simplify and refactor `withPublicPath` function in `url.ts` to use `urlJoin` function for all cases of joining `base` and `str` parameters ([link](https://github.com/web-infra-dev/modern.js/pull/4535/files?diff=unified&w=0#diff-ad14255930bb4d5c7ddf1a40506cde183fb39cb1c4c9e2bfda63b6d69d24a3b4L14-L17),[link](https://github.com/web-infra-dev/modern.js/pull/4535/files?diff=unified&w=0#diff-ad14255930bb4d5c7ddf1a40506cde183fb39cb1c4c9e2bfda63b6d69d24a3b4L24-R19))
* Update test cases for `withPublicPath` function in `url.test.ts` to match the new function logic and output ([link](https://github.com/web-infra-dev/modern.js/pull/4535/files?diff=unified&w=0#diff-309cb00a4a31269d1cb11d77950425cd1686c11ac1abe083682e98e17d5a614aL12-R20))
* Remove unused import of `path` module from `url.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4535/files?diff=unified&w=0#diff-ad14255930bb4d5c7ddf1a40506cde183fb39cb1c4c9e2bfda63b6d69d24a3b4L2))
* Add changeset file for `@modern-js/builder-shared` package with patch update and summary of fix in `.changeset/few-olives-remain.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4535/files?diff=unified&w=0#diff-5a8f320c53283e14b138086db1f6498b1ad6a9da23954e339a70aff0d9f88fe0R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
