### PR TITLE
fix(builder): remove extra quote from generated CSS module types

### DIFF
--- a/.changeset/few-icons-scream.md
+++ b/.changeset/few-icons-scream.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): remove extra quote from generated CSS module types
+
+fix(builder): 移除生成的 CSS module 类型中多余的引号

--- a/packages/builder/builder-shared/src/loaders/css-modules-typescript-loader.ts
+++ b/packages/builder/builder-shared/src/loaders/css-modules-typescript-loader.ts
@@ -47,10 +47,20 @@ const getTypeMismatchError = ({
   );
 };
 
+export function wrapQuotes(key: string) {
+  // Check if key is a valid identifier
+  const isValidIdentifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key);
+  if (isValidIdentifier) {
+    return key;
+  }
+
+  return `'${key}'`;
+}
+
 const cssModuleToInterface = (cssModuleKeys: string[]) => {
   const interfaceFields = cssModuleKeys
     .sort()
-    .map(key => `  '${key}': string;`)
+    .map(key => `  ${wrapQuotes(key)}: string;`)
     .join('\n');
 
   return `interface CssExports {\n${interfaceFields}\n}`;

--- a/packages/builder/builder-shared/tests/loaders/wrapQuotes.test.ts
+++ b/packages/builder/builder-shared/tests/loaders/wrapQuotes.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from 'vitest';
+import { wrapQuotes } from '../../src/loaders/css-modules-typescript-loader';
+
+it('should wrap key correctly', () => {
+  // do not need wrap
+  expect(wrapQuotes('foo')).toBe(`foo`);
+  expect(wrapQuotes('f1o')).toBe(`f1o`);
+  expect(wrapQuotes('Foo')).toBe(`Foo`);
+  expect(wrapQuotes('$foo')).toBe(`$foo`);
+  expect(wrapQuotes('_foo')).toBe(`_foo`);
+  expect(wrapQuotes('foo1')).toBe(`foo1`);
+  expect(wrapQuotes('fooBar')).toBe(`fooBar`);
+
+  // need wrap
+  expect(wrapQuotes('#foo')).toBe(`'#foo'`);
+  expect(wrapQuotes('1foo')).toBe(`'1foo'`);
+  expect(wrapQuotes('-bar')).toBe(`'-bar'`);
+  expect(wrapQuotes('foo-bar')).toBe(`'foo-bar'`);
+  expect(wrapQuotes('foo~bar')).toBe(`'foo~bar'`);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29305,7 +29305,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
-      ts-node: 10.9.1(@types/node@16.11.68)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@18.11.17)(typescript@5.0.4)
       yaml: 1.10.2
     dev: true
 

--- a/tests/e2e/builder/cases/css/css-modules-dom/index.test.ts
+++ b/tests/e2e/builder/cases/css/css-modules-dom/index.test.ts
@@ -30,7 +30,7 @@ test('enableCssModuleTSDeclaration', async () => {
       .readFileSync(join(fixtures, 'src/App.module.less.d.ts'), {
         encoding: 'utf-8',
       })
-      .includes(`'title': string;`),
+      .includes(`title: string;`),
   ).toBeTruthy();
 
   expect(
@@ -42,7 +42,7 @@ test('enableCssModuleTSDeclaration', async () => {
       .readFileSync(join(fixtures, 'src/App.module.scss.d.ts'), {
         encoding: 'utf-8',
       })
-      .includes(`'header': string;`),
+      .includes(`header: string;`),
   ).toBeTruthy();
 });
 

--- a/tests/e2e/builder/cases/css/css-modules-ts-declaration/index.test.ts
+++ b/tests/e2e/builder/cases/css/css-modules-ts-declaration/index.test.ts
@@ -37,9 +37,9 @@ test('should generator ts declaration correctly for css modules auto true', asyn
   });
 
   expect(content).toMatch(/'the-b-class': string;/);
-  expect(content).toMatch(/'theBClass': string;/);
-  expect(content).toMatch(/'primary': string;/);
-  expect(content).toMatch(/'btn': string;/);
+  expect(content).toMatch(/theBClass: string;/);
+  expect(content).toMatch(/primary: string;/);
+  expect(content).toMatch(/btn: string;/);
 
   await clear();
 });


### PR DESCRIPTION
## Summary

Remove extra quote from generated CSS module types, so it will not conflict with ESLint or prettier.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea98a2e</samp>

This pull request fixes a bug in the `@modern-js/builder-shared` package that caused extra quotes in the generated CSS module types. It also updates the relevant test cases and adds a changeset file to document the patch version update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea98a2e</samp>

* Fix a bug in `css-modules-typescript-loader.ts` that caused extra quotes in generated CSS module types, which could lead to syntax errors or invalid identifiers in TypeScript ([link](https://github.com/web-infra-dev/modern.js/pull/4639/files?diff=unified&w=0#diff-2390ff2afad68fb8240df46c80e1dbf21b3c8fc1bfe19cb630fa5f2bca47ee84L50-R63))
* Add a test file for the `wrapQuotes` function that checks if a CSS class name is a valid identifier in TypeScript, and if not, wraps it with single quotes ([link](https://github.com/web-infra-dev/modern.js/pull/4639/files?diff=unified&w=0#diff-4e38501e178974e0dab6e85088ab0586300f3907904703b04bcdb8811d834ffbR1-R20))
* Update the `css-modules-dom` and `css-modules-ts-declaration` test cases to reflect the bug fix and expect valid identifiers without quotes in the declaration files ([link](https://github.com/web-infra-dev/modern.js/pull/4639/files?diff=unified&w=0#diff-38e29fb707a71de93ca0a10a5c2d7c27cf18adfea87267ce95b6a7c35159a6dbL33-R33),[link](https://github.com/web-infra-dev/modern.js/pull/4639/files?diff=unified&w=0#diff-38e29fb707a71de93ca0a10a5c2d7c27cf18adfea87267ce95b6a7c35159a6dbL45-R45),[link](https://github.com/web-infra-dev/modern.js/pull/4639/files?diff=unified&w=0#diff-7f03769c70a6ee0dc256846bdda9f7a0fe1c9951f31ce53288d77b01b2638952L40-R42))
* Add a changeset file to document the patch version update and the bug fix for the `@modern-js/builder-shared` package, with a Chinese translation ([link](https://github.com/web-infra-dev/modern.js/pull/4639/files?diff=unified&w=0#diff-adc622a928b3f4b90e74585dbcf0259d7ff55db4d610e768176c9911a57073b6R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
