### PR TITLE
fix: the server need use headersSent without use flushHeader

### DIFF
--- a/.changeset/moody-parents-breathe.md
+++ b/.changeset/moody-parents-breathe.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix(prod-server): the server need use headersSent without use flushHeader
+fix(prod-server): 没有 flushHeader 时 server 应该使用 headersSent

--- a/packages/server/prod-server/src/libs/preload/flushServerHeader.ts
+++ b/packages/server/prod-server/src/libs/preload/flushServerHeader.ts
@@ -37,4 +37,5 @@ export async function flushServerHeader({
   }
 
   res.flushHeaders();
+  res.flushedHeaders = true;
 }

--- a/packages/server/prod-server/src/libs/preload/flushServerHeader.ts
+++ b/packages/server/prod-server/src/libs/preload/flushServerHeader.ts
@@ -37,5 +37,5 @@ export async function flushServerHeader({
   }
 
   res.flushHeaders();
-  res.flushedHeaders = true;
+  res.modernFlushedHeaders = true;
 }

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -635,7 +635,11 @@ export class ModernServer implements ModernServerInterface {
 
   private isSend(res: ServerResponse) {
     /// Is true after response.end() has been called.
-    if (res.writableEnded) {
+    if (res.flushedHeaders) {
+      if (res.writableFinished) {
+        return true;
+      }
+    } else if (res.headersSent) {
       return true;
     }
 

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -635,7 +635,7 @@ export class ModernServer implements ModernServerInterface {
 
   private isSend(res: ServerResponse) {
     /// Is true after response.end() has been called.
-    if (res.flushedHeaders) {
+    if (res.modernFlushedHeaders) {
       if (res.writableFinished) {
         return true;
       }

--- a/packages/server/prod-server/src/type.ts
+++ b/packages/server/prod-server/src/type.ts
@@ -21,7 +21,7 @@ declare module 'http' {
 
   interface OutgoingMessage {
     set: (key: string, value: any) => this;
-    flushedHeaders?: boolean;
+    modernFlushedHeaders?: boolean;
   }
 }
 

--- a/packages/server/prod-server/src/type.ts
+++ b/packages/server/prod-server/src/type.ts
@@ -21,6 +21,7 @@ declare module 'http' {
 
   interface OutgoingMessage {
     set: (key: string, value: any) => this;
+    flushedHeaders?: boolean;
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b86a0de</samp>

This pull request fixes a bug in the `@modern-js/prod-server` package that caused errors when the server tried to flush headers manually. It adds a new `flushedHeaders` property to the response object and updates the `isSend` method to use it. It also updates the changelog and the type definitions accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b86a0de</samp>

*  Update changelog for `@modern-js/prod-server` package with bug fixes ([link](https://github.com/web-infra-dev/modern.js/pull/4660/files?diff=unified&w=0#diff-8730994113bbaa2cba32762f89574ebd394e5d332fc3a3a1c3ead968c706324dR1-R6))
*  Add `flushedHeaders` property to response object to indicate header flushing status ([link](https://github.com/web-infra-dev/modern.js/pull/4660/files?diff=unified&w=0#diff-3a47d18bc1951ca0312c72156ff16989c0f0397efc6a3e5ab0fb2d668ddde6b4R40), [link](https://github.com/web-infra-dev/modern.js/pull/4660/files?diff=unified&w=0#diff-43eeb40674837c6fea50840b269fbf2cc78be93bb1445caed035d0897ce76f47R24))
*  Use `flushedHeaders` and `headersSent` properties to check if response is sent in `isSend` method of `ModernServer` class ([link](https://github.com/web-infra-dev/modern.js/pull/4660/files?diff=unified&w=0#diff-19d2036aa9230b30bc04609d579c91d8123744fb8d3ce9cedbb9f1351a3bc24bL638-R642))
*  Fix header flushing logic in `flushServerHeader` function in `prod-server/src/libs/preload/flushServerHeader.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4660/files?diff=unified&w=0#diff-3a47d18bc1951ca0312c72156ff16989c0f0397efc6a3e5ab0fb2d668ddde6b4R40))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
