### PR TITLE
fix: trigger workflow group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,4 +130,4 @@ jobs:
           -H 'Content-Type: application/json' \
           -H 'Authorization: Bearer ${{ secrets.REPO_SCOPED_TOKEN }}' \
           -d '{"ref": "main", "inputs": {"version": "latest"}}' \
-          https://api.github.com/repos/caohuilin/rspress/actions/workflows/release-pull-request-with-modernjs.yml/dispatches
+          https://api.github.com/repos/web-infra-dev/rspress/actions/workflows/release-pull-request-with-modernjs.yml/dispatches


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f62bfb</samp>

This file updates the release workflow to use the correct repository for the modern.js project. It is part of a pull request to migrate the rspress project to the modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f62bfb</samp>

* Updated the GitHub API URL to trigger the release workflow for the modern.js repository ([link](https://github.com/web-infra-dev/modern.js/pull/4646/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L133-R133))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
