### PR TITLE
fix(eslint-config): remove the markdown plugin

### DIFF
--- a/.changeset/new-deers-sip.md
+++ b/.changeset/new-deers-sip.md
@@ -1,0 +1,7 @@
+---
+'@modern-js-app/eslint-config': patch
+---
+
+fix(eslint-config): remove the markdown plugin
+
+fix(eslint-config): 移除 markdown 插件

--- a/packages/review/eslint-config-app/base.js
+++ b/packages/review/eslint-config-app/base.js
@@ -44,8 +44,6 @@ module.exports = {
     'promise',
     // https://www.npmjs.com/package/eslint-plugin-node
     'node',
-    // https: //github.com/eslint/eslint-plugin-markdown
-    'markdown',
   ],
   // https://eslint.org/docs/user-guide/configuring#extending-configuration-files
   extends: [
@@ -1276,10 +1274,6 @@ module.exports = {
     {
       files: ['*.stories.[tj]sx', '*.stories.[tj]s'],
       rules: { 'import/no-anonymous-default-export': 'off' },
-    },
-    {
-      files: ['**/*.md'],
-      processor: 'markdown/markdown',
     },
     // ignore auto-generated css module declarations
     {

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -33,7 +33,6 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.24.1",
-    "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3555,9 +3555,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.24.1
         version: 2.26.0(@typescript-eslint/parser@5.59.6)(eslint@8.28.0)
-      eslint-plugin-markdown:
-        specifier: ^3.0.0
-        version: 3.0.0(eslint@8.28.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.28.0)
@@ -21335,18 +21332,6 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-markdown@3.0.0(eslint@8.28.0):
-    resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      eslint: 8.28.0
-      mdast-util-from-markdown: 0.8.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /eslint-plugin-node@11.1.0(eslint@8.28.0):
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
@@ -26038,18 +26023,6 @@ packages:
       unist-util-visit-parents: 5.1.1
     dev: true
 
-  /mdast-util-from-markdown@0.8.5:
-    resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
-    dependencies:
-      '@types/mdast': 3.0.10
-      mdast-util-to-string: 2.0.0
-      micromark: 2.11.4
-      parse-entities: 2.0.0
-      unist-util-stringify-position: 2.0.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /mdast-util-from-markdown@1.2.0:
     resolution: {integrity: sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==}
     dependencies:
@@ -26215,10 +26188,6 @@ packages:
 
   /mdast-util-to-string@1.1.0:
     resolution: {integrity: sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==}
-    dev: false
-
-  /mdast-util-to-string@2.0.0:
-    resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
     dev: false
 
   /mdast-util-to-string@3.1.0:
@@ -26691,15 +26660,6 @@ packages:
   /micromark-util-types@1.0.2:
     resolution: {integrity: sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==}
     dev: true
-
-  /micromark@2.11.4:
-    resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
-    dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
-      parse-entities: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /micromark@3.1.0:
     resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}


### PR DESCRIPTION
## Summary

Remove the markdown plugin for:

- The markdown linter never worked in modern.js repo.
- Lint markdown is not a good idea, because the code blocks in markdown are often incomplete code.
- Mdx is not supported by the plugin.
- Reduce dependencies.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4aabac1</samp>

This pull request simplifies the eslint configuration for the app package by removing unnecessary plugins and rules for markdown files. It also updates the changeset file and the package.json file to reflect the patch version update of the `@modern-js-app/eslint-config` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4aabac1</samp>

*  Remove markdown plugin and dependency from app eslint config ([link](https://github.com/web-infra-dev/modern.js/pull/4610/files?diff=unified&w=0#diff-aaca3b5dde0cf9edd549873e1239bcf625e4c9603b312c3cdb6ecafa9817bcc4L47-L48), [link](https://github.com/web-infra-dev/modern.js/pull/4610/files?diff=unified&w=0#diff-aaca3b5dde0cf9edd549873e1239bcf625e4c9603b312c3cdb6ecafa9817bcc4L1280-L1283), [link](https://github.com/web-infra-dev/modern.js/pull/4610/files?diff=unified&w=0#diff-d61007e6a4f882d26ca3f691465e069175887da72988065c1aed67b34a6f2ac6L36))
*  Update changeset file for patch version of `@modern-js-app/eslint-config` package ([link](https://github.com/web-infra-dev/modern.js/pull/4610/files?diff=unified&w=0#diff-943d594efe50ed31de666196819255495773ab48b7a280c70172b9b05486b63cR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
