### PR TITLE
chore: extract swc test cases

### DIFF
--- a/tests/e2e/builder/cases/css/css-modules-dom/index.test.ts
+++ b/tests/e2e/builder/cases/css/css-modules-dom/index.test.ts
@@ -1,12 +1,11 @@
 import { join, resolve } from 'path';
 import { fs } from '@modern-js/utils';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { webpackOnlyTest } from '@scripts/helper';
 import { expect, test } from '@modern-js/e2e/playwright';
 
 const fixtures = resolve(__dirname);
 
-webpackOnlyTest('enableCssModuleTSDeclaration', async () => {
+test('enableCssModuleTSDeclaration', async () => {
   fs.removeSync(join(fixtures, 'src/App.module.less.d.ts'));
   fs.removeSync(join(fixtures, 'src/App.module.scss.d.ts'));
 

--- a/tests/e2e/builder/cases/lodash/index.swc.test.ts
+++ b/tests/e2e/builder/cases/lodash/index.swc.test.ts
@@ -1,0 +1,49 @@
+import * as path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
+
+test('should optimize lodash bundle size when using SWC plugin', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.ts'),
+    },
+    builderConfig: {
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+    plugins: [builderPluginSwc()],
+    runServer: false,
+  });
+
+  const { content, size } = await builder.getIndexFile();
+  expect(content.includes('debounce')).toBeFalsy();
+  expect(size < 10).toBeTruthy();
+});
+
+test('should not optimize lodash bundle size when transformLodash is false and using SWC plugin', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.ts'),
+    },
+    builderConfig: {
+      performance: {
+        transformLodash: false,
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+    plugins: [builderPluginSwc()],
+    runServer: false,
+  });
+
+  const { content, size } = await builder.getIndexFile();
+  expect(content.includes('debounce')).toBeTruthy();
+  expect(size > 30).toBeTruthy();
+});

--- a/tests/e2e/builder/cases/lodash/index.test.ts
+++ b/tests/e2e/builder/cases/lodash/index.test.ts
@@ -1,24 +1,7 @@
-import assert from 'assert';
 import * as path from 'path';
 import { expect } from '@modern-js/e2e/playwright';
 import { webpackOnlyTest } from '@scripts/helper';
 import { build } from '@scripts/shared';
-import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
-
-const getIndexFile = async (builder: Awaited<ReturnType<typeof build>>) => {
-  const files = await builder.unwrapOutputJSON();
-  const [lodashBundle, content] =
-    Object.entries(files).find(
-      ([file]) => file.includes('index') && file.endsWith('.js'),
-    ) || [];
-
-  assert(lodashBundle);
-
-  return {
-    content: content!,
-    size: content!.length / 1024,
-  };
-};
 
 // TODO: needs builtin:swc-loader
 webpackOnlyTest('should optimize lodash bundle size by default', async () => {
@@ -37,35 +20,10 @@ webpackOnlyTest('should optimize lodash bundle size by default', async () => {
     runServer: false,
   });
 
-  const { content, size } = await getIndexFile(builder);
+  const { content, size } = await builder.getIndexFile();
   expect(content.includes('debounce')).toBeFalsy();
   expect(size < 10).toBeTruthy();
 });
-
-webpackOnlyTest(
-  'should optimize lodash bundle size when using SWC plugin',
-  async () => {
-    const builder = await build({
-      cwd: __dirname,
-      entry: {
-        index: path.resolve(__dirname, './src/index.ts'),
-      },
-      builderConfig: {
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
-          },
-        },
-      },
-      plugins: [builderPluginSwc()],
-      runServer: false,
-    });
-
-    const { content, size } = await getIndexFile(builder);
-    expect(content.includes('debounce')).toBeFalsy();
-    expect(size < 10).toBeTruthy();
-  },
-);
 
 webpackOnlyTest(
   'should not optimize lodash bundle size when transformLodash is false',
@@ -86,33 +44,7 @@ webpackOnlyTest(
       runServer: false,
     });
 
-    const { content, size } = await getIndexFile(builder);
-    expect(content.includes('debounce')).toBeTruthy();
-    expect(size > 30).toBeTruthy();
-  },
-);
-
-webpackOnlyTest(
-  'should not optimize lodash bundle size when transformLodash is false and using SWC plugin',
-  async () => {
-    const builder = await build({
-      cwd: __dirname,
-      entry: {
-        index: path.resolve(__dirname, './src/index.ts'),
-      },
-      builderConfig: {
-        performance: {
-          transformLodash: false,
-          chunkSplit: {
-            strategy: 'all-in-one',
-          },
-        },
-      },
-      plugins: [builderPluginSwc()],
-      runServer: false,
-    });
-
-    const { content, size } = await getIndexFile(builder);
+    const { content, size } = await builder.getIndexFile();
     expect(content.includes('debounce')).toBeTruthy();
     expect(size > 30).toBeTruthy();
   },

--- a/tests/e2e/builder/cases/performance/removeConsole.swc.test.ts
+++ b/tests/e2e/builder/cases/performance/removeConsole.swc.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
+import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
 
 const cwd = join(__dirname, 'removeConsole');
 
@@ -19,12 +20,13 @@ const expectConsoleType = async (
   });
 };
 
-test('should remove specified console correctly', async () => {
+test('should remove specified console correctly when using SWC plugin', async () => {
   const builder = await build({
     cwd,
     entry: {
       main: join(cwd, 'src/index.js'),
     },
+    plugins: [builderPluginSwc()],
     builderConfig: {
       performance: {
         removeConsole: ['log', 'warn'],
@@ -40,12 +42,13 @@ test('should remove specified console correctly', async () => {
   });
 });
 
-test('should remove all console correctly', async () => {
+test('should remove all console correctly when using SWC plugin', async () => {
   const builder = await build({
     cwd,
     entry: {
       main: join(cwd, 'src/index.js'),
     },
+    plugins: [builderPluginSwc()],
     builderConfig: {
       performance: {
         removeConsole: true,

--- a/tests/e2e/builder/cases/swc/index.swc.test.ts
+++ b/tests/e2e/builder/cases/swc/index.swc.test.ts
@@ -91,15 +91,7 @@ test('should use define for class', async () => {
     runServer: true,
   });
 
-  const files = await builder.unwrapOutputJSON(true);
-  const file =
-    files[
-      Reflect.ownKeys(files).find(
-        fileName =>
-          (fileName as string).includes('index') &&
-          (fileName as string).endsWith('.js'),
-      ) as string
-    ];
+  const { content: file } = await builder.getIndexFile();
 
   // this is because setting useDefineForClassFields to false
   expect(file.includes('this.bar = 1')).toBe(true);

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "pnpm run test:webpack && pnpm run test:rspack",
     "test:webpack": "playwright test",
-    "test:rspack": "PROVIDE_TYPE=rspack playwright test"
+    "test:rspack": "PROVIDE_TYPE=rspack playwright test",
+    "test:swc": "playwright test swc"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -6,7 +6,7 @@
     "test": "pnpm run test:webpack && pnpm run test:rspack",
     "test:webpack": "playwright test",
     "test:rspack": "PROVIDE_TYPE=rspack playwright test",
-    "test:swc": "playwright test swc"
+    "test:webpack-swc": "playwright test swc"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/tests/e2e/builder/scripts/shared.ts
+++ b/tests/e2e/builder/scripts/shared.ts
@@ -1,4 +1,5 @@
 import { URL } from 'url';
+import assert from 'assert';
 import { join } from 'path';
 import fs from '@modern-js/utils/fs-extra';
 import type { CreateBuilderOptions } from '@modern-js/builder';
@@ -175,12 +176,28 @@ export async function build<BuilderType = 'webpack'>({
     });
   };
 
+  const getIndexFile = async () => {
+    const files = await unwrapOutputJSON();
+    const [name, content] =
+      Object.entries(files).find(
+        ([file]) => file.includes('index') && file.endsWith('.js'),
+      ) || [];
+
+    assert(name);
+
+    return {
+      content: content!,
+      size: content!.length / 1024,
+    };
+  };
+
   return {
     distPath,
     port,
     clean,
     close,
     unwrapOutputJSON,
+    getIndexFile,
     providerType: process.env.PROVIDE_TYPE || 'webpack',
     instance: builder,
   };


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dee8912</samp>

Refactored and split some e2e test cases for the builder to support both webpack and rspack bundlers. Added new test cases and utility functions to verify the SWC plugin features and bundle size optimization. Added a new script to run the SWC plugin test cases separately.

## Details

When we execute `﻿test:rspack`, certain test cases are excluded. Some of these require support in rspack, while others (such as swc-plugin cases) are not required to be supported. 
Therefore, to make calculate the functional alignment percentage of rspack and webpack more efficient, I have separated the swc test cases into `.swc.test.ts`. Thus, when ﻿`test:rspack` is executed, all swc test cases will be automatically ignored.

<img width="908" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/465878f5-c70e-4cc0-9369-e9be45a01d47">



before:
<img width="275" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/225e4421-8f89-441a-9536-ee1649227fab">
after:

<img width="276" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/650002dc-054a-4722-81ba-64ea388e4991">


<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dee8912</samp>

*  Add and modify test cases for the SWC plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-1f6b3c9954abbf1c79335d321009243f291f7a6baadb8f47b5ff3e355e05686fR1-R49), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-0927d7428220d2ad6569c51386ab8235c6b7caa57447db9f7ab520c095d10a31L1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-0927d7428220d2ad6569c51386ab8235c6b7caa57447db9f7ab520c095d10a31L40-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-0927d7428220d2ad6569c51386ab8235c6b7caa57447db9f7ab520c095d10a31L46-L70), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-0927d7428220d2ad6569c51386ab8235c6b7caa57447db9f7ab520c095d10a31L89-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-46661982e8dfbc67f69bf3f0b5b09000541d627f356392e2c2292cfaec73a37bR1-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-5ba3ab5410c60d3a93f01c3dbbd4702bbf3d0078184307346496a4267f8fc64eL4-L5), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-5ba3ab5410c60d3a93f01c3dbbd4702bbf3d0078184307346496a4267f8fc64eL65-L114), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-b525425972e39abcfdaebd1672b517877ff1cf38b8897f7c69d95fb4e8d2fc2bL94-R94), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-283456d349870a43f9269898463ae8e4041fd489a775c83b2aa27776d895b137L8-R9))
  - Use the `test` function from `@modern-js/e2e/playwright` instead of `webpackOnlyTest` to support both webpack and rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-38e29fb707a71de93ca0a10a5c2d7c27cf18adfea87267ce95b6a7c35159a6dbL4-R8))
  - Use the `build` function from `@scripts/shared` and the `builderPluginSwc` from `@modern-js/builder-plugin-swc` to configure the builder with the SWC plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-1f6b3c9954abbf1c79335d321009243f291f7a6baadb8f47b5ff3e355e05686fR1-R49), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-46661982e8dfbc67f69bf3f0b5b09000541d627f356392e2c2292cfaec73a37bR1-R65))
  - Split the test cases for lodash and console removal into separate files for webpack and SWC ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-0927d7428220d2ad6569c51386ab8235c6b7caa57447db9f7ab520c095d10a31L46-L70), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-5ba3ab5410c60d3a93f01c3dbbd4702bbf3d0078184307346496a4267f8fc64eL65-L114))
  - Add a new script `test:webpack-swc` to run the test cases with the `swc` filter ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-283456d349870a43f9269898463ae8e4041fd489a775c83b2aa27776d895b137L8-R9))
* Add a shared utility function `getIndexFile` to the `build` function ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-c315a24d60f9b1bcc59f235721dec1646952bc77ef04ed3733a890ef6104525aR179-R193), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-c315a24d60f9b1bcc59f235721dec1646952bc77ef04ed3733a890ef6104525aR200))
  - Import `assert` from the `assert` module to use in the `getIndexFile` function ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-c315a24d60f9b1bcc59f235721dec1646952bc77ef04ed3733a890ef6104525aR2))
  - Return the content and size of the index file from the output files of the builder ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-c315a24d60f9b1bcc59f235721dec1646952bc77ef04ed3733a890ef6104525aR179-R193))
  - Expose the `getIndexFile` function to the test cases that use the `build` function ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-c315a24d60f9b1bcc59f235721dec1646952bc77ef04ed3733a890ef6104525aR200))
  - Replace the separate `getIndexFile` and `unwrapOutputJSON` functions in the test files with the shared `getIndexFile` function ([link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-0927d7428220d2ad6569c51386ab8235c6b7caa57447db9f7ab520c095d10a31L40-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4561/files?diff=unified&w=0#diff-b525425972e39abcfdaebd1672b517877ff1cf38b8897f7c69d95fb4e8d2fc2bL94-R94))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
