### PR TITLE
feat(builder): support inline assets by file size

### DIFF
--- a/.changeset/rare-wolves-tease.md
+++ b/.changeset/rare-wolves-tease.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder': patch
+'@modern-js/utils': patch
+'@modern-js/core': patch
+---
+
+feat(builder): support inline assets by file size
+
+feat(builder): 支持基于文件体积来内联资源

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1493,9 +1493,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "htmlPlugin": [Function],
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
-      "tests": [
+      "scriptTests": [
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
       ],
+      "styleTests": [],
     },
   ],
   "resolve": {

--- a/packages/builder/builder-shared/src/mergeBuilderConfig.ts
+++ b/packages/builder/builder-shared/src/mergeBuilderConfig.ts
@@ -1,4 +1,5 @@
 import _ from '@modern-js/utils/lodash';
+import { isOverriddenConfigKey } from '@modern-js/utils';
 
 export const mergeBuilderConfig = <T>(...configs: T[]): T =>
   _.mergeWith(
@@ -11,8 +12,8 @@ export const mergeBuilderConfig = <T>(...configs: T[]): T =>
         return undefined;
       }
 
-      // always use source override target, if target defined.
-      if (['removeConsole'].includes(key)) {
+      // Some keys should use source to override target
+      if (isOverriddenConfigKey(key)) {
         return source ?? target;
       }
 

--- a/packages/builder/builder-shared/src/plugins/index.ts
+++ b/packages/builder/builder-shared/src/plugins/index.ts
@@ -5,7 +5,10 @@ export { HtmlCrossOriginPlugin } from './HtmlCrossOriginPlugin';
 export { HtmlNoncePlugin } from './HtmlNoncePlugin';
 export { HtmlAppIconPlugin } from './HtmlAppIconPlugin';
 export { HtmlFaviconUrlPlugin, type FaviconUrls } from './HtmlFaviconUrlPlugin';
-export { InlineChunkHtmlPlugin } from './InlineChunkHtmlPlugin';
+export {
+  InlineChunkHtmlPlugin,
+  type InlineChunkTest,
+} from './InlineChunkHtmlPlugin';
 export { AssetsRetryPlugin } from './AssetsRetryPlugin';
 export { CheckSyntaxPlugin } from './CheckSyntaxPlugin';
 export { HtmlNetworkPerformancePlugin } from './HtmlNetworkPerformancePlugin';

--- a/packages/builder/builder-shared/src/schema/output.ts
+++ b/packages/builder/builder-shared/src/schema/output.ts
@@ -77,6 +77,12 @@ export const SvgDefaultExportSchema: ZodType<SvgDefaultExport> = z.enum([
   'url',
 ]);
 
+const inlineSchema = z.union([
+  z.boolean(),
+  z.instanceof(RegExp),
+  z.anyFunction(),
+]);
+
 export const sharedOutputConfigSchema = z.partialObj({
   distPath: DistPathConfigSchema,
   filename: FilenameConfigSchema,
@@ -100,8 +106,8 @@ export const sharedOutputConfigSchema = z.partialObj({
   enableAssetFallback: z.boolean(),
   enableLatestDecorators: z.boolean(),
   enableCssModuleTSDeclaration: z.boolean(),
-  enableInlineScripts: z.union([z.boolean(), z.instanceof(RegExp)]),
-  enableInlineStyles: z.union([z.boolean(), z.instanceof(RegExp)]),
+  enableInlineScripts: inlineSchema,
+  enableInlineStyles: inlineSchema,
   externals: z.any(),
   overrideBrowserslist: z.union([
     z.array(z.string()),

--- a/packages/builder/builder-shared/src/types/config/output.ts
+++ b/packages/builder/builder-shared/src/types/config/output.ts
@@ -1,3 +1,4 @@
+import type { InlineChunkTest } from '../../plugins/InlineChunkHtmlPlugin';
 import type { BuilderTarget } from '../builder';
 import type { CrossOrigin } from './html';
 import type { Externals } from 'webpack';
@@ -261,11 +262,11 @@ export interface SharedOutputConfig {
   /**
    * Whether to inline output scripts files (.js files) into HTML with `<script>` tags.
    */
-  enableInlineScripts?: boolean | RegExp;
+  enableInlineScripts?: boolean | InlineChunkTest;
   /**
    * Whether to inline output style files (.css files) into html with `<style>` tags.
    */
-  enableInlineStyles?: boolean | RegExp;
+  enableInlineStyles?: boolean | InlineChunkTest;
   /**
    * Specifies the range of target browsers that the project is compatible with.
    * This value will be used by [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env) and
@@ -300,8 +301,8 @@ export interface NormalizedSharedOutputConfig extends SharedOutputConfig {
   enableAssetFallback: boolean;
   enableLatestDecorators: boolean;
   enableCssModuleTSDeclaration: boolean;
-  enableInlineScripts: boolean | RegExp;
-  enableInlineStyles: boolean | RegExp;
+  enableInlineScripts: boolean | InlineChunkTest;
+  enableInlineStyles: boolean | InlineChunkTest;
   svgDefaultExport: SvgDefaultExport;
   cssModules: {
     exportLocalsConvention: CssModuleLocalsConvention;

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1833,9 +1833,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
       "htmlPlugin": [Function],
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
-      "tests": [
+      "scriptTests": [
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
       ],
+      "styleTests": [],
     },
     MiniCssExtractPlugin {
       "_sortedModulesCache": WeakMap {},

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
@@ -49,9 +49,10 @@ exports[`plugins/inlineChunk > should add InlineChunkHtmlPlugin properly by defa
       "htmlPlugin": [Function],
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
-      "tests": [
+      "scriptTests": [
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
       ],
+      "styleTests": [],
     },
   ],
 }
@@ -106,7 +107,8 @@ exports[`plugins/inlineChunk > should use proper plugin options when disableInli
       "htmlPlugin": [Function],
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
-      "tests": [],
+      "scriptTests": [],
+      "styleTests": [],
     },
   ],
 }
@@ -161,10 +163,11 @@ exports[`plugins/inlineChunk > should use proper plugin options when enableInlin
       "htmlPlugin": [Function],
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
-      "tests": [
-        /\\\\\\.js\\$/,
+      "scriptTests": [
+        /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$/,
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
       ],
+      "styleTests": [],
     },
   ],
 }
@@ -219,9 +222,11 @@ exports[`plugins/inlineChunk > should use proper plugin options when enableInlin
       "htmlPlugin": [Function],
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
-      "tests": [
-        /\\\\\\.css\\$/,
+      "scriptTests": [
         /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
+      ],
+      "styleTests": [
+        /\\\\\\.css\\$/,
       ],
     },
   ],

--- a/packages/builder/builder/src/plugins/inlineChunk.ts
+++ b/packages/builder/builder/src/plugins/inlineChunk.ts
@@ -1,8 +1,11 @@
 import {
   pick,
+  JS_REGEX,
+  CSS_REGEX,
   RUNTIME_CHUNK_NAME,
   isHtmlDisabled,
   DefaultBuilderPlugin,
+  type InlineChunkTest,
 } from '@modern-js/builder-shared';
 
 export const builderPluginInlineChunk = (): DefaultBuilderPlugin => ({
@@ -28,22 +31,23 @@ export const builderPluginInlineChunk = (): DefaultBuilderPlugin => ({
           enableInlineScripts,
         } = config.output;
 
-        const tests: RegExp[] = [];
+        const scriptTests: InlineChunkTest[] = [];
+        const styleTests: InlineChunkTest[] = [];
 
         if (enableInlineScripts) {
-          tests.push(
-            enableInlineScripts === true ? /\.js$/ : enableInlineScripts,
+          scriptTests.push(
+            enableInlineScripts === true ? JS_REGEX : enableInlineScripts,
           );
         }
 
         if (enableInlineStyles) {
-          tests.push(
-            enableInlineStyles === true ? /\.css$/ : enableInlineStyles,
+          styleTests.push(
+            enableInlineStyles === true ? CSS_REGEX : enableInlineStyles,
           );
         }
 
         if (!disableInlineRuntimeChunk) {
-          tests.push(
+          scriptTests.push(
             // RegExp like /builder-runtime([.].+)?\.js$/
             // matches builder-runtime.js and builder-runtime.123456.js
             new RegExp(`${RUNTIME_CHUNK_NAME}([.].+)?\\.js$`),
@@ -53,7 +57,8 @@ export const builderPluginInlineChunk = (): DefaultBuilderPlugin => ({
         chain.plugin(CHAIN_ID.PLUGIN.INLINE_HTML).use(InlineChunkHtmlPlugin, [
           HtmlPlugin,
           {
-            tests,
+            styleTests,
+            scriptTests,
             distPath: pick(config.output.distPath, ['js', 'css']),
           },
         ]);

--- a/packages/cli/core/src/utils/mergeConfig.ts
+++ b/packages/cli/core/src/utils/mergeConfig.ts
@@ -1,4 +1,4 @@
-import { ensureArray } from '@modern-js/utils';
+import { ensureArray, isOverriddenConfigKey } from '@modern-js/utils';
 import { mergeWith, isFunction } from '@modern-js/utils/lodash';
 import { UserConfig, NormalizedConfig } from '../types';
 
@@ -6,12 +6,17 @@ export const mergeConfig = <ExtendConfig extends Record<string, any>>(
   configs: Array<UserConfig<ExtendConfig> | NormalizedConfig<ExtendConfig>>,
 ): NormalizedConfig<ExtendConfig> =>
   mergeWith({}, ...configs, (target: any, source: any, key: string) => {
-    // Do not use the following merge logic for source.designSystem and tools.tailwind(css)
+    // Do not use the following merge logic for some keys
     if (
       key === 'designSystem' ||
       (key === 'tailwindcss' && typeof source === 'object')
     ) {
       return mergeWith({}, target ?? {}, source ?? {});
+    }
+
+    // Some keys should use source to override target
+    if (isOverriddenConfigKey(key)) {
+      return source ?? target;
     }
 
     if (Array.isArray(target) || Array.isArray(source)) {

--- a/packages/document/builder-doc/docs/en/config/output/enableInlineScripts.md
+++ b/packages/document/builder-doc/docs/en/config/output/enableInlineScripts.md
@@ -1,4 +1,12 @@
-- **Type:** `boolean`
+- **Type:**
+
+```ts
+type EnableInlineScripts =
+  | boolean
+  | RegExp
+  | ((params: { size: number; name: string }) => boolean);
+```
+
 - **Default:** `false`
 - **Bundler:** `only support webpack`
 
@@ -64,5 +72,24 @@ export default {
 ```
 
 :::tip
-The production filename will contains a hash by default, such as `/main.18a568e5.js`.
+The production filename includes a hash value by default, such as `static/js/main.18a568e5.js`. Therefore, in regular expressions, `\w+` is used to match the hash.
 :::
+
+### Using Function
+
+You can also set `output.enableInlineScripts` to a function that accepts the following parameters:
+
+- `name`: The filename, such as `static/js/main.18a568e5.js`.
+- `size`: The file size in bytes.
+
+For example, if we want to inline assets that are smaller than 10KB, we can add the following configuration:
+
+```js
+export default {
+  output: {
+    enableInlineScripts({ size }) {
+      return size < 10 * 1000;
+    },
+  },
+};
+```

--- a/packages/document/builder-doc/docs/en/config/output/enableInlineStyles.md
+++ b/packages/document/builder-doc/docs/en/config/output/enableInlineStyles.md
@@ -1,4 +1,12 @@
-- **Type:** `boolean`
+- **Type:**
+
+```ts
+type EnableInlineStyles =
+  | boolean
+  | RegExp
+  | ((params: { size: number; name: string }) => boolean);
+```
+
 - **Default:** `false`
 
 Whether to inline output style files (.css files) into HTML with `<style>` tags in production mode.
@@ -64,5 +72,24 @@ export default {
 ```
 
 :::tip
-The production filename will contains a hash by default, such as `/main.18a568e5.css`.
+The production filename includes a hash value by default, such as `static/css/main.18a568e5.css`. Therefore, in regular expressions, `\w+` is used to match the hash.
 :::
+
+### Using Function
+
+You can also set `output.enableInlineStyles` to a function that accepts the following parameters:
+
+- `name`: The filename, such as `static/css/main.18a568e5.css`.
+- `size`: The file size in bytes.
+
+For example, if we want to inline assets that are smaller than 10KB, we can add the following configuration:
+
+```js
+export default {
+  output: {
+    enableInlineStyles({ size }) {
+      return size < 10 * 1000;
+    },
+  },
+};
+```

--- a/packages/document/builder-doc/docs/zh/config/output/enableInlineScripts.md
+++ b/packages/document/builder-doc/docs/zh/config/output/enableInlineScripts.md
@@ -79,8 +79,8 @@ export default {
 
 你也可以将 `output.enableInlineScripts` 设置为一个函数，函数接收以下参数：
 
-- `name`: 文件名，比如 `static/js/main.18a568e5.js`。
-- `size`: 资源大小，单位为 byte。
+- `name`：文件名，比如 `static/js/main.18a568e5.js`。
+- `size`：文件大小，单位为 byte。
 
 比如，我们希望内联小于 10KB 的资源，可以添加如下配置：
 

--- a/packages/document/builder-doc/docs/zh/config/output/enableInlineScripts.md
+++ b/packages/document/builder-doc/docs/zh/config/output/enableInlineScripts.md
@@ -1,4 +1,12 @@
-- **类型：** `boolean | RegExp`
+- **类型：**
+
+```ts
+type EnableInlineScripts =
+  | boolean
+  | RegExp
+  | ((params: { size: number; name: string }) => boolean);
+```
+
 - **默认值：** `false`
 - **打包工具：** `仅支持 webpack`
 
@@ -64,5 +72,24 @@ export default {
 ```
 
 :::tip
-生产环境的文件名中默认包含了一个 hash 值，比如 `/main.18a568e5.js`。
+生产环境的文件名中默认包含了一个 hash 值，比如 `static/js/main.18a568e5.js`。因此，在正则表达式中需要通过 `\w+` 来匹配 hash。
 :::
+
+### 通过函数匹配
+
+你也可以将 `output.enableInlineScripts` 设置为一个函数，函数接收以下参数：
+
+- `name`: 文件名，比如 `static/js/main.18a568e5.js`。
+- `size`: 资源大小，单位为 byte。
+
+比如，我们希望内联小于 10KB 的资源，可以添加如下配置：
+
+```js
+export default {
+  output: {
+    enableInlineScripts({ size }) {
+      return size < 10 * 1000;
+    },
+  },
+};
+```

--- a/packages/document/builder-doc/docs/zh/config/output/enableInlineStyles.md
+++ b/packages/document/builder-doc/docs/zh/config/output/enableInlineStyles.md
@@ -1,4 +1,12 @@
-- **类型：** `boolean | RegExp`
+- **类型：**
+
+```ts
+type EnableInlineStyles =
+  | boolean
+  | RegExp
+  | ((params: { size: number; name: string }) => boolean);
+```
+
 - **默认值：** `false`
 
 用来控制生产环境中是否用 `<style>` 标签将产物中的 style 文件（.css 文件）inline 到 HTML 中。
@@ -64,5 +72,24 @@ export default {
 ```
 
 :::tip
-生产环境的文件名中默认包含了一个 hash 值，比如 `/main.18a568e5.css`。
+生产环境的文件名中默认包含了一个 hash 值，比如 `static/css/main.18a568e5.css`。因此，在正则表达式中需要通过 `\w+` 来匹配 hash。
 :::
+
+### 通过函数匹配
+
+你也可以将 `output.enableInlineStyles` 设置为一个函数，函数接收以下参数：
+
+- `name`: 文件名，比如 `static/css/main.18a568e5.css`。
+- `size`: 资源大小，单位为 byte。
+
+比如，我们希望内联小于 10KB 的资源，可以添加如下配置：
+
+```js
+export default {
+  output: {
+    enableInlineStyles({ size }) {
+      return size < 10 * 1000;
+    },
+  },
+};
+```

--- a/packages/document/builder-doc/docs/zh/config/output/enableInlineStyles.md
+++ b/packages/document/builder-doc/docs/zh/config/output/enableInlineStyles.md
@@ -79,8 +79,8 @@ export default {
 
 你也可以将 `output.enableInlineStyles` 设置为一个函数，函数接收以下参数：
 
-- `name`: 文件名，比如 `static/css/main.18a568e5.css`。
-- `size`: 资源大小，单位为 byte。
+- `name`：文件名，比如 `static/css/main.18a568e5.css`。
+- `size`：文件大小，单位为 byte。
 
 比如，我们希望内联小于 10KB 的资源，可以添加如下配置：
 

--- a/packages/toolkit/utils/src/cli/config.ts
+++ b/packages/toolkit/utils/src/cli/config.ts
@@ -1,0 +1,5 @@
+/**
+ * When merging config, some properties prefer `override` rather than `merge to array`
+ */
+export const isOverriddenConfigKey = (key: string) =>
+  ['removeConsole', 'enableInlineScripts', 'enableInlineStyles'].includes(key);

--- a/packages/toolkit/utils/src/cli/index.ts
+++ b/packages/toolkit/utils/src/cli/index.ts
@@ -17,3 +17,4 @@ export * from './prettyInstructions';
 export * from './require';
 export * from './runtimeExports';
 export * from './watch';
+export * from './config';

--- a/tests/e2e/builder/cases/inline-chunk/index.test.ts
+++ b/tests/e2e/builder/cases/inline-chunk/index.test.ts
@@ -226,17 +226,47 @@ webpackOnlyTest('using RegExp to inline scripts', async () => {
     },
     builderConfig: {
       output: {
-        enableInlineScripts: /\/main\.\w+\.js$/,
+        enableInlineScripts: /\/index\.\w+\.js$/,
       },
       tools: toolsConfig,
     },
   });
   const files = await builder.unwrapOutputJSON(false);
 
-  // no main.js in output
+  // no index.js in output
   expect(
     Object.keys(files).filter(
-      fileName => fileName.endsWith('.js') && fileName.includes('/main.'),
+      fileName => fileName.endsWith('.js') && fileName.includes('/index.'),
+    ).length,
+  ).toEqual(0);
+
+  // all source maps in output
+  expect(
+    Object.keys(files).filter(fileName => fileName.endsWith('.js.map')).length,
+  ).toEqual(3);
+});
+
+webpackOnlyTest('inline scripts by filename and file size', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    builderConfig: {
+      output: {
+        enableInlineScripts({ size, name }) {
+          return name.includes('index') && size < 1000;
+        },
+      },
+      tools: toolsConfig,
+    },
+  });
+  const files = await builder.unwrapOutputJSON(false);
+
+  // no index.js in output
+  expect(
+    Object.keys(files).filter(
+      fileName => fileName.endsWith('.js') && fileName.includes('/index.'),
     ).length,
   ).toEqual(0);
 
@@ -254,17 +284,42 @@ test('using RegExp to inline styles', async () => {
     },
     builderConfig: {
       output: {
-        enableInlineStyles: /\/main\.\w+\.css$/,
+        enableInlineStyles: /\/index\.\w+\.css$/,
       },
       tools: toolsConfig,
     },
   });
   const files = await builder.unwrapOutputJSON(false);
 
-  // no main.css in output
+  // no index.css in output
   expect(
     Object.keys(files).filter(
-      fileName => fileName.endsWith('.css') && fileName.includes('/main.'),
+      fileName => fileName.endsWith('.css') && fileName.includes('/index.'),
+    ).length,
+  ).toEqual(0);
+});
+
+test('inline styles by filename and file size', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    builderConfig: {
+      output: {
+        enableInlineStyles({ size, name }) {
+          return name.includes('index') && size < 1000;
+        },
+      },
+      tools: toolsConfig,
+    },
+  });
+  const files = await builder.unwrapOutputJSON(false);
+
+  // no index.css in output
+  expect(
+    Object.keys(files).filter(
+      fileName => fileName.endsWith('.css') && fileName.includes('/index.'),
     ).length,
   ).toEqual(0);
 });


### PR DESCRIPTION
## Summary

Users can inline scripts by the file size, such as inline small scripts to HTML:

```js
export default {
  output: {
    enableInlineScripts({ size }) {
      return size < 10 * 1000;
    },
  },
};
```

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e9f48c</samp>

This pull request adds more flexibility and customization to the inline scripts and styles feature of the `@modern-js/builder` package. It refactors and improves the code quality of the `InlineChunkHtmlPlugin` and the config merging modules. It also updates the documentation and the test cases for the feature. It exports some new types and a utility function from the `@modern-js/toolkit/utils` and the `@modern-js/builder` packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e9f48c</samp>

*  Add a changeset file to describe the changes and version bumps ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-da3e674eeabc0ad81e3cc5534f4c3a67cf1c6ecae9fbed354e5cc0e4d069493bR1-R10))
*  Add a new function `isOverriddenConfigKey` to determine which config keys should use source to override target instead of merging ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-970084606bc26d94291c7311c047cce86988af84c8ecef79bb8abe7762bdb26cR1-R5))
*  Export the `isOverriddenConfigKey` function from the `@modern-js/toolkit/utils` package ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8aac5478574eea52dc8b594f0c725ec404014b84577cc13a778193db47d455d9R20))
*  Use the `isOverriddenConfigKey` function in the `mergeBuilderConfig` and `mergeConfig` modules to replace the hard-coded arrays of config keys ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-d83687beb8fef03a2246bce5645bb67db717cb76d9ff60a1cf0e6fdf48b6fa89R2), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-d83687beb8fef03a2246bce5645bb67db717cb76d9ff60a1cf0e6fdf48b6fa89L14-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-6fb533195533d50a676fef97f6a9f985e407e5e2c15f64655ae744710eeadedcL1-R1), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-6fb533195533d50a676fef97f6a9f985e407e5e2c15f64655ae744710eeadedcL9-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-6fb533195533d50a676fef97f6a9f985e407e5e2c15f64655ae744710eeadedcR17-R21))
*  Add new types `InlineChunkTest` and `InlineChunkHtmlPluginOptions` to define the options for the `InlineChunkHtmlPlugin` ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL16-R24), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-4aa1bceaea7909a4213851fc0b29e4b4f7ce3d0c49e6f356a2186ff9ec423d81L8-R11))
*  Export the `InlineChunkTest` type from the `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-4aa1bceaea7909a4213851fc0b29e4b4f7ce3d0c49e6f356a2186ff9ec423d81L8-R11))
*  Add new properties `styleTests` and `scriptTests` to the `InlineChunkHtmlPlugin` class to store the options ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL27-R37))
*  Update the constructor of the `InlineChunkHtmlPlugin` class to accept the new options and assign them to the properties ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL37-R50))
*  Add a new method `matchTests` to the `InlineChunkHtmlPlugin` class to check if a file matches any of the tests ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aR93-R102))
*  Update the `processScriptTag` and `processStyleTag` methods of the `InlineChunkHtmlPlugin` class to use the `matchTests` method and add some checks and comments ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL90-R118), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aR125-R128), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aR157), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8efea8d04e574e05888437a357f791253b2215220f6f4f1b6996dc7d7fa9448aL141-R177))
*  Add a new schema `inlineSchema` to validate the `enableInlineScripts` and `enableInlineStyles` config options ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8507a2109c24da79987b4b9d5559bafda0160425e4b78256b426344b56f7e90aR80-R85))
*  Update the `sharedOutputConfigSchema` variable to use the `inlineSchema` for the `enableInlineScripts` and `enableInlineStyles` config options ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-8507a2109c24da79987b4b9d5559bafda0160425e4b78256b426344b56f7e90aL103-R110))
*  Update the `SharedOutputConfig` and `NormalizedSharedOutputConfig` interfaces to use the `InlineChunkTest` type for the `enableInlineScripts` and `enableInlineStyles` config options ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-42e9c77fc1a6c3a3d3cecbfed0575b9b07c1b9dec393e5dabeef20b3c68ce516R1), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-42e9c77fc1a6c3a3d3cecbfed0575b9b07c1b9dec393e5dabeef20b3c68ce516L264-R269), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-42e9c77fc1a6c3a3d3cecbfed0575b9b07c1b9dec393e5dabeef20b3c68ce516L303-R305))
*  Update the `builderPluginInlineChunk` function to use the new `styleTests` and `scriptTests` options for the `InlineChunkHtmlPlugin` and replace the hard-coded regular expressions with the `JS_REGEX` and `CSS_REGEX` constants ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-4b8bcdc256aef0f6c6b32a0c74eac94a2b4510c77510a159000392c8e775fb1aL3-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-4b8bcdc256aef0f6c6b32a0c74eac94a2b4510c77510a159000392c8e775fb1aL31-R50), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-4b8bcdc256aef0f6c6b32a0c74eac94a2b4510c77510a159000392c8e775fb1aL56-R61))
*  Update the documentation for the `output.enableInlineScripts` and `output.enableInlineStyles` config options in English and Chinese to reflect the new type and usage ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-98ca67a9dd8b741618fdeb7a33089cb6b4c16b78ead36635835c5a2ca393e795L1-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-98ca67a9dd8b741618fdeb7a33089cb6b4c16b78ead36635835c5a2ca393e795L67-R95), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-82aec24ce4ac0f48b99c5e92bedfe5e8903db43542eedf05dcddd32fc8f57ab4L1-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-82aec24ce4ac0f48b99c5e92bedfe5e8903db43542eedf05dcddd32fc8f57ab4L67-R95), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-e2a5cf2b3127d915ee823a9a0cd5062da17250c645e200deb8dec97fa0e18122L1-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-e2a5cf2b3127d915ee823a9a0cd5062da17250c645e200deb8dec97fa0e18122L67-R95), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-c780b706f0f3a72acbbf5b08f43d5f40310eb6cdacc347012becce9a75f87367L1-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-c780b706f0f3a72acbbf5b08f43d5f40310eb6cdacc347012becce9a75f87367L67-R95))
*  Update the test case for the `inline scripts by filename` feature to match the `index` file instead of the `main` file ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL229-R229), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL236-R239))
*  Add a new test case for the `inline scripts by filename and file size` feature to use a function to match the file size and name ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caR249-R278))
*  Update the test case for the `inline styles by filename` feature to match the `index` file instead of the `main` file ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL257-R287), [link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL264-R325))
*  Add a new test case for the `inline styles by filename and file size` feature to use a function to match the file size and name ([link](https://github.com/web-infra-dev/modern.js/pull/4563/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL257-R287))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
