### PR TITLE
feat(builder): split package scheduler into chunk `lib-react.js`

### DIFF
--- a/.changeset/purple-planes-occur.md
+++ b/.changeset/purple-planes-occur.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder': patch
+---
+
+feat: split package `scheduler` into chunk `lib-react.js`
+feat: 修改拆包规则添加 `scheduler` 到 `lib-react.js` 中

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -679,7 +679,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",
@@ -1464,7 +1464,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",
@@ -2730,7 +2730,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -792,7 +792,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",
@@ -1775,7 +1775,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",

--- a/packages/builder/builder/src/plugins/splitChunks.ts
+++ b/packages/builder/builder/src/plugins/splitChunks.ts
@@ -91,7 +91,7 @@ async function splitByExperience(
   const experienceCacheGroup: CacheGroup = {};
 
   const packageRegExps: Record<string, RegExp> = {
-    react: createDependenciesRegExp('react', 'react-dom'),
+    react: createDependenciesRegExp('react', 'react-dom', 'scheduler'),
     router: createDependenciesRegExp(
       'react-router',
       'react-router-dom',

--- a/packages/builder/builder/tests/plugins/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/builder/builder/tests/plugins/__snapshots__/splitChunks.test.ts.snap
@@ -137,7 +137,7 @@ exports[`plugins/splitChunks > 'should set split-by-experience config correctly 
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",
@@ -195,7 +195,7 @@ exports[`plugins/splitChunks > 'should set split-by-experience config' 1`] = `
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",


### PR DESCRIPTION
## Summary

Split package `scheduler` into chunk `lib-react.js` according to https://github.com/facebook/react/blob/main/packages/react-dom/package.json#L21.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d330e9a</samp>

This pull request adds a new feature to the `@modern-js/builder` package that optimizes the chunk splitting for React applications that use the `scheduler` package. It updates the changelog and the `splitChunks.ts` plugin to group the `react` and `scheduler` packages into the same chunk, `lib-react.js`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d330e9a</samp>

*  Add feature to split `scheduler` package into `lib-react.js` chunk for React applications ([link](https://github.com/web-infra-dev/modern.js/pull/4612/files?diff=unified&w=0#diff-3ed6b52271e0ce9d16bc589bd3d906df30825e91af2ce5a2366e5982ab717d5fR1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4612/files?diff=unified&w=0#diff-acd8a3657576d12badbc5b7b055318732b09ef565ffcee6e27629005bf5f1951L94-R94))
  * Update changelog for `@modern-js/builder` package with patch update and feature description in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4612/files?diff=unified&w=0#diff-3ed6b52271e0ce9d16bc589bd3d906df30825e91af2ce5a2366e5982ab717d5fR1-R6))
  * Modify `splitByExperience` function in `splitChunks.ts` plugin to group `scheduler` and `react` packages into the same chunk ([link](https://github.com/web-infra-dev/modern.js/pull/4612/files?diff=unified&w=0#diff-acd8a3657576d12badbc5b7b055318732b09ef565ffcee6e27629005bf5f1951L94-R94))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
