### PR TITLE
fix(builder): incorrect devMiddleware schema

### DIFF
--- a/.changeset/strong-suits-attack.md
+++ b/.changeset/strong-suits-attack.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): incorrect devMiddleware schema
+
+fix(builder): 修复 devMiddleware 的 schema 错误

--- a/packages/builder/builder-shared/src/schema/tools.ts
+++ b/packages/builder/builder-shared/src/schema/tools.ts
@@ -16,11 +16,12 @@ const sharedDevServerConfigSchema = z.partialObj({
     port: z.string(),
     host: z.string(),
   }),
-  devMiddleware: z.object({
+  devMiddleware: z.partialObj({
     writeToDisk: z.union([
       z.boolean(),
       z.function().args(z.string()).returns(z.boolean()),
     ]),
+    outputFileSystem: z.record(z.any()),
   }),
   historyApiFallback: z.union([z.boolean(), z.record(z.unknown())]),
   compress: z.boolean(),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fef9eb7</samp>

This pull request fixes a schema validation bug for the `outputFileSystem` option in the `@modern-js/builder-shared` package. It also adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fef9eb7</samp>

* Fix schema validation for `outputFileSystem` option in `@modern-js/builder-shared` package ([link](https://github.com/web-infra-dev/modern.js/pull/4623/files?diff=unified&w=0#diff-61ad4c9c4759d986fb9c8138d1f12cb15e3f468d48a93b8fc29e38ceeca21cb8L19-R24), .changeset/strong-suits-attack.md)

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
