### PR TITLE
feat(builder): unify progress bar style in webpack / Rspack mode

### DIFF
--- a/.changeset/unlucky-ants-greet.md
+++ b/.changeset/unlucky-ants-greet.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+feat(builder): unify progress bar style in webpack / Rspack mode
+
+feat(builder): 对齐 webpack / Rspack 模式下的进度条样式

--- a/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
@@ -1,5 +1,13 @@
-import { logger, debug, formatStats } from '@modern-js/builder-shared';
+import {
+  debug,
+  logger,
+  formatStats,
+  TARGET_ID_MAP,
+  getProgressColor,
+} from '@modern-js/builder-shared';
 import type { Context, RspackConfig } from '../types';
+import prettyTime from '../../compiled/pretty-time';
+import chalk from '@modern-js/utils/chalk';
 
 export async function createCompiler({
   context,
@@ -27,9 +35,16 @@ export async function createCompiler({
     });
 
     if (!stats.hasErrors()) {
-      obj.children?.forEach(c => {
-        c.time &&
-          logger.success(`${c.name} compiled successfully in`, c.time, 'ms');
+      obj.children?.forEach((c, index) => {
+        if (c.time) {
+          const color = chalk[getProgressColor(index)];
+          const time = prettyTime([0, c.time * 10 ** 6], 1);
+          const target = Array.isArray(context.target)
+            ? context.target[index]
+            : context.target;
+          const name = TARGET_ID_MAP[target || 'web'];
+          logger.log(color(`✔ ${name}  succeed in`, time));
+        }
       });
     }
 

--- a/packages/builder/builder-shared/src/index.ts
+++ b/packages/builder/builder-shared/src/index.ts
@@ -31,3 +31,4 @@ export * from './manifest';
 export * from './css';
 export * from './minimize';
 export * from './core-js';
+export * from './progress';

--- a/packages/builder/builder-shared/src/progress.ts
+++ b/packages/builder/builder-shared/src/progress.ts
@@ -1,0 +1,17 @@
+import type { ForegroundColor as Color } from '@modern-js/utils/compiled/chalk';
+
+const colorList: Array<typeof Color> = [
+  'green',
+  'cyan',
+  'yellow',
+  'blue',
+  'greenBright',
+  'cyanBright',
+  'yellowBright',
+  'blueBright',
+  'redBright',
+  'magentaBright',
+];
+
+export const getProgressColor = (index: number) =>
+  colorList[index % colorList.length];

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
@@ -108,7 +108,7 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
     compiler.hooks.done.tap(this.name, stat => {
       if (startTime) {
         this.hasCompileErrors = stat.hasErrors();
-        this.compileTime = prettyTime(process.hrtime(startTime), 2);
+        this.compileTime = prettyTime(process.hrtime(startTime), 1);
         startTime = null;
       }
     });

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
@@ -8,13 +8,13 @@ const defaultOption: Props = {
   current: 0,
   color: 'green',
   bgColor: 'gray',
-  char: '■',
+  char: '━',
   width: 25,
   buildIcon: '◯',
   finishIcon: '✔',
-  finishInfo: 'Succeed',
+  finishInfo: 'succeed',
   errorIcon: '✖',
-  errorInfo: 'Compile Failed',
+  errorInfo: 'compile failed',
   message: '',
   done: false,
   spaceWidth: 1,
@@ -85,7 +85,7 @@ export const renderBar = (option: Partial<Props>) => {
     );
 
     if (terminalWidth >= MIDDLE_WIDTH) {
-      return [id, doneColor(`${icon}${space}${message}`)].join('');
+      return [idColor(icon), id, doneColor(`${space}${message}`)].join('');
     }
     return [id, doneColor(`${message}`)].join('');
   }
@@ -104,8 +104,8 @@ export const renderBar = (option: Partial<Props>) => {
 
   if (terminalWidth >= FULL_WIDTH) {
     return [
+      idColor(buildIcon),
       id,
-      barColor(buildIcon),
       space,
       barStr,
       space,
@@ -116,8 +116,8 @@ export const renderBar = (option: Partial<Props>) => {
   }
 
   if (terminalWidth >= MIDDLE_WIDTH) {
-    return [id, barColor(buildIcon), space, barStr, space, percentStr].join('');
+    return [idColor(buildIcon), id, space, barStr, space, percentStr].join('');
   }
 
-  return [id, barColor(buildIcon), space, percentStr].join('');
+  return [idColor(buildIcon), id, space, percentStr].join('');
 };

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
@@ -6,20 +6,7 @@ import type { Props } from './type';
 import { FULL_WIDTH, renderBar } from './bar';
 import { create } from './log';
 import type { LogUpdate } from './log';
-import type { ForegroundColor as Color } from '@modern-js/utils/compiled/chalk';
-
-const colorList: Array<typeof Color> = [
-  'green',
-  'cyan',
-  'yellow',
-  'blue',
-  'greenBright',
-  'cyanBright',
-  'yellowBright',
-  'blueBright',
-  'redBright',
-  'magentaBright',
-];
+import { getProgressColor } from '@modern-js/builder-shared';
 
 class Bus {
   states: Partial<Props>[] = [];
@@ -72,7 +59,7 @@ class Bus {
         cliTruncate(
           renderBar({
             maxIdLen,
-            color: i.color ?? colorList[k % colorList.length],
+            color: i.color ?? getProgressColor(k),
             ...i,
           }),
           columns,


### PR DESCRIPTION
## Summary

<img width="387" alt="Screenshot 2023-09-18 at 10 15 14" src="https://github.com/web-infra-dev/modern.js/assets/7237365/7bd800ac-eb52-4650-a213-ed199dec3b61">

Ref: https://github.com/web-infra-dev/rspack/pull/4197

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31b4799</samp>

This pull request updates the builder packages to improve the consistency and compatibility of the webpack and rspack modes. It uses some helper modules from `builder-shared` to format and color the progress bars and the compilation output. It also adjusts the precision of the prettyTime function and adds a changeset file to document the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31b4799</samp>

*  Add a changeset file to describe the updates to the builder packages ([link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-9e97c5620c72043f6c896d87d9ac03cc1b1cc3f02b2b68cff659f34a18b561f4R1-R9))
  - Importing and using the modules from the builder-shared package to format the compilation time and output, and to get the color for the progress bar based on the target index in the `createCompiler` module ([link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L30-R47))
  - Exporting the `progress` module from the builder-shared package, which contains the `getProgressColor` function ([link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-057faf79ac89dea7fb92b571ce15153429a02e0ef592e56170404c7a5ac319e5R34))
  - Adding the `progress` module to the builder-shared package, which contains the `getProgressColor` function ([link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-e4a343f3363da22bf56f7f21e4d656ea05334b5bed10865a6ebd4f805c335608R1-R17))
  - Modifying the default properties and the render function of the progress bar in the `bar` module to match the style of the rspack mode, and to use the `getProgressColor` function to color the icon based on the target index ([link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-5f00a7aab1a777042d4d7f3189b7c726cc87e2df1862312d8a267b7720935ca7L11-R17), [link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-5f00a7aab1a777042d4d7f3189b7c726cc87e2df1862312d8a267b7720935ca7L88-R88), [link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-5f00a7aab1a777042d4d7f3189b7c726cc87e2df1862312d8a267b7720935ca7L107-R108), [link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-5f00a7aab1a777042d4d7f3189b7c726cc87e2df1862312d8a267b7720935ca7L119-R122))
  - Replacing the local color list with the `getProgressColor` function in the `bus` module to manage the states and the output of the progress bars ([link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-a4504fca2d9827cddacdfe648cc40efb71325090e54ac8ae7b02095de4d6a17dL9-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-a4504fca2d9827cddacdfe648cc40efb71325090e54ac8ae7b02095de4d6a17dL75-R62))
  - Reducing the precision of the `prettyTime` function in the `ProgressPlugin` module to one decimal place to match the rspack mode ([link](https://github.com/web-infra-dev/modern.js/pull/4665/files?diff=unified&w=0#diff-b37e5fb8c8109c56fa9b9a837517fde37af30fb9f27d14bb90999154811c14c9L111-R111))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
