### PR TITLE
fix: lazy import preload, then update include.type to include.as

### DIFF
--- a/.changeset/blue-pears-allow.md
+++ b/.changeset/blue-pears-allow.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/server-core': patch
+---
+
+fix: lazy import preload, then update include.type to include.as
+fix: 动态加载 preload 功能, 对齐规范将 include.type 属性更新为 include.as

--- a/packages/server/core/src/types/config/server.ts
+++ b/packages/server/core/src/types/config/server.ts
@@ -11,9 +11,8 @@ type Route =
     };
 export type Routes = Record<string, Route>;
 
-type PreloadInclude = Array<
-  string | { url: string; type?: string; rel?: string }
->;
+type PreloadLink = { url: string; as?: string; rel?: string };
+type PreloadInclude = Array<string | PreloadLink>;
 interface PreloadAttributes {
   script?: Record<string, boolean | string>;
   style?: Record<string, boolean | string>;

--- a/packages/server/prod-server/src/libs/preload/flushServerHeader.ts
+++ b/packages/server/prod-server/src/libs/preload/flushServerHeader.ts
@@ -4,41 +4,6 @@ import { ModernServerContext } from '@modern-js/types';
 import { parseLinks } from './parseLinks';
 import { transformLinks2String } from './transformLinks2String';
 
-export function transformToRegExp(input: string | RegExp): RegExp {
-  if (typeof input === 'string') {
-    return new RegExp(input);
-  }
-  return input;
-}
-
-export function shouldFlushServerHeader(
-  serverConf: ServerOptions['server'],
-  userAgent?: string,
-  disablePreload?: boolean,
-) {
-  const { ssr: ssrConf } = serverConf || {};
-
-  if (disablePreload) {
-    return false;
-  }
-
-  if (typeof ssrConf === 'object' && ssrConf.preload) {
-    // ssr.preload: 'object'
-    if (typeof ssrConf.preload === 'object') {
-      const { userAgentFilter } = ssrConf.preload;
-      if (userAgentFilter && userAgent) {
-        return !transformToRegExp(userAgentFilter).test(userAgent);
-      }
-      return true;
-    }
-    // ssr.preload: true;
-    return true;
-  }
-
-  // ssr: false or ssr: true
-  return false;
-}
-
 export interface FlushServerHeaderOptions {
   ctx: ModernServerContext;
   distDir: string;

--- a/packages/server/prod-server/src/libs/preload/shouldFlushServerHeader.ts
+++ b/packages/server/prod-server/src/libs/preload/shouldFlushServerHeader.ts
@@ -1,0 +1,36 @@
+import type { ServerOptions } from '@modern-js/server-core';
+
+export function transformToRegExp(input: string | RegExp): RegExp {
+  if (typeof input === 'string') {
+    return new RegExp(input);
+  }
+  return input;
+}
+
+export function shouldFlushServerHeader(
+  serverConf: ServerOptions['server'],
+  userAgent?: string,
+  disablePreload?: boolean,
+) {
+  const { ssr: ssrConf } = serverConf || {};
+
+  if (disablePreload) {
+    return false;
+  }
+
+  if (typeof ssrConf === 'object' && ssrConf.preload) {
+    // ssr.preload: 'object'
+    if (typeof ssrConf.preload === 'object') {
+      const { userAgentFilter } = ssrConf.preload;
+      if (userAgentFilter && userAgent) {
+        return !transformToRegExp(userAgentFilter).test(userAgent);
+      }
+      return true;
+    }
+    // ssr.preload: true;
+    return true;
+  }
+
+  // ssr: false or ssr: true
+  return false;
+}

--- a/packages/server/prod-server/src/libs/preload/transformLinks2String.ts
+++ b/packages/server/prod-server/src/libs/preload/transformLinks2String.ts
@@ -1,6 +1,6 @@
 import { SSRPreload } from '@modern-js/server-core';
 import { Link } from './parseLinks';
-import { transformToRegExp } from './flushServerHeader';
+import { transformToRegExp } from './shouldFlushServerHeader';
 
 export function transformLinks2String(
   links: Link[],
@@ -62,7 +62,7 @@ function addInclude(links: Link[], include?: SSRPreload['include']) {
         })();
         return { uri: item, as: type };
       }
-      return { uri: item.url, as: item.type, rel: item.rel };
+      return { uri: item.url, as: item.as, rel: item.rel };
     }) || [];
 
   return links.concat(includes);

--- a/packages/server/prod-server/src/libs/render/index.ts
+++ b/packages/server/prod-server/src/libs/render/index.ts
@@ -5,7 +5,7 @@ import { ServerOptions } from '@modern-js/server-core';
 import { RenderResult, ServerHookRunner } from '../../type';
 import { ModernRoute } from '../route';
 import { ERROR_DIGEST } from '../../constants';
-import { flushServerHeader, shouldFlushServerHeader } from '../preload';
+import { shouldFlushServerHeader } from '../preload/shouldFlushServerHeader';
 import { handleDirectory } from './static';
 import { readFile } from './reader';
 import * as ssr from './ssr';
@@ -84,7 +84,9 @@ export const createRenderHandler: CreateRenderHandler = ({
         const disablePreload = Boolean(
           ctx.headers[`x-${cutNameByHyphen(metaName)}-disable-preload`],
         );
+
         if (shouldFlushServerHeader(conf.server, userAgent, disablePreload)) {
+          const { flushServerHeader } = await import('../preload');
           flushServerHeader({
             serverConf: conf.server,
             ctx,

--- a/packages/server/prod-server/tests/preload.test.ts
+++ b/packages/server/prod-server/tests/preload.test.ts
@@ -3,10 +3,10 @@ import type { ServerOptions } from '@modern-js/server-core';
 import { fs } from '@modern-js/utils';
 import {
   flushServerHeader,
-  shouldFlushServerHeader,
-  parseLinks,
   FlushServerHeaderOptions,
+  parseLinks,
 } from '../src/libs/preload';
+import { shouldFlushServerHeader } from '../src/libs/preload/shouldFlushServerHeader';
 
 describe('test preload', () => {
   const distDir = path.join(__dirname, 'fixtures', 'preload');
@@ -121,8 +121,8 @@ describe('test preload', () => {
         ssr: {
           preload: {
             include: [
-              { url: 'http://example.com', type: 'script' },
-              { url: 'http://example.com', type: 'script' },
+              { url: 'http://example.com', as: 'script' },
+              { url: 'http://example.com', as: 'script' },
               {
                 url: 'http://example3.com',
                 rel: 'dns-prefetch',

--- a/tests/integration/ssr/fixtures/preload/modern.config.ts
+++ b/tests/integration/ssr/fixtures/preload/modern.config.ts
@@ -3,7 +3,14 @@ import { appTools, defineConfig } from '@modern-js/app-tools';
 export default defineConfig({
   server: {
     ssr: {
-      preload: true,
+      preload: {
+        include: [
+          {
+            url: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/nuvshpqnulg/eden-x-logo.png',
+            as: 'image',
+          },
+        ],
+      },
     },
   },
   runtime: {

--- a/tests/integration/ssr/tests/__snapshots__/preload.test.ts.snap
+++ b/tests/integration/ssr/tests/__snapshots__/preload.test.ts.snap
@@ -9,5 +9,6 @@ exports[`SSR preload should add Links to response headers 1`] = `
   "</static/js/lib-react.js>; rel=preload; as=script",
   "</static/js/lib-router.js>; rel=preload; as=script",
   "</static/js/main.js>; rel=preload; as=script",
+  "<https://lf3-static.bytednsdoc.com/obj/eden-cn/nuvshpqnulg/eden-x-logo.png>; rel=preload; as=image",
 ]
 `;


### PR DESCRIPTION
## Summary

unuse preload, but it would run some effect actions.

![60351d66-18a7-45bf-b617-6b8dc7ddd475](https://github.com/web-infra-dev/modern.js/assets/58852732/bb0f5bbf-fc9b-4c1a-abf9-b0fdaeb317cc)


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6bb0e46</samp>

This pull request improves and fixes the preload feature of the `@modern-js/prod-server` package, which allows the server to send preload hints to the browser for faster loading of resources. It changes the type definition, the file structure, and the import paths for the preload-related functions and types. It also updates the tests and the changelogs for the affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6bb0e46</samp>

*  Add a changeset file to document the patch-level changes for `@modern-js/prod-server` and `@modern-js/server-core` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-88d1e60fb52223cfdb00c01c164b7a34cd31c0e415184807357ad40dc453460cR1-R7))
*  Change the `PreloadInclude` type to use `as` instead of `type` for the preload links, and update the `Routes` type accordingly in `packages/server/core/src/types/config/server.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-46035a5cbf825c2d0e563764cb143b5229b2a2cbed44eec0a9dc38343fb15ef1L14-R15))
*  Move the `shouldFlushServerHeader` function to a separate file `packages/server/prod-server/src/libs/preload/shouldFlushServerHeader.ts` to isolate the preload condition logic ([link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-3a47d18bc1951ca0312c72156ff16989c0f0397efc6a3e5ab0fb2d668ddde6b4L7-L41), [link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-455e71c29ff48ee7a9691d7767959a2a2f8c7411ce6906d48b142f8eb4a5c47bR1-R36))
*  Update the import statements for the `shouldFlushServerHeader` function in `packages/server/prod-server/src/libs/preload/transformLinks2String.ts` and `packages/server/prod-server/src/libs/render/index.ts` to use the new file path ([link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-0151800124741edede484eb182018a40ca939b22aa5deb96f49a24b34690f8c6L3-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bL8-R8))
*  Use dynamic import for the `flushServerHeader` function in `packages/server/prod-server/src/libs/render/index.ts` to optimize the server loading time ([link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-3a47d18bc1951ca0312c72156ff16989c0f0397efc6a3e5ab0fb2d668ddde6b4L7-L41), [link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bL87-R89))
*  Update the `addInclude` function and the test case in `packages/server/prod-server/src/libs/preload/transformLinks2String.ts` and `packages/server/prod-server/tests/preload.test.ts` to use `as` instead of `type` for the preload links ([link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-0151800124741edede484eb182018a40ca939b22aa5deb96f49a24b34690f8c6L65-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-9c62111546f8b5eff5e9001d1422f143c0af3b4f27a0ea0ace7309f2b07adec2L124-R125))
*  Update the server configuration and the integration test for the preload feature in `tests/integration/ssr/fixtures/preload/modern.config.ts` to use the `include` option and the `as` property ([link](https://github.com/web-infra-dev/modern.js/pull/4589/files?diff=unified&w=0#diff-9b7eb48c8a0e2c9478282748f5a2a08a0e95b2ab0fbd44bbe6e8f116d86be35bL6-R13))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
