### PR TITLE
fix(builder): update inlineRuntimeChunk test case

### DIFF
--- a/tests/e2e/builder/cases/css/less-exclude/index.test.ts
+++ b/tests/e2e/builder/cases/css/less-exclude/index.test.ts
@@ -3,6 +3,8 @@ import { expect } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
 import { webpackOnlyTest } from '@scripts/helper';
 
+// 'error[javascript]: JavaScript parsing error' in rspack
+// The rspack default rule type seems to be inconsistent with webpack. Not sure if that will fix when disableTransformByDefault supported.
 webpackOnlyTest('should exclude specified less file', async () => {
   const builder = await build({
     cwd: __dirname,

--- a/tests/e2e/builder/cases/inline-chunk/index.test.ts
+++ b/tests/e2e/builder/cases/inline-chunk/index.test.ts
@@ -4,11 +4,10 @@ import { webpackOnlyTest } from '@scripts/helper';
 import { build, getHrefByEntryName } from '@scripts/shared';
 import { BundlerChain, RUNTIME_CHUNK_NAME } from '@modern-js/builder-shared';
 
-// todo: Rspack not output RUNTIME_CHUNK_NAME.js.map
+// Rspack will not output builder runtime source map, but it not necessary
+// Identify whether the builder runtime chunk is included through some specific code snippets
 const isRuntimeChunkInHtml = (html: string): boolean =>
-  Boolean(
-    html.match(new RegExp(`static/js/${RUNTIME_CHUNK_NAME}\\.(.+)\\.js\\.map`)),
-  );
+  Boolean(html.includes('builder-runtime') && html.includes('Loading chunk'));
 
 // use source-map for easy to test. By default, builder use hidden-source-map
 const toolsConfig = {
@@ -62,18 +61,9 @@ test.describe('disableInlineRuntimeChunk', () => {
       ),
     ).toBe(true);
   });
-
-  webpackOnlyTest('should emit source map of builder runtime', async () => {
-    expect(
-      Object.keys(files).some(
-        fileName =>
-          fileName.includes(RUNTIME_CHUNK_NAME) && fileName.endsWith('.js.map'),
-      ),
-    ).toBe(true);
-  });
 });
 
-webpackOnlyTest('inline runtime chunk by default', async ({ page }) => {
+test('inline runtime chunk by default', async ({ page }) => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
@@ -98,14 +88,6 @@ webpackOnlyTest('inline runtime chunk by default', async ({ page }) => {
     ),
   ).toBe(false);
 
-  // should emit source map of builder runtime
-  expect(
-    Object.keys(files).some(
-      fileName =>
-        fileName.includes(RUNTIME_CHUNK_NAME) && fileName.endsWith('.js.map'),
-    ),
-  ).toBe(true);
-
   // found builder-runtime file in html
   const indexHtml =
     files[path.resolve(__dirname, './dist/html/index/index.html')];
@@ -115,66 +97,60 @@ webpackOnlyTest('inline runtime chunk by default', async ({ page }) => {
   builder.close();
 });
 
-webpackOnlyTest(
-  'inline runtime chunk and remove source map when devtool is "hidden-source-map"',
-  async () => {
-    const builder = await build({
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index.js') },
-      builderConfig: {
-        tools: {
-          bundlerChain(chain) {
-            chain.devtool('hidden-source-map');
-          },
+test('inline runtime chunk and remove source map when devtool is "hidden-source-map"', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
+      tools: {
+        bundlerChain(chain) {
+          chain.devtool('hidden-source-map');
         },
       },
-    });
+    },
+  });
 
-    const files = await builder.unwrapOutputJSON(false);
+  const files = await builder.unwrapOutputJSON(false);
 
-    // should not emit source map of builder runtime
-    expect(
-      Object.keys(files).some(
-        fileName =>
-          fileName.includes(RUNTIME_CHUNK_NAME) && fileName.endsWith('.js.map'),
-      ),
-    ).toBe(false);
-  },
-);
+  // should not emit source map of builder runtime
+  expect(
+    Object.keys(files).some(
+      fileName =>
+        fileName.includes(RUNTIME_CHUNK_NAME) && fileName.endsWith('.js.map'),
+    ),
+  ).toBe(false);
+});
 
-webpackOnlyTest(
-  'inline runtime chunk by default with multiple entries',
-  async () => {
-    const builder = await build({
-      cwd: __dirname,
-      entry: {
-        index: path.resolve(__dirname, './src/index.js'),
-        another: path.resolve(__dirname, './src/another.js'),
-      },
-      builderConfig: {
-        tools: toolsConfig,
-      },
-    });
-    const files = await builder.unwrapOutputJSON(false);
+test('inline runtime chunk by default with multiple entries', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+      another: path.resolve(__dirname, './src/another.js'),
+    },
+    builderConfig: {
+      tools: toolsConfig,
+    },
+  });
+  const files = await builder.unwrapOutputJSON(false);
 
-    // no builder-runtime file in output
-    expect(
-      Object.keys(files).some(
-        fileName =>
-          fileName.includes(RUNTIME_CHUNK_NAME) && fileName.endsWith('.js'),
-      ),
-    ).toBe(false);
+  // no builder-runtime file in output
+  expect(
+    Object.keys(files).some(
+      fileName =>
+        fileName.includes(RUNTIME_CHUNK_NAME) && fileName.endsWith('.js'),
+    ),
+  ).toBe(false);
 
-    // found builder-runtime file in html
-    const indexHtml =
-      files[path.resolve(__dirname, './dist/html/index/index.html')];
-    const anotherHtml =
-      files[path.resolve(__dirname, './dist/html/another/index.html')];
+  // found builder-runtime file in html
+  const indexHtml =
+    files[path.resolve(__dirname, './dist/html/index/index.html')];
+  const anotherHtml =
+    files[path.resolve(__dirname, './dist/html/another/index.html')];
 
-    expect(isRuntimeChunkInHtml(indexHtml)).toBeTruthy();
-    expect(isRuntimeChunkInHtml(anotherHtml)).toBeTruthy();
-  },
-);
+  expect(isRuntimeChunkInHtml(indexHtml)).toBeTruthy();
+  expect(isRuntimeChunkInHtml(anotherHtml)).toBeTruthy();
+});
 
 webpackOnlyTest(
   'inline all scripts and emit all source maps',

--- a/tests/e2e/builder/cases/top-level-await/index.swc.test.ts
+++ b/tests/e2e/builder/cases/top-level-await/index.swc.test.ts
@@ -1,14 +1,17 @@
 import * as path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { webpackOnlyTest } from '../../scripts/helper';
+import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
 
-webpackOnlyTest('should run top level await correctly', async ({ page }) => {
+test('should run top level await correctly when using SWC', async ({
+  page,
+}) => {
   const builder = await build({
     cwd: __dirname,
     entry: {
       index: path.resolve(__dirname, './src/index.ts'),
     },
+    plugins: [builderPluginSwc()],
     runServer: true,
   });
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4b9c1a</samp>

This pull request improves the test coverage and compatibility of the `builder` module for different bundler tools and JavaScript compilers. It updates some test cases to run for both `webpack` and `rspack`, splits the `top-level-await` test case into two files for `Babel` and `SWC`, and adds comments to clarify some test logic and limitations.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4b9c1a</samp>

*  Enable SWC as an alternative compiler for the `top-level-await` test case ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-ece14a7c2da229006ebeb4f084f018e5fe858c1f3ddb320338f895fd4985afa4R1-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-23d0641db42d79a3c221845d1ddab95c440543a4f5d3e459effde1343def5ec0L4), [link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-23d0641db42d79a3c221845d1ddab95c440543a4f5d3e459effde1343def5ec0L22-L41))
  * Add a new test file `index.swc.test.ts` that uses the `builderPluginSwc` plugin and runs the test case for both webpack and rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-ece14a7c2da229006ebeb4f084f018e5fe858c1f3ddb320338f895fd4985afa4R1-R23))
  * Remove the unused import of the `builderPluginSwc` plugin and the test case with SWC from the original `index.test.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-23d0641db42d79a3c221845d1ddab95c440543a4f5d3e459effde1343def5ec0L4), [link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-23d0641db42d79a3c221845d1ddab95c440543a4f5d3e459effde1343def5ec0L22-L41))
*  Fix the `css/less-exclude` test case to run for both webpack and rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-14a84d922474367f1d66f7f079988f5f94286e162e7331f523c048c6b11452adR6-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL7-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL65-R66), [link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL101-L108))
  * Add a comment to explain why the test case is skipped for rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-14a84d922474367f1d66f7f079988f5f94286e162e7331f523c048c6b11452adR6-R7))
  * Copy and modify the `isRuntimeChunkInHtml` function from the `inline-chunk` test case to check the builder runtime chunk in the HTML output ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL7-R10))
  * Remove the `webpackOnlyTest` wrapper from the test case ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL65-R66))
  * Remove the assertion that checks the source map of the builder runtime chunk, because rspack does not emit it ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL101-L108))
*  Remove the `webpackOnlyTest` wrapper from the `inline-chunk` and `top-level-await` test cases, because they should run for both webpack and rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4564/files?diff=unified&w=0#diff-f6f11ff0c8e603f1a35ef9ff88516459093c8cae92d47a8b1b262b5c45a154caL118-R153))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
