### PR TITLE
fix: ssr style link should not add scriptLoading attributes

### DIFF
--- a/.changeset/pink-teachers-hug.md
+++ b/.changeset/pink-teachers-hug.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: ssr style link should not add scriptLoading attrributes
+fix: ssr style link 标签 不应该添加 scriptLoading 属性

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
@@ -52,7 +52,10 @@ class LoadableCollector implements Collector {
     chunksMap.js = (chunksMap.js || '') + getLoadableScripts(extractor);
 
     for (const v of chunks) {
-      const fileType = extname(v.url!).slice(1);
+      if (!v.url) {
+        continue;
+      }
+      const fileType = extname(v.url).slice(1);
       const attributes: Record<string, any> = {};
       const { crossorigin, scriptLoading = 'defer' } = config;
       if (crossorigin) {
@@ -60,17 +63,17 @@ class LoadableCollector implements Collector {
           crossorigin === true ? 'anonymous' : crossorigin;
       }
 
-      switch (scriptLoading) {
-        case 'defer':
-          attributes.defer = true;
-          break;
-        case 'module':
-          attributes.type = 'module';
-          break;
-        default:
-      }
-
       if (fileType === 'js') {
+        // scriptLoading just apply for script tag.
+        switch (scriptLoading) {
+          case 'defer':
+            attributes.defer = true;
+            break;
+          case 'module':
+            attributes.type = 'module';
+            break;
+          default:
+        }
         const jsChunkReg = new RegExp(`<script .*src="${v.url}".*>`);
         // we should't repeatly registe the script, if template already has it.
         if (!jsChunkReg.test(template)) {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef41885</samp>

This pull request fixes a bug in the server-side rendering of loadable components with `@modern-js/runtime`. It prevents adding unnecessary scriptLoading attributes to style and invalid chunks, and updates the package version and changelog.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef41885</samp>

* Fix bug that caused ssr style link tag to have scriptLoading attributes ([link](https://github.com/web-infra-dev/modern.js/pull/4676/files?diff=unified&w=0#diff-093da70f67894f4c7e3225e317803a391d81867b4af19613535b2b1142a9100eR1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4676/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L63-R76))
* Skip invalid chunks that have no url property in `loadable.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4676/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L55-R58))
* Add patch version update for `@modern-js/runtime` package in `.changeset/pink-teachers-hug.md` ([link](https://github.com/web-infra-dev/modern.js/pull/4676/files?diff=unified&w=0#diff-093da70f67894f4c7e3225e317803a391d81867b4af19613535b2b1142a9100eR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
