### PR TITLE
fix(swc): fix transform core-js-pure incorrectly, allow using new decorator for js

### DIFF
--- a/.changeset/shiny-deers-live.md
+++ b/.changeset/shiny-deers-live.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/libuild-plugin-swc': patch
+'@modern-js/builder-plugin-swc': patch
+---
+
+fix(swc): fix transform core-js-pure incorrectly, allow using new decorator for js
+fix(swc): 修复误转换core-js-pure，对js允许使用新 decorator

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -64,7 +64,7 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.22.15",
     "@modern-js/builder-shared": "workspace:*",
-    "@modern-js/swc-plugins": "0.6.0",
+    "@modern-js/swc-plugins": "0.6.3",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.5.1",
     "core-js": "~3.32.1"

--- a/packages/builder/plugin-swc/tests/fixtures/extensions/lock-corejs-versions/actual.js
+++ b/packages/builder/plugin-swc/tests/fixtures/extensions/lock-corejs-versions/actual.js
@@ -1,0 +1,7 @@
+/** should be transformed */
+import 'core-js/foo/bar'
+import '@swc/helpers/foo/bar'
+
+/** should stay as is */
+import 'core-js-pure/foo/bar'
+import '@swc/helpers-custom/foo/bar'

--- a/packages/builder/plugin-swc/tests/fixtures/extensions/lock-corejs-versions/expected.js
+++ b/packages/builder/plugin-swc/tests/fixtures/extensions/lock-corejs-versions/expected.js
@@ -1,0 +1,4 @@
+/** should be transformed */ import "/path/to/corejs/foo/bar";
+import "/path/to/helper/foo/bar";
+/** should stay as is */ import "<CORE_JS>-pure/foo/bar";
+import "<SWC_HELPER>-custom/foo/bar";

--- a/packages/builder/plugin-swc/tests/fixtures/extensions/lock-corejs-versions/option.json
+++ b/packages/builder/plugin-swc/tests/fixtures/extensions/lock-corejs-versions/option.json
@@ -1,0 +1,8 @@
+{
+  "extensions": {
+    "lockCorejsVersion": {
+      "corejs": "/path/to/corejs",
+      "swcHelpers": "/path/to/helper"
+    }
+  }
+}

--- a/packages/libuild/libuild-plugin-swc/package.json
+++ b/packages/libuild/libuild-plugin-swc/package.json
@@ -21,7 +21,7 @@
     "@modern-js/libuild-utils": "workspace:*"
   },
   "dependencies": {
-    "@modern-js/swc-plugins": "0.6.0",
+    "@modern-js/swc-plugins": "0.6.3",
     "chalk": "4.1.0"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,8 +617,8 @@ importers:
         specifier: workspace:*
         version: link:../builder-shared
       '@modern-js/swc-plugins':
-        specifier: 0.6.0
-        version: 0.6.0(@swc/helpers@0.5.1)
+        specifier: 0.6.3
+        version: 0.6.3(@swc/helpers@0.5.1)
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
@@ -3405,8 +3405,8 @@ importers:
   packages/libuild/libuild-plugin-swc:
     dependencies:
       '@modern-js/swc-plugins':
-        specifier: 0.6.0
-        version: 0.6.0(@swc/helpers@0.5.1)
+        specifier: 0.6.3
+        version: 0.6.3(@swc/helpers@0.5.1)
       chalk:
         specifier: 4.1.0
         version: 4.1.0
@@ -8414,6 +8414,24 @@ importers:
         specifier: ^14
         version: 14.18.35
 
+  tests/integration/swc/fixtures/decorator/legacy:
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../../packages/solutions/app-tools
+      '@modern-js/plugin-swc':
+        specifier: workspace:*
+        version: link:../../../../../../packages/cli/plugin-swc
+
+  tests/integration/swc/fixtures/decorator/new:
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../../packages/solutions/app-tools
+      '@modern-js/plugin-swc':
+        specifier: workspace:*
+        version: link:../../../../../../packages/cli/plugin-swc
+
   tests/integration/swc/fixtures/minify-css:
     dependencies:
       '@modern-js/runtime':
@@ -12568,8 +12586,8 @@ packages:
       - supports-color
     dev: false
 
-  /@modern-js/swc-plugins-darwin-arm64@0.6.0:
-    resolution: {integrity: sha512-LFJTagB66tv/BW21F+A1BlnhaCqQLjlvHCQfLvlV7n+UJz/FrTc+/BfcXnaj6gV2Opppof31eMb0V0ncyu/suA==}
+  /@modern-js/swc-plugins-darwin-arm64@0.6.3:
+    resolution: {integrity: sha512-LzBNgNl9CBeBK0BpyBCybXzpH4Jj95Kad/QjJkVy8gzdFISI6uTpTC/OG3+sGYquvITLjTA9HYNpR1QPS+YTyg==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [darwin]
@@ -12577,8 +12595,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-darwin-x64@0.6.0:
-    resolution: {integrity: sha512-MOF3dQYyRyKbuEtMAdbVyuSKfM7XCWwdUMPlRikyoegMhgzsZE5TBpiefoRGviDqXG0Iko0SoMIoimkr+uQdcQ==}
+  /@modern-js/swc-plugins-darwin-x64@0.6.3:
+    resolution: {integrity: sha512-k1l3eIuuKFKsepC+yQEFtNS7SKs+0Y5O6Xl489+ifZnMFQ6EAgKx2mx0x9Fb6icFFdDfOv6fNspYuGIZ+5Phzg==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [darwin]
@@ -12586,8 +12604,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-gnu@0.6.0:
-    resolution: {integrity: sha512-hi3RH0vxKcAvfsYXYyNhzkg9zBLog/p95p15FQQmqzPVhd1zg3JBCKjuP9lO0ZLSrVcjJzkOiQMsEuPxwp0YEw==}
+  /@modern-js/swc-plugins-linux-arm64-gnu@0.6.3:
+    resolution: {integrity: sha512-ds0NqYwYysayELzNE1b2uCPE6ZuhhGDEoQHt2czjKKtQ4yt7hLqEmkuSlYGjYuTm39yLl4/IKEMk7bI3TcuOGg==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -12595,8 +12613,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-musl@0.6.0:
-    resolution: {integrity: sha512-EBuBF11zTjBd1tn2KijQretTc80X/uDtxjXO8gLyZ9vNHK9QBuYP2BigupCdLDfgdWOBiVhNsnfwqWBHvrSUHA==}
+  /@modern-js/swc-plugins-linux-arm64-musl@0.6.3:
+    resolution: {integrity: sha512-YC/RMox7uGz+ZEHO4xfeDJHCpnwcBkOS2tNqLFkm/D+OotjEjvA9lLCSfaPF9D68XdmQCQCH6rJcqhdTidVa1g==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -12604,8 +12622,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-gnu@0.6.0:
-    resolution: {integrity: sha512-Ysx5QUt7GjpBUqwD2NuFdgHUTdM3RyVo4xzkKdb/4F3rERD6JmYH127kjMrGwE5SCsCK493ZtRe6kcO8mabokQ==}
+  /@modern-js/swc-plugins-linux-x64-gnu@0.6.3:
+    resolution: {integrity: sha512-YJ9Xt6E0TbEckGCtj6+T1Ek4S3ljoOrdav9qp++X5FuaUzoT+DUf/pHIdnuWbxye1/6i4aF9z2kRIaOrZ6wpVA==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -12613,8 +12631,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-musl@0.6.0:
-    resolution: {integrity: sha512-Gd6XHoft+Ur7zOiRXTwDgZvHBcmLKxqG+bZHYTYQB7GehnveGNSha4tYbLgNDebJj64UPYH92IuGl7odlN1sUQ==}
+  /@modern-js/swc-plugins-linux-x64-musl@0.6.3:
+    resolution: {integrity: sha512-8MNk8trv48hSKpW6E8Xl3dZfG3L84k56GqfPv47EpkCTfR/gBJAdhyBnMwv5r6lXdvNTbd9qmvIQnMfQAwFG2g==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -12622,8 +12640,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-arm64-msvc@0.6.0:
-    resolution: {integrity: sha512-rfPf1uJpgLA7UHJkWOsU1tSTU1YGt+gSQIocU0Fa5LXMvkT5cwZ4MfdCAbjMnxqQtPaHy3QDO02qe6QE2nvH4Q==}
+  /@modern-js/swc-plugins-win32-arm64-msvc@0.6.3:
+    resolution: {integrity: sha512-E8V6ZNp4tgZlzFFdIESdMRxPqYtTO5PEYm1ALunBcOp7lydUTSF58pC8dGnFMNpJ6HfH2jy1ORLlhpAwQ8zyKg==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [win32]
@@ -12631,8 +12649,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-x64-msvc@0.6.0:
-    resolution: {integrity: sha512-wPp537dlMPnWGSeO3nXLb3rcUNAa3VlSab1cpi3h+MIv1+0x0SSQ30/MBSu+VQOww6kr79DOh8iC6ODp6iyBog==}
+  /@modern-js/swc-plugins-win32-x64-msvc@0.6.3:
+    resolution: {integrity: sha512-7mKljY6MyidBHDlGmp0kEcSSvfhr9s+tOluVfSHn3U31QwIfVS4p9ByODnuJuAgffd3bZ02rblGzfQfY6mSWFw==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [win32]
@@ -12640,22 +12658,22 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins@0.6.0(@swc/helpers@0.5.1):
-    resolution: {integrity: sha512-tMmrGcBDlPbemB4eJUXgdHBUMDozXaS3UMIP4UorQ+ImG7VwOKMEuLSN4FMd8YbH8WyGCEYtH8M3GOs5Rj/Cfg==}
+  /@modern-js/swc-plugins@0.6.3(@swc/helpers@0.5.1):
+    resolution: {integrity: sha512-BXUBfoGV+0Mzf7t1z2SsFuKcBUjHrp7Jn2C7Ax9pDVzC0+kcK55kHZJ20tgiIRoD3gTO5uHFbIaLK3snDc2NNg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       '@swc/helpers': 0.5.1
     dependencies:
       '@swc/helpers': 0.5.1
     optionalDependencies:
-      '@modern-js/swc-plugins-darwin-arm64': 0.6.0
-      '@modern-js/swc-plugins-darwin-x64': 0.6.0
-      '@modern-js/swc-plugins-linux-arm64-gnu': 0.6.0
-      '@modern-js/swc-plugins-linux-arm64-musl': 0.6.0
-      '@modern-js/swc-plugins-linux-x64-gnu': 0.6.0
-      '@modern-js/swc-plugins-linux-x64-musl': 0.6.0
-      '@modern-js/swc-plugins-win32-arm64-msvc': 0.6.0
-      '@modern-js/swc-plugins-win32-x64-msvc': 0.6.0
+      '@modern-js/swc-plugins-darwin-arm64': 0.6.3
+      '@modern-js/swc-plugins-darwin-x64': 0.6.3
+      '@modern-js/swc-plugins-linux-arm64-gnu': 0.6.3
+      '@modern-js/swc-plugins-linux-arm64-musl': 0.6.3
+      '@modern-js/swc-plugins-linux-x64-gnu': 0.6.3
+      '@modern-js/swc-plugins-linux-x64-musl': 0.6.3
+      '@modern-js/swc-plugins-win32-arm64-msvc': 0.6.3
+      '@modern-js/swc-plugins-win32-x64-msvc': 0.6.3
     dev: false
 
   /@modern-js/utils@2.18.0(react-dom@18.2.0)(react@18.2.0):

--- a/tests/integration/swc/fixtures/decorator/legacy/modern.config.ts
+++ b/tests/integration/swc/fixtures/decorator/legacy/modern.config.ts
@@ -1,0 +1,19 @@
+import appTools, { defineConfig } from '@modern-js/app-tools';
+import { swcPlugin } from '@modern-js/plugin-swc';
+
+export default defineConfig({
+  tools: {
+    swc: {
+      jsc: {
+        transform: {
+          /** ts cant use new decorator */
+          legacyDecorator: false,
+        },
+      },
+    },
+  },
+  output: {
+    disableMinimize: true,
+  },
+  plugins: [appTools(), swcPlugin()],
+});

--- a/tests/integration/swc/fixtures/decorator/legacy/package.json
+++ b/tests/integration/swc/fixtures/decorator/legacy/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "swc-test-decorator-legacy",
+  "version": "2.9.0",
+  "dependencies": {},
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/plugin-swc": "workspace:*"
+  }
+}

--- a/tests/integration/swc/fixtures/decorator/legacy/src/index.ts
+++ b/tests/integration/swc/fixtures/decorator/legacy/src/index.ts
@@ -1,0 +1,12 @@
+function newDecorator() {
+  console.log('foo decorator');
+}
+
+class Foo {
+  @newDecorator()
+  foo() {
+    console.log('foo');
+  }
+}
+
+console.log(new Foo());

--- a/tests/integration/swc/fixtures/decorator/new/modern.config.ts
+++ b/tests/integration/swc/fixtures/decorator/new/modern.config.ts
@@ -1,0 +1,19 @@
+import appTools, { defineConfig } from '@modern-js/app-tools';
+import { swcPlugin } from '@modern-js/plugin-swc';
+
+export default defineConfig({
+  tools: {
+    swc: {
+      jsc: {
+        transform: {
+          /** use new decorator */
+          legacyDecorator: false,
+        },
+      },
+    },
+  },
+  output: {
+    disableMinimize: true,
+  },
+  plugins: [appTools(), swcPlugin()],
+});

--- a/tests/integration/swc/fixtures/decorator/new/package.json
+++ b/tests/integration/swc/fixtures/decorator/new/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "swc-test-decorator",
+  "version": "2.9.0",
+  "dependencies": {},
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/plugin-swc": "workspace:*"
+  }
+}

--- a/tests/integration/swc/fixtures/decorator/new/src/index.js
+++ b/tests/integration/swc/fixtures/decorator/new/src/index.js
@@ -1,0 +1,12 @@
+function newDecorator() {
+  console.log('foo decorator');
+}
+
+class Foo {
+  @newDecorator()
+  foo() {
+    console.log('foo');
+  }
+}
+
+console.log(new Foo());

--- a/tests/integration/swc/tests/decorator.test.ts
+++ b/tests/integration/swc/tests/decorator.test.ts
@@ -1,0 +1,36 @@
+import path from 'path';
+import { readFileSync, readdirSync } from 'fs';
+import { modernBuild } from '../../../utils/modernTestUtils';
+
+const fixtures = path.resolve(__dirname, '../fixtures');
+
+const getJsFiles = (appDir: string) =>
+  readdirSync(path.resolve(appDir, 'dist/static/js'))
+    .filter(filepath => /\.js$/.test(filepath))
+    .map(filePath =>
+      readFileSync(path.join(appDir, 'dist/static/js', filePath)),
+    );
+
+describe('swc use new decorator', () => {
+  test('should use new decorator', async () => {
+    const appDir = path.resolve(fixtures, 'decorator/new');
+
+    await modernBuild(appDir);
+
+    const jsFiles = getJsFiles(appDir);
+    expect(
+      jsFiles.some(item => item.includes('@swc/helpers/esm/_decorate.js')),
+    ).toBeTruthy();
+  });
+
+  test('should use legacy decorator', async () => {
+    const appDir = path.resolve(fixtures, 'decorator/legacy');
+
+    await modernBuild(appDir);
+
+    const jsFiles = getJsFiles(appDir);
+    expect(
+      jsFiles.every(item => !item.includes('@swc/helpers/esm/_decorate.js')),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Update swc-plugins, to fix:
- transform core-js-pure to core-js
- not using new decorator even in js modules

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c3f9d4</samp>

This pull request updates the swc plugin dependencies and fixes the issue of transforming `core-js-pure` imports. It also adds support for the new decorator syntax for both TypeScript and JavaScript files, and adds test fixtures and cases to verify the functionality.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c3f9d4</samp>

*  Add a changeset file to document the patch updates and the fix for the swc plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-f6d49b431d24ca989747701b8e99bbae5f6f4d8724ec0cf7c51a91f1b60984bbR1-R7))
*  Update the dependency version of `@modern-js/swc-plugins` in both `@modern-js/libuild-plugin-swc` and `@modern-js/builder-plugin-swc` packages to use the latest features and fixes ([link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-34ed68e35fc7b09be4c7b86093bb347bb44eb062dc6ad1961198c212ccf433caL67-R67), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-9a0096851b44cc1986035406e7425ccac3a66d63726b082014b0b761c2c7a21bL24-R24))
*  Add test fixture files and option files for the `lockCorejsVersion` extension option of the swc plugin, which controls how the plugin transforms or preserves `core-js-pure` imports ([link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-8f54d22779dc3e7e0afaea9e329907ae6991b8f6e603ad81a20e79b620cc5e0aR1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-4b5e45b85cce42821cf3e37c7c6af788b5e1a0de18ab6ef5043dfe587ff8825eR1-R4), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-8a80cb408130d28ff4b14493490ba8012fd1a67ef4334787136fb4d11edb4cbeR1-R8))
*  Add test fixture apps and configuration files for the `legacyDecorator` option of the swc plugin, which controls how the plugin transforms the new decorator syntax for TypeScript and JavaScript files ([link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-92e9e230ae8797e8860461c64c4aaf74d66125a2df09746b1fe7b9bb2c8c8b0bR1-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-c0f39b62a28efb72b988ce3e39504281ba3a986c5dbcd17d1a1778ea98890f95R1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-1755f0809983baf4e2458f385409912f85672025311a47a000c445090a37f4ebR1-R12), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-cc72fed575bbb01bf7742cb02acc9fb09a3c7f0bbfaa01271c7c70ff63c5c298R1-R19), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-8329232d574c8659e7c1f40ff6683c08b33452fe312dfac3368e52acec96db19R1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-8fd8e2e7f27817f4b3c807f26dc7250a023044223b59a2cc88caa3eb0870b4e3R1-R12))
*  Add a test file for the swc plugin that verifies the behavior of the `legacyDecorator` option for both TypeScript and JavaScript files, using the `modernBuild` utility function and checking the output files for the `@swc/helpers/esm/_decorate.js` import ([link](https://github.com/web-infra-dev/modern.js/pull/4680/files?diff=unified&w=0#diff-c190a6333de3f21d494df3a009987190704c9be956b1c8171333270e61cd6d70R1-R36))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
