### PR TITLE
fix(module-tools): failed to run pre and gen-release-note command

### DIFF
--- a/.changeset/heavy-kiwis-brake.md
+++ b/.changeset/heavy-kiwis-brake.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): failed to run pre and gen-release-note command
+
+fix(module-tools): 修复无法执行 pre 和 gen-release-note 命令的问题

--- a/packages/solutions/module-tools/src/plugins.ts
+++ b/packages/solutions/module-tools/src/plugins.ts
@@ -15,6 +15,8 @@ export const getPlugins = (runningCmd: string) => {
     case 'change':
     case 'release':
     case 'bump':
+    case 'pre':
+    case 'gen-release-note':
       plugins = [changesetPlugin()];
       break;
     default:


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d26386</samp>

This pull request fixes a bug in the `@modern-js/module-tools` package that prevented the execution of the `pre` and `gen-release-note` commands. It adds the missing cases to the `getPlugins` function in the `plugins.ts` file and updates the changeset file with the patch information and translation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5d26386</samp>

*  Add support for `pre` and `gen-release-note` commands in module tools ([link](https://github.com/web-infra-dev/modern.js/pull/4572/files?diff=unified&w=0#diff-f14560e0be5e21b3a6aded8839b3a9699e102863b9bc94851c274901d47bd3aeR18-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4572/files?diff=unified&w=0#diff-b88c369e87c960bd6ba83fc4fcaf1b4e74640f39d928de610b1c7ad9854e161dR1-R7))

## Related Issue

- close https://github.com/web-infra-dev/modern.js/issues/4548

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
