### PR TITLE
fix(builder): should not apply babel in rspack mode when tools.babel not modify config

### DIFF
--- a/.changeset/rude-walls-work.md
+++ b/.changeset/rude-walls-work.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): should not apply babel in rspack mode when tools.babel not modify config
+
+fix(builder): 在使用 rspack 构建时，如果 tools.babel 未实际修改配置时，则不使用 babel

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`plugins/babel > should not set babel-loader 1`] = `{}`;
 
+exports[`plugins/babel > should not set babel-loader when babel config is null 1`] = `{}`;
+
+exports[`plugins/babel > should not set babel-loader when babel config is return null 1`] = `{}`;
+
 exports[`plugins/babel > should set babel-loader 1`] = `
 {
   "module": {
@@ -25,7 +29,16 @@ exports[`plugins/babel > should set babel-loader 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "babel-plugin-import",
+                  {
+                    "libraryDirectory": "es",
+                    "libraryName": "xxx-components",
+                    "style": true,
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",

--- a/packages/builder/builder-rspack-provider/tests/plugins/babel.test.ts
+++ b/packages/builder/builder-rspack-provider/tests/plugins/babel.test.ts
@@ -8,6 +8,52 @@ describe('plugins/babel', () => {
       plugins: [builderPluginBabel()],
       builderConfig: {
         tools: {
+          babel(config: any) {
+            // 添加一个插件，比如配置某个组件库的按需引入
+            config.plugins.push([
+              'babel-plugin-import',
+              {
+                libraryName: 'xxx-components',
+                libraryDirectory: 'es',
+                style: true,
+              },
+            ]);
+          },
+        },
+      },
+    });
+
+    const {
+      origin: { bundlerConfigs },
+    } = await builder.inspectConfig();
+
+    expect(bundlerConfigs[0]).toMatchSnapshot();
+  });
+
+  it('should not set babel-loader when babel config is return null', async () => {
+    const builder = await createBuilder({
+      plugins: [builderPluginBabel()],
+      builderConfig: {
+        tools: {
+          babel: () => {
+            // do nothing
+          },
+        } as any,
+      },
+    });
+
+    const {
+      origin: { bundlerConfigs },
+    } = await builder.inspectConfig();
+
+    expect(bundlerConfigs[0]).toMatchSnapshot();
+  });
+
+  it('should not set babel-loader when babel config is null', async () => {
+    const builder = await createBuilder({
+      plugins: [builderPluginBabel()],
+      builderConfig: {
+        tools: {
           babel: {},
         } as any,
       },

--- a/packages/builder/builder-rspack-provider/tests/plugins/babel.test.ts
+++ b/packages/builder/builder-rspack-provider/tests/plugins/babel.test.ts
@@ -9,7 +9,6 @@ describe('plugins/babel', () => {
       builderConfig: {
         tools: {
           babel(config: any) {
-            // 添加一个插件，比如配置某个组件库的按需引入
             config.plugins.push([
               'babel-plugin-import',
               {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8caacfe</samp>

This pull request fixes a bug in the `builderPluginBabel` function that caused the babel-loader to be always used in the webpack config, even if the user did not provide any babel options. It also adds tests and a changeset file to document and verify the fix.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8caacfe</samp>

*  Add markdown file for changeset tool ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-511003e83e69a509b71133e9100b673d3b91f7e0dae422c4774588d72ed04c79R1-R7))
*  Fix bug where babel-loader was always applied even if user did not specify babel options ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65R7), [link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65L47-R74), [link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65L73-R93))
   *  Import `cloneDeep` and `isEqual` functions from `@modern-js/utils/lodash` ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65R7))
   *  Clone and compare base and user babel configurations in `getBabelOptions` function ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65L47-R74))
   *  Return empty object if user babel configuration has not modified base configuration ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65L47-R74))
   *  Destructure and check `includes`, `excludes`, and `babelOptions` properties before setting babel-loader in `builderPluginBabel` function ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65L73-R93))
*  Add test cases for `builderPluginBabel` function when user babel configuration is null or returns null ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-20e3614ef9f0faff4cd0b7752c7a2ff09b6fde8f0998f5667944b5d7d6468ef9R11-R56))
   *  Use `createBuilder` and `inspectConfig` functions to generate and compare webpack config ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-20e3614ef9f0faff4cd0b7752c7a2ff09b6fde8f0998f5667944b5d7d6468ef9R11-R56))
   *  Use `toMatchSnapshot` matcher to verify expected output ([link](https://github.com/web-infra-dev/modern.js/pull/4648/files?diff=unified&w=0#diff-20e3614ef9f0faff4cd0b7752c7a2ff09b6fde8f0998f5667944b5d7d6468ef9R11-R56))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
