### PR TITLE
test(builder): add source-map test case

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6233,6 +6233,18 @@ importers:
         specifier: ^15
         version: 15.7.5
 
+  tests/e2e/builder/cases/source-map:
+    dependencies:
+      react:
+        specifier: ^18
+        version: 18.2.0
+      react-dom:
+        specifier: ^18
+        version: 18.2.0(react@18.2.0)
+      source-map:
+        specifier: 0.7.4
+        version: 0.7.4
+
   tests/e2e/builder/cases/vue:
     dependencies:
       vue:

--- a/tests/e2e/builder/cases/source-map/package.json
+++ b/tests/e2e/builder/cases/source-map/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "@e2e/webpack-builder-source-map",
+  "version": "2.9.0",
+  "dependencies": {
+    "source-map": "0.7.4",
+    "react": "^18",
+    "react-dom": "^18"
+  }
+}

--- a/tests/e2e/builder/cases/source-map/source.test.ts
+++ b/tests/e2e/builder/cases/source-map/source.test.ts
@@ -1,0 +1,87 @@
+import { join } from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build } from '@scripts/shared';
+import sourceMap from 'source-map';
+
+const fixtures = __dirname;
+
+async function validateSourceMap(
+  rawSourceMap: string,
+  generatedPositions: {
+    line: number;
+    column: number;
+  }[],
+) {
+  const consumer = await new sourceMap.SourceMapConsumer(rawSourceMap);
+
+  const originalPositions = generatedPositions.map(generatedPosition =>
+    consumer.originalPositionFor({
+      line: generatedPosition.line,
+      column: generatedPosition.column,
+    }),
+  );
+
+  consumer.destroy();
+  return originalPositions;
+}
+
+test('source-map', async () => {
+  const builder = await build({
+    cwd: fixtures,
+    entry: {
+      main: join(fixtures, 'src/index.js'),
+    },
+    builderConfig: {
+      output: {
+        legalComments: 'none',
+      },
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+  });
+
+  const files = await builder.unwrapOutputJSON(false);
+  const [, jsMapContent] = Object.entries(files).find(
+    ([name]) => name.includes('static/js/') && name.endsWith('.js.map'),
+  )!;
+
+  const [, jsContent] = Object.entries(files).find(
+    ([name]) => name.includes('static/js/') && name.endsWith('.js'),
+  )!;
+
+  const AppContentIndex = jsContent.indexOf('Hello Builder!');
+  const indexContentIndex = jsContent.indexOf('window.aa');
+
+  const originalPositions = (
+    await validateSourceMap(jsMapContent, [
+      {
+        line: 1,
+        column: AppContentIndex,
+      },
+      {
+        line: 1,
+        column: indexContentIndex,
+      },
+    ])
+  ).map(o => ({
+    ...o,
+    source: o.source!.split('webpack-builder-source-map/')[1] || o.source,
+  }));
+
+  expect(originalPositions[0]).toEqual({
+    source: 'src/App.jsx',
+    line: 2,
+    column: 24,
+    name: null,
+  });
+
+  expect(originalPositions[1]).toEqual({
+    source: 'src/index.js',
+    line: 6,
+    column: 0,
+    name: 'window',
+  });
+});

--- a/tests/e2e/builder/cases/source-map/src/App.jsx
+++ b/tests/e2e/builder/cases/source-map/src/App.jsx
@@ -1,0 +1,5 @@
+function App() {
+  return <div id="test">Hello Builder!</div>;
+}
+
+export default App;

--- a/tests/e2e/builder/cases/source-map/src/index.js
+++ b/tests/e2e/builder/cases/source-map/src/index.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import { render } from 'react-dom';
+import App from './App';
+
+window.aa = 2;
+
+render(React.createElement(App), document.getElementById('root'));


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc282df</samp>

This pull request adds a new end-to-end test case for the webpack builder that verifies the source map functionality. The test case consists of a `package.json` file, a `source.test.ts` file, and two source files (`App.jsx` and `index.js`) that use React. The test case builds the project with a custom builder config and checks the source map output with the source-map library.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dc282df</samp>

*  Add a test case for source map generation and validation of the webpack builder ([link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-f02592e4f5e330ce8f86151f72bf3d37f255d7ad66c3c7438f0508739af1b867R1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-7f460642934a95c1d454986e37805c6ad8fd6502e1ebb2468109e7b349510b04R1-R87), [link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-dafd6f84d1eb6ea05333c90c75b10741349a8bec6c47ed374d80845f9ffbf8e4R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-6070ac55d6a14d16211f3f253b99bcfeae46527387b3c7df476017dced12d365R1-R8))
  * Create a `package.json` file with the dependencies and metadata for the test project ([link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-f02592e4f5e330ce8f86151f72bf3d37f255d7ad66c3c7438f0508739af1b867R1-R10))
  * Create a `source.test.ts` file that uses playwright to build and verify the source map output ([link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-7f460642934a95c1d454986e37805c6ad8fd6502e1ebb2468109e7b349510b04R1-R87))
  * Create a `src` folder with two source files: `App.jsx` and `index.js` ([link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-dafd6f84d1eb6ea05333c90c75b10741349a8bec6c47ed374d80845f9ffbf8e4R1-R5), [link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-6070ac55d6a14d16211f3f253b99bcfeae46527387b3c7df476017dced12d365R1-R8))
    * Define a simple React component in `App.jsx` that renders a div with some text ([link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-dafd6f84d1eb6ea05333c90c75b10741349a8bec6c47ed374d80845f9ffbf8e4R1-R5))
    * Import React and App modules, set a global variable, and render the App component in `index.js` ([link](https://github.com/web-infra-dev/modern.js/pull/4627/files?diff=unified&w=0#diff-6070ac55d6a14d16211f3f253b99bcfeae46527387b3c7df476017dced12d365R1-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
