### PR TITLE
fix: emit modern.config.json when distPath.root is absolute path

### DIFF
--- a/.changeset/large-olives-march.md
+++ b/.changeset/large-olives-march.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/prod-server': patch
+---
+
+fix(app-tools): failed to emit modern.config.json when distPath.root is absolute path
+
+fix(app-tools): 修复 distPath.root 为绝对路径时无法输出 modern.config.json 的问题

--- a/packages/document/builder-doc/docs/en/config/output/distPath.md
+++ b/packages/document/builder-doc/docs/en/config/output/distPath.md
@@ -50,6 +50,12 @@ Detail:
 - `server`: The output directory of server bundles when target is `node`.
 - `worker`: The output directory of worker bundles when target is `service-worker`.
 
+### Root Directory
+
+The `root` is the root directory of the build artifacts and can be specified as a relative or absolute path. If the value of `root` is a relative path, it will be appended to the project's root directory to form an absolute path.
+
+Other directories can only be specified as relative paths and will be output relative to the `root` directory.
+
 ### Example
 
 The JavaScript files will be output to the `distPath.root` + `distPath.js` directory, which is `dist/static/js`.

--- a/packages/document/builder-doc/docs/zh/config/output/distPath.md
+++ b/packages/document/builder-doc/docs/zh/config/output/distPath.md
@@ -50,6 +50,12 @@ const defaultDistPath = {
 - `server`: 表示服务端产物的输出目录，仅在 target 为 `node` 时有效。
 - `worker`: 表示 worker 产物的输出目录，仅在 target 为 `service-worker` 时有效。
 
+### 根目录
+
+`root` 是构建产物的根目录，可以为相对路径或绝对路径。如果 `root` 的值为相对路径，则会基于当前项目的根目录拼接为绝对路径。
+
+其他目录只能为相对路径，并且会相对于 `root` 进行输出。
+
 ### 示例
 
 以 JavaScript 文件为例，会输出到 `distPath.root` + `distPath.js` 目录，即为 `dist/static/js`。

--- a/packages/server/prod-server/src/server/index.ts
+++ b/packages/server/prod-server/src/server/index.ts
@@ -11,6 +11,7 @@ import {
   dotenv,
   dotenvExpand,
   INTERNAL_SERVER_PLUGINS,
+  ensureAbsolutePath,
 } from '@modern-js/utils';
 import {
   serverManager,
@@ -164,10 +165,9 @@ export class Server {
 
     const finalServerConfig = this.runConfigHook(runner, serverConfig);
 
-    const resolvedConfigPath = path.join(
+    const resolvedConfigPath = ensureAbsolutePath(
       pwd,
-      config.output.path || 'dist',
-      OUTPUT_CONFIG_FILE,
+      path.join(config.output.path || 'dist', OUTPUT_CONFIG_FILE),
     );
 
     options.config = loadConfig({

--- a/packages/solutions/app-tools/src/utils/config.ts
+++ b/packages/solutions/app-tools/src/utils/config.ts
@@ -1,10 +1,11 @@
 import * as path from 'path';
 import { bundle } from '@modern-js/node-bundle-require';
 import {
-  CONFIG_FILE_EXTENSIONS,
   fs,
   getServerConfig,
+  ensureAbsolutePath,
   OUTPUT_CONFIG_FILE,
+  CONFIG_FILE_EXTENSIONS,
 } from '@modern-js/utils';
 import type { ServerConfig } from '@modern-js/server-core';
 import type { AppNormalizedConfig } from '../types';
@@ -95,11 +96,14 @@ export const emitResolvedConfig = async (
   appDirectory: string,
   resolvedConfig: AppNormalizedConfig<'shared'>,
 ) => {
-  const outputPath = path.join(
+  const outputPath = ensureAbsolutePath(
     appDirectory,
-    resolvedConfig.output.distPath?.root || './dist',
-    OUTPUT_CONFIG_FILE,
+    path.join(
+      resolvedConfig.output.distPath?.root || './dist',
+      OUTPUT_CONFIG_FILE,
+    ),
   );
+
   await fs.writeJSON(outputPath, resolvedConfig, {
     spaces: 2,
     replacer: safeReplacer(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7040,6 +7040,37 @@ importers:
         specifier: ^14
         version: 14.18.35
 
+  tests/integration/custom-dist-path:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^18
+        version: 18.2.0
+      react-dom:
+        specifier: ^18
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../packages/solutions/app-tools
+      '@types/jest':
+        specifier: ^29
+        version: 29.2.6
+      '@types/node':
+        specifier: ^14
+        version: 14.18.35
+      '@types/react':
+        specifier: ^18
+        version: 18.0.21
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.0.6
+      typescript:
+        specifier: ^5
+        version: 5.0.4
+
   tests/integration/custom-render:
     dependencies:
       '@modern-js/runtime':
@@ -29268,7 +29299,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
-      ts-node: 10.9.1(@types/node@16.11.68)(typescript@5.0.4)
+      ts-node: 10.9.1(@types/node@18.11.17)(typescript@5.0.4)
       yaml: 1.10.2
     dev: true
 

--- a/tests/integration/custom-dist-path/modern.config.ts
+++ b/tests/integration/custom-dist-path/modern.config.ts
@@ -1,0 +1,10 @@
+import path from 'path';
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  output: {
+    distPath: {
+      root: path.join(__dirname, 'dist/foo'),
+    },
+  },
+});

--- a/tests/integration/custom-dist-path/package.json
+++ b/tests/integration/custom-dist-path/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "name": "integration-custom-dist-path",
+  "version": "2.9.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "serve": "modern serve"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "typescript": "^5",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@types/jest": "^29",
+    "@types/node": "^14"
+  }
+}

--- a/tests/integration/custom-dist-path/src/App.tsx
+++ b/tests/integration/custom-dist-path/src/App.tsx
@@ -1,0 +1,3 @@
+const App = () => <div>hello</div>;
+
+export default App;

--- a/tests/integration/custom-dist-path/tests/index.test.ts
+++ b/tests/integration/custom-dist-path/tests/index.test.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+import { fs, OUTPUT_CONFIG_FILE } from '@modern-js/utils';
+import { modernBuild } from '../../../utils/modernTestUtils';
+
+test(`should allow distPath.root to be an absolute path`, async () => {
+  const appDir = path.resolve(__dirname, '..');
+  await modernBuild(appDir);
+
+  const distPath = path.join(appDir, 'dist/foo');
+  const configFile = path.join(distPath, OUTPUT_CONFIG_FILE);
+  const htmlFile = path.join(distPath, 'html/main/index.html');
+  expect(fs.existsSync(configFile)).toBeTruthy();
+  expect(fs.existsSync(htmlFile)).toBeTruthy();
+});

--- a/tests/integration/custom-dist-path/tsconfig.json
+++ b/tests/integration/custom-dist-path/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "outDir": "dist"
+  },
+  "include": ["src", "tests", "modern.config.ts"]
+}


### PR DESCRIPTION
## Summary

Fix failed to emit modern.config.json when distPath.root is absolute path.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0306ca9</samp>

This pull request fixes a bug that prevented the `modern.config.json` file from being emitted when the `distPath.root` option was set to an absolute path in the app configuration. It also adds a utility function to resolve absolute paths, updates the documentation and the changeset for the affected packages, and adds a new integration test case for the custom `distPath.root` scenario.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0306ca9</samp>

*  Add a changeset file to document the patch updates and the bug fix for the issue of failing to emit `modern.config.json` when the `distPath.root` is an absolute path ([link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-df9bdc775c12c91f0a520a8af1b5a9c8ccfdc2a721795333c19ac5bf8694ef9aR1-R8))
*  Import and use the `ensureAbsolutePath` utility function from `@modern-js/utils` to resolve the absolute path of the `modern.config.json` file in the `@modern-js/prod-server` and `@modern-js/app-tools` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-5cbeedfd701ea461dc9742e0bff36e00e9dd1faae4fb4dc686213499a62cb542R14), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-5cbeedfd701ea461dc9742e0bff36e00e9dd1faae4fb4dc686213499a62cb542L167-R170), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-022809e91016093b79e71cc561337e42d781d455a51def1bde694ec2e8031256L4-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-022809e91016093b79e71cc561337e42d781d455a51def1bde694ec2e8031256L98-R106))
*  Add a new section to the English and Chinese documentation of the `distPath` configuration option to explain the meaning and usage of the `root` property and clarify that other properties under `distPath` can only be relative paths ([link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-1016588ac324444ea3eb40f2aa0fa3f82392af03e79f03e50fdd9df0de239246R53-R58), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-06de006cf92c7cfc91e5a676739fef7bcee6081db327f65e7c231bf93028e391R53-R58))
*  Add a new integration test case for the `custom-dist-path` scenario, which sets the `distPath.root` to an absolute path and verifies that the `modern.config.json` and the `index.html` files are correctly output to the custom path ([link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-00af3947104aac23f1638dc7e29d70003d476b3190cccf02049062d65c7ee298R1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-206462aa6c94ceba4bcc8b02ea73502362001901a73fe80128226c8c1dff9dc6R1-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-f8b838a0aa395a055e2d93a86ba0a140205e5f0a69564113d2cf39dd07eed908R1-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-64e0d96b3cd9ad0d96117bba2a3aee610de4a29572949cec125d107305a95493R1-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4649/files?diff=unified&w=0#diff-4124357d1418da2a155cabd0fe71a634ea741575205ccb77a44b1195dda2e3d8R1-R10))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
