### PR TITLE
test: fix garfish e2e failed due to log message change

### DIFF
--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/nonTty.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/helpers/nonTty.ts
@@ -24,16 +24,16 @@ export function createNonTTYLogger() {
 
       prevPercentage = 100;
       if (hasErrors) {
-        logger.error(`[${id}] compile failed in ${compileTime}`);
+        logger.error(`${id} compile failed in ${compileTime}`);
       } else {
-        logger.success(`[${id}] compile succeed in ${compileTime}`);
+        logger.ready(`${id} compiled in ${compileTime}`);
       }
     }
     // print progress when percentage increased by more than 10%
     // because we don't want to spam the console
     else if (current - prevPercentage > 10) {
       prevPercentage = current;
-      logger.info(`[${id}] compile progress: ${current.toFixed(0)}%`);
+      logger.info(`${id} compile progress: ${current.toFixed(0)}%`);
     }
   };
 

--- a/packages/document/builder-doc/docs/en/api/builder-instance.mdx
+++ b/packages/document/builder-doc/docs/en/api/builder-instance.mdx
@@ -228,7 +228,6 @@ After successfully starting Dev Server, you can see the following logs:
 
 ```bash
 info    Starting dev server...
-info    Dev server running at:
 
   > Local:    http://localhost:8080
   > Network:  http://192.168.0.1:8080

--- a/packages/document/builder-doc/docs/en/guide/quick-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/quick-start.mdx
@@ -105,7 +105,6 @@ After successfully starting Dev Server, you can see the following logs:
 
 ```bash
 info    Starting dev server...
-info    Dev server running at:
 
   > Local:    http://localhost:8081
   > Network:  http://192.168.0.1:8081

--- a/packages/document/builder-doc/docs/zh/api/builder-instance.mdx
+++ b/packages/document/builder-doc/docs/zh/api/builder-instance.mdx
@@ -228,7 +228,6 @@ await builder.startDevServer();
 
 ```bash
 info    Starting dev server...
-info    Dev server running at:
 
   > Local:    http://localhost:8080
   > Network:  http://192.168.0.1:8080

--- a/packages/document/builder-doc/docs/zh/guide/quick-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/quick-start.mdx
@@ -105,7 +105,6 @@ await builder.startDevServer();
 
 ```bash
 info    Starting dev server...
-info    Dev server running at:
 
   > Local:    http://localhost:8081
   > Network:  http://192.168.0.1:8081

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -89,8 +89,8 @@ function runModernCommandDev(argv, stdOut, options = {}) {
     function handleStdout(data) {
       const message = data.toString();
       const bootupMarkers = {
-        dev: /(App|Dev server|Preview server) running at/i,
-        serve: /(App|Dev server|Preview server) running at/i,
+        dev: /> Local:/i,
+        serve: /> Local:/i,
       };
       if (bootupMarkers[options.modernServe ? 'serve' : 'dev'].test(message)) {
         if (!didResolve) {


### PR DESCRIPTION
## Summary

Fix: https://github.com/web-infra-dev/modern.js/actions/runs/6230873657/job/16911539518

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12f7746</samp>

Removed the dev server running at message from the output and the documentation of the `builder-instance` API and the quick-start guide. Simplified the non-TTY progress plugin messages. Updated the test marker for the modern command dev test.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 12f7746</samp>

*  Simplify the logger messages for the non-TTY progress plugin by removing the brackets around the id and changing the success message to ready ([link](https://github.com/web-infra-dev/modern.js/pull/4677/files?diff=unified&w=0#diff-df47f787962204042f61f25468349c10c91ff4f89a7f0eafdb5711a6778cc592L27-R29), [link](https://github.com/web-infra-dev/modern.js/pull/4677/files?diff=unified&w=0#diff-df47f787962204042f61f25468349c10c91ff4f89a7f0eafdb5711a6778cc592L36-R36))
* Remove the info message for the dev server running at from the builder-instance API documents in English and Chinese, as it is not relevant for the API usage and may confuse the readers (`builder-instance.mdx` files in `packages/document/builder-doc/docs/en/api` and `packages/document/builder-doc/docs/zh/api` directories) ([link](https://github.com/web-infra-dev/modern.js/pull/4677/files?diff=unified&w=0#diff-45ba4d93ed345aa04adad80e8dd717e3c9a4212b695401d9fcaeb2d71b70683dL231), [link](https://github.com/web-infra-dev/modern.js/pull/4677/files?diff=unified&w=0#diff-854c8cb3e207b8b4b5eee437feb44cd9d6e62a724e7bf4a360ab093bf4034f74L231))
* Remove the info message for the dev server running at from the quick-start guide documents in English and Chinese, as it is not relevant for the guide and may confuse the readers (`quick-start.mdx` files in `packages/document/builder-doc/docs/en/guide` and `packages/document/builder-doc/docs/zh/guide` directories) ([link](https://github.com/web-infra-dev/modern.js/pull/4677/files?diff=unified&w=0#diff-2175ac7871d8c6aac7b82666435860bff0b7c0055f24ceccdddf51a1e1eba26fL108), [link](https://github.com/web-infra-dev/modern.js/pull/4677/files?diff=unified&w=0#diff-9d4d65b6cc32aff0cd338fa02e6319bd8875734d6d28d7bb0c45af1ed00e6e87L108))
* Change the bootup marker for the modern command dev test from the dev server running at message to the local URL message, as the former was removed from the output and the latter is more reliable to detect the server readiness (`modernTestUtils.js` file in `tests/utils` directory) ([link](https://github.com/web-infra-dev/modern.js/pull/4677/files?diff=unified&w=0#diff-2c94a567997b7cf8a86231aeb32003dc404ccfa9fb2f8be08db7b02d38ffd54bL92-R93))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
