### PR TITLE
build(workflow): deploy devtools site with a short sha hash pathname

### DIFF
--- a/.github/workflows/build-devtools-website.yml
+++ b/.github/workflows/build-devtools-website.yml
@@ -35,11 +35,17 @@ jobs:
             turbo-${{ github.ref_name }}-
             turbo-
 
+      - name: Set outputs
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Install Dependencies
         run: pnpm install
 
       - name: Build Website
         run: pnpm --filter @modern-js/devtools-client run build
+        env:
+          ASSET_PREFIX: https://web-infra-dev.github.io/devtools/${{ steps.vars.outputs.sha_short }}
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.4.1
@@ -48,7 +54,7 @@ jobs:
           branch: main
           folder: packages/devtools/client/dist
           token: ${{ secrets.MODERN_DEPLOY_TOKEN }}
-          target-folder: devtools/${{ github.sha }}
+          target-folder: devtools/${{ steps.vars.outputs.sha_short }}
           git-config-name: gh-pages-bot
           git-config-email: 41898282+github-actions[bot]@users.noreply.github.com
           clean: true


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91cb2ca</samp>

This pull request improves the devtools website deployment workflow by using a short commit hash variable and setting the asset prefix dynamically.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91cb2ca</samp>

* Set output variable `sha_short` with short commit hash for deployment folder name ([link](https://github.com/web-infra-dev/modern.js/pull/4598/files?diff=unified&w=0#diff-1b32dfe2c99c3ee8661eafde4bac40a001c722085e83a5439b9e4f6adbc0ebe7R38-R41))
* Set environment variable `ASSET_PREFIX` with deployed website URL using `sha_short` ([link](https://github.com/web-infra-dev/modern.js/pull/4598/files?diff=unified&w=0#diff-1b32dfe2c99c3ee8661eafde4bac40a001c722085e83a5439b9e4f6adbc0ebe7R47-R48))
* Change deployment target folder to use `sha_short` instead of full commit hash ([link](https://github.com/web-infra-dev/modern.js/pull/4598/files?diff=unified&w=0#diff-1b32dfe2c99c3ee8661eafde4bac40a001c722085e83a5439b9e4f6adbc0ebe7L51-R57))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
