### PR TITLE
fix(plugin): run async setup function in the correct order

### DIFF
--- a/.changeset/fifty-apes-yell.md
+++ b/.changeset/fifty-apes-yell.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin': patch
+---
+
+fix(plugin): run async setup function in the correct order
+
+fix(plugin): 以正确的顺序执行异步的 setup 函数

--- a/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/implement.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/framework-plugin/implement.mdx
@@ -170,6 +170,8 @@ export const myPlugin = (): CliPlugin => ({
 });
 ```
 
+Note that the setup function of the next plugin is not executed until the async setup function of the current plugin has finished. Therefore, you should avoid performing time-consuming asynchronous operations in the setup function to avoid slowing down the startup performance of the CLI.
+
 ## Adding Plugins
 
 Custom plugins can be used by following the instructions in the [plugins](/configure/app/plugins) section of the documentation. Below is the recommended way to implement plugins in Modern.js.

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/implement.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/framework-plugin/implement.mdx
@@ -177,6 +177,8 @@ export const myPlugin = (): CliPlugin => ({
 });
 ```
 
+注意，只有当前插件的 setup 异步函数执行完毕，才会继续执行下一个插件的 setup 函数。因此，你需要避免在 setup 函数中进行耗时过长的异步操作，防止影响 CLI 启动性能。
+
 ## 添加插件
 
 自定义插件的使用方式可以查看：[plugins (框架插件)](/configure/app/plugins)。下面会介绍 Modern.js 中推荐的插件实现方法。

--- a/packages/document/module-doc/docs/en/plugins/guide/setup-function.mdx
+++ b/packages/document/module-doc/docs/en/plugins/guide/setup-function.mdx
@@ -103,6 +103,8 @@ export const myPlugin = (): CliPlugin<ModuleTools> => ({
 });
 ```
 
+Note that the setup function of the next plugin is not executed until the async setup function of the current plugin has finished. Therefore, you should avoid performing time-consuming asynchronous operations in the setup function to avoid slowing down the startup performance of the CLI.
+
 ## Life cycle hooks
 
 We know that the `setup` function returns a Hooks object, which can also be understood as an object with Modern.js Module lifecycle hooks.

--- a/packages/document/module-doc/docs/zh/plugins/guide/setup-function.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/guide/setup-function.mdx
@@ -103,6 +103,8 @@ export const myPlugin = (): CliPlugin<ModuleTools> => ({
 });
 ```
 
+注意，只有当前插件的 setup 异步函数执行完毕，才会继续执行下一个插件的 setup 函数。因此，你需要避免在 setup 函数中进行耗时过长的异步操作，防止影响 CLI 启动性能。
+
 ## 生命周期钩子
 
 我们知道 `setup` 函数会返回一个 Hooks 对象，所谓 Hooks 对象也可以理解是具有 Modern.js Module 生命周期钩子的对象。

--- a/packages/toolkit/plugin/src/manager/async.ts
+++ b/packages/toolkit/plugin/src/manager/async.ts
@@ -182,7 +182,7 @@ export const createAsyncManager = <
       plugins = [];
     };
 
-    const init: AsyncManager<Hooks, API>['init'] = () => {
+    const init: AsyncManager<Hooks, API>['init'] = async () => {
       const sortedPlugins = sortPlugins(plugins);
       const mergedPluginAPI = {
         ...pluginAPI,
@@ -191,12 +191,13 @@ export const createAsyncManager = <
 
       checkPlugins(sortedPlugins);
 
-      return Promise.all(
-        sortedPlugins.map(plugin => plugin.setup(mergedPluginAPI)),
-      ).then(hooksList => {
-        runners = generateRunner<Hooks>(hooksList, currentHooks);
-        return runners;
-      });
+      const hooksList: (void | Partial<ToThreads<Hooks>>)[] = [];
+      for (const plugin of sortedPlugins) {
+        hooksList.push(await plugin.setup(mergedPluginAPI));
+      }
+
+      runners = generateRunner<Hooks>(hooksList, currentHooks);
+      return runners;
     };
 
     const run: AsyncManager<Hooks, API>['run'] = cb => cb();

--- a/packages/toolkit/plugin/src/workflow/async.ts
+++ b/packages/toolkit/plugin/src/workflow/async.ts
@@ -15,6 +15,9 @@ export type AsyncWorkflow<I, O> = {
   [ASYNC_WORKFLOW_SYMBOL]: true;
 };
 
+const isPromise = (obj: any): obj is Promise<any> =>
+  obj && typeof obj.then === 'function';
+
 export const isAsyncWorkflow = (input: any): input is AsyncWorkflow<any, any> =>
   Boolean(input?.[ASYNC_WORKFLOW_SYMBOL]);
 
@@ -53,7 +56,3 @@ const mapAsyncWorkerToAsyncMiddleware =
     Promise.resolve(worker(input)).then(result =>
       Promise.resolve(next(input)).then(nextResult => [result, ...nextResult]),
     );
-
-function isPromise(obj: any): obj is Promise<any> {
-  return obj && typeof obj.then === 'function';
-}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d9b605</samp>

This pull request fixes a bug in the `@modern-js/plugin` package that caused the async setup functions of the plugins to run in the wrong order. It also refactors the plugin code to improve async hook handling and avoid duplication. Additionally, it updates the documentation and the changelog to reflect the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7d9b605</samp>

*  Fix plugin async setup order bug and update documentation (`@modern-js/plugin` package) ([link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-6670fa629f5ac75d016f570f0365bd1af3d5dd33de876b368d732856b4ec4d91R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-861ceacb2cf3c438abb95ce31b70b93a720d6929a9c3a9d9d0887374ebd655abL185-R185), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-861ceacb2cf3c438abb95ce31b70b93a720d6929a9c3a9d9d0887374ebd655abL194-R200), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-2a5c4a94cc063ae097473764025857f94d8d206ac6f09fc273d003d5e2eab679L62-R88))
*  Add utility function `isPromise` to check if an object is a promise ([link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-7365051307403646d3ef396702363f7a827f4c9553581a52aef5744c2df8f338R18-R20), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-7365051307403646d3ef396702363f7a827f4c9553581a52aef5744c2df8f338L56-L59))
*  Modify `generateRunner` function to handle async hooks using `isPromise` ([link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-7365051307403646d3ef396702363f7a827f4c9553581a52aef5744c2df8f338L56-L59))
*  Add notes to English and Chinese documentation of framework plugin implementation guide and plugin setup function guide, explaining the async setup order and performance implications ([link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-213996fa3a55506d40af9f48b0a0ec4739968dd259083db62f693971f78a6659R173-R174), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-44edc5108d088fd4950f78b3eca7dfda6459f694fb5117da8bcf0d0d599147dbR180-R181), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-3275b3bb257bacba29ca69948a2c9c55be60c9b4d7d6d1069d7ebb941a76d192R106-R107), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-6cd185dcc5fd3c7771fdc96bf3bfcfd0c1f90837edf64677067eb6f2997165b0R106-R107))
*  Modify existing test cases to use `await expect().rejects.toThrowError()` syntax for async `init` method ([link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-2a5c4a94cc063ae097473764025857f94d8d206ac6f09fc273d003d5e2eab679L285-R311), [link](https://github.com/web-infra-dev/modern.js/pull/4681/files?diff=unified&w=0#diff-2a5c4a94cc063ae097473764025857f94d8d206ac6f09fc273d003d5e2eab679L327-R353))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
