### PR TITLE
feat: new and upgrade command support --no-need-install params

### DIFF
--- a/.changeset/lovely-doors-attend.md
+++ b/.changeset/lovely-doors-attend.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/monorepo-tools': patch
+'@modern-js/module-tools': patch
+'@modern-js/app-tools': patch
+---
+
+feat: new and upgrade command support --no-need-install params

--- a/packages/generator/new-action/src/module.ts
+++ b/packages/generator/new-action/src/module.ts
@@ -33,6 +33,7 @@ interface IModuleNewActionOption {
   registry?: string;
   config?: string;
   cwd?: string;
+  needInstall?: boolean;
 }
 
 export const ModuleNewAction = async (options: IModuleNewActionOption) => {
@@ -43,6 +44,7 @@ export const ModuleNewAction = async (options: IModuleNewActionOption) => {
     registry = '',
     config = '{}',
     cwd = process.cwd(),
+    needInstall = true,
   } = options;
 
   let UserConfig: Record<string, unknown> = {};
@@ -134,6 +136,7 @@ export const ModuleNewAction = async (options: IModuleNewActionOption) => {
 
   const finalConfig = merge(
     UserConfig,
+    { noNeedInstall: !needInstall },
     ans,
     {
       locale: (UserConfig.locale as string) || locale,

--- a/packages/generator/new-action/src/monorepo.ts
+++ b/packages/generator/new-action/src/monorepo.ts
@@ -13,6 +13,7 @@ interface IMonorepoNewActionOption {
   config?: string;
   plugin?: string[];
   cwd?: string;
+  needInstall?: boolean;
 }
 
 const REPO_GENERATOR = '@modern-js/repo-generator';
@@ -26,6 +27,7 @@ export const MonorepoNewAction = async (options: IMonorepoNewActionOption) => {
     config = '{}',
     plugin = [],
     cwd = process.cwd(),
+    needInstall = true,
   } = options;
   let UserConfig: Record<string, unknown> = {};
 
@@ -66,6 +68,7 @@ export const MonorepoNewAction = async (options: IMonorepoNewActionOption) => {
     isMonorepo: true,
     distTag,
     plugins,
+    noNeedInstall: !needInstall,
   });
 
   let generator = REPO_GENERATOR;

--- a/packages/generator/new-action/src/mwa.ts
+++ b/packages/generator/new-action/src/mwa.ts
@@ -37,6 +37,7 @@ interface IMWANewActionOption {
   registry?: string;
   config?: string;
   cwd?: string;
+  needInstall?: boolean;
 }
 
 export const MWANewAction = async (options: IMWANewActionOption) => {
@@ -47,6 +48,7 @@ export const MWANewAction = async (options: IMWANewActionOption) => {
     registry = '',
     config = '{}',
     cwd = process.cwd(),
+    needInstall = true,
   } = options;
 
   let UserConfig: Record<string, unknown> = {};
@@ -141,6 +143,7 @@ export const MWANewAction = async (options: IMWANewActionOption) => {
 
   const finalConfig = merge(
     UserConfig,
+    { noNeedInstall: !needInstall },
     ans,
     {
       locale: (UserConfig.locale as string) || locale,

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -237,6 +237,10 @@ export const appTools = (
           .option('-d, --debug', i18n.t(localeKeys.command.new.debug), false)
           .option('--dist-tag <tag>', i18n.t(localeKeys.command.new.distTag))
           .option('--registry', i18n.t(localeKeys.command.new.registry))
+          .option(
+            '--no-need-install',
+            i18n.t(localeKeys.command.shared.noNeedInstall),
+          )
           .action(async (options: any) => {
             const { MWANewAction } = await import('@modern-js/new-action');
             await MWANewAction({ ...options, locale: options.lang || locale });
@@ -272,6 +276,10 @@ export const appTools = (
             .option(
               '-c --config <config>',
               i18n.t(localeKeys.command.shared.config),
+            )
+            .option(
+              '--no-need-install',
+              i18n.t(localeKeys.command.shared.noNeedInstall),
             ),
         );
       },

--- a/packages/solutions/app-tools/src/locale/en.ts
+++ b/packages/solutions/app-tools/src/locale/en.ts
@@ -5,6 +5,7 @@ export const EN_LOCALE = {
       config:
         'specify the configuration file, which can be a relative or absolute path',
       skipBuild: 'skip the build phase',
+      noNeedInstall: 'not run install command',
     },
     dev: {
       describe: 'starting the dev server',

--- a/packages/solutions/app-tools/src/locale/zh.ts
+++ b/packages/solutions/app-tools/src/locale/zh.ts
@@ -4,6 +4,7 @@ export const ZH_LOCALE = {
       analyze: '分析构建产物体积，查看各个模块打包后的大小',
       config: '指定配置文件路径，可以为相对路径或绝对路径',
       skipBuild: '跳过构建阶段',
+      noNeedInstall: '无需安装依赖',
     },
     dev: {
       describe: '启动开发服务器',

--- a/packages/solutions/module-tools/src/command.ts
+++ b/packages/solutions/module-tools/src/command.ts
@@ -91,6 +91,10 @@ export const newCommand = async (program: Command) => {
     .option('-d, --debug', i18n.t(localeKeys.command.new.debug), false)
     .option('--dist-tag <tag>', i18n.t(localeKeys.command.new.distTag))
     .option('--registry', i18n.t(localeKeys.command.new.registry))
+    .option(
+      '--no-need-install',
+      i18n.t(localeKeys.command.shared.noNeedInstall),
+    )
     .action(async options => {
       const { ModuleNewAction } = await import('@modern-js/new-action');
       const { getLocaleLanguage } = await import(
@@ -108,6 +112,10 @@ export const upgradeCommand = async (program: Command) => {
   defineCommand(
     program
       .command('upgrade')
-      .option('-c --config <config>', i18n.t(localeKeys.command.shared.config)),
+      .option('-c --config <config>', i18n.t(localeKeys.command.shared.config))
+      .option(
+        '--no-need-install',
+        i18n.t(localeKeys.command.shared.noNeedInstall),
+      ),
   );
 };

--- a/packages/solutions/module-tools/src/locale/en.ts
+++ b/packages/solutions/module-tools/src/locale/en.ts
@@ -12,6 +12,7 @@ export const EN_LOCALE = {
     shared: {
       config:
         'sspecify the configuration file, which can be a relative or absolute path',
+      noNeedInstall: 'not run install command',
     },
     build: {
       describe: 'build the module for production',

--- a/packages/solutions/module-tools/src/locale/zh.ts
+++ b/packages/solutions/module-tools/src/locale/zh.ts
@@ -11,6 +11,7 @@ export const ZH_LOCALE = {
   command: {
     shared: {
       config: '指定配置文件路径，可以为相对路径或绝对路径',
+      noNeedInstall: '无需安装依赖',
     },
     build: {
       describe: '构建生产环境产物',

--- a/packages/solutions/monorepo-tools/src/cli/new.ts
+++ b/packages/solutions/monorepo-tools/src/cli/new.ts
@@ -25,6 +25,10 @@ export const newCli = (program: Command, locale?: string) => {
     .option('-d, --debug', i18n.t(localeKeys.command.new.debug), false)
     .option('--dist-tag <tag>', i18n.t(localeKeys.command.new.distTag))
     .option('--registry', i18n.t(localeKeys.command.new.registry))
+    .option(
+      '--no-need-install',
+      i18n.t(localeKeys.command.shared.noNeedInstall),
+    )
     .action(async options => {
       await MonorepoNewAction({ ...options, locale: options.lang || locale });
     });

--- a/packages/solutions/monorepo-tools/src/index.ts
+++ b/packages/solutions/monorepo-tools/src/index.ts
@@ -40,6 +40,10 @@ export const monorepoTools = (): CliPlugin<MonorepoTools> => ({
             .option(
               '-c --config <config>',
               i18n.t(localeKeys.command.shared.config),
+            )
+            .option(
+              '--no-need-install',
+              i18n.t(localeKeys.command.shared.noNeedInstall),
             ),
         );
       },

--- a/packages/solutions/monorepo-tools/src/locale/en.ts
+++ b/packages/solutions/monorepo-tools/src/locale/en.ts
@@ -3,6 +3,7 @@ export const EN_LOCALE = {
     shared: {
       config:
         'specify the configuration file, which can be a relative or absolute path',
+      noNeedInstall: 'not run install command',
     },
     new: {
       describe: 'generator runner for monorepo project',

--- a/packages/solutions/monorepo-tools/src/locale/zh.ts
+++ b/packages/solutions/monorepo-tools/src/locale/zh.ts
@@ -2,6 +2,7 @@ export const ZH_LOCALE = {
   command: {
     shared: {
       config: '指定配置文件路径，可以为相对路径或绝对路径',
+      noNeedInstall: '无需安装依赖',
     },
     new: {
       describe: 'Monorepo 创建子项目',


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b78f175</samp>

This pull request adds a new feature to various commands of the `modern.js` framework that allows users to skip the install command after generating or updating projects. It introduces a new option `--no-need-install` to the `new` and `upgrade` commands of the `appTools`, `moduleTools`, and `monorepoTools` programs, and to the `new` command of the module, monorepo, and modern web app generators. It also updates the interfaces, classes, methods, and locale files related to these commands and programs.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b78f175</samp>

*  Add `--no-need-install` option to `new` and `upgrade` commands for `appTools`, `moduleTools`, and `monorepoTools` programs to allow users to skip the install command when creating or upgrading projects ([link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR240-R243), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-7faca8f35926f59df729025a8e6f972eaee25b5ea384bd9288c46b211c5931ebR279-R282), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-a20cb2b1c80dd3f40ea746005d954c2efbe9a0fd79c14d1a90f18a20c2765fa7R94-R97), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-a20cb2b1c80dd3f40ea746005d954c2efbe9a0fd79c14d1a90f18a20c2765fa7L111-R119), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-d39b26085a0d7d94cae3228dabd2751af173b1f4316b534608d1c2388f1e4966R28-R31), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-7c1160007e67e48b78d371458745e86d05546576d0b6d10b11352446e5a4dc19R43-R46))
*  Add `needInstall` property to `IModuleNewActionOption`, `IMonorepoNewActionOption`, and `IMWANewActionOption` interfaces to indicate whether the install command should be run after generating projects ([link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-880dbe83176b62879be636bb02cab51bdb2465dfcd118ff2251e5f6c28fe8ef3R36), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-ff50e92f2bd846595b0cfc8af1b0b1b18909c8e84404a6d0ec620e4e0823be91R16), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-0f049aa0fa7f021a4c01a8d8a92ec357b678f2172c87c987aa694489f061845dR40))
*  Set default value of `needInstall` to `true` in `ModuleNewAction`, `MonorepoNewAction`, and `MWANewAction` classes ([link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-880dbe83176b62879be636bb02cab51bdb2465dfcd118ff2251e5f6c28fe8ef3R47), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-ff50e92f2bd846595b0cfc8af1b0b1b18909c8e84404a6d0ec620e4e0823be91R30), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-0f049aa0fa7f021a4c01a8d8a92ec357b678f2172c87c987aa694489f061845dR51))
*  Pass `noNeedInstall` option (negation of `needInstall`) to `generate` method of `ModuleNewAction`, `MonorepoNewAction`, and `MWANewAction` classes to decide whether to run the install command or not ([link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-880dbe83176b62879be636bb02cab51bdb2465dfcd118ff2251e5f6c28fe8ef3R139), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-ff50e92f2bd846595b0cfc8af1b0b1b18909c8e84404a6d0ec620e4e0823be91R71), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-0f049aa0fa7f021a4c01a8d8a92ec357b678f2172c87c987aa694489f061845dR146))
*  Add `noNeedInstall` locale key to `EN_LOCALE` and `ZH_LOCALE` objects for `appTools`, `moduleTools`, and `monorepoTools` programs to provide descriptions of the `--no-need-install` option in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-96bc59386bd0aecfd52724f9a2e14e502bacee107ca38fa72a9a834f5bcedbd8R8), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-a86aec521f74ce94a132bf546f59fbf09b7e53c9948b84dbd8a633f2f1d7a1e5R7), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-044266080bf8162ec64961353e7f64de96a77d536bc9b2aacda435ba28b0c55cR15), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-6f0fa3593edef4f07b0b158eda75b877e7307c02189b5681f15beef8195f02f2R14), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-d7fbf5c14fef1b06aade81cac0f888aa3d39a6b64e66c5b866baa0c136a203c8R6), [link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-fe6ca53c740956c0c902bb8bf9ecc91ae11db3f65aaffbb16e5d09f7fd851af0R5))
*  Add changeset file to describe the patch updates for `@modern-js/monorepo-tools`, `@modern-js/module-tools`, and `@modern-js/app-tools` packages and the feature added by the pull request ([link](https://github.com/web-infra-dev/modern.js/pull/4555/files?diff=unified&w=0#diff-d32988c3bfc6ce56f7f1722a9ab1219419d2310032bd456b34c3409894c642edR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
