### PR TITLE
fix(builder): `html.meta.referrer` can't accept literal false value

### DIFF
--- a/.changeset/red-dolphins-change.md
+++ b/.changeset/red-dolphins-change.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): `html.meta.referrer` can't accept literal false value
+fix(builder): `html.meta.referrer` 配置无法接受 false 字面量作为值

--- a/packages/builder/builder-shared/src/schema/html.ts
+++ b/packages/builder/builder-shared/src/schema/html.ts
@@ -15,7 +15,7 @@ export const MetaAttributesSchema: ZodType<MetaAttributes> = z.record(
 );
 
 export const MetaOptionsSchema: ZodType<MetaOptions> = z.record(
-  z.union([z.string(), z.literal('false'), MetaAttributesSchema]),
+  z.union([z.string(), z.literal(false), MetaAttributesSchema]),
 );
 
 export const ScriptLoadingSchema: ZodType<ScriptLoading> = z.enum([


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3ba6ea</samp>

This pull request fixes a bug in the `@modern-js/builder-shared` package that prevented using `false` as a value for the `html.meta.referrer` option. It also adds a changeset file to document the fix and prepare for a new release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d3ba6ea</samp>

* Fix `html.meta.referrer` option validation in `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/4549/files?diff=unified&w=0#diff-a76ea8cbeafa8ec5b4243170d41c44c9bbecf23be2224acbe9a574bed50b8f5bL18-R18), [link](https://github.com/web-infra-dev/modern.js/pull/4549/files?diff=unified&w=0#diff-478601f1b817f3c9c1e33913fbaec173c9ce389ec85d132bc94b4c25d819bd15R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
