### PR TITLE
fix(CI): failed to build website

### DIFF
--- a/.github/workflows/build-builder-website.yml
+++ b/.github/workflows/build-builder-website.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Turbo Cache
         id: turbo-cache
@@ -37,10 +37,6 @@ jobs:
           restore-keys: |
             turbo-${{ github.ref_name }}-
             turbo-
-
-
-      - name: Build Dependencies
-        run: pnpm turbo run build --filter="@modern-js/builder-doc"
 
       - name: Build Website
         run: pnpm --filter @modern-js/builder-doc run build:doc

--- a/.github/workflows/build-main-website.yml
+++ b/.github/workflows/build-main-website.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Turbo Cache
         id: turbo-cache
@@ -41,9 +41,6 @@ jobs:
 
       - name: Build Main Doc
         run: cd packages/document/main-doc && npm run build && cd ../../../
-
-      - name: Build Dependencies
-        run: pnpm turbo run build --filter="@modern-js/main-doc"
 
       - name: Build Website
         run: pnpm --filter @modern-js/main-doc run build:doc

--- a/.github/workflows/build-module-website.yml
+++ b/.github/workflows/build-module-website.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Turbo Cache
         id: turbo-cache
@@ -37,9 +37,6 @@ jobs:
           restore-keys: |
             turbo-${{ github.ref_name }}-
             turbo-
-
-      - name: Build Dependencies
-        run: pnpm turbo run build --filter="@modern-js/module-tools-docs"
 
       - name: Build Website
         run: pnpm --filter @modern-js/module-tools-docs run build:doc


### PR DESCRIPTION
## Summary

We need to build all dependencies to make Rspress work, because Rspress depends on some internal packages and pnpm do not known about it.

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/e0cb7e00-86d7-4014-9e2c-8d5b04bdadab)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
