### PR TITLE
fix: error header key in other metaName

### DIFF
--- a/.changeset/green-pandas-buy.md
+++ b/.changeset/green-pandas-buy.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix(prod-server): error header key in other metaName
+fix(prod-server): 错误的 header key 在不同的 metaName

--- a/packages/server/prod-server/src/libs/render/index.ts
+++ b/packages/server/prod-server/src/libs/render/index.ts
@@ -27,6 +27,9 @@ type CreateRenderHandler = (ctx: {
   metaName?: string;
 }) => RenderHandler;
 
+const calcFallback = (metaName: string) =>
+  `x-${cutNameByHyphen(metaName)}-ssr-fallback`;
+
 export const createRenderHandler: CreateRenderHandler = ({
   distDir,
   staticGenerate,
@@ -73,9 +76,7 @@ export const createRenderHandler: CreateRenderHandler = ({
 
     // handles ssr first
     const useCSR =
-      forceCSR &&
-      (ctx.query.csr ||
-        ctx.headers[`x-${cutNameByHyphen(metaName)}-ssr-fallback`]);
+      forceCSR && (ctx.query.csr || ctx.headers[calcFallback(metaName)]);
     if (route.isSSR && !useCSR) {
       try {
         const userAgent = ctx.getReqHeader('User-Agent') as string | undefined;
@@ -129,7 +130,7 @@ export const createRenderHandler: CreateRenderHandler = ({
           ERROR_DIGEST.ERENDER,
           (err as Error).stack || (err as Error).message,
         );
-        ctx.res.set('x-modern-ssr-fallback', '1');
+        ctx.res.set(calcFallback(metaName), '1');
       }
     }
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43b5999</samp>

Refactor SSR logic and add changeset for `@modern-js/prod-server` package. The refactor improves the fallback handling for SSR errors and client-side rendering. The changeset documents the patch version update and the fixes in both languages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43b5999</samp>

*  Add a changeset file to document the patch version update and the fix messages for the `@modern-js/prod-server` package ([link](https://github.com/web-infra-dev/modern.js/pull/4695/files?diff=unified&w=0#diff-a5fdace78c486221964b15879eceb4de93eff2392dac1c434e7fa68291b77181R1-R6))
*  Extract a helper function `calcFallback` to generate the header key for the SSR fallback mode based on the metaName ([link](https://github.com/web-infra-dev/modern.js/pull/4695/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bR30-R32))
*  Use the `calcFallback` function to replace the hardcoded header keys in the `render` function of the `prod-server/src/libs/render/index.ts` file, which handles the SSR logic for each request ([link](https://github.com/web-infra-dev/modern.js/pull/4695/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bL76-R79), [link](https://github.com/web-infra-dev/modern.js/pull/4695/files?diff=unified&w=0#diff-b478428abf7644f686320a9790eccc857eb6a3c73ed99b4cc8b00f4045bb4a6bL132-R133))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
