### PR TITLE
[WIP] feat: avoid ssr useless prerender

### DIFF
--- a/.changeset/long-lamps-dance.md
+++ b/.changeset/long-lamps-dance.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': minor
+'@modern-js/prod-server': minor
+---
+
+feat: avoid ssr unless prerender
+feat: 避免 ssr 不必要的预渲染

--- a/packages/runtime/plugin-runtime/src/ssr/cli/babel-plugin-ssr-loader-id.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/babel-plugin-ssr-loader-id.ts
@@ -6,6 +6,9 @@ import { get } from '@modern-js/utils/lodash';
 const RUNTIME_PACKAGE_NAMES = ['@modern-js/runtime'];
 const FUNCTION_USE_LOADER_NAME = 'useLoader';
 
+// eslint-disable-next-line import/no-mutable-exports
+export let hasUseLoader = false;
+
 function getHash(filepath: string) {
   const cwd = process.cwd();
   const point = filepath.indexOf(cwd);
@@ -73,6 +76,7 @@ function getSelfRunLoaderExpression(
   loaderExpression: t.Expression,
   id: string,
 ) {
+  hasUseLoader = true;
   return t.callExpression(
     t.functionExpression(
       null,
@@ -95,8 +99,7 @@ function getSelfRunLoaderExpression(
   );
 }
 
-// eslint-disable-next-line import/no-commonjs
-module.exports = function () {
+export default function () {
   let useLoader: string | null = null;
   let hash = '';
   let index = 0;
@@ -108,6 +111,7 @@ module.exports = function () {
   return {
     name: 'babel-plugin-ssr-loader-id',
     pre() {
+      hasUseLoader = false;
       index = 0;
       useLoader = null;
       hash = '';
@@ -156,4 +160,4 @@ module.exports = function () {
       },
     },
   };
-};
+}

--- a/packages/runtime/plugin-runtime/src/ssr/cli/babel-plugin-ssr-loader-id.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/babel-plugin-ssr-loader-id.ts
@@ -6,8 +6,11 @@ import { get } from '@modern-js/utils/lodash';
 const RUNTIME_PACKAGE_NAMES = ['@modern-js/runtime'];
 const FUNCTION_USE_LOADER_NAME = 'useLoader';
 
-// eslint-disable-next-line import/no-mutable-exports
-export let hasUseLoader = false;
+let hasUseLoader = false;
+
+export function getHasUseLoader(): boolean {
+  return hasUseLoader;
+}
 
 function getHash(filepath: string) {
   const cwd = process.cwd();

--- a/packages/runtime/plugin-runtime/src/ssr/cli/babel-plugin-ssr-loader-id.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/babel-plugin-ssr-loader-id.ts
@@ -6,11 +6,15 @@ import { get } from '@modern-js/utils/lodash';
 const RUNTIME_PACKAGE_NAMES = ['@modern-js/runtime'];
 const FUNCTION_USE_LOADER_NAME = 'useLoader';
 
-let hasUseLoader = false;
-
-export function getHasUseLoader(): boolean {
-  return hasUseLoader;
-}
+export const loaderState = {
+  _hasLoader: false,
+  get() {
+    return this._hasLoader;
+  },
+  set(value: boolean) {
+    this._hasLoader = value;
+  },
+};
 
 function getHash(filepath: string) {
   const cwd = process.cwd();
@@ -79,7 +83,7 @@ function getSelfRunLoaderExpression(
   loaderExpression: t.Expression,
   id: string,
 ) {
-  hasUseLoader = true;
+  loaderState.set(true);
   return t.callExpression(
     t.functionExpression(
       null,
@@ -114,7 +118,6 @@ export default function () {
   return {
     name: 'babel-plugin-ssr-loader-id',
     pre() {
-      hasUseLoader = false;
       index = 0;
       useLoader = null;
       hash = '';

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -6,6 +6,8 @@ import {
   isUseSSRBundle,
   createRuntimeExportsUtils,
   isSSGEntry,
+  ROUTE_SPEC_FILE,
+  fs,
 } from '@modern-js/utils';
 import type {
   AppNormalizedConfig,
@@ -57,7 +59,22 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
 
     let pluginsExportsUtils: any;
 
+    const afterDevOrBuild = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      const { hasUseLoader } = require('./babel-plugin-ssr-loader-id');
+      const { distDirectory } = api.useAppContext();
+
+      const routesSpecPath = path.join(distDirectory, ROUTE_SPEC_FILE);
+      const routesSpec = JSON.parse(await fs.readFile(routesSpecPath, 'utf-8'));
+      await fs.outputFile(
+        routesSpecPath,
+        JSON.stringify({ ...routesSpec, hasUseLoader }, null, 2),
+      );
+    };
+
     return {
+      afterDev: afterDevOrBuild,
+      afterBuild: afterDevOrBuild,
       config() {
         const appContext = api.useAppContext();
         pluginsExportsUtils = createRuntimeExportsUtils(

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -60,10 +60,11 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
     let pluginsExportsUtils: any;
 
     const afterDevOrBuild = async () => {
-      const { getHasUseLoader } = await import('./babel-plugin-ssr-loader-id');
+      const { loaderState } = await import('./babel-plugin-ssr-loader-id');
+
       const { distDirectory } = api.useAppContext();
 
-      const hasUseLoader = getHasUseLoader();
+      const hasUseLoader = loaderState.get();
       const routesSpecPath = path.join(distDirectory, ROUTE_SPEC_FILE);
       const routesSpec = JSON.parse(await fs.readFile(routesSpecPath, 'utf-8'));
       await fs.outputFile(

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -60,10 +60,10 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
     let pluginsExportsUtils: any;
 
     const afterDevOrBuild = async () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-      const { hasUseLoader } = require('./babel-plugin-ssr-loader-id');
+      const { getHasUseLoader } = await import('./babel-plugin-ssr-loader-id');
       const { distDirectory } = api.useAppContext();
 
+      const hasUseLoader = getHasUseLoader();
       const routesSpecPath = path.join(distDirectory, ROUTE_SPEC_FILE);
       const routesSpec = JSON.parse(await fs.readFile(routesSpecPath, 'utf-8'));
       await fs.outputFile(

--- a/packages/runtime/plugin-runtime/src/ssr/prefetch.tsx
+++ b/packages/runtime/plugin-runtime/src/ssr/prefetch.tsx
@@ -5,7 +5,8 @@ import { RuntimeContext } from '../core';
 
 function checkHasUseLoader(serverContext: RuntimeContext['ssrContext']) {
   const routeSpec = serverContext?.routeSpec;
-  return Boolean(routeSpec?.hasUseLoader);
+  // We think it need pre-render if routeSpect.hasUseLoader === True or undefined.
+  return routeSpec?.hasUseLoader !== false;
 }
 
 // todo: SSRContext

--- a/packages/runtime/plugin-runtime/src/ssr/prefetch.tsx
+++ b/packages/runtime/plugin-runtime/src/ssr/prefetch.tsx
@@ -3,6 +3,11 @@ import { run } from '@modern-js/utils/runtime-node';
 import { ChunkExtractor } from '@loadable/server';
 import { RuntimeContext } from '../core';
 
+function checkHasUseLoader(serverContext: RuntimeContext['ssrContext']) {
+  const routeSpec = serverContext?.routeSpec;
+  return Boolean(routeSpec?.hasUseLoader);
+}
+
 // todo: SSRContext
 const prefetch = async (
   App: React.ComponentType<any>,
@@ -12,14 +17,18 @@ const prefetch = async (
     const { ssrContext } = context;
     const { loadableStats } = ssrContext!;
 
-    if (loadableStats) {
-      const extractor = new ChunkExtractor({
-        stats: loadableStats,
-        entrypoints: [ssrContext!.entryName].filter(Boolean),
-      });
-      renderToStaticMarkup(extractor.collectChunks(<App context={context} />));
-    } else {
-      renderToStaticMarkup(<App context={context} />);
+    if (checkHasUseLoader(ssrContext)) {
+      if (loadableStats) {
+        const extractor = new ChunkExtractor({
+          stats: loadableStats,
+          entrypoints: [ssrContext!.entryName].filter(Boolean),
+        });
+        renderToStaticMarkup(
+          extractor.collectChunks(<App context={context} />),
+        );
+      } else {
+        renderToStaticMarkup(<App context={context} />);
+      }
     }
 
     if (!context.loaderManager.hasPendingLoaders()) {

--- a/packages/server/prod-server/src/libs/render/ssr.ts
+++ b/packages/server/prod-server/src/libs/render/ssr.ts
@@ -5,6 +5,7 @@ import {
   LOADABLE_STATS_FILE,
   ROUTE_MANIFEST_FILE,
   SERVER_RENDER_FUNCTION_NAME,
+  ROUTE_SPEC_FILE,
 } from '@modern-js/utils';
 import type { ModernServerContext } from '@modern-js/types';
 import { RenderResult, ServerHookRunner } from '../../type';
@@ -44,6 +45,10 @@ export const render = async (
   const routeManifest = fs.existsSync(routesManifestUri)
     ? require(routesManifestUri)
     : undefined;
+  const routeSpecUri = path.join(distDir, ROUTE_SPEC_FILE);
+  const routeSpec = fs.existsSync(routeSpecUri)
+    ? require(routeSpecUri)
+    : undefined;
 
   const context: SSRServerContext = {
     request: {
@@ -66,6 +71,7 @@ export const render = async (
     },
     redirection: {},
     template,
+    routeSpec,
     loadableStats,
     routeManifest, // for streaming ssr
     entryName,

--- a/packages/toolkit/types/server/context.d.ts
+++ b/packages/toolkit/types/server/context.d.ts
@@ -70,6 +70,10 @@ export type BaseSSRServerContext = {
   redirection: { url?: string; status?: number };
   loadableStats: Record<string, any>;
   routeManifest?: Record<string, any>;
+  routeSpec?: {
+    routes: Record<string, any>;
+    hasUseLoader?: boolean;
+  };
   template: string;
   entryName: string;
   logger: {
@@ -89,6 +93,7 @@ export type BaseSSRServerContext = {
       tags: Record<string, unknown> = {},
     ) => void;
   };
+
   reporter: Reporter;
   serverTiming: ServerTiming;
   cacheConfig?: any;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9003,6 +9003,34 @@ importers:
         specifier: ^5
         version: 5.0.4
 
+  tests/integration/ssr/fixtures/useLoader:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^18.0.1
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.0.1
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/tsconfig':
+        specifier: workspace:*
+        version: link:../../../../../packages/review/tsconfig
+      '@types/react':
+        specifier: ^18
+        version: 18.0.21
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.0.6
+      typescript:
+        specifier: ^5
+        version: 5.0.4
+
   tests/integration/swc:
     dependencies:
       '@types/jest':

--- a/tests/integration/ssr/fixtures/useLoader/modern.config.ts
+++ b/tests/integration/ssr/fixtures/useLoader/modern.config.ts
@@ -1,0 +1,14 @@
+import { appTools, defineConfig } from '@modern-js/app-tools';
+
+const bundler = process.env.BUNDLER;
+
+export default defineConfig({
+  server: {
+    ssr: true,
+  },
+  plugins: [
+    appTools({
+      bundler: bundler === 'rspack' ? 'experimental-rspack' : 'webpack',
+    }),
+  ],
+});

--- a/tests/integration/ssr/fixtures/useLoader/package.json
+++ b/tests/integration/ssr/fixtures/useLoader/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ssr-use-loader",
+  "version": "2.9.0",
+  "private": true,
+  "scripts": {
+    "dev": "modern dev"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18.0.1",
+    "react-dom": "^18.0.1"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/tsconfig": "workspace:*",
+    "typescript": "^5",
+    "@types/react": "^18",
+    "@types/react-dom": "^18"
+  }
+}

--- a/tests/integration/ssr/fixtures/useLoader/src/App.tsx
+++ b/tests/integration/ssr/fixtures/useLoader/src/App.tsx
@@ -1,0 +1,9 @@
+import { useLoader } from '@modern-js/runtime';
+
+export default () => {
+  const { data } = useLoader(async () => {
+    return 'Hello-Edenx';
+  });
+
+  return <div>{data}</div>;
+};

--- a/tests/integration/ssr/fixtures/useLoader/tsconfig.json
+++ b/tests/integration/ssr/fixtures/useLoader/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ],
+      "@shared/*": [
+        "./shared/*"
+      ],
+      "@api/*": [
+        "./api/*"
+      ]
+    }
+  },
+  "include": [
+    "src",
+    "shared",
+    "config",
+    "modern.config.ts",
+    "api"
+  ]
+}

--- a/tests/integration/ssr/tests/useLoader.test.ts
+++ b/tests/integration/ssr/tests/useLoader.test.ts
@@ -1,0 +1,68 @@
+import http, { OutgoingHttpHeaders } from 'http';
+import path from 'path';
+import { fs } from '@modern-js/utils';
+import { launchApp, getPort, killApp } from '../../../utils/modernTestUtils';
+
+const fixtureDir = path.resolve(__dirname, '../fixtures');
+
+async function request(
+  url: string,
+  options?: { timeout?: number },
+): Promise<{
+  body: string;
+  headers: OutgoingHttpHeaders;
+}> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      reject(`timeout: ${options?.timeout || 3000}`);
+    }, options?.timeout || 3000);
+    const req = http.request(url, res => {
+      res.on('error', reject);
+      let data = '';
+      res.on('data', chunk => {
+        data += chunk.toString();
+      });
+      res.on('end', () => {
+        resolve({
+          headers: res.headers,
+          body: data,
+        });
+      });
+    });
+
+    req.end();
+  });
+}
+
+describe('SSR use loader', () => {
+  let app: any;
+  let appPort: number;
+  const appDir = path.join(fixtureDir, 'useLoader');
+
+  beforeAll(async () => {
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort);
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await killApp(app);
+    }
+  });
+
+  test(`should content `, async () => {
+    const url = `http://127.0.0.1:${appPort}`;
+    const { body } = await request(url);
+
+    expect(body).toMatch('Hello-Edenx');
+  });
+
+  test('should set routes.json hasUseLoader is true', async () => {
+    const routePath = path.resolve(appDir, 'dist', 'route.json');
+
+    const content = JSON.parse(fs.readFileSync(routePath, 'utf-8'));
+
+    expect(content.hasUseLoader).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 753c705</samp>

This pull request enhances the SSR plugin and the server-side rendering module to support optional loaders for SSR entries. It also updates the babel plugin `ssr-loader-id` to use ES6 syntax and track its usage. It adds a changeset file to document the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 753c705</samp>

*  Add a changeset file to specify the affected packages and versions ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-4f632df3e560392e91eb15260475df6587cd70a9cadeaaccf1212ccaa77c245dR1-R7))
*  Add and export a `hasUseLoader` variable to track the loader usage in the babel plugin `ssr-loader-id` ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-98c9a48c6f1f62dbcd0d64f2c1ad34cd9cf3a3fe4002b68755070f30401d84d5R9-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-98c9a48c6f1f62dbcd0d64f2c1ad34cd9cf3a3fe4002b68755070f30401d84d5L98-R102))
*  Set and reset the `hasUseLoader` variable in the `getSelfRunLoaderExpression` and `Program` functions of the babel plugin `ssr-loader-id` ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-98c9a48c6f1f62dbcd0d64f2c1ad34cd9cf3a3fe4002b68755070f30401d84d5R79), [link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-98c9a48c6f1f62dbcd0d64f2c1ad34cd9cf3a3fe4002b68755070f30401d84d5R114))
*  Remove an unnecessary semicolon in the babel plugin `ssr-loader-id` ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-98c9a48c6f1f62dbcd0d64f2c1ad34cd9cf3a3fe4002b68755070f30401d84d5L159-R163))
*  Import the `hasUseLoader` variable from the babel plugin `ssr-loader-id` in the `cli/index.ts` module ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5R9-R10))
*  Add `afterDev` and `afterBuild` hooks to the `ssrPlugin` object in the `cli/index.ts` module to read and write the route specification file `ROUTE_SPEC_FILE` ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5R9-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5L60-R77))
*  Add a `checkHasUseLoader` function to the `prefetch.tsx` module to determine the loader usage from the route specification object ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-f101a2b994f6a9674089eb10c342b7770ff8cda675ea6a24c36a7bff4b55bdb2R6-R10))
*  Modify the `prefetch` function in the `prefetch.tsx` module to use or skip the `ChunkExtractor` based on the `checkHasUseLoader` function ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-f101a2b994f6a9674089eb10c342b7770ff8cda675ea6a24c36a7bff4b55bdb2L15-R31))
*  Import the `ROUTE_SPEC_FILE` constant in the `ssr.ts` module ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-11c102982d4c6e9170690b8a835eabccf0e03018adbf774498acb0ce7c97047fR8))
*  Add a `routeSpec` variable to the `render` function in the `ssr.ts` module to read and require the route specification file ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-11c102982d4c6e9170690b8a835eabccf0e03018adbf774498acb0ce7c97047fR48-R51))
*  Add the `routeSpec` variable to the `ssrContext` object in the `ssr.ts` module to pass the route specification information to the `prefetch` function and the `App` component ([link](https://github.com/web-infra-dev/modern.js/pull/4536/files?diff=unified&w=0#diff-11c102982d4c6e9170690b8a835eabccf0e03018adbf774498acb0ce7c97047fR74))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
