### PR TITLE
feat(builder): add code pointer for check syntax results

### DIFF
--- a/.changeset/wise-mirrors-help.md
+++ b/.changeset/wise-mirrors-help.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+feat(builder): add code pointer for check syntax results
+
+feat(builder): 增加 check syntax 结果的指针提示

--- a/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/generateError.ts
+++ b/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/generateError.ts
@@ -3,6 +3,15 @@ import { SourceMapConsumer } from 'source-map';
 import { chalk, fs } from '@modern-js/utils';
 import { checkIsExcludeSource } from './utils';
 
+export function displayCodePointer(code: string, pos: number) {
+  const SUB_LEN = 80;
+  const start = Math.max(pos - SUB_LEN / 2, 0);
+  const subCode = code.slice(start, start + SUB_LEN);
+  const arrowPos = pos - start;
+  const arrowLine = chalk.yellow('^'.padStart(arrowPos + 11, ' '));
+  return `${subCode}\n${arrowLine}`;
+}
+
 export async function generateError({
   err,
   code,
@@ -23,14 +32,13 @@ export async function generateError({
   });
 
   if (!error) {
-    const SUB_LEN = 25;
-    const path = filepath.replace(process.cwd(), '');
+    const path = filepath.replace(rootPath, '');
     error = new SyntaxError(err.message, {
       source: {
         path,
         line: err.loc.line,
         column: err.loc.column,
-        code: code.substring(err.pos - SUB_LEN, err.pos + SUB_LEN).trim(),
+        code: displayCodePointer(code, err.pos),
       },
     });
   }

--- a/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/printErrors.ts
+++ b/packages/builder/builder-shared/src/plugins/CheckSyntaxPlugin/helpers/printErrors.ts
@@ -54,7 +54,7 @@ function printMain(error: Error, logest: number) {
     if (!content) {
       return;
     }
-    const title = chalk.magenta(`${fillWhiteSpace(`${key}:`, logest)}`);
+    const title = chalk.magenta(`${fillWhiteSpace(`${key}:`, logest + 1)}`);
     console.info(`  ${title}  ${content}`);
   });
   console.info('');

--- a/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
+++ b/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import { getHtmlScripts } from '../../src/plugins/CheckSyntaxPlugin/helpers/generateHtmlScripts';
 import { getEcmaVersion } from '../../src/plugins/CheckSyntaxPlugin/helpers/getEcmaVersion';
-import { makeCodeFrame } from '../../src/plugins/CheckSyntaxPlugin/helpers';
+import {
+  makeCodeFrame,
+  displayCodePointer,
+} from '../../src/plugins/CheckSyntaxPlugin/helpers';
 
 describe('getHtmlScripts', () => {
   test('should extract inline scripts correctly', async () => {
@@ -104,5 +107,18 @@ describe('makeCodeFrame', () => {
            7 | });
            8 | "
     `);
+  });
+});
+
+describe('displayCodePointer', () => {
+  test('should display code pointer correctly', () => {
+    const code =
+      '(self.webpackChunktmp=self.webpackChunktmp||[]).push([[179],{530:()=>{console.log(1);let e=1;e="2"}},e=>{var l;l=530,e(e.s=l)}]);';
+    expect(`\n  code:    ${displayCodePointer(code, 66)}`)
+      .toMatchInlineSnapshot(`
+        "
+          code:    =self.webpackChunktmp||[]).push([[179],{530:()=>{console.log(1);let e=1;e=\\"2\\"}},e=>{var l;
+                                                               ^"
+      `);
   });
 });

--- a/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
+++ b/packages/builder/builder-shared/tests/plugins/CheckSyntaxPlugin.test.ts
@@ -117,8 +117,8 @@ describe('displayCodePointer', () => {
     expect(`\n  code:    ${displayCodePointer(code, 66)}`)
       .toMatchInlineSnapshot(`
         "
-          code:    =self.webpackChunktmp||[]).push([[179],{530:()=>{console.log(1);let e=1;e=\\"2\\"}},e=>{var l;
-                                                               ^"
+          code:    .webpackChunktmp||[]).push([[179],{530:()=>{console.log(1);let e=1;e=\\"2\\"}},e=>{v
+                                                          ^"
       `);
   });
 });


### PR DESCRIPTION
## Summary

Sometimes the error code cannot be parsed by source map, so we need to add a pointer for this type of result to make it more clearer.

Old: 

<img width="910" alt="Screenshot 2023-09-06 at 10 53 05" src="https://github.com/web-infra-dev/modern.js/assets/7237365/6a44b362-49f7-4229-9c64-60e6f95a1be8">

New:

<img width="972" alt="Screenshot 2023-09-06 at 10 51 44" src="https://github.com/web-infra-dev/modern.js/assets/7237365/4d9a0657-9a89-48f1-a6c0-1a74db838c10">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7686ece</samp>

This pull request enhances the `CheckSyntaxPlugin` of the `@modern-js/builder-shared` package by adding a code pointer feature and a unit test. It also updates the changeset file and adjusts the output formatting.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7686ece</samp>

*  Add a changeset file to document the patch update for the `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/4584/files?diff=unified&w=0#diff-8f26216ba05de99f7c8716f4258cd06d5e85363871a915957e1fb86c64a1bd39R1-R7))
*  Add a new helper function `displayCodePointer` to show a code snippet with a yellow arrow pointing to the error location ([link](https://github.com/web-infra-dev/modern.js/pull/4584/files?diff=unified&w=0#diff-6ea72a57cea30e8e5020788e4aae2a01f82ad164e68aaf25ffeb30bfaa091e71R6-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4584/files?diff=unified&w=0#diff-8e07cc58775721e483bb461e2dcadd9db7e0f178257f8540c32a3f910803af47L4-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4584/files?diff=unified&w=0#diff-8e07cc58775721e483bb461e2dcadd9db7e0f178257f8540c32a3f910803af47R112-R124))
*  Use the new helper function to generate the code property of the error object in the `generateError` function ([link](https://github.com/web-infra-dev/modern.js/pull/4584/files?diff=unified&w=0#diff-6ea72a57cea30e8e5020788e4aae2a01f82ad164e68aaf25ffeb30bfaa091e71L33-R41))
*  Use the root path instead of the process cwd to replace the filepath in the error message in the `generateError` function ([link](https://github.com/web-infra-dev/modern.js/pull/4584/files?diff=unified&w=0#diff-6ea72a57cea30e8e5020788e4aae2a01f82ad164e68aaf25ffeb30bfaa091e71L26-R35))
*  Add one more space to the title padding in the `printMain` function to improve the alignment of the output ([link](https://github.com/web-infra-dev/modern.js/pull/4584/files?diff=unified&w=0#diff-2addc4790c63b5e24dccb00b84f5308e14f158f2683b14f355ef96cc59659808L57-R57))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
