### PR TITLE
docs(deps): bump rspress 0.0.10

### DIFF
--- a/packages/document/builder-doc/package.json
+++ b/packages/document/builder-doc/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@modern-js/tsconfig": "workspace:*",
-    "rspress": "0.0.6",
+    "rspress": "0.0.10",
     "@types/node": "^14",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/document/main-doc/package.json
+++ b/packages/document/main-doc/package.json
@@ -43,7 +43,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5",
     "fs-extra": "^10",
-    "rspress": "0.0.6",
+    "rspress": "0.0.10",
     "@rspress/shared": "0.0.6",
     "@types/node": "^16",
     "@types/fs-extra": "^9"

--- a/packages/document/module-doc/package.json
+++ b/packages/document/module-doc/package.json
@@ -20,7 +20,7 @@
     "@modern-js/doc-plugin-auto-sidebar": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rspress": "0.0.6",
+    "rspress": "0.0.10",
     "@rspress/shared": "0.0.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1705,8 +1705,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       rspress:
-        specifier: 0.0.6
-        version: 0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+        specifier: 0.0.10
+        version: 0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
 
   packages/document/main-doc:
     dependencies:
@@ -1745,8 +1745,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       rspress:
-        specifier: 0.0.6
-        version: 0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+        specifier: 0.0.10
+        version: 0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@16.11.68)(typescript@5.0.4)
@@ -1769,8 +1769,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       rspress:
-        specifier: 0.0.6
-        version: 0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+        specifier: 0.0.10
+        version: 0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
 
   packages/generator/generator-cases:
     dependencies:
@@ -13235,8 +13235,8 @@ packages:
       tapable: 2.2.1
     dev: false
 
-  /@rspress/core@0.0.6(react@18.2.0)(rspress@0.0.6)(ts-node@10.9.1)(webpack@5.88.1):
-    resolution: {integrity: sha512-isvpsnhyX77AHyqlCCF75e4diQWfxbsKUMM+V12Ny4fY4q0vIHY1DRermgk7aQ3Flz0apUmF/5kz+OxIwQwC+A==}
+  /@rspress/core@0.0.10(react@18.2.0)(rspress@0.0.10)(ts-node@10.9.1)(webpack@5.88.1):
+    resolution: {integrity: sha512-kO/1ARR3Y4U4it2DZWbmxnSeEvAVSHWqrti5YmM3GvViD1DDBu4Qvguz8benxa+TxmD76L3vjZjd5fONPlEnAA==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17'
@@ -13250,11 +13250,11 @@ packages:
       '@modern-js/builder-rspack-provider': link:packages/builder/builder-rspack-provider
       '@modern-js/mdx-rs-binding': 0.2.5
       '@modern-js/utils': link:packages/toolkit/utils
-      '@rspress/plugin-auto-nav-sidebar': 0.0.6(rspress@0.0.6)
-      '@rspress/plugin-last-updated': 0.0.6(rspress@0.0.6)
-      '@rspress/plugin-medium-zoom': 0.0.6(rspress@0.0.6)
-      '@rspress/remark-container': 0.0.5(rspress@0.0.6)
-      '@rspress/shared': 0.0.6
+      '@rspress/plugin-auto-nav-sidebar': 0.0.10(rspress@0.0.10)
+      '@rspress/plugin-container-syntax': 0.0.10(rspress@0.0.10)
+      '@rspress/plugin-last-updated': 0.0.10(rspress@0.0.10)
+      '@rspress/plugin-medium-zoom': 0.0.10(rspress@0.0.10)
+      '@rspress/shared': 0.0.10
       '@types/compression': 1.7.2
       '@types/polka': 0.5.4
       acorn: 8.10.0
@@ -13293,6 +13293,7 @@ packages:
       remark-html: 15.0.1
       remark-parse: 10.0.1
       remark-rehype: 10.1.0
+      rspack-plugin-virtual-module: 0.1.11
       sirv: 2.0.3
       source-map: 0.7.4
       string-replace-loader: 3.1.0(webpack@5.88.1)
@@ -13310,40 +13311,49 @@ packages:
       - utf-8-validate
       - webpack
 
-  /@rspress/plugin-auto-nav-sidebar@0.0.6(rspress@0.0.6):
-    resolution: {integrity: sha512-amg1V2nrK54WOxLba6V5MSLnmQ3E1yeKS3FdXAXR5mfzmZDqG8UOEEkifc3EF0lzb3h2VVSkLsDLSlt4wzIIMQ==}
+  /@rspress/plugin-auto-nav-sidebar@0.0.10(rspress@0.0.10):
+    resolution: {integrity: sha512-Qz82NiahM096NSAlokzdSl9a0YNtq0DDFu7cYVu5gEtJA7NMcnw59FtoM6KvTxqIwV2ctRTtOYmcZNaZzDwysA==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       rspress: '*'
     dependencies:
       '@modern-js/utils': link:packages/toolkit/utils
-      rspress: 0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+      '@rspress/shared': 0.0.10
+      rspress: 0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
 
-  /@rspress/plugin-last-updated@0.0.6(rspress@0.0.6):
-    resolution: {integrity: sha512-RZJWWXLnP18CJDl3ztHOSytqhnfnSMQnzVXhHLZPFO5YEMa62ZvokRq1dg6dmU3yqUCrFZKbTcmylA/PW8cgvQ==}
+  /@rspress/plugin-container-syntax@0.0.10(rspress@0.0.10):
+    resolution: {integrity: sha512-IGxOIUp4HHRWe0m6QoFmGSGqkSCHdZhjwoOkR7AvhqsHd6DEhkJti9iLUQgjZyUUP3TaaKMgXmXcyLr38GsT2Q==}
+    engines: {node: '>=14.17.6'}
+    peerDependencies:
+      rspress: '*'
+    dependencies:
+      rspress: 0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+
+  /@rspress/plugin-last-updated@0.0.10(rspress@0.0.10):
+    resolution: {integrity: sha512-YJE7DT3j5u/JpVZdCntL8yjdQygKbMvsqZ535yakVGqlIe5UHCmOqGY9wDAJ0PsdEaJBjSSIVO37WThgQSrUyw==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       rspress: '*'
     dependencies:
       '@modern-js/utils': link:packages/toolkit/utils
-      rspress: 0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+      rspress: 0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
 
-  /@rspress/plugin-medium-zoom@0.0.6(rspress@0.0.6):
-    resolution: {integrity: sha512-BbINYlkIpI/cwpSGuJAdznfC43yr3tZ/hxbSCL8JXULi7PSQtdYvWcwKGYwtvhhWqMU5MeWJnPq7Q4cHii2nDQ==}
+  /@rspress/plugin-medium-zoom@0.0.10(rspress@0.0.10):
+    resolution: {integrity: sha512-/PnJnejUKT9n7b+dK5MPZdYwaP8oletsRdHedxdP5VWMrF1IXGPYyxw6ra8CxzJaGOCid1CbqsMxXtMBhF2Tgw==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       rspress: '*'
     dependencies:
       medium-zoom: 1.0.8
-      rspress: 0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+      rspress: 0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
 
-  /@rspress/remark-container@0.0.5(rspress@0.0.6):
-    resolution: {integrity: sha512-HlHkkByxc2jMkGWHCCwOkLRZ8PLUSd4FsuEmLlXRPMlOUacCsZmMm0Pj3VQMGhWzN6PkBmo2EixWd11QjaWIBQ==}
-    engines: {node: '>=14.17.6'}
-    peerDependencies:
-      rspress: '*'
+  /@rspress/shared@0.0.10:
+    resolution: {integrity: sha512-dnS+IyeBZ7ILRwrENBNbgwH0Wx00tdJQ+BlptYnnheoIdRa1MP4qcFFwD8qftCq6opEuP7z/1drlZKsbpjui7A==}
     dependencies:
-      rspress: 0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1)
+      '@modern-js/builder': link:packages/builder/builder
+      '@modern-js/builder-rspack-provider': link:packages/builder/builder-rspack-provider
+      chalk: 4.1.2
+      unified: 10.1.2
 
   /@rspress/shared@0.0.6:
     resolution: {integrity: sha512-xZ97GwDNDM5p7wGxp/1Lpiob6h7bBell2Slr7jaABUjiMvM004GxNrEooHGG1l0rafi/L+DKlCdMPgeQ9oVVgw==}
@@ -28225,7 +28235,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
-      ts-node: 10.9.1(@types/node@16.11.68)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@18.11.17)(typescript@5.0.4)
       yaml: 1.10.2
 
   /postcss-load-config@3.1.4(postcss@8.4.27)(ts-node@10.9.1):
@@ -31629,18 +31639,23 @@ packages:
       webpack-sources: 2.3.1
     dev: false
 
+  /rspack-plugin-virtual-module@0.1.11:
+    resolution: {integrity: sha512-dD7vo8PY3sG7nM1JAuytJ4XTXqALKUDjISFaxFyIHcSvUBKu8nmJf9TaRq1htS+bsXujqkKhKR859k0/zTHwxQ==}
+    dependencies:
+      fs-extra: 11.1.1
+
   /rspack-plugin-virtual-module@0.1.7:
     resolution: {integrity: sha512-8LFxQ+YI0KeveA5Vl7SWMB9LRq8pBnrtmzF6klOU3pNfWFWsaRf+D8OnDRHHlrYUq6l+1Q8yTlZB/HgqksRD9Q==}
     dependencies:
       fs-extra: 11.1.1
     dev: false
 
-  /rspress@0.0.6(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1):
-    resolution: {integrity: sha512-TTOkHC99nN5PlyzjZ31ywhgxRXWvUAZ+B4z8g1tqNf/yNGUbUFEBfL0k3EDkb/XUnFa869Kuhwtaj3jrbbSbtg==}
+  /rspress@0.0.10(react@18.2.0)(ts-node@10.9.1)(webpack@5.88.1):
+    resolution: {integrity: sha512-OuBft8gBm41Jd4Wt39DqIefG+pB+8S+phSa4LOziN17shBOTOK2GecOofrQcFfTQN+LZaQByNjsmnFwqY2jRBw==}
     hasBin: true
     dependencies:
       '@modern-js/node-bundle-require': link:packages/toolkit/node-bundle-require
-      '@rspress/core': 0.0.6(react@18.2.0)(rspress@0.0.6)(ts-node@10.9.1)(webpack@5.88.1)
+      '@rspress/core': 0.0.10(react@18.2.0)(rspress@0.0.10)(ts-node@10.9.1)(webpack@5.88.1)
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.5.3
@@ -33636,6 +33651,7 @@ packages:
       typescript: 5.0.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
 
   /ts-node@10.9.1(@types/node@18.11.17)(typescript@5.0.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}


### PR DESCRIPTION
## Summary

rspress v0.0.6 -> v0.0.10

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac6e4c5</samp>

*  Updated `rspress` dependency to version 0.0.10 in three packages: `builder-doc`, `main-doc`, and `module-doc` ([link](https://github.com/web-infra-dev/modern.js/pull/4599/files?diff=unified&w=0#diff-9d688c8e7678bb542dc806f20d201af7f3dd7187ad6d00aeb931d75e50472266L31-R31), [link](https://github.com/web-infra-dev/modern.js/pull/4599/files?diff=unified&w=0#diff-b76b38d66b7c2bb38868203f49fa82dbb7fccac8622eae50988649d69c0bbca9L46-R46), [link](https://github.com/web-infra-dev/modern.js/pull/4599/files?diff=unified&w=0#diff-2318ccc7632795dc9cd65f039aa01f398767cc65bb97e422079a4dcc94e13700L23-R23))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
