### PR TITLE
fix(libuild-plugin-node-polyfill): fix error resolve path

### DIFF
--- a/.changeset/twenty-months-march.md
+++ b/.changeset/twenty-months-march.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/libuild-plugin-node-polyfill': patch
+---
+
+fix(libuild-plugin-node-polyfill): fix error resolve path
+fix(libuild-plugin-node-polyfill): 修复错误的解析路径

--- a/packages/libuild/libuild-plugin-node-polyfill/src/index.ts
+++ b/packages/libuild/libuild-plugin-node-polyfill/src/index.ts
@@ -25,7 +25,7 @@ function addResolveFallback(object: Record<string, string | null>, overrides: Re
   const newObject: Record<string, string> = {};
   for (const key of keys) {
     if (object[key] === null) {
-      newObject[key] = path.join(__dirname, `../mock/${key}.js`);
+      newObject[key] = path.join(__dirname, `./mock/${key}.js`);
     } else {
       newObject[key] = object[key] as string;
     }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e581469</samp>

This pull request fixes a bug in the `libuild-plugin-node-polyfill` package that prevented node built-in modules from being polyfilled in the browser. It also adds a changeset file to document the patch version update and the fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e581469</samp>

* Fix error resolve path for mock modules in `libuild-plugin-node-polyfill` package ([link](https://github.com/web-infra-dev/modern.js/pull/4688/files?diff=unified&w=0#diff-e989d96d0f148c495fa628f9c94eb2f820a9370ec0cb50c0ebf8da6e9b91ae35L28-R28))
* Add changeset file for patch version update and fix message for `libuild-plugin-node-polyfill` package ([link](https://github.com/web-infra-dev/modern.js/pull/4688/files?diff=unified&w=0#diff-a99007f99359fc7cccfac68b8adf42660a0386a229661ff0bc0e17a95aa1c372R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
