### PR TITLE
feat(builder): improve the logs of checkSyntax, add code frame

### DIFF
--- a/.changeset/three-ducks-warn.md
+++ b/.changeset/three-ducks-warn.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/builder': patch
+---
+
+feat(builder): improve the logs of checkSyntax, add code frame
+
+feat(builder): 优化 checkSyntax 的日志, 增加 code frame

--- a/packages/builder/builder-shared/src/constants.ts
+++ b/packages/builder/builder-shared/src/constants.ts
@@ -63,6 +63,8 @@ export const MEDIA_EXTENSIONS = [
 export const DEFAULT_ASSET_PREFIX = '/';
 
 // RegExp
+export const HTML_REGEX = /\.html$/;
+export const JSON_REGEX = /\.json$/;
 export const JS_REGEX = /\.(js|mjs|cjs|jsx)$/;
 export const TS_REGEX = /\.(ts|mts|cts|tsx)$/;
 export const SVG_REGEX = /\.svg$/;

--- a/packages/builder/builder-shared/src/fallback.ts
+++ b/packages/builder/builder-shared/src/fallback.ts
@@ -1,4 +1,4 @@
-import { JS_REGEX, TS_REGEX } from './constants';
+import { JS_REGEX, TS_REGEX, HTML_REGEX, JSON_REGEX } from './constants';
 import type { RuleSetRule } from 'webpack';
 
 type Rules = (undefined | null | false | '' | 0 | RuleSetRule | '...')[];
@@ -45,8 +45,8 @@ export const resourceRuleFallback = (
       JS_REGEX,
       TS_REGEX,
       // exclude `html` and `json`, they get processed by webpack internal loaders.
-      /\.html$/,
-      /\.json$/,
+      HTML_REGEX,
+      JSON_REGEX,
     ],
     type: 'asset/resource',
   };

--- a/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/generateError.ts
+++ b/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/generateError.ts
@@ -42,13 +42,13 @@ export async function generateError({
   return error;
 }
 
-function makeCodeFrame(lines: string[], highlightLine: number) {
-  const startLine = Math.max(highlightLine - 3, 0);
-  const endLine = Math.min(highlightLine + 4, lines.length - 1);
+export function makeCodeFrame(lines: string[], highlightIndex: number) {
+  const startLine = Math.max(highlightIndex - 3, 0);
+  const endLine = Math.min(highlightIndex + 4, lines.length - 1);
   const ret: string[] = [];
 
   for (let i = startLine; i < endLine; i++) {
-    if (i === highlightLine) {
+    if (i === highlightIndex) {
       const lineNumber = `> ${i + 1}`.padStart(6, ' ');
       ret.push(chalk.yellow(`${lineNumber} | ${lines[i]}`));
     } else {
@@ -96,7 +96,6 @@ async function tryGenerateErrorFromSourceMap({
 
     const path = sm.source.replace(/webpack:\/\/(tmp)?/g, '');
     const relativeFilepath = filepath.replace(rootPath, '');
-
     const rawLines = smContent.split(/\r?\n/g);
     const highlightLine = (sm.line ?? 1) - 1;
 

--- a/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/printErrors.ts
+++ b/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/printErrors.ts
@@ -30,7 +30,7 @@ export function printErrors(errors: SyntaxError[]) {
   );
 
   errs.forEach((err, index) => {
-    console.info(`${chalk.red(`  ERROR#${index + 1}`)}:`);
+    console.info(chalk.red.bold(`  ERROR ${index + 1}`));
     printMain(err, longest);
   });
 
@@ -54,8 +54,8 @@ function printMain(error: Error, logest: number) {
     if (!content) {
       return;
     }
-    const title = chalk.red(fillWhiteSpace(key, logest));
-    console.info(`  ${title} - ${content}`);
+    const title = chalk.magenta(`${fillWhiteSpace(`${key}:`, logest)}`);
+    console.info(`  ${title}  ${content}`);
   });
   console.info('');
 }

--- a/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/index.ts
+++ b/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/index.ts
@@ -11,11 +11,9 @@ import {
   checkIsExcludeSource,
   CheckSyntaxExclude,
 } from './helpers';
+import { JS_REGEX, HTML_REGEX } from '../../constants';
 import { EcmaVersion, CheckSyntaxOptions } from '../../types';
 import type { Compiler, Compilation } from 'webpack';
-
-const HTML_REGEX = /\.html$/;
-const JS_REGEX = /\.js$/;
 
 export class CheckSyntaxPlugin {
   errors: SyntaxError[] = [];
@@ -24,14 +22,19 @@ export class CheckSyntaxPlugin {
 
   targets: string[];
 
+  rootPath: string;
+
   exclude: CheckSyntaxExclude | undefined;
 
   constructor(
     options: CheckSyntaxOptions &
-      Required<Pick<CheckSyntaxOptions, 'targets' | 'exclude'>>,
+      Required<Pick<CheckSyntaxOptions, 'targets' | 'exclude'>> & {
+        rootPath: string;
+      },
   ) {
     this.targets = options.targets;
     this.exclude = options.exclude;
+    this.rootPath = options.rootPath;
     this.ecmaVersion = options.ecmaVersion || getEcmaVersion(this.targets);
   }
 
@@ -90,6 +93,7 @@ export class CheckSyntaxPlugin {
         code,
         filepath,
         exclude: this.exclude,
+        rootPath: this.rootPath,
       });
 
       if (error) {

--- a/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
+++ b/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { getHtmlScripts } from '../../src/plugins/CheckSyntaxPlugin/helpers/generateHtmlScripts';
 import { getEcmaVersion } from '../../src/plugins/CheckSyntaxPlugin/helpers/getEcmaVersion';
+import { makeCodeFrame } from '../../src/plugins/CheckSyntaxPlugin/helpers';
 
 describe('getHtmlScripts', () => {
   test('should extract inline scripts correctly', async () => {
@@ -69,5 +70,39 @@ describe('checkIsSupportBrowser', () => {
   test('should get ecma version of multiple browsers correctly', async () => {
     expect(getEcmaVersion(['ie >= 11', 'Chrome >= 53'])).toEqual(5);
     expect(getEcmaVersion(['Edge >= 15', 'Chrome >= 53'])).toEqual(6);
+  });
+});
+
+describe('makeCodeFrame', () => {
+  test('should make code frame correctly', () => {
+    const lines = [
+      'const a = 1;',
+      '',
+      'var b = 2;',
+      '',
+      'console.log(() => {',
+      '  return a + b;',
+      '});',
+      '',
+      'var c = 3;',
+    ];
+
+    expect(makeCodeFrame(lines, 0)).toMatchInlineSnapshot(`
+      "
+         > 1 | const a = 1;
+           2 | 
+           3 | var b = 2;
+           4 | "
+    `);
+    expect(makeCodeFrame(lines, 4)).toMatchInlineSnapshot(`
+      "
+           2 | 
+           3 | var b = 2;
+           4 | 
+         > 5 | console.log(() => {
+           6 |   return a + b;
+           7 | });
+           8 | "
+    `);
   });
 });

--- a/packages/builder/builder/src/plugins/checkSyntax.ts
+++ b/packages/builder/builder/src/plugins/checkSyntax.ts
@@ -36,6 +36,7 @@ export function builderPluginCheckSyntax(): DefaultBuilderPlugin {
         chain.plugin(CheckSyntaxPlugin.name).use(CheckSyntaxPlugin, [
           {
             targets,
+            rootPath: api.context.rootPath,
             ...(typeof checkSyntax === 'object' ? checkSyntax : {}),
           },
         ]);

--- a/packages/builder/builder/tests/plugins/__snapshots__/checkSyntax.test.ts.snap
+++ b/packages/builder/builder/tests/plugins/__snapshots__/checkSyntax.test.ts.snap
@@ -7,6 +7,7 @@ exports[`plugins/check-syntax > should add check-syntax plugin properly 1`] = `
       "ecmaVersion": 5,
       "errors": [],
       "exclude": undefined,
+      "rootPath": "<ROOT>/tests/plugins",
       "targets": [
         "> 0.01%",
         "not dead",
@@ -28,6 +29,7 @@ exports[`plugins/check-syntax > should use default browserlist as targets when o
       "exclude": [
         /\\$\\.html/,
       ],
+      "rootPath": "<ROOT>/tests/plugins",
       "targets": [
         "iOS 9",
         "Android 4.4",

--- a/packages/document/builder-doc/docs/en/config/security/checkSyntax.md
+++ b/packages/document/builder-doc/docs/en/config/security/checkSyntax.md
@@ -38,7 +38,7 @@ error   [Syntax Checker] Find some syntax errors after production build:
   Error 1
   source:  /node_modules/foo/index.js:1:0
   output:  /dist/static/js/main.3f7a4d7e.js:2:39400
-  reason:  The keyword 'const' is reserved (2:39400)
+  reason:  Unexpected token (1:178)
   code:
      9 |
     10 | var b = 2;
@@ -50,7 +50,7 @@ error   [Syntax Checker] Find some syntax errors after production build:
 ```
 
 :::tip
-Currently, syntax checking is implemented based on AST parser. Each time it performs a check, it can only identify the first incompatible syntax found in the file. If there are multiple incompatible syntaxes in one file, you need to fix the detected syntax and re-run the check.
+Currently, syntax checking is implemented based on AST parser. Each time it performs a check, it can only identify the first incompatible syntax found in the file. If there are multiple incompatible syntaxes in the file, you need to fix the detected syntax and re-run the check.
 :::
 
 ### Solutions

--- a/packages/document/builder-doc/docs/en/config/security/checkSyntax.md
+++ b/packages/document/builder-doc/docs/en/config/security/checkSyntax.md
@@ -33,14 +33,25 @@ When you enable `checkSyntax`, Builder will perform the detection during product
 The format of the error logs is as follows, including the source file, artifact location, error reason, and source code:
 
 ```bash
-error [Syntax Checker] Find some syntax errors after production build:
+error   [Syntax Checker] Find some syntax errors after production build:
 
-   ERROR#1:
-   source - /node_modules/foo/index.js:1:0
-   output - /Project/dist/static/js/main.3f7a4d7e.js:2:39400
-   reason - The keyword 'const' is reserved (2:39400)
-   code - const foo = 'bar';
+  Error 1
+  source:  /node_modules/foo/index.js:1:0
+  output:  /dist/static/js/main.3f7a4d7e.js:2:39400
+  reason:  The keyword 'const' is reserved (2:39400)
+  code:
+     9 |
+    10 | var b = 2;
+    11 |
+  > 12 | console.log(() => {
+    13 |   return a + b;
+    14 | });
+    15 |
 ```
+
+:::tip
+Currently, syntax checking is implemented based on AST parser. Each time it performs a check, it can only identify the first incompatible syntax found in the file. If there are multiple incompatible syntaxes in one file, you need to fix the detected syntax and re-run the check.
+:::
 
 ### Solutions
 

--- a/packages/document/builder-doc/docs/zh/config/security/checkSyntax.md
+++ b/packages/document/builder-doc/docs/zh/config/security/checkSyntax.md
@@ -35,12 +35,23 @@ export default {
 ```bash
 error   [Syntax Checker] Find some syntax errors after production build:
 
-  ERROR#1:
-  source - /node_modules/foo/index.js:1:0
-  output - /Project/dist/static/js/main.3f7a4d7e.js:2:39400
-  reason - The keyword 'const' is reserved (2:39400)
-  code   - const foo = 'bar';
+  Error 1
+  source:  /node_modules/foo/index.js:1:0
+  output:  /dist/static/js/main.3f7a4d7e.js:2:39400
+  reason:  The keyword 'const' is reserved (2:39400)
+  code:
+     9 |
+    10 | var b = 2;
+    11 |
+  > 12 | console.log(() => {
+    13 |   return a + b;
+    14 | });
+    15 |
 ```
+
+:::tip
+目前语法检测是基于 AST parser 来实现的，每次检测时，只能找出文件中的第一个不兼容语法。如果一个文件中存在多个不兼容语法，你需要修复已发现的语法，并重新执行检测。
+:::
 
 ### 解决方法
 

--- a/packages/document/builder-doc/docs/zh/config/security/checkSyntax.md
+++ b/packages/document/builder-doc/docs/zh/config/security/checkSyntax.md
@@ -38,7 +38,7 @@ error   [Syntax Checker] Find some syntax errors after production build:
   Error 1
   source:  /node_modules/foo/index.js:1:0
   output:  /dist/static/js/main.3f7a4d7e.js:2:39400
-  reason:  The keyword 'const' is reserved (2:39400)
+  reason:  Unexpected token (1:178)
   code:
      9 |
     10 | var b = 2;


### PR DESCRIPTION
## Summary

Old: 

<img width="1062" alt="Screenshot 2023-09-05 at 15 14 07" src="https://github.com/web-infra-dev/modern.js/assets/7237365/97b4a8cd-3505-4c70-86be-6af015d2c492">

New:

<img width="783" alt="Screenshot 2023-09-05 at 15 11 27" src="https://github.com/web-infra-dev/modern.js/assets/7237365/aa815a0d-4923-4390-a6c7-57066a45bae1">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9e235b</samp>

This pull request improves the `CheckSyntaxPlugin` in the `@modern-js/builder-shared` and `@modern-js/builder` packages by adding colors, symbols, and code frames to the error logs. It also refactors some code to use constants and relative filepaths. It updates the tests and the documentation to reflect the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9e235b</samp>

*  Add a changeset file to document the features and version bumps for `@modern-js/builder-shared` and `@modern-js/builder` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-ad0ab3b16e420dbe9acbac68929e4e22b8ba46a203f96b66047ab6ac00074135R1-R8))
*  Add `HTML_REGEX` and `JSON_REGEX` constants to `constants.ts` and use them in `fallback.ts` to exclude HTML and JSON files from the `resourceRuleFallback` function ([link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-d75bc2bebe393676e9833866225d34ae065324dcbf284d725b6971c46a766bd3R66-R67), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-ab26b248d82b655491ee18e931becbdb61d3363596b7e8502b19f40b5f7e6b31L1-R1), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-ab26b248d82b655491ee18e931becbdb61d3363596b7e8502b19f40b5f7e6b31L48-R49))
*  Improve the logs and code frame of the `CheckSyntaxPlugin` by using the `chalk` module, the `makeCodeFrame` function, and the `rootPath` parameter in `generateError.ts`, `printErrors.ts`, and `index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-6ea72a57cea30e8e5020788e4aae2a01f82ad164e68aaf25ffeb30bfaa091e71L3-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-6ea72a57cea30e8e5020788e4aae2a01f82ad164e68aaf25ffeb30bfaa091e71L39-R71), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-6ea72a57cea30e8e5020788e4aae2a01f82ad164e68aaf25ffeb30bfaa091e71L68-R100), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-6ea72a57cea30e8e5020788e4aae2a01f82ad164e68aaf25ffeb30bfaa091e71L76-R110), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-2addc4790c63b5e24dccb00b84f5308e14f158f2683b14f355ef96cc59659808L33-R33), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-2addc4790c63b5e24dccb00b84f5308e14f158f2683b14f355ef96cc59659808L57-R58), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-e650927f0aa75ae5d30efa9654832171892a90fdf5e25b9693c0f178cc0bcba9L14-R17), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-e650927f0aa75ae5d30efa9654832171892a90fdf5e25b9693c0f178cc0bcba9L27-R37), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-e650927f0aa75ae5d30efa9654832171892a90fdf5e25b9693c0f178cc0bcba9R96))
*  Add a test case for the `makeCodeFrame` function in `CheckSyntaxPlugin.test.ts` and use the `toMatchInlineSnapshot` method to compare the output ([link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-8e07cc58775721e483bb461e2dcadd9db7e0f178257f8540c32a3f910803af47R4), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-8e07cc58775721e483bb461e2dcadd9db7e0f178257f8540c32a3f910803af47R75-R108))
*  Pass the `rootPath` property from the `api.context.rootPath` value to the `builderPluginCheckSyntax` function call in `checkSyntax.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-9df8158cec3fc39e4a038d8046f10d174b8ee42d4a1eaf79095de9f12d4b1039R39))
*  Update the examples and tips of the error log output in the English and Chinese documentation files `checkSyntax.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-0126541a1563ef6db2ff82358fb4cf5340df4f2d61de0e3dfea0f3d91a349b9cL36-R55), [link](https://github.com/web-infra-dev/modern.js/pull/4578/files?diff=unified&w=0#diff-b4120e2faee0f367288b49c842c7e49f21adb69e13fb326db3bfc14b63cdd48bL38-R55))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
