### PR TITLE
docs(main): reuse the path alias document from Builder

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/advanced/alias.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/alias.mdx
@@ -1,0 +1,5 @@
+# Path Aliases
+
+import Alias from '@en/shared/alias.md';
+
+<Alias />

--- a/packages/document/builder-doc/docs/en/shared/alias.md
+++ b/packages/document/builder-doc/docs/en/shared/alias.md
@@ -1,13 +1,11 @@
-# Path Aliases
-
 Path aliases allow developers to define aliases for modules, making it easier to reference them in code. This can be useful when you want to use a short, easy-to-remember name for a module instead of a long, complex path.
 
 For example, if you frequently reference the `src/common/request.ts` module in your project, you can define an alias for it as `@request` and then use `import request from '@request'` in your code instead of writing the full relative path every time. This also allows you to move the module to a different location without needing to update all the import statements in your code.
 
-In Builder, there are two ways to set up path aliases:
+In Modern.js Builder, there are two ways to set up path aliases:
 
 - Through the `paths` configuration in `tsconfig.json`.
-- Through the [source.alias](/api/config-source.html#sourcealias) configuration.
+- Through the [source.alias](https://modernjs.dev/builder/en/api/config-source.html#sourcealias) configuration.
 
 ## Using `tsconfig.json`'s `paths` Configuration
 
@@ -33,7 +31,7 @@ You can refer to the [TypeScript - paths](https://www.typescriptlang.org/tsconfi
 
 ## Use `source.alias` Configuration
 
-Builder provides the [source.alias](/api/config-source.html#sourcealias) configuration option, which corresponds to the webpack/Rspack native [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) configuration. You can configure this option using an object or a function.
+Modern.js Builder provides the [source.alias](https://modernjs.dev/builder/en/api/config-source.html#sourcealias) configuration option, which corresponds to the webpack/Rspack native [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) configuration. You can configure this option using an object or a function.
 
 ### Use Cases
 
@@ -43,7 +41,7 @@ The `source.alias` configuration can address this limitation by allowing you to 
 
 ### Object Usage
 
-You can configure `source.alias` using an object, where the relative paths will be automatically resolved to absolute paths by Builder.
+You can configure `source.alias` using an object, where the relative paths will be automatically resolved to absolute paths.
 
 For example:
 
@@ -80,4 +78,4 @@ export default {
 
 The `paths` configuration in `tsconfig.json` takes precedence over the `source.alias` configuration. When a path matches the rules defined in both `paths` and `source.alias`, the value defined in `paths` will be used.
 
-You can adjust the priority of these two options using [source.aliasStrategy](/api/config-source.html#sourcealiasstrategy).
+You can adjust the priority of these two options using [source.aliasStrategy](https://modernjs.dev/builder/en/api/config-source.html#sourcealiasstrategy).

--- a/packages/document/builder-doc/docs/zh/guide/advanced/alias.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/alias.mdx
@@ -1,0 +1,5 @@
+# 路径别名
+
+import Alias from '@zh/shared/alias.md';
+
+<Alias />

--- a/packages/document/builder-doc/docs/zh/shared/alias.md
+++ b/packages/document/builder-doc/docs/zh/shared/alias.md
@@ -1,13 +1,11 @@
-# 路径别名
-
 路径别名（alias）允许开发者为模块定义别名，以便于在代码中更方便的引用它们。当你想要使用一个简短、易于记忆的名称来代替冗长复杂的路径时，这将非常有用。
 
 例如，假如你在项目中经常引用 `src/common/request.ts` 模块，你可以为它定义一个别名 `@request`，然后在代码中通过 `import request from '@request'` 来引用它，而不需要每次都写出完整的相对路径。同时，这也允许你将模块移动到不同的位置，而不需要更新代码中的所有 import 语法。
 
-在 Builder 中，你有两种方式可以设置路径别名:
+在 Modern.js Builder 中，你有两种方式可以设置路径别名:
 
 - 通过 `tsconfig.json` 中的 `paths` 配置。
-- 通过 [source.alias](/api/config-source.html#sourcealias) 配置。
+- 通过 [source.alias](http://modernjs.dev/builder/api/config-source.html#sourcealias) 配置。
 
 ## 通过 `tsconfig.json` 的 `paths` 配置
 
@@ -33,7 +31,7 @@
 
 ## 通过 `source.alias` 配置
 
-Builder 提供了 [source.alias](/api/config-source.html#sourcealias) 配置项，对应 webpack / Rspack 原生的 [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) 配置，你可以通过对象或者函数的方式来配置这个选项。
+Modern.js Builder 提供了 [source.alias](http://modernjs.dev/builder/api/config-source.html#sourcealias) 配置项，对应 webpack / Rspack 原生的 [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) 配置，你可以通过对象或者函数的方式来配置这个选项。
 
 ### 使用场景
 
@@ -43,7 +41,7 @@ Builder 提供了 [source.alias](/api/config-source.html#sourcealias) 配置项�
 
 ### 对象用法
 
-你可以通过对象的方式来配置 `source.alias`，其中的相对路径会被 Builder 自动补全为绝对路径。
+你可以通过对象的方式来配置 `source.alias`，其中的相对路径会被自动补全为绝对路径。
 
 比如：
 
@@ -80,4 +78,4 @@ export default {
 
 `tsconfig.json` 的 `paths` 配置的优先级高于 `source.alias`，当一个路径同时匹配到这两者定义的规则时，会优先使用 `tsconfig.json` 的 `paths` 定义的值。
 
-你可以通过 [source.aliasStrategy](/api/config-source.html#sourcealiasstrategy) 来调整这两个选项的优先级。
+你可以通过 [source.aliasStrategy](http://modernjs.dev/builder/api/config-source.html#sourcealiasstrategy) 来调整这两个选项的优先级。

--- a/packages/document/main-doc/docs/en/guides/basic-features/alias.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/alias.mdx
@@ -4,64 +4,25 @@ sidebar_position: 3
 
 # Path Alias
 
-Modern.js allows you to use alias to import modules from custom directories in JS and CSS, and comes with the following built-in alias:
+import Alias from '@modern-js/builder-doc/docs/en/shared/alias';
 
-```js
-{
-  '@': '<appDirectory>/src',
-  '@shared': '<appDirectory>/shared',
-}
-```
+<Alias />
 
-:::info
-When enabling optional features, the `new` command will also dynamically add built-in alias specific to the features. For example, when enabling BFF, the `@api` alias is added by default.
+## Default Aliases
 
-:::
-
-For example, importing modules from the `src/common` directory in the `src/App.tsx` file:
-
-```bash
-.
-├── common
-│   ├── styles
-│   │   └── base.css
-│   └── utils
-│       └── index.ts
-└── App.tsx
-```
-
-The code in `src/App.tsx` is as follows:
-
-```ts
-import utils from '@/src/common/utils';
-import '@/src/common/styles/base.css';
-```
-
-Modern.js also provides a way to customize alias. For example, adding the `@common` alias is as follows:
-
-For TypeScript projects, just set `compilerOptions.paths` in the project's `tsconfig.json`:
+The Modern.js framework comes with the following aliases built-in:
 
 ```json
 {
-  "compilerOptions": {
-    "paths": {
-      "@/*": ["./src/*"],
-      "@/common/*": ["./src/common/*"]
-    }
-  }
+  "@": "./src",
+  "@shared": "./shared"
 }
 ```
 
-For JavaScript projects, set `source.alias` in `modern.config.js`:
+Additionally, when the BFF plugin of the framework is enabled, the `@api` alias is automatically added.
 
-```ts title="modern.config.js"
-export default defineConfig({
-  source: {
-    alias: {
-      '@common': './src/common',
-    },
-  },
-});
+```json
+{
+  "@api": "./api"
+}
 ```
-
-For the specific usage of alias configuration, please refer to the [source.alias documentation](/configure/app/source/alias).

--- a/packages/document/main-doc/docs/zh/guides/basic-features/alias.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/alias.mdx
@@ -4,64 +4,25 @@ sidebar_position: 3
 
 # 路径别名
 
-Modern.js 允许在 JS 和 CSS 中使用别名导入自定义目录下的模块，并内置了以下别名:
+import Alias from '@modern-js/builder-doc/docs/zh/shared/alias';
 
-```js
-{
-  '@': '<appDirectory>/src',
-  '@shared': '<appDirectory>/shared',
-}
-```
+<Alias />
 
-:::info
-在开启可选功能时，new 命令也会动态的添加内置别名，例如启用 BFF 时默认会添加 `@api` 别名。
+## 默认别名
 
-:::
-
-例如从 `src/App.tsx` 文件中导入 `src/common` 目录下的模块：
-
-```bash
-.
-├── common
-│   ├── styles
-│   │   └── base.css
-│   └── utils
-│       └── index.ts
-└── App.tsx
-```
-
-`src/App.tsx` 中写法如下：
-
-```ts
-import utils from '@/src/common/utils';
-import '@/src/common/styles/base.css';
-```
-
-Modern.js 也提供了自定义别名的方式，以添加 `@common` 别名为例：
-
-对于 TypeScript 项目，只需要在项目根目录 `tsconfig.json` 下配置 `compilerOptions.paths`：
+Modern.js 框架内置了以下别名:
 
 ```json
 {
-  "compilerOptions": {
-    "paths": {
-      "@/*": ["./src/*"],
-      "@/common/*": ["./src/common/*"]
-    }
-  }
+  "@": "./src",
+  "@shared": "./shared"
 }
 ```
 
-JavaScript 项目可以在 `modern.config.js` 中配置 [`source.alias`](/configure/app/source/alias)：
+此外，在启用框架的 BFF 插件时，默认会添加 `@api` 别名。
 
-```ts title="modern.config.ts"
-export default defineConfig({
-  source: {
-    alias: {
-      '@common': './src/common',
-    },
-  },
-});
+```json
+{
+  "@api": "./api"
+}
 ```
-
-对于别名配置的具体用法，请参考 [source.alias 文档](/configure/app/source/alias)。


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8e1957</samp>

This pull request refactors and updates the documentation of the `alias` feature for both the Modern.js framework and the Modern.js Builder. It creates shared components for the `alias` content in `packages/document/builder-doc/docs/en/shared/alias.md` and `packages/document/builder-doc/docs/zh/shared/alias.md`, and imports them as MDX components in the relevant files under `packages/document/builder-doc/docs` and `packages/document/main-doc/docs`. It also documents the default aliases that the framework provides and fixes some broken links.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8e1957</samp>

*  Extract the common content of the `alias` feature documentation into shared files and import them as MDX components in the framework and builder documentation files ([link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-0222a7f2d650ce37c6884d4a0b668b86deb75b98e326eb9d7f8da99208a5b1a0R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-cf5efaea2d2600e9a9617ff2a30bae5e74ee8b2f17cf568ac9fd5dc44e329106L1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-26c1a9e519cc2eb75559ebd9b853eb6c8855de478de27258298eb588af5f7964R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-74bdc8682b8c4fe1093c1d2eee9a8110928df1be5fdad297c8ab9406678a83e2L1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-17d3bd97bf35b2fde4947d6f17c92d178291c31ee5fd96922945292d0baededaL7-R28), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-9fbb7a16a8ce4e34a400680a50c7027370cdb9bea84b902c1032e04243446e9bL7-R28))
*  Rename the original `alias` documentation files to `shared/alias.md` to indicate their reusability ([link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-cf5efaea2d2600e9a9617ff2a30bae5e74ee8b2f17cf568ac9fd5dc44e329106L1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-74bdc8682b8c4fe1093c1d2eee9a8110928df1be5fdad297c8ab9406678a83e2L1-R8))
*  Remove the title and the references to the Builder from the shared files, since they are specific to the context of each documentation file ([link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-cf5efaea2d2600e9a9617ff2a30bae5e74ee8b2f17cf568ac9fd5dc44e329106L1-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-74bdc8682b8c4fe1093c1d2eee9a8110928df1be5fdad297c8ab9406678a83e2L1-R8))
*  Replace the word "Builder" with "Modern.js Builder" and add the full URLs to the links to the `source.alias` and `source.aliasStrategy` documentation in the shared files, to avoid confusion and broken links ([link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-cf5efaea2d2600e9a9617ff2a30bae5e74ee8b2f17cf568ac9fd5dc44e329106L36-R34), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-cf5efaea2d2600e9a9617ff2a30bae5e74ee8b2f17cf568ac9fd5dc44e329106L46-R44), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-cf5efaea2d2600e9a9617ff2a30bae5e74ee8b2f17cf568ac9fd5dc44e329106L83-R81), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-74bdc8682b8c4fe1093c1d2eee9a8110928df1be5fdad297c8ab9406678a83e2L36-R34), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-74bdc8682b8c4fe1093c1d2eee9a8110928df1be5fdad297c8ab9406678a83e2L46-R44), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-74bdc8682b8c4fe1093c1d2eee9a8110928df1be5fdad297c8ab9406678a83e2L83-R81))
*  Add a new section to the framework documentation files to document the default aliases that the framework provides, such as `@modern-js/runtime` and `@modern-js/app-tools` ([link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-17d3bd97bf35b2fde4947d6f17c92d178291c31ee5fd96922945292d0baededaL7-R28), [link](https://github.com/web-infra-dev/modern.js/pull/4588/files?diff=unified&w=0#diff-9fbb7a16a8ce4e34a400680a50c7027370cdb9bea84b902c1032e04243446e9bL7-R28))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
