### PR TITLE
docs(module-doc): update content about input config

### DIFF
--- a/.changeset/gentle-turtles-draw.md
+++ b/.changeset/gentle-turtles-draw.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools-docs': patch
+---
+
+docs(module-doc): update content about `input` config
+docs(module-doc): 更新关于 input 配置的内容

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -596,7 +596,7 @@ type Input =
 
 **Array usage:**
 
-In `bundle` mode, the following configurations will be built using `src/index.ts` and `src/index2.ts` as entry points. The usage of catalogs is not supported.
+In `bundle` mode, the following configurations will be built using `src/index.ts` and `src/index2.ts` as entry points. The `bundle` mode does not support configuring `input` as a directory.
 
 ```js title="modern.config.ts"
 export default {

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -596,13 +596,40 @@ type Input =
 
 **Array usage:**
 
+In `bundle` mode, the following configurations will be built using `src/index.ts` and `src/index2.ts` as entry points. The usage of catalogs is not supported.
+
 ```js title="modern.config.ts"
 export default {
   buildConfig: {
+    buildType: 'bundle',
     input: ['src/index.ts', 'src/index2.ts'],
   },
 };
 ```
+
+In `bundleless` mode, the following configuration compiles both files in the `src/a` directory and `src/index.ts` file.
+
+```js title="modern.config.ts"
+export default defineConfig({
+  buildConfig: {
+    buildType: 'bundleless',
+    input: ['src/a', 'src/index.ts'],
+  },
+});
+```
+
+In `bundleless` mode, **Array usage** also supports the usage of `!` to filter partial files:
+
+```js title="modern.config.ts"
+export default defineConfig({
+  buildConfig: {
+    buildType: 'bundleless',
+    input: ['src', '!src/*.spec.ts'],
+  },
+});
+```
+
+The above configuration will build the files in the `src` directory, and will also filter files with the `spec.ts` suffix.This is useful in cases where the test files are in the same root directory as the source files.
 
 **Object usage:**
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -594,7 +594,7 @@ type Input =
 
 **数组用法：**
 
-在 `bundle` 模式下，下面的配置会以 `src/index.ts` 和 `src/index2.ts` 为入口分别进行构建。不支持使用目录。
+在 `bundle` 模式下，下面的配置会以 `src/index.ts` 和 `src/index2.ts` 为入口分别进行构建。`bundle` 模式不支持配置 `input` 为目录。
 
 ```js title="modern.config.ts"
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -594,13 +594,41 @@ type Input =
 
 **数组用法：**
 
+在 `bundle` 模式下，下面的配置会以 `src/index.ts` 和 `src/index2.ts` 为入口分别进行构建。不支持使用目录。
+
 ```js title="modern.config.ts"
 export default defineConfig({
   buildConfig: {
+    buildType: 'bundle',
     input: ['src/index.ts', 'src/index2.ts'],
   },
 });
 ```
+
+在 `bundleless` 模式下，下面的配置会同时处理 `src/a` 目录下的文件和 `src/index.ts` 文件。
+
+```js title="modern.config.ts"
+export default defineConfig({
+  buildConfig: {
+    buildType: 'bundleless',
+    input: ['src/a', 'src/index.ts'],
+  },
+});
+```
+
+在 `bundleless` 模式下，数组模式还支持使用 `!` 来过滤部分文件：
+
+```js title="modern.config.ts"
+export default defineConfig({
+  buildConfig: {
+    buildType: 'bundleless',
+    input: ['src', '!src/*.spec.ts'],
+  },
+});
+```
+
+上面的配置将打包 `src` 目录下的文件，同时会过滤以 `spec.ts` 为后缀的文件。这在测试文件与源码文件在同一个根目录下的情况会很有用。
+
 
 **对象用法：**
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a97c52c</samp>

This pull request improves the documentation of the `input` option for the `buildConfig` API in the `@modern-js/module-tools-docs` package. It adds more details, examples, and clarifications in both English and Chinese. It also adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a97c52c</samp>

*  Add changeset file to document patch update for `@modern-js/module-tools-docs` package ([link](https://github.com/web-infra-dev/modern.js/pull/4587/files?diff=unified&w=0#diff-b70b9e2385160665071122f0eaf606a586b906f03e25eaa24a0ca963f729cad7R1-R6))
*  Clarify that directories are not supported as input for `buildConfig` API in `bundle` mode and add `buildType` property to code example in both English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4587/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baL599-R604), [link](https://github.com/web-infra-dev/modern.js/pull/4587/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791L597-R602))
*  Document how to use array of files and directories as input for `buildConfig` API in `bundleless` mode and how to filter out files with `!` operator in both English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4587/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baR610-R633), [link](https://github.com/web-infra-dev/modern.js/pull/4587/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791R608-R632))
*  Explain the use case of filtering out test files that are in the same root directory as the source files for `buildConfig` API in `bundleless` mode in both English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4587/files?diff=unified&w=0#diff-90a0f132c4140e37c110b40455aa3d8ad4d6a89ca7a8c8d19aa1b9a975b2d3baR610-R633), [link](https://github.com/web-infra-dev/modern.js/pull/4587/files?diff=unified&w=0#diff-c586a6521b4022a3ce9cca9155cb7658a6d5808af1138b83eb5bcd5d11e48791R608-R632))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
