### PR TITLE
fix(builder): VS Code break points not work in monorepo

### DIFF
--- a/.changeset/wild-dancers-jam.md
+++ b/.changeset/wild-dancers-jam.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): VS Code break points not work in monorepo
+
+fix(builder): 修复 VS Code 断点在 monorepo 中不生效

--- a/packages/builder/builder-webpack-provider/src/plugins/basic.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/basic.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { BuilderPlugin } from '../types';
 import { applyBuilderBasicPlugin } from '@modern-js/builder-shared';
 
@@ -10,7 +11,7 @@ export const builderPluginBasic = (): BuilderPlugin => ({
   setup(api) {
     applyBuilderBasicPlugin(api);
 
-    api.modifyWebpackChain(async (chain, { isServer, isWebWorker }) => {
+    api.modifyWebpackChain(async (chain, { env, isServer, isWebWorker }) => {
       /**
        * If the chunk size exceeds 3MB, we will throw a warning.
        * If the target is server or web-worker, we will increase
@@ -27,6 +28,15 @@ export const builderPluginBasic = (): BuilderPlugin => ({
           exportsPresence: 'error',
         },
       });
+
+      if (env === 'development') {
+        // Set correct path for source map
+        // this helps VS Code break points working correctly in monorepo
+        chain.output.devtoolModuleFilenameTemplate(
+          (info: { absoluteResourcePath: string }) =>
+            path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
+        );
+      }
     });
   },
 });

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -807,6 +807,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "output": {
     "chunkFilename": "static/js/async/[name].js",
+    "devtoolModuleFilenameTemplate": [Function],
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/dist",


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f3ac89</samp>

This pull request fixes the source map file names for the `@modern-js/builder-webpack-provider` package, which is a webpack provider plugin for the `@modern-js/builder` tool. It also adds some dependencies and parameters to the `basic.ts` file to improve compatibility and functionality.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f3ac89</samp>

*  Fix VS Code break points issue in monorepo projects by setting `devtoolModuleFilenameTemplate` option for webpack output ([link](https://github.com/web-infra-dev/modern.js/pull/4634/files?diff=unified&w=0#diff-a70e59e88431ce18033a96c20e9cf52570c221b79b102900895c1bace3de06b2L13-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4634/files?diff=unified&w=0#diff-a70e59e88431ce18033a96c20e9cf52570c221b79b102900895c1bace3de06b2R31-R39), [link](https://github.com/web-infra-dev/modern.js/pull/4634/files?diff=unified&w=0#diff-b9f0627b12a4f46d22da11e9b88b49de3f1ffb2dda503332ac0b669cd8d5ef59R1-R7))
* Import `path` module to resolve and normalize file paths in `basic.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4634/files?diff=unified&w=0#diff-a70e59e88431ce18033a96c20e9cf52570c221b79b102900895c1bace3de06b2R1))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
