### PR TITLE
fix: dev tools build error in node 14

### DIFF
--- a/packages/devtools/mount/modern.config.ts
+++ b/packages/devtools/mount/modern.config.ts
@@ -37,7 +37,7 @@ export default defineConfig<'rspack'>({
       insert: function insert(element) {
         const key = `__DEVTOOLS_STYLE_${process.env.DEVTOOLS_MARK}`;
         // @ts-expect-error
-        window[key] ||= [];
+        window[key] = window[key] || [];
         // @ts-expect-error
         window[key].push(element);
       },


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f0cb2c</samp>

Fixed a syntax error in `modern.config.ts` that caused devtools to fail in older browsers. Replaced the `||=` operator with a more compatible alternative.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f0cb2c</samp>

*  Replace `||=` operator with `||` and `=` to fix syntax error in older browsers ([link](https://github.com/web-infra-dev/modern.js/pull/4642/files?diff=unified&w=0#diff-dfd6c4baa89fe0da7b8a06bb15d492bf8c2b5ff41dee2b2ece50dcf8864dc9adL40-R40))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
