### PR TITLE
fix(plugin-swc): update core-js

### DIFF
--- a/.changeset/strong-news-rhyme.md
+++ b/.changeset/strong-news-rhyme.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-plugin-swc': patch
+---
+
+fix(plugin-swc): update core-js
+
+fix(plugin-swc): 升级 core-js

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -62,7 +62,7 @@
     "@swc/helpers": "0.5.1",
     "rspack-manifest-plugin": "5.0.0-alpha0",
     "caniuse-lite": "^1.0.30001520",
-    "core-js": "~3.30.0",
+    "core-js": "~3.32.1",
     "react-refresh": "0.14.0",
     "rspack-plugin-virtual-module": "0.1.7",
     "style-loader": "3.3.3",

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -36,7 +36,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       },
     ],
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -789,7 +789,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       },
     ],
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -2046,7 +2046,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
       },
     ],
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/swc.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/swc.test.ts.snap
@@ -14,7 +14,7 @@ exports[`plugins/swc > should add antd pluginImport 1`] = `
       },
     ],
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -47,7 +47,7 @@ exports[`plugins/swc > should add browserslist 1`] = `
       "legacy": true,
     },
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "chrome 98",
@@ -78,7 +78,7 @@ exports[`plugins/swc > should add browserslist 2`] = `
       "legacy": true,
     },
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "chrome 98",
@@ -114,7 +114,7 @@ exports[`plugins/swc > should add pluginImport 1`] = `
       },
     ],
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -147,7 +147,7 @@ exports[`plugins/swc > should disable all pluginImport 1`] = `
       "legacy": true,
     },
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -223,7 +223,7 @@ exports[`plugins/swc > should enable entry mode preset_env 1`] = `
       "legacy": true,
     },
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -256,7 +256,7 @@ exports[`plugins/swc > should has correct core-js 1`] = `
       "legacy": true,
     },
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -289,7 +289,7 @@ exports[`plugins/swc > should has correct core-js 2`] = `
       "legacy": true,
     },
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",
@@ -342,7 +342,7 @@ exports[`plugins/swc > should'n override browserslist when target platform is no
       "legacy": true,
     },
     "presetEnv": {
-      "coreJs": "3.30",
+      "coreJs": "3.32",
       "mode": "entry",
       "targets": [
         "> 0.01%",

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -230,7 +230,7 @@ exports[`webpackConfig > should not have any pluginImport in Babel 1`] = `
                 "bugfixes": false,
                 "corejs": {
                   "proposals": true,
-                  "version": "3.30",
+                  "version": "3.32",
                 },
                 "exclude": [
                   "transform-typeof-symbol",
@@ -330,7 +330,7 @@ exports[`webpackConfig > should not have any pluginImport in Babel 1`] = `
                 "bugfixes": false,
                 "corejs": {
                   "proposals": true,
-                  "version": "3.30",
+                  "version": "3.32",
                 },
                 "exclude": [
                   "transform-typeof-symbol",
@@ -449,7 +449,7 @@ exports[`webpackConfig > should not set default pluginImport for Babel 1`] = `
                 "bugfixes": false,
                 "corejs": {
                   "proposals": true,
-                  "version": "3.30",
+                  "version": "3.32",
                 },
                 "exclude": [
                   "transform-typeof-symbol",
@@ -558,7 +558,7 @@ exports[`webpackConfig > should not set default pluginImport for Babel 1`] = `
                 "bugfixes": false,
                 "corejs": {
                   "proposals": true,
-                  "version": "3.30",
+                  "version": "3.32",
                 },
                 "exclude": [
                   "transform-typeof-symbol",
@@ -699,7 +699,7 @@ exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
                 "bugfixes": false,
                 "corejs": {
                   "proposals": true,
-                  "version": "3.30",
+                  "version": "3.32",
                 },
                 "exclude": [
                   "transform-typeof-symbol",
@@ -807,7 +807,7 @@ exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
                 "bugfixes": false,
                 "corejs": {
                   "proposals": true,
-                  "version": "3.30",
+                  "version": "3.32",
                 },
                 "exclude": [
                   "transform-typeof-symbol",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -88,7 +88,7 @@ exports[`plugins/babel > should add rule to compile Data URI when enable source.
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -188,7 +188,7 @@ exports[`plugins/babel > should add rule to compile Data URI when enable source.
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -509,7 +509,7 @@ exports[`plugins/babel > should apply exclude condition when using source.exclud
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -609,7 +609,7 @@ exports[`plugins/babel > should apply exclude condition when using source.exclud
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -731,7 +731,7 @@ exports[`plugins/babel > should override targets of babel-preset-env when using 
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -829,7 +829,7 @@ exports[`plugins/babel > should override targets of babel-preset-env when using 
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -941,7 +941,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -1041,7 +1041,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -1159,7 +1159,7 @@ exports[`plugins/babel > should set include/exclude 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -1259,7 +1259,7 @@ exports[`plugins/babel > should set include/exclude 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -564,7 +564,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                     "bugfixes": true,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -709,7 +709,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                     "bugfixes": true,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -1505,7 +1505,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                     "bugfixes": true,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -1650,7 +1650,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                     "bugfixes": true,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -3196,7 +3196,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                     "bugfixes": true,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -3341,7 +3341,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                     "bugfixes": true,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
@@ -85,7 +85,7 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -194,7 +194,7 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -67,7 +67,7 @@
     "@modern-js/swc-plugins": "0.6.0",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.5.1",
-    "core-js": "~3.30.0"
+    "core-js": "~3.32.1"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",

--- a/packages/builder/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/builder/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -26,7 +26,7 @@ exports[`plugins/swc > should apply source.include and source.exclude correctly 
             "options": {
               "cwd": "<ROOT>",
               "env": {
-                "coreJs": "3.30",
+                "coreJs": "3.32",
                 "mode": "entry",
                 "targets": [
                   "> 0.01%",
@@ -88,7 +88,7 @@ exports[`plugins/swc > should apply source.include and source.exclude correctly 
             "options": {
               "cwd": "<ROOT>",
               "env": {
-                "coreJs": "3.30",
+                "coreJs": "3.32",
                 "mode": "entry",
                 "targets": [
                   "> 0.01%",
@@ -153,7 +153,7 @@ exports[`plugins/swc > should disable react refresh when dev.hmr is false 1`] = 
           "options": {
             "cwd": "<ROOT>",
             "env": {
-              "coreJs": "3.30",
+              "coreJs": "3.32",
               "mode": "entry",
               "targets": [
                 "> 0.01%",
@@ -217,7 +217,7 @@ exports[`plugins/swc > should disable react refresh when target is not web 1`] =
           "options": {
             "cwd": "<ROOT>",
             "env": {
-              "coreJs": "3.30",
+              "coreJs": "3.32",
               "mode": "entry",
               "targets": [
                 "chrome >= 61",
@@ -283,7 +283,7 @@ exports[`plugins/swc > should disable react refresh when target is not web 2`] =
           "options": {
             "cwd": "<ROOT>",
             "env": {
-              "coreJs": "3.30",
+              "coreJs": "3.32",
               "mode": "entry",
               "targets": [
                 "node >= 14",
@@ -345,7 +345,7 @@ exports[`plugins/swc > should disable react refresh when target is not web 3`] =
           "options": {
             "cwd": "<ROOT>",
             "env": {
-              "coreJs": "3.30",
+              "coreJs": "3.32",
               "mode": "entry",
               "targets": [
                 "> 0.01%",
@@ -409,7 +409,7 @@ exports[`plugins/swc > should disable react refresh when target is not web 4`] =
           "options": {
             "cwd": "<ROOT>",
             "env": {
-              "coreJs": "3.30",
+              "coreJs": "3.32",
               "mode": "entry",
               "targets": [
                 "> 0.01%",
@@ -473,7 +473,7 @@ exports[`plugins/swc > should disable react refresh when target is not web 5`] =
           "options": {
             "cwd": "<ROOT>",
             "env": {
-              "coreJs": "3.30",
+              "coreJs": "3.32",
               "mode": "entry",
               "targets": [
                 "> 0.01%",
@@ -580,7 +580,7 @@ exports[`plugins/swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>",
           "env": {
-            "coreJs": "3.30",
+            "coreJs": "3.32",
             "mode": "entry",
             "targets": [
               "> 0.01%",
@@ -643,7 +643,7 @@ exports[`plugins/swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>",
           "env": {
-            "coreJs": "3.30",
+            "coreJs": "3.32",
             "mode": "entry",
             "targets": [
               "> 0.01%",
@@ -701,7 +701,7 @@ exports[`plugins/swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>",
           "env": {
-            "coreJs": "3.30",
+            "coreJs": "3.32",
             "mode": "entry",
             "targets": [
               "> 0.01%",
@@ -793,7 +793,7 @@ exports[`plugins/swc > should set swc-loader 1`] = `
             "options": {
               "cwd": "<ROOT>",
               "env": {
-                "coreJs": "3.30",
+                "coreJs": "3.32",
                 "mode": "entry",
                 "targets": [
                   "> 0.01%",
@@ -855,7 +855,7 @@ exports[`plugins/swc > should set swc-loader 1`] = `
             "options": {
               "cwd": "<ROOT>",
               "env": {
-                "coreJs": "3.30",
+                "coreJs": "3.32",
                 "mode": "entry",
                 "targets": [
                   "> 0.01%",

--- a/packages/builder/plugin-swc/tests/core-js.ts
+++ b/packages/builder/plugin-swc/tests/core-js.ts
@@ -1,0 +1,19 @@
+import { transformSync } from '../src/binding';
+import { describe } from 'vitest';
+
+describe('run code', () => {
+  const { code } = transformSync(
+    {
+      env: {
+        targets: 'ie 9',
+        mode: 'entry',
+      },
+    },
+    'test.js',
+    'import "core-js"',
+  );
+
+  try {
+    eval(code);
+  } catch (e) {}
+});

--- a/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -130,7 +130,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -236,7 +236,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -408,7 +408,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -512,7 +512,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",

--- a/packages/builder/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -122,7 +122,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -228,7 +228,7 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -400,7 +400,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",
@@ -506,7 +506,7 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                     "bugfixes": false,
                     "corejs": {
                       "proposals": true,
-                      "version": "3.30",
+                      "version": "3.32",
                     },
                     "exclude": [
                       "transform-typeof-symbol",

--- a/packages/cli/babel-preset-app/package.json
+++ b/packages/cli/babel-preset-app/package.json
@@ -42,7 +42,7 @@
     "@babel/types": "^7.21.5",
     "@modern-js/babel-preset-base": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "core-js": "~3.30.0",
+    "core-js": "~3.32.1",
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {

--- a/packages/cli/babel-preset-app/tests/utils.test.ts
+++ b/packages/cli/babel-preset-app/tests/utils.test.ts
@@ -3,7 +3,7 @@ import { getCoreJsVersion } from '@modern-js/utils';
 describe('getCoreJsVersion', () => {
   it('should get correct core-js version', () => {
     expect(getCoreJsVersion(require.resolve('core-js/package.json'))).toEqual(
-      '3.30',
+      '3.32',
     );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^1.0.30001520
         version: 1.0.30001520
       core-js:
-        specifier: ~3.30.0
-        version: 3.30.0
+        specifier: ~3.32.1
+        version: 3.32.1
       postcss:
         specifier: 8.4.27
         version: 8.4.27
@@ -632,8 +632,8 @@ importers:
         specifier: 0.5.1
         version: 0.5.1
       core-js:
-        specifier: ~3.30.0
-        version: 3.30.0
+        specifier: ~3.32.1
+        version: 3.32.1
     devDependencies:
       '@modern-js/builder-webpack-provider':
         specifier: workspace:*
@@ -782,8 +782,8 @@ importers:
         specifier: 0.5.1
         version: 0.5.1
       core-js:
-        specifier: ~3.30.0
-        version: 3.30.0
+        specifier: ~3.32.1
+        version: 3.32.1
     devDependencies:
       '@scripts/build':
         specifier: workspace:*
@@ -14580,7 +14580,7 @@ packages:
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
@@ -14614,7 +14614,7 @@ packages:
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       memoizerific: 1.11.3
       react: 17.0.2
@@ -14644,7 +14644,7 @@ packages:
       '@storybook/node-logger': 6.5.12
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -14691,7 +14691,7 @@ packages:
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       babel-loader: 8.2.5(@babel/core@7.21.8)(webpack@5.88.1)
-      core-js: 3.30.0
+      core-js: 3.32.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
@@ -14784,7 +14784,7 @@ packages:
       '@storybook/builder-webpack5': 6.5.12(esbuild@0.17.19)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       '@storybook/node-logger': 6.5.12
-      core-js: 3.30.0
+      core-js: 3.32.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
@@ -14817,7 +14817,7 @@ packages:
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/router': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@types/qs': 6.9.7
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       prop-types: 15.8.1
       qs: 6.11.0
@@ -14844,7 +14844,7 @@ packages:
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -14867,7 +14867,7 @@ packages:
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -14893,7 +14893,7 @@ packages:
       '@storybook/router': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/source-loader': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       estraverse: 5.3.0
       loader-utils: 2.0.4
       prop-types: 15.8.1
@@ -14919,7 +14919,7 @@ packages:
       '@storybook/client-logger': 6.5.12
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
@@ -14942,7 +14942,7 @@ packages:
       '@storybook/components': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/core-events': 6.5.12
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       memoizerific: 1.11.3
       prop-types: 15.8.1
@@ -14965,7 +14965,7 @@ packages:
       '@storybook/router': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@types/webpack-env': 1.17.0
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -14984,7 +14984,7 @@ packages:
       '@storybook/router': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
@@ -15029,7 +15029,7 @@ packages:
       autoprefixer: 9.8.8
       babel-loader: 8.2.5(@babel/core@7.21.8)(webpack@4.46.0)
       case-sensitive-paths-webpack-plugin: 2.4.0
-      core-js: 3.30.0
+      core-js: 3.32.1
       css-loader: 3.6.0(webpack@4.46.0)
       file-loader: 6.2.0(webpack@4.46.0)
       find-up: 5.0.0
@@ -15097,7 +15097,7 @@ packages:
       babel-plugin-named-exports-order: 0.0.2
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
-      core-js: 3.30.0
+      core-js: 3.32.1
       css-loader: 5.2.7(webpack@5.88.1)
       fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.28.0)(typescript@5.0.4)(webpack@5.88.1)
       glob: 7.2.0
@@ -15134,7 +15134,7 @@ packages:
       '@storybook/channels': 6.5.12
       '@storybook/client-logger': 6.5.12
       '@storybook/core-events': 6.5.12
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       qs: 6.11.0
       telejson: 6.0.8
@@ -15145,7 +15145,7 @@ packages:
     dependencies:
       '@storybook/channels': 6.5.12
       '@storybook/client-logger': 6.5.12
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       telejson: 6.0.8
     dev: false
@@ -15153,7 +15153,7 @@ packages:
   /@storybook/channels@6.5.12:
     resolution: {integrity: sha512-X5XaKbe4b7LXJ4sUakBo00x6pXnW78JkOonHoaKoWsccHLlEzwfBZpVVekhVZnqtCoLT23dB8wjKgA71RYWoiw==}
     dependencies:
-      core-js: 3.30.0
+      core-js: 3.32.1
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
@@ -15172,7 +15172,7 @@ packages:
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@types/qs': 6.9.7
       '@types/webpack-env': 1.17.0
-      core-js: 3.30.0
+      core-js: 3.32.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
@@ -15190,7 +15190,7 @@ packages:
   /@storybook/client-logger@6.5.12:
     resolution: {integrity: sha512-IrkMr5KZcudX935/C2balFbxLHhkvQnJ78rbVThHDVckQ7l3oIXTh66IMzldeOabVFDZEMiW8AWuGEYof+JtLw==}
     dependencies:
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
 
   /@storybook/components@6.5.12(react-dom@17.0.2)(react@17.0.2):
@@ -15202,7 +15202,7 @@ packages:
       '@storybook/client-logger': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       memoizerific: 1.11.3
       qs: 6.11.0
       react: 17.0.2
@@ -15234,7 +15234,7 @@ packages:
       '@storybook/ui': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       lodash: 4.17.21
       qs: 6.11.0
@@ -15271,7 +15271,7 @@ packages:
       '@storybook/ui': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       lodash: 4.17.21
       qs: 6.11.0
@@ -15325,7 +15325,7 @@ packages:
       babel-plugin-macros: 3.1.0
       babel-plugin-polyfill-corejs3: 0.1.7(@babel/core@7.21.8)
       chalk: 4.1.2
-      core-js: 3.30.0
+      core-js: 3.32.1
       express: 4.18.1
       file-system-cache: 1.1.0
       find-up: 5.0.0
@@ -15359,7 +15359,7 @@ packages:
   /@storybook/core-events@6.5.12:
     resolution: {integrity: sha512-0AMyMM19R/lHsYRfWqM8zZTXthasTAK2ExkSRzYi2GkIaVMxRKtM33YRwxKIpJ6KmIKIs8Ru3QCXu1mfCmGzNg==}
     dependencies:
-      core-js: 3.30.0
+      core-js: 3.32.1
 
   /@storybook/core-server@6.5.12(@storybook/builder-webpack5@6.5.12)(@storybook/manager-webpack5@6.5.12)(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
     resolution: {integrity: sha512-q1b/XKwoLUcCoCQ+8ndPD5THkEwXZYJ9ROv16i2VGUjjjAuSqpEYBq5GMGQUgxlWp1bkxtdGL2Jz+6pZfvldzA==}
@@ -15401,7 +15401,7 @@ packages:
       cli-table3: 0.6.2
       commander: 6.2.1
       compression: 1.7.4
-      core-js: 3.30.0
+      core-js: 3.32.1
       cpy: 8.1.2
       detect-port: 1.3.0
       express: 4.18.1
@@ -15495,7 +15495,7 @@ packages:
       '@babel/types': 7.21.5
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/mdx1-csf': 0.0.1(@babel/core@7.21.8)
-      core-js: 3.30.0
+      core-js: 3.32.1
       fs-extra: 9.1.0
       global: 4.4.0
       regenerator-runtime: 0.13.11
@@ -15515,7 +15515,7 @@ packages:
       '@babel/core': 7.21.8
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       doctrine: 3.0.0
       lodash: 4.17.21
       regenerator-runtime: 0.13.11
@@ -15549,7 +15549,7 @@ packages:
       babel-loader: 8.2.5(@babel/core@7.21.8)(webpack@4.46.0)
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
-      core-js: 3.30.0
+      core-js: 3.32.1
       css-loader: 3.6.0(webpack@4.46.0)
       express: 4.18.1
       file-loader: 6.2.0(webpack@4.46.0)
@@ -15606,7 +15606,7 @@ packages:
       babel-loader: 8.2.5(@babel/core@7.21.8)(webpack@5.88.1)
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
-      core-js: 3.30.0
+      core-js: 3.32.1
       css-loader: 5.2.7(webpack@5.88.1)
       express: 4.18.1
       find-up: 5.0.0
@@ -15664,7 +15664,7 @@ packages:
     dependencies:
       '@types/npmlog': 4.1.4
       chalk: 4.1.2
-      core-js: 3.30.0
+      core-js: 3.32.1
       npmlog: 5.0.1
       pretty-hrtime: 1.0.3
     dev: false
@@ -15672,7 +15672,7 @@ packages:
   /@storybook/postinstall@6.5.12:
     resolution: {integrity: sha512-6K73f9c2UO+w4Wtyo2BxEpEsnhPvMgqHSaJ9Yt6Tc90LaDGUbcVgy6PNibsRyuJ/KQ543WeiRO5rSZfm2uJU9A==}
     dependencies:
-      core-js: 3.30.0
+      core-js: 3.32.1
     dev: false
 
   /@storybook/preview-web@6.5.12(react-dom@17.0.2)(react@17.0.2):
@@ -15688,7 +15688,7 @@ packages:
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/store': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       ansi-to-html: 0.6.15
-      core-js: 3.30.0
+      core-js: 3.32.1
       global: 4.4.0
       lodash: 4.17.21
       qs: 6.11.0
@@ -15772,7 +15772,7 @@ packages:
       acorn-walk: 7.2.0
       babel-plugin-add-react-displayname: 0.0.5
       babel-plugin-react-docgen: 4.2.1
-      core-js: 3.30.0
+      core-js: 3.32.1
       escodegen: 2.0.0
       fs-extra: 9.1.0
       global: 4.4.0
@@ -15819,7 +15819,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@storybook/client-logger': 6.5.12
-      core-js: 3.30.0
+      core-js: 3.32.1
       memoizerific: 1.11.3
       qs: 6.11.0
       react: 17.0.2
@@ -15831,7 +15831,7 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      core-js: 3.30.0
+      core-js: 3.32.1
       find-up: 4.1.0
 
   /@storybook/source-loader@6.5.12(react-dom@17.0.2)(react@17.0.2):
@@ -15843,7 +15843,7 @@ packages:
       '@storybook/addons': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/client-logger': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      core-js: 3.30.0
+      core-js: 3.32.1
       estraverse: 5.3.0
       global: 4.4.0
       loader-utils: 2.0.4
@@ -15864,7 +15864,7 @@ packages:
       '@storybook/client-logger': 6.5.12
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      core-js: 3.30.0
+      core-js: 3.32.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
       lodash: 4.17.21
@@ -15885,7 +15885,7 @@ packages:
       '@storybook/client-logger': 6.5.12
       '@storybook/core-common': 6.5.12(eslint@8.28.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
       chalk: 4.1.2
-      core-js: 3.30.0
+      core-js: 3.32.1
       detect-package-manager: 2.0.1
       fetch-retry: 5.0.2
       fs-extra: 9.1.0
@@ -15913,7 +15913,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@storybook/client-logger': 6.5.12
-      core-js: 3.30.0
+      core-js: 3.32.1
       memoizerific: 1.11.3
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -15934,7 +15934,7 @@ packages:
       '@storybook/router': 6.5.12(react-dom@17.0.2)(react@17.0.2)
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.5.12(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.30.0
+      core-js: 3.32.1
       memoizerific: 1.11.3
       qs: 6.11.0
       react: 17.0.2
@@ -20591,6 +20591,11 @@ packages:
 
   /core-js@3.30.0:
     resolution: {integrity: sha512-hQotSSARoNh1mYPi9O2YaWeiq/cEB95kOrFb4NCrO4RIFt1qqNpKsaE+vy/L3oiqvND5cThqXzUU3r9F7Efztg==}
+    requiresBuild: true
+    dev: false
+
+  /core-js@3.32.1:
+    resolution: {integrity: sha512-lqufgNn9NLnESg5mQeYsxQP5w7wrViSj0jr/kv6ECQiByzQkrn1MKvV0L3acttpDqfQrHLwr2KCMgX5b8X+lyQ==}
     requiresBuild: true
 
   /core-util-is@1.0.3:
@@ -26814,7 +26819,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.5
       app-root-dir: 1.0.2
-      core-js: 3.30.0
+      core-js: 3.32.1
       dotenv: 8.6.0
       dotenv-expand: 5.1.0
     dev: false

--- a/tests/e2e/builder/cases/swc/index.swc.test.ts
+++ b/tests/e2e/builder/cases/swc/index.swc.test.ts
@@ -111,3 +111,53 @@ test('should use define for class', async () => {
 
   await builder.close();
 });
+
+test('core-js-entry', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/core-js-entry.ts'),
+    },
+    plugins: [
+      builderPluginSwc({
+        env: {
+          targets: 'ie 9',
+          mode: 'entry',
+        },
+      }),
+    ],
+    builderConfig: {
+      output: {
+        disableMinimize: true,
+      },
+    },
+    runServer: true,
+  });
+
+  await builder.close();
+});
+
+test('core-js-usage', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/core-js-usage.ts'),
+    },
+    plugins: [
+      builderPluginSwc({
+        env: {
+          targets: 'ie 9',
+          mode: 'usage',
+        },
+      }),
+    ],
+    builderConfig: {
+      output: {
+        disableMinimize: true,
+      },
+    },
+    runServer: true,
+  });
+
+  await builder.close();
+});

--- a/tests/e2e/builder/cases/swc/src/core-js-entry.ts
+++ b/tests/e2e/builder/cases/swc/src/core-js-entry.ts
@@ -1,0 +1,1 @@
+import 'core-js';

--- a/tests/e2e/builder/cases/swc/src/core-js-usage.ts
+++ b/tests/e2e/builder/cases/swc/src/core-js-usage.ts
@@ -1,0 +1,4 @@
+/* eslint-disable node/no-unsupported-features/node-builtins */
+/* eslint-disable node/prefer-global/url-search-params */
+const params = new URLSearchParams();
+params.delete('foo');


### PR DESCRIPTION
## Summary

Update core-js to latest, as SWC will inject core-js path of newer version

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd2d719</samp>

This pull request updates the core-js dependency version to `~3.32.1` in several packages and adds tests to verify the functionality of the `@modern-js/builder-plugin-swc` package with the `env` option. It also adds a changeset file to document the patch update of the package and the reason for it.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bd2d719</samp>

*  Update core-js dependency version to `~3.32.1` in three packages to align with the latest version and avoid compatibility issues ([link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L65-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-34ed68e35fc7b09be4c7b86093bb347bb44eb062dc6ad1961198c212ccf433caL70-R70), [link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-39a47b27019a89c1800f61b47e382196b23eb3631f78b10da31fb801a6f9157fL45-R45))
*  Fix test case in `utils.test.ts` to expect the correct core-js version ([link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-05d3b6087232eb1c19bb12ed19a4a0127a9166079e44c2e897a4f8bd244f56daL6-R6))
*  Add changeset file to document the patch update of `@modern-js/builder-plugin-swc` and the reason for it ([link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-3ba6ba231f0a99d3da60ddcf9f05ec04c623a0ebe7575a453b45461c465df098R1-R7))
*  Add test file `core-js.ts` to verify the plugin-swc can transform core-js import with `env` option ([link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-093137ced8e7adf20039ac9bc53e4c9a8878af7734eec7b3cd0b790c423cba5fR1-R19))
*  Add two test cases in `index.swc.test.ts` to check the output of plugin-swc with `env` option set to `entry` and `usage` ([link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-b525425972e39abcfdaebd1672b517877ff1cf38b8897f7c69d95fb4e8d2fc2bR114-R163))
*  Add two source files `core-js-entry.ts` and `core-js-usage.ts` to import and use core-js features for testing plugin-swc ([link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-2bb6f2a973341c2a0eca0b27df889f80aae35531b2f39357705d18cccfcbfe13R1), [link](https://github.com/web-infra-dev/modern.js/pull/4558/files?diff=unified&w=0#diff-d8a23c0a613fbfa4b9273babe25c36271ba59d1afbdab0e685a176c6d1eb9871R1-R4))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
