### PR TITLE
fix(builder): support enableLatestDecorators in rspack mode

### DIFF
--- a/.changeset/fast-flowers-look.md
+++ b/.changeset/fast-flowers-look.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): support enableLatestDecorators in rspack mode
+
+fix(builder): 修复在使用 rspack 构建时 enableLatestDecorators 报错问题

--- a/packages/builder/builder-rspack-provider/src/plugins/swc.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/swc.ts
@@ -60,11 +60,13 @@ async function applyDefaultConfig(
   api: BuilderPluginAPI,
   target: BuilderTarget,
 ) {
+  const legacy = !builderConfig.output.enableLatestDecorators;
   /**
    * Swc only enable latestDecorator for JS module, not TS module.
    */
   setConfig(rspackConfig, 'builtins.decorator', {
-    legacy: !builderConfig.output.enableLatestDecorators,
+    legacy,
+    emitMetadata: legacy,
   });
 
   rspackConfig.builtins ??= {};

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -11,6 +11,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       },
     },
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "define": {
@@ -761,6 +762,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       },
     },
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "define": {
@@ -1566,6 +1568,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
       },
     },
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "define": {
@@ -2057,6 +2060,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
       },
     },
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "define": {

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/swc.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/swc.test.ts.snap
@@ -4,6 +4,7 @@ exports[`plugins/swc > should add antd pluginImport 1`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "pluginImport": [
@@ -44,6 +45,7 @@ exports[`plugins/swc > should add browserslist 1`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -75,6 +77,7 @@ exports[`plugins/swc > should add browserslist 2`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -106,6 +109,7 @@ exports[`plugins/swc > should add pluginImport 1`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "pluginImport": [
@@ -144,6 +148,7 @@ exports[`plugins/swc > should disable all pluginImport 1`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -177,6 +182,7 @@ exports[`plugins/swc > should disable preset_env in target other than web 1`] = 
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -197,6 +203,7 @@ exports[`plugins/swc > should disable preset_env mode 1`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -220,6 +227,7 @@ exports[`plugins/swc > should enable entry mode preset_env 1`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -253,6 +261,7 @@ exports[`plugins/swc > should has correct core-js 1`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -286,6 +295,7 @@ exports[`plugins/swc > should has correct core-js 2`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -319,6 +329,7 @@ exports[`plugins/swc > should has correct core-js 3`] = `
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {
@@ -339,6 +350,7 @@ exports[`plugins/swc > should'n override browserslist when target platform is no
 {
   "builtins": {
     "decorator": {
+      "emitMetadata": true,
       "legacy": true,
     },
     "presetEnv": {

--- a/tests/e2e/builder/cases/decorator/common/index.test.ts
+++ b/tests/e2e/builder/cases/decorator/common/index.test.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build, getHrefByEntryName } from '@scripts/shared';
+
+test('decorator legacy(default)', async ({ page }) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    runServer: true,
+    builderConfig: {},
+  });
+
+  await page.goto(getHrefByEntryName('index', builder.port));
+  expect(await page.evaluate('window.aaa')).toBe('hello!');
+  expect(await page.evaluate('window.bbb')).toBe('world');
+
+  builder.close();
+});
+
+test('decorator latest', async ({ page }) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    runServer: true,
+    builderConfig: {
+      output: {
+        enableLatestDecorators: true,
+      },
+    },
+  });
+
+  await page.goto(getHrefByEntryName('index', builder.port));
+  expect(await page.evaluate('window.aaa')).toBe('hello!');
+  expect(await page.evaluate('window.bbb')).toBe('world');
+
+  builder.close();
+});

--- a/tests/e2e/builder/cases/decorator/common/src/index.js
+++ b/tests/e2e/builder/cases/decorator/common/src/index.js
@@ -1,0 +1,17 @@
+function logged() {
+  // eslint-disable-next-line no-undef
+  window.bbb = 'world';
+  console.log('hhhhh');
+}
+
+class C {
+  message = 'hello!';
+
+  @logged
+  m() {
+    return this.message;
+  }
+}
+
+// eslint-disable-next-line no-undef
+window.aaa = new C().m();

--- a/tests/e2e/builder/cases/decorator/latest/index.test.ts
+++ b/tests/e2e/builder/cases/decorator/latest/index.test.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build, getHrefByEntryName } from '@scripts/shared';
+
+test('decorator latest', async ({ page }) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    runServer: true,
+    builderConfig: {
+      output: {
+        enableLatestDecorators: true,
+      },
+    },
+  });
+
+  await page.goto(getHrefByEntryName('index', builder.port));
+  expect(await page.evaluate('window.aaa')).toBe('hello world');
+
+  // swc...
+  if (builder.providerType !== 'rspack') {
+    expect(await page.evaluate('window.bbb')).toContain(
+      "Cannot assign to read only property 'message' of object",
+    );
+
+    expect(await page.evaluate('window.ccc')).toContain(
+      "Cannot assign to read only property 'message' of object",
+    );
+  }
+
+  builder.close();
+});

--- a/tests/e2e/builder/cases/decorator/latest/src/index.js
+++ b/tests/e2e/builder/cases/decorator/latest/src/index.js
@@ -1,0 +1,51 @@
+// only have one param
+function readonly(elementDescriptor) {
+  elementDescriptor.descriptor.writable = false;
+
+  return elementDescriptor;
+}
+
+function decorator(value) {
+  return function (elementDescriptor) {
+    const original = elementDescriptor.descriptor.value;
+
+    elementDescriptor.descriptor.value = function (...args) {
+      return original.apply(this, args) + value;
+    };
+
+    return elementDescriptor;
+  };
+}
+
+class TestClass {
+  @readonly
+  message = 'hello';
+
+  @decorator(' world')
+  targetMethod() {
+    return this.message;
+  }
+
+  update() {
+    try {
+      this.message = 'aaaa';
+    } catch (e) {
+      // eslint-disable-next-line no-undef
+      window.bbb = e.message;
+    }
+  }
+}
+
+const instance = new TestClass();
+
+// eslint-disable-next-line no-undef
+window.aaa = instance.targetMethod();
+
+instance.update();
+
+try {
+  instance.message = 'bbbb';
+} catch (e) {
+  // eslint-disable-next-line no-undef
+  window.ccc = e.message;
+}

--- a/tests/e2e/builder/cases/decorator/legacy/index.test.ts
+++ b/tests/e2e/builder/cases/decorator/legacy/index.test.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+import { expect, test } from '@modern-js/e2e/playwright';
+import { build, getHrefByEntryName } from '@scripts/shared';
+
+test('decorator legacy(default)', async ({ page }) => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: {
+      index: path.resolve(__dirname, './src/index.js'),
+    },
+    runServer: true,
+    builderConfig: {},
+  });
+
+  await page.goto(getHrefByEntryName('index', builder.port));
+  expect(await page.evaluate('window.aaa')).toBe('hello world');
+
+  if (builder.providerType !== 'rspack') {
+    expect(await page.evaluate('window.ccc')).toContain(
+      "Cannot assign to read only property 'message' of object",
+    );
+  }
+
+  builder.close();
+});

--- a/tests/e2e/builder/cases/decorator/legacy/src/index.js
+++ b/tests/e2e/builder/cases/decorator/legacy/src/index.js
@@ -1,0 +1,38 @@
+function decorator(value) {
+  return function (target, property, descriptor) {
+    const original = descriptor.value;
+
+    descriptor.value = function (...args) {
+      return original.apply(this, args) + value;
+    };
+    return descriptor;
+  };
+}
+
+function readonly(target, property, descriptor = {}) {
+  descriptor.writable = false;
+
+  return descriptor;
+}
+
+class TestClass {
+  @readonly
+  message = 'hello';
+
+  @decorator(' world')
+  targetMethod() {
+    return this.message;
+  }
+}
+
+const instance = new TestClass();
+
+// eslint-disable-next-line no-undef
+window.aaa = instance.targetMethod();
+
+try {
+  instance.message = 'bbbb';
+} catch (e) {
+  // eslint-disable-next-line no-undef
+  window.ccc = e.message;
+}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<img width="778" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/669d930d-53f7-4252-95b5-1c025d6b54be">


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 694785d</samp>

This pull request fixes a bug and adds tests for the `decorator` feature of the `@modern-js/builder-rspack-provider` package. It updates the `swc` compiler configuration to support the latest decorator syntax when the `enableLatestDecorators` option is `true`. It also adds test cases for both the legacy and the latest decorator syntax, using different source files and checking the expected global variables. It creates a `.changeset` file to document the change and bump the package version.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 694785d</samp>

*  Fix a bug that caused an error when using the `enableLatestDecorators` option in the `rspack` mode of the builder ([link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-309853f7a4fd8480af0ebfb35e9b8c04011fb60372a4d5b4ac23e803bfdddcf6R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-40472263d401ace07efe02124aba4a15a2890aec689e94f1f13868aec4d94a1aL63-R69))
* Add test cases for testing the `decorator` feature of the builder with different syntax and options ([link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-90a39e4a074cffcd9bf157d943e82b6adf9c2bad0339d65ccb32389706305c21R1-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-48fec0c62ded06257e01f9fd03bf3ed64a8f809cb227d26673e7f1ca7ab9e861R1-R17), [link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-8c0479e40383c4501190ec9f362c90ef674ca2c24dc444d9bf0353df0647de3dR1-R34), [link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-0f0c97a27d30aff5e6d35b1e729ca68d6347381d86ff1bf062880ab9d0c56c82R1-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-c5a7c9e628d7ab13ba8d00f2b942ce9ec8e2aef97d81f24263a288902482dae9R1-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4637/files?diff=unified&w=0#diff-7ea60e795ee276a8b46bb08192a6e72be4767b094c75ba1362f94ce348c6b247R1-R38))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
