### PR TITLE
fix: upgrade react-router-dom to avoid issues

### DIFF
--- a/.changeset/healthy-timers-camp.md
+++ b/.changeset/healthy-timers-camp.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/utils': patch
+---
+
+fix: upgrade react-router-dom to avoid issues
+fix: 升级 react-router-dom 的版本，避免问题

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -308,7 +308,7 @@
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0",
     "react-router-dom": "6.15.0",
-    "@remix-run/router": "1.6.1",
+    "@remix-run/router": "1.8.0",
     "@swc/helpers": "0.5.1"
   },
   "peerDependencies": {

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -307,7 +307,7 @@
     "caniuse-lite": "^1.0.30001520",
     "lodash": "^4.17.21",
     "serialize-javascript": "^6.0.0",
-    "react-router-dom": "6.11.1",
+    "react-router-dom": "6.15.0",
     "@remix-run/router": "1.6.1",
     "@swc/helpers": "0.5.1"
   },

--- a/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
+++ b/packages/toolkit/utils/src/runtime/nestedRoutes.tsx
@@ -47,7 +47,7 @@ export const renderNestedRoute = (
   const Component = component as unknown as React.ComponentType<any>;
   const { parent, DeferredDataComponent, props = {}, reporter } = options;
 
-  const routeProps: Omit<RouteProps, 'children'> = {
+  const routeProps: Omit<RouteProps, 'children' | 'lazy'> = {
     caseSensitive: nestedRoute.caseSensitive,
     path: nestedRoute.path,
     id: nestedRoute.id,
@@ -124,9 +124,9 @@ export const renderNestedRoute = (
   });
 
   const routeElement = index ? (
-    <Route key={id} {...routeProps} index={true} />
+    <Route key={id} {...routeProps} index={true as const} />
   ) : (
-    <Route key={id} {...routeProps} index={false}>
+    <Route key={id} {...routeProps} index={false as const}>
       {childElements}
     </Route>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5357,8 +5357,8 @@ importers:
   packages/toolkit/utils:
     dependencies:
       '@remix-run/router':
-        specifier: 1.6.1
-        version: 1.6.1
+        specifier: 1.8.0
+        version: 1.8.0
       '@swc/helpers':
         specifier: 0.5.1
         version: 0.5.1
@@ -13787,7 +13787,7 @@ packages:
       react-router-dom:
         optional: true
     dependencies:
-      '@remix-run/router': 1.6.1
+      '@remix-run/router': 1.8.0
       caniuse-lite: 1.0.30001520
       lodash: 4.17.21
       react: 18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3290,10 +3290,10 @@ importers:
         version: 2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(esbuild@0.17.19)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1)
       '@modern-js/doc-plugin-api-docgen':
         specifier: 2.31.2
-        version: 2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(@types/react@18.0.21)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.11.1)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1)
+        version: 2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(@types/react@18.0.21)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.15.0)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1)
       '@modern-js/doc-plugin-preview':
         specifier: 2.31.2
-        version: 2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.11.1)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1)
+        version: 2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.15.0)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1)
     devDependencies:
       '@modern-js/module-tools':
         specifier: workspace:*
@@ -5369,8 +5369,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       react-router-dom:
-        specifier: 6.11.1
-        version: 6.11.1(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.15.0
+        version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
       serialize-javascript:
         specifier: ^6.0.0
         version: 6.0.1
@@ -12852,7 +12852,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
       react-lazy-with-preload: 2.2.1
-      react-router-dom: 6.11.1(react-dom@18.2.0)(react@18.2.0)
+      react-router-dom: 6.15.0(react-dom@18.2.0)(react@18.2.0)
       react-syntax-highlighter: 15.5.0(react@18.2.0)
       rehype-autolink-headings: 6.1.1
       rehype-external-links: 2.0.1
@@ -12897,7 +12897,7 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /@modern-js/doc-plugin-api-docgen@2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(@types/react@18.0.21)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.11.1)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1):
+  /@modern-js/doc-plugin-api-docgen@2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(@types/react@18.0.21)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.15.0)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1):
     resolution: {integrity: sha512-zNhoNC9l0yOpyiodo9fcBuJ44TWB06U8LgthwDeEO2i2dsdm+eepynkiij/LCQs4qrKDp3IpaFncmvOE4K2J4g==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
@@ -12910,7 +12910,7 @@ packages:
       react: 18.2.0
       react-docgen-typescript: 2.2.2(typescript@5.0.4)
       react-markdown: 8.0.6(@types/react@18.0.21)(react@18.2.0)
-      react-router-dom: 6.11.1(react-dom@18.2.0)(react@18.2.0)
+      react-router-dom: 6.15.0(react-dom@18.2.0)(react@18.2.0)
       remark-gfm: 3.0.1
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -12971,7 +12971,7 @@ packages:
       - react-dom
     dev: false
 
-  /@modern-js/doc-plugin-preview@2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.11.1)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1):
+  /@modern-js/doc-plugin-preview@2.31.2(@modern-js/core@2.32.1)(@modern-js/doc-tools@2.32.1)(esbuild@0.17.19)(react-dom@18.2.0)(react-router-dom@6.15.0)(react@18.2.0)(ts-node@10.9.1)(typescript@5.0.4)(webpack@5.88.1):
     resolution: {integrity: sha512-f7AAS9rc/OQIIRrTxEaAjvP0LcBZkiQbbOI/d5BVQWMEoTAN4dgKq15IKoi2T73CmRhmvCk2Rf0nnf6F3quOFA==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
@@ -12983,7 +12983,7 @@ packages:
       '@modern-js/utils': 2.31.2(react-dom@18.2.0)(react@18.2.0)
       qrcode.react: 3.1.0(react@18.2.0)
       react: 18.2.0
-      react-router-dom: 6.11.1(react-dom@18.2.0)(react@18.2.0)
+      react-router-dom: 6.15.0(react-dom@18.2.0)(react@18.2.0)
       remark-gfm: 3.0.1
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -14284,6 +14284,10 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /@remix-run/router@1.8.0:
+    resolution: {integrity: sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==}
+    engines: {node: '>=14.0.0'}
+
   /@remix-run/server-runtime@1.13.0:
     resolution: {integrity: sha512-gjIW3XCeIlOt3rrOZMD6HixQydRgs1SwYjP99ZAVruG2+gNq/tL2OusMFYTLvtWrybt215tPROyF/6iTLsaO3g==}
     engines: {node: '>=14'}
@@ -14703,7 +14707,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
       react-lazy-with-preload: 2.2.1
-      react-router-dom: 6.11.1(react-dom@18.2.0)(react@18.2.0)
+      react-router-dom: 6.15.0(react-dom@18.2.0)(react@18.2.0)
       react-syntax-highlighter: 15.5.0(react@18.2.0)
       rehype-autolink-headings: 6.1.1
       rehype-external-links: 2.0.1
@@ -32931,6 +32935,18 @@ packages:
       react-router: 6.11.2(react@18.2.0)
     dev: true
 
+  /react-router-dom@6.15.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.8.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-router: 6.15.0(react@18.2.0)
+
   /react-router@5.3.4(react@18.2.0):
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
@@ -32966,6 +32982,15 @@ packages:
       '@remix-run/router': 1.6.2
       react: 18.2.0
     dev: true
+
+  /react-router@6.15.0(react@18.2.0):
+    resolution: {integrity: sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.8.0
+      react: 18.2.0
 
   /react-side-effect@2.1.2(react@18.2.0):
     resolution: {integrity: sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==}

--- a/tests/integration/bff-express/src/modern-app-env.d.ts
+++ b/tests/integration/bff-express/src/modern-app-env.d.ts
@@ -2,4 +2,3 @@
 /// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-micro-frontend/type' />
 /// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />


### PR DESCRIPTION
## Summary

react-router-dom has some issues in react17:
1. https://github.com/remix-run/react-router/issues/10446
2. https://github.com/remix-run/react-router/pull/10448

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac9fafb</samp>

This pull request fixes a compatibility issue between `@modern-js/utils` and `@remix-run/router` by updating the `renderNestedRoute` function and the `react-router-dom` dependency. It also adds a changeset file to document the patch.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac9fafb</samp>

*  Add changeset file for `@modern-js/utils` package ([link](https://github.com/web-infra-dev/modern.js/pull/4566/files?diff=unified&w=0#diff-c17df7ed82cf50788c8baac5126238b3cba0c4c6cd8306af9b557a4879bc6b5fR1-R6))
*  Update `react-router-dom` dependency version in `package.json` ([link](https://github.com/web-infra-dev/modern.js/pull/4566/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L310-R310))
*  Fix type issues in `renderNestedRoute` function in `nestedRoutes.tsx` ([link](https://github.com/web-infra-dev/modern.js/pull/4566/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L50-R50), [link](https://github.com/web-infra-dev/modern.js/pull/4566/files?diff=unified&w=0#diff-0edae52700e63e2541ffa4d70e69e7586ff0e9850ef38b0cc781c9d7c99e07e1L127-R129))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
