### PR TITLE
chore(builder): apply chunkIds deterministic in Rspack mode production

### DIFF
--- a/.changeset/stale-comics-change.md
+++ b/.changeset/stale-comics-change.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+chore(builder): apply chunkIds deterministic in Rspack mode production
+
+chore(builder): 在 Rspack 模式下，生产环境开启 chunkIds 'deterministic'

--- a/packages/builder/builder-rspack-provider/src/plugins/transition.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/transition.ts
@@ -6,7 +6,13 @@ import type { BuilderPlugin } from '../types';
 export const builderPluginTransition = (): BuilderPlugin => ({
   name: 'builder-plugin-transition',
 
-  setup() {
+  setup(api) {
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+
+    api.modifyBundlerChain(async (chain, { isProd }) => {
+      if (isProd) {
+        chain.optimization.chunkIds('deterministic');
+      }
+    });
   },
 });

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1390,6 +1390,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "name": "Client",
   "optimization": {
+    "chunkIds": "deterministic",
     "minimize": true,
     "minimizer": [
       Plugin {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a764f80</samp>

This pull request applies a patch to the `@modern-js/builder-rspack-provider` package to enable deterministic chunk IDs for webpack bundles in production mode. This can improve the caching and performance of the output bundles and is documented in the changelog.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a764f80</samp>

* Set chunk IDs to deterministic in production mode when using Rspack as the bundler ([link](https://github.com/web-infra-dev/modern.js/pull/4654/files?diff=unified&w=0#diff-cc53bd04dfb62d632e0a49d06097f9e2b503952a211577329836c880af324411L9-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4654/files?diff=unified&w=0#diff-3ca083adf5af532ddcca1f20fbc923f30fc5f5ab68cdedb1846c93c408c8a822R1-R7))
  - Modify `builderPluginTransition` plugin to use `modifyBundlerChain` API ([link](https://github.com/web-infra-dev/modern.js/pull/4654/files?diff=unified&w=0#diff-cc53bd04dfb62d632e0a49d06097f9e2b503952a211577329836c880af324411L9-R16))
  - Update changelog for `@modern-js/builder-rspack-provider` package with patch version bump and change description ([link](https://github.com/web-infra-dev/modern.js/pull/4654/files?diff=unified&w=0#diff-3ca083adf5af532ddcca1f20fbc923f30fc5f5ab68cdedb1846c93c408c8a822R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
