### PR TITLE
fix(builder): resolve-url-loader performance regression issue

### DIFF
--- a/.changeset/khaki-pumas-exercise.md
+++ b/.changeset/khaki-pumas-exercise.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): resolve-url-loader performance regression issue
+
+fix(builder): 修复 resolve-url-loader 导致的性能下降问题

--- a/packages/builder/builder-rspack-provider/src/plugins/sass.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/sass.ts
@@ -46,6 +46,10 @@ export function builderPluginSass(): BuilderPlugin {
           .loader(utils.getCompiledPath('resolve-url-loader'))
           .options({
             join: await getResolveUrlJoinFn(),
+            // 'resolve-url-loader' relies on 'adjust-sourcemap-loader',
+            // it has performance regression issues in some scenarios,
+            // so we need to disable the sourceMap option.
+            sourceMap: false,
           })
           .end()
           .use(utils.CHAIN_ID.USE.SASS)

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/css.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/css.test.ts.snap
@@ -958,6 +958,7 @@ exports[`plugins/sass > should add sass-loader 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1015,6 +1016,7 @@ exports[`plugins/sass > should add sass-loader 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1102,6 +1104,7 @@ exports[`plugins/sass > should add sass-loader and css-loader when disableCssExt
             "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
             "options": {
               "join": [Function],
+              "sourceMap": false,
             },
           },
           {
@@ -1174,6 +1177,7 @@ exports[`plugins/sass > should add sass-loader with excludes 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1234,6 +1238,7 @@ exports[`plugins/sass > should add sass-loader with excludes 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -547,6 +547,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -604,6 +605,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1297,6 +1299,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1354,6 +1357,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1930,6 +1934,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1952,6 +1957,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -2602,6 +2608,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -2659,6 +2666,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {

--- a/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
+++ b/packages/builder/builder-rspack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
@@ -648,6 +648,7 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -711,6 +712,7 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1201,6 +1203,7 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {
@@ -1264,6 +1267,7 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
                 "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
                 "options": {
                   "join": [Function],
+                  "sourceMap": false,
                 },
               },
               {

--- a/packages/builder/builder-webpack-provider/src/plugins/sass.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/sass.ts
@@ -45,6 +45,10 @@ export function builderPluginSass(): BuilderPlugin {
           .loader(utils.getCompiledPath('resolve-url-loader'))
           .options({
             join: await getResolveUrlJoinFn(),
+            // 'resolve-url-loader' relies on 'adjust-sourcemap-loader',
+            // it has performance regression issues in some scenarios,
+            // so we need to disable the sourceMap option.
+            sourceMap: false,
           })
           .end()
           .use(utils.CHAIN_ID.USE.SASS)

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -368,6 +368,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
             "options": {
               "join": [Function],
+              "sourceMap": false,
             },
           },
           {
@@ -1303,6 +1304,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
             "options": {
               "join": [Function],
+              "sourceMap": false,
             },
           },
           {
@@ -2229,6 +2231,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
             "options": {
               "join": [Function],
+              "sourceMap": false,
             },
           },
           {
@@ -3027,6 +3030,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
             "options": {
               "join": [Function],
+              "sourceMap": false,
             },
           },
           {

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/rem.test.ts.snap
@@ -421,6 +421,7 @@ exports[`plugins/rem > should order plugins and run rem plugin with default conf
             "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
             "options": {
               "join": [Function],
+              "sourceMap": false,
             },
           },
           {
@@ -769,6 +770,7 @@ exports[`plugins/rem > should run rem plugin with default config 1`] = `
             "loader": "<WORKSPACE>/packages/builder/builder-shared/compiled/resolve-url-loader",
             "options": {
               "join": [Function],
+              "sourceMap": false,
             },
           },
           {


### PR DESCRIPTION
## Summary

'resolve-url-loader' relies on 'adjust-sourcemap-loader', it has performance regression issues in some scenarios, so we need to disable the sourceMap option.

![44e61406-c6eb-48e6-9349-48dcb7ee0938](https://github.com/web-infra-dev/modern.js/assets/7237365/3a74c1bc-9d21-4334-9ac5-5e966fa25ccb)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8950cec</samp>

This pull request fixes a performance regression issue in the Sass loader plugins for both Webpack and Rollup bundlers. It does so by disabling source maps in the `resolve-url-loader` dependency, which is used to resolve relative URLs in Sass files.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8950cec</samp>

*  Disable source map generation by `resolve-url-loader` to fix performance regression issue in Sass files ([link](https://github.com/web-infra-dev/modern.js/pull/4659/files?diff=unified&w=0#diff-e26b6ac5407632d9ab7c3f2147ccf91d560e91bf412b31b9430823bfe207a6f2R49-R52), [link](https://github.com/web-infra-dev/modern.js/pull/4659/files?diff=unified&w=0#diff-9917a0079ac77e650ed304b6d446f4915be2ddd16053d25a4b73a6eac03b2d7bR48-R51))
* Document the patch updates for `@modern-js/builder-webpack-provider` and `@modern-js/builder-rspack-provider` packages in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4659/files?diff=unified&w=0#diff-88854ab80b92c9e5b7c5163c4ff627f2172c218d35c2e481ef20ed9fa4d234d7R1-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
