### PR TITLE
fix: some link should not have as attributes

### DIFF
--- a/.changeset/dull-bees-yell.md
+++ b/.changeset/dull-bees-yell.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/server-core': patch
+---
+
+fix: some link shouldn't have as attributes
+fix: 一些 link 头不应该添加 as 属性

--- a/packages/server/core/src/types/config/server.ts
+++ b/packages/server/core/src/types/config/server.ts
@@ -12,7 +12,7 @@ type Route =
 export type Routes = Record<string, Route>;
 
 type PreloadInclude = Array<
-  string | { url: string; type: string; rel?: string }
+  string | { url: string; type?: string; rel?: string }
 >;
 interface PreloadAttributes {
   script?: Record<string, boolean | string>;

--- a/packages/server/prod-server/tests/__snapshots__/preload.test.ts.snap
+++ b/packages/server/prod-server/tests/__snapshots__/preload.test.ts.snap
@@ -21,7 +21,7 @@ exports[`test preload test flushServerHeader 1`] = `
       "<style1.css>; rel=preload; as=style; id=css_link_id",
       "<style2.css>; rel=preload; as=style; id=css_link_id",
       "<http://example.com>; rel=preload; as=script; crossorigin; id=script_id",
-      "<http://example3.com>; rel=dns-prefetch; as=script; crossorigin; id=script_id",
+      "<http://example3.com>; rel=dns-prefetch",
     ],
   },
   {

--- a/packages/server/prod-server/tests/preload.test.ts
+++ b/packages/server/prod-server/tests/preload.test.ts
@@ -125,7 +125,6 @@ describe('test preload', () => {
               { url: 'http://example.com', type: 'script' },
               {
                 url: 'http://example3.com',
-                type: 'script',
                 rel: 'dns-prefetch',
               },
               '/static/js/async/three_user/layout.js',


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/modern.js/assets/58852732/c51f590c-9212-446f-b5e7-4b3928858ce2)


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e3252e</samp>

This pull request fixes a bug in the preload headers for the `@modern-js/prod-server` and `@modern-js/server-core` packages. It makes the `type` property optional in the `PreloadInclude` type and removes a redundant test case.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e3252e</samp>

*  Fix link header bug and update changelog ([link](https://github.com/web-infra-dev/modern.js/pull/4575/files?diff=unified&w=0#diff-10a24b742ce74c2c63c78f197b6e26725aaa01804bded4e88c74c94fe170d31aR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4575/files?diff=unified&w=0#diff-46035a5cbf825c2d0e563764cb143b5229b2a2cbed44eec0a9dc38343fb15ef1L15-R15), [link](https://github.com/web-infra-dev/modern.js/pull/4575/files?diff=unified&w=0#diff-9c62111546f8b5eff5e9001d1422f143c0af3b4f27a0ea0ace7309f2b07adec2L128))
  - Make `type` property optional in `PreloadInclude` type in `server.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4575/files?diff=unified&w=0#diff-46035a5cbf825c2d0e563764cb143b5229b2a2cbed44eec0a9dc38343fb15ef1L15-R15))
  - Remove redundant `type` property in `preload.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4575/files?diff=unified&w=0#diff-9c62111546f8b5eff5e9001d1422f143c0af3b4f27a0ea0ace7309f2b07adec2L128))
  - Bump patch versions of `@modern-js/prod-server` and `@modern-js/server-core` in `.changeset/dull-bees-yell.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4575/files?diff=unified&w=0#diff-10a24b742ce74c2c63c78f197b6e26725aaa01804bded4e88c74c94fe170d31aR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
