### PR TITLE
fix(swc): update binding to reduce package size

### DIFF
--- a/.changeset/eleven-wolves-look.md
+++ b/.changeset/eleven-wolves-look.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/libuild-plugin-swc': patch
+'@modern-js/builder-plugin-swc': patch
+'swc-integration': patch
+---
+
+fix(swc): update binding to reduce package size

--- a/.changeset/eleven-wolves-look.md
+++ b/.changeset/eleven-wolves-look.md
@@ -1,7 +1,6 @@
 ---
 '@modern-js/libuild-plugin-swc': patch
 '@modern-js/builder-plugin-swc': patch
-'swc-integration': patch
 ---
 
 fix(swc): update binding to reduce package size

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -64,7 +64,7 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.22.15",
     "@modern-js/builder-shared": "workspace:*",
-    "@modern-js/swc-plugins": "0.6.3",
+    "@modern-js/swc-plugins": "0.6.4",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.5.1",
     "core-js": "~3.32.1"

--- a/packages/libuild/libuild-plugin-swc/package.json
+++ b/packages/libuild/libuild-plugin-swc/package.json
@@ -21,7 +21,7 @@
     "@modern-js/libuild-utils": "workspace:*"
   },
   "dependencies": {
-    "@modern-js/swc-plugins": "0.6.3",
+    "@modern-js/swc-plugins": "0.6.4",
     "chalk": "4.1.0"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,8 +617,8 @@ importers:
         specifier: workspace:*
         version: link:../builder-shared
       '@modern-js/swc-plugins':
-        specifier: 0.6.3
-        version: 0.6.3(@swc/helpers@0.5.1)
+        specifier: 0.6.4
+        version: 0.6.4(@swc/helpers@0.5.1)
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
@@ -3405,8 +3405,8 @@ importers:
   packages/libuild/libuild-plugin-swc:
     dependencies:
       '@modern-js/swc-plugins':
-        specifier: 0.6.3
-        version: 0.6.3(@swc/helpers@0.5.1)
+        specifier: 0.6.4
+        version: 0.6.4(@swc/helpers@0.5.1)
       chalk:
         specifier: 4.1.0
         version: 4.1.0
@@ -12595,8 +12595,8 @@ packages:
       - supports-color
     dev: false
 
-  /@modern-js/swc-plugins-darwin-arm64@0.6.3:
-    resolution: {integrity: sha512-LzBNgNl9CBeBK0BpyBCybXzpH4Jj95Kad/QjJkVy8gzdFISI6uTpTC/OG3+sGYquvITLjTA9HYNpR1QPS+YTyg==}
+  /@modern-js/swc-plugins-darwin-arm64@0.6.4:
+    resolution: {integrity: sha512-JunAQouAx1/d1I6omWFh9iSs5SdefDlrhGmiqg4OdNC5rXJe6b4BGu30a/g4Ijkg9FPj+F0Pysn9wPAJz13Bfg==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [darwin]
@@ -12604,8 +12604,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-darwin-x64@0.6.3:
-    resolution: {integrity: sha512-k1l3eIuuKFKsepC+yQEFtNS7SKs+0Y5O6Xl489+ifZnMFQ6EAgKx2mx0x9Fb6icFFdDfOv6fNspYuGIZ+5Phzg==}
+  /@modern-js/swc-plugins-darwin-x64@0.6.4:
+    resolution: {integrity: sha512-z7I03iIdCsQBBfOlOyXT6/zMM1oDEgWY5d7/DR2u82MBaqYPd4jmhjypJLvyo2xRwLA50ipMaCOrZ236yUVg3w==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [darwin]
@@ -12613,8 +12613,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-gnu@0.6.3:
-    resolution: {integrity: sha512-ds0NqYwYysayELzNE1b2uCPE6ZuhhGDEoQHt2czjKKtQ4yt7hLqEmkuSlYGjYuTm39yLl4/IKEMk7bI3TcuOGg==}
+  /@modern-js/swc-plugins-linux-arm64-gnu@0.6.4:
+    resolution: {integrity: sha512-s+duNlG891PFLsootfm+DqFG8Qev8ynGqSJoJNDZqQbFRkrVg/v4heaKdUrEKfJRyV6zY/NPp46s6iNiI2KSpQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -12622,8 +12622,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-arm64-musl@0.6.3:
-    resolution: {integrity: sha512-YC/RMox7uGz+ZEHO4xfeDJHCpnwcBkOS2tNqLFkm/D+OotjEjvA9lLCSfaPF9D68XdmQCQCH6rJcqhdTidVa1g==}
+  /@modern-js/swc-plugins-linux-arm64-musl@0.6.4:
+    resolution: {integrity: sha512-kDIg8Ei0sTn5kSBS/jPakdViTnsb6uBw+fDnBGCUT33fawZaVz0tiAd0UK+NyrlT7MZrbatqPEEERfvULOunnw==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -12631,8 +12631,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-gnu@0.6.3:
-    resolution: {integrity: sha512-YJ9Xt6E0TbEckGCtj6+T1Ek4S3ljoOrdav9qp++X5FuaUzoT+DUf/pHIdnuWbxye1/6i4aF9z2kRIaOrZ6wpVA==}
+  /@modern-js/swc-plugins-linux-x64-gnu@0.6.4:
+    resolution: {integrity: sha512-3MrgfHJhZPVbRwdbbsMwUfG8cvZ6oEWdNUj8NAMxVRwFgV+QWp1vTzljqi+ZgSjwygvADdZBIFKJ6k2OVgAM7w==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -12640,8 +12640,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-linux-x64-musl@0.6.3:
-    resolution: {integrity: sha512-8MNk8trv48hSKpW6E8Xl3dZfG3L84k56GqfPv47EpkCTfR/gBJAdhyBnMwv5r6lXdvNTbd9qmvIQnMfQAwFG2g==}
+  /@modern-js/swc-plugins-linux-x64-musl@0.6.4:
+    resolution: {integrity: sha512-UHEIzOb/JImyeyr8FCX8ffLXU8sIQAZuvxHX4AU4ntlxLe/7lVHKiSMKJ6D3XeQ3lf3qj0wTMSBzNuN9tYN3cg==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -12649,8 +12649,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-arm64-msvc@0.6.3:
-    resolution: {integrity: sha512-E8V6ZNp4tgZlzFFdIESdMRxPqYtTO5PEYm1ALunBcOp7lydUTSF58pC8dGnFMNpJ6HfH2jy1ORLlhpAwQ8zyKg==}
+  /@modern-js/swc-plugins-win32-arm64-msvc@0.6.4:
+    resolution: {integrity: sha512-QEvLEgVnPgS46iQKiDOgcB5v0nGyt6io2IQfCCx00fid+3O2flHegW2NhPf6qCM1nXszv3r/stw35vAIIGAnHQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [win32]
@@ -12658,8 +12658,8 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins-win32-x64-msvc@0.6.3:
-    resolution: {integrity: sha512-7mKljY6MyidBHDlGmp0kEcSSvfhr9s+tOluVfSHn3U31QwIfVS4p9ByODnuJuAgffd3bZ02rblGzfQfY6mSWFw==}
+  /@modern-js/swc-plugins-win32-x64-msvc@0.6.4:
+    resolution: {integrity: sha512-JP9VvQ9yK/wiOQ8PCcym0oWPLpwoW/d0b1l5RxjangEtIwagIMKr1cHDchR70rcN2J2enZxqc0RFabunyOd8PA==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [win32]
@@ -12667,22 +12667,22 @@ packages:
     dev: false
     optional: true
 
-  /@modern-js/swc-plugins@0.6.3(@swc/helpers@0.5.1):
-    resolution: {integrity: sha512-BXUBfoGV+0Mzf7t1z2SsFuKcBUjHrp7Jn2C7Ax9pDVzC0+kcK55kHZJ20tgiIRoD3gTO5uHFbIaLK3snDc2NNg==}
+  /@modern-js/swc-plugins@0.6.4(@swc/helpers@0.5.1):
+    resolution: {integrity: sha512-0p0iEzUxl9N5BL5JXwBVMdNXr2ClI7OV7CAhD6licUA4cRS0RLkruyddI90EZ2/zuTQ5XCFdwK3JjDeY3HiGdg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       '@swc/helpers': 0.5.1
     dependencies:
       '@swc/helpers': 0.5.1
     optionalDependencies:
-      '@modern-js/swc-plugins-darwin-arm64': 0.6.3
-      '@modern-js/swc-plugins-darwin-x64': 0.6.3
-      '@modern-js/swc-plugins-linux-arm64-gnu': 0.6.3
-      '@modern-js/swc-plugins-linux-arm64-musl': 0.6.3
-      '@modern-js/swc-plugins-linux-x64-gnu': 0.6.3
-      '@modern-js/swc-plugins-linux-x64-musl': 0.6.3
-      '@modern-js/swc-plugins-win32-arm64-msvc': 0.6.3
-      '@modern-js/swc-plugins-win32-x64-msvc': 0.6.3
+      '@modern-js/swc-plugins-darwin-arm64': 0.6.4
+      '@modern-js/swc-plugins-darwin-x64': 0.6.4
+      '@modern-js/swc-plugins-linux-arm64-gnu': 0.6.4
+      '@modern-js/swc-plugins-linux-arm64-musl': 0.6.4
+      '@modern-js/swc-plugins-linux-x64-gnu': 0.6.4
+      '@modern-js/swc-plugins-linux-x64-musl': 0.6.4
+      '@modern-js/swc-plugins-win32-arm64-msvc': 0.6.4
+      '@modern-js/swc-plugins-win32-x64-msvc': 0.6.4
     dev: false
 
   /@modern-js/utils@2.18.0(react-dom@18.2.0)(react@18.2.0):

--- a/tests/integration/swc/tests/decorator.test.ts
+++ b/tests/integration/swc/tests/decorator.test.ts
@@ -29,8 +29,6 @@ describe('swc use new decorator', () => {
     await modernBuild(appDir);
 
     const jsFiles = getJsFiles(appDir);
-    expect(
-      jsFiles.every(item => !item.includes('@swc/helpers/esm/_decorate.js')),
-    ).toBeTruthy();
+    expect(jsFiles.some(item => item.includes('_ts_decorate'))).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

old version swc binding has wrong package size, update to the correct one

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d15bc1b</samp>

This pull request updates the swc-related packages to use a custom binding for swc that reduces the package size and fixes the decorator feature. It also adds a changeset file and an integration test for the swc updates.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d15bc1b</samp>

*  Add changeset file for swc-related packages and integration test ([link](https://github.com/web-infra-dev/modern.js/pull/4687/files?diff=unified&w=0#diff-ebbe120994e6be962c5c94a18c0c4714c8ce2c2c4689f4328bfe6044246242d8R1-R7))
*  Bump `@modern-js/swc-plugins` dependency to `0.6.4` in `@modern-js/builder-plugin-swc` and `@modern-js/libuild-plugin-swc` packages to reduce package size with custom swc binding ([link](https://github.com/web-infra-dev/modern.js/pull/4687/files?diff=unified&w=0#diff-34ed68e35fc7b09be4c7b86093bb347bb44eb062dc6ad1961198c212ccf433caL67-R67), [link](https://github.com/web-infra-dev/modern.js/pull/4687/files?diff=unified&w=0#diff-9a0096851b44cc1986035406e7425ccac3a66d63726b082014b0b761c2c7a21bL24-R24))
*  Update integration test for decorator feature in swc to check for `_ts_decorate` helper function instead of `@swc/helpers/esm/_decorate.js` module ([link](https://github.com/web-infra-dev/modern.js/pull/4687/files?diff=unified&w=0#diff-c190a6333de3f21d494df3a009987190704c9be956b1c8171333270e61cd6d70L32-R32))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
