### PR TITLE
fix(plugin-proxy): failed to run networksetup command in Windows

### DIFF
--- a/.changeset/shaggy-ants-worry.md
+++ b/.changeset/shaggy-ants-worry.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-proxy': patch
+---
+
+fix(plugin-proxy): failed to run networksetup command in Windows
+
+fix(plugin-proxy): 修复 Windows 下运行 networksetup 失败的问题

--- a/packages/cli/plugin-proxy/src/utils/macProxyManager.ts
+++ b/packages/cli/plugin-proxy/src/utils/macProxyManager.ts
@@ -2,6 +2,8 @@ import execSync from './execSync';
 
 const networkTypes = ['Ethernet', 'Thunderbolt Ethernet', 'Wi-Fi'];
 
+const isMacOS = () => process.platform === 'darwin';
+
 const getNetworkType = () => {
   // eslint-disable-next-line @typescript-eslint/prefer-for-of
   for (let i = 0; i < networkTypes.length; i++) {
@@ -17,6 +19,11 @@ const getNetworkType = () => {
 };
 
 export const enableGlobalProxy = (ip: string, port: string) => {
+  // The `networksetup` command only exists under macOS
+  if (!isMacOS()) {
+    return;
+  }
+
   const networkType = getNetworkType();
 
   // && networksetup -setproxybypassdomains ${networkType} localhost localhost
@@ -25,6 +32,10 @@ export const enableGlobalProxy = (ip: string, port: string) => {
 };
 
 export const disableGlobalProxy = () => {
+  if (!isMacOS()) {
+    return;
+  }
+
   const networkType = getNetworkType();
   execSync(`networksetup -setwebproxystate ${networkType} off`);
   execSync(`networksetup -setsecurewebproxystate ${networkType} off`);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8b0d1f</samp>

This pull request fixes a bug in the `@modern-js/plugin-proxy` package that caused errors when running on non-macOS platforms. It adds OS checks to the `macProxyManager` module and updates the changeset file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8b0d1f</samp>

*  Add a changeset file for patching `@modern-js/plugin-proxy` package and fixing a bug related to macOS proxy settings ([link](https://github.com/web-infra-dev/modern.js/pull/4700/files?diff=unified&w=0#diff-d7152e76521d7ae489cebd9058137aa3275fb19a7dbad9f64901abc7968dd1d2R1-R7))
*  Check the current operating system before using `networksetup` command in `macProxyManager.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4700/files?diff=unified&w=0#diff-97a08b3bfa45d6684effc3f453ce9309f4ced0be6853dd28f93e931044c400d8R5-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4700/files?diff=unified&w=0#diff-97a08b3bfa45d6684effc3f453ce9309f4ced0be6853dd28f93e931044c400d8R22-R26), [link](https://github.com/web-infra-dev/modern.js/pull/4700/files?diff=unified&w=0#diff-97a08b3bfa45d6684effc3f453ce9309f4ced0be6853dd28f93e931044c400d8R35-R38))
   *  Return early from `getNetworkType` function if not macOS ([link](https://github.com/web-infra-dev/modern.js/pull/4700/files?diff=unified&w=0#diff-97a08b3bfa45d6684effc3f453ce9309f4ced0be6853dd28f93e931044c400d8R22-R26))
   *  Return early from `enableGlobalProxy` function if not macOS ([link](https://github.com/web-infra-dev/modern.js/pull/4700/files?diff=unified&w=0#diff-97a08b3bfa45d6684effc3f453ce9309f4ced0be6853dd28f93e931044c400d8R35-R38))
   *  Add a utility function `isMacOS` to check the `process.platform` property ([link](https://github.com/web-infra-dev/modern.js/pull/4700/files?diff=unified&w=0#diff-97a08b3bfa45d6684effc3f453ce9309f4ced0be6853dd28f93e931044c400d8R5-R6))

## Related Issue

 - https://github.com/web-infra-dev/modern.js/issues/4696

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
