### PR TITLE
test(integration): fix failed to run twin.macro test case

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8533,8 +8533,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3(ts-node@10.9.1)
       twin.macro:
-        specifier: ^3
-        version: 3.1.0(tailwindcss@3.3.3)
+        specifier: ^3.4.0
+        version: 3.4.0(tailwindcss@3.3.3)
 
   tests/integration/temp-dir:
     dependencies:
@@ -14966,7 +14966,7 @@ packages:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     dev: false
@@ -15044,7 +15044,7 @@ packages:
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       ts-dedent: 2.2.0
@@ -15218,7 +15218,7 @@ packages:
       global: 4.4.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
     dev: false
 
@@ -15269,7 +15269,7 @@ packages:
       core-js: 3.30.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
     dev: false
 
   /@storybook/addon-viewport@6.5.12(react-dom@17.0.2)(react@17.0.2):
@@ -15295,7 +15295,7 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
     dev: false
 
   /@storybook/addons@6.5.12(react-dom@17.0.2)(react@17.0.2):
@@ -15338,7 +15338,7 @@ packages:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       store2: 2.13.2
       telejson: 6.0.8
       ts-dedent: 2.2.0
@@ -15527,7 +15527,7 @@ packages:
       qs: 6.11.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       store2: 2.13.2
       synchronous-promise: 2.0.15
       ts-dedent: 2.2.0
@@ -15554,7 +15554,7 @@ packages:
       qs: 6.11.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       util-deprecate: 1.0.2
     dev: false
 
@@ -15587,7 +15587,7 @@ packages:
       qs: 6.11.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
       typescript: 5.0.4
       unfetch: 4.2.0
@@ -15624,7 +15624,7 @@ packages:
       qs: 6.11.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
       typescript: 5.0.4
       unfetch: 4.2.0
@@ -15763,7 +15763,7 @@ packages:
       prompts: 2.4.2
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       serve-favicon: 2.5.0
       slash: 3.0.0
       telejson: 6.0.8
@@ -15845,7 +15845,7 @@ packages:
       core-js: 3.30.0
       fs-extra: 9.1.0
       global: 4.4.0
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -15865,7 +15865,7 @@ packages:
       core-js: 3.30.0
       doctrine: 3.0.0
       lodash: 4.17.21
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
     transitivePeerDependencies:
       - react
       - react-dom
@@ -15908,7 +15908,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
       style-loader: 1.3.0(webpack@4.46.0)
       telejson: 6.0.8
@@ -16041,7 +16041,7 @@ packages:
       qs: 6.11.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       synchronous-promise: 2.0.15
       ts-dedent: 2.2.0
       unfetch: 4.2.0
@@ -16171,7 +16171,7 @@ packages:
       qs: 6.11.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
 
   /@storybook/semver@7.3.2:
     resolution: {integrity: sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==}
@@ -16198,7 +16198,7 @@ packages:
       prettier: 2.3.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
     dev: false
 
   /@storybook/store@6.5.12(react-dom@17.0.2)(react@17.0.2):
@@ -16218,7 +16218,7 @@ packages:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       slash: 3.0.0
       stable: 0.1.8
       synchronous-promise: 2.0.15
@@ -16240,7 +16240,7 @@ packages:
       isomorphic-unfetch: 3.1.0
       nanoid: 3.3.4
       read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
     transitivePeerDependencies:
       - encoding
       - eslint
@@ -16264,7 +16264,7 @@ packages:
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
 
   /@storybook/ui@6.5.12(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-P7+ARI5NvaEYkrbIciT/UMgy3kxMt4WCtHMXss2T01UMCIWh1Ws4BJaDNqtQSpKuwjjS4eqZL3aQWhlUpYAUEg==}
@@ -16286,7 +16286,7 @@ packages:
       qs: 6.11.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
     dev: false
 
@@ -33181,7 +33181,7 @@ packages:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      resolve: 1.22.1
+      resolve: 1.22.4
 
   /redent@1.0.0:
     resolution: {integrity: sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==}
@@ -33248,9 +33248,6 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-
-  /regenerator-runtime@0.13.9:
-    resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
 
   /regenerator-transform@0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
@@ -36094,11 +36091,11 @@ packages:
       - ts-node
     dev: false
 
-  /twin.macro@3.1.0(tailwindcss@3.3.3):
-    resolution: {integrity: sha512-7DSR/xdvSaAqhTM4JptBgI+1IzXQR5v+2hp0CDMmHMjlm44IBEewU8MeqPlXmFgQI06zpLyJMaKRbJu96drAJw==}
+  /twin.macro@3.4.0(tailwindcss@3.3.3):
+    resolution: {integrity: sha512-sOZN3PAlUpA/5ZITFkK1UjYhAKqKUGLrAbqviVagmd/B18Es6faozVdUceJTpMklD/dAjxhHCMPP2gwpJLCbyg==}
     engines: {node: '>=16.14.0'}
     peerDependencies:
-      tailwindcss: ^3.2.4
+      tailwindcss: '>=3.3.1'
     dependencies:
       '@babel/template': 7.20.7
       babel-plugin-macros: 3.1.0

--- a/tests/integration/tailwindcss/fixtures/twin.macro-v3/package.json
+++ b/tests/integration/tailwindcss/fixtures/twin.macro-v3/package.json
@@ -8,7 +8,7 @@
     "@modern-js/runtime": "workspace:*",
     "postcss": "8.4.27",
     "tailwindcss": "^3.3.3",
-    "twin.macro": "^3",
+    "twin.macro": "^3.4.0",
     "react": "^18",
     "react-dom": "^18"
   }


### PR DESCRIPTION
## Summary

Fix:

<img width="1053" alt="Screenshot 2023-08-29 at 19 49 06" src="https://github.com/web-infra-dev/modern.js/assets/7237365/82720235-62f5-4ad1-8430-5a6bfa721a06">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41f3ae9</samp>

Updated `twin.macro` dependency and integration tests to support Tailwind CSS v3. This allows using the `tw` prop syntax for styling components with Tailwind classes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41f3ae9</samp>

* Update the `twin.macro` dependency to the latest version for Tailwind CSS v3 support ([link](https://github.com/web-infra-dev/modern.js/pull/4540/files?diff=unified&w=0#diff-e6f309edb283be18610e0fab66538dcc1898661553150fe6f83cf5d91dac14dfL11-R11))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
