### PR TITLE
feat(builder): improve time logs format

### DIFF
--- a/.changeset/rude-ghosts-reflect.md
+++ b/.changeset/rude-ghosts-reflect.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+feat(builder): improve time logs format
+
+feat(builder): 优化时间日志的格式

--- a/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
@@ -35,7 +35,7 @@ export async function createCompiler({
     if (!stats.hasErrors()) {
       obj.children?.forEach((c, index) => {
         if (c.time) {
-          const time = prettyTime([0, c.time * 10 ** 6], 0);
+          const time = prettyTime([0, c.time * 10 ** 6]);
           const target = Array.isArray(context.target)
             ? context.target[index]
             : context.target;

--- a/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
@@ -1,11 +1,11 @@
 import {
   debug,
   logger,
+  prettyTime,
   formatStats,
   TARGET_ID_MAP,
 } from '@modern-js/builder-shared';
 import type { Context, RspackConfig } from '../types';
-import prettyTime from '@modern-js/builder-shared/pretty-time';
 
 export async function createCompiler({
   context,

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -94,10 +94,6 @@
       "types": "./compiled/postcss-modules-values/index.d.ts",
       "default": "./compiled/postcss-modules-values/index.js"
     },
-    "./pretty-time": {
-      "types": "./compiled/pretty-time/index.d.ts",
-      "default": "./compiled/pretty-time/index.js"
-    },
     "./webpack-merge": {
       "types": "./compiled/webpack-merge/index.d.ts",
       "default": "./compiled/webpack-merge/index.js"
@@ -147,9 +143,6 @@
       ],
       "postcss-modules-values": [
         "./compiled/postcss-modules-values/index.d.ts"
-      ],
-      "pretty-time": [
-        "./compiled/pretty-time/index.d.ts"
       ],
       "webpack-merge": [
         "./compiled/webpack-merge/types/index.d.ts"
@@ -212,7 +205,6 @@
       "./postcss-modules-local-by-default": "./compiled/postcss-modules-local-by-default/index.js",
       "./postcss-modules-scope": "./compiled/postcss-modules-scope/index.js",
       "./postcss-modules-values": "./compiled/postcss-modules-values/index.js",
-      "./pretty-time": "./compiled/pretty-time/index.js",
       "./webpack-merge": "./compiled/webpack-merge/index.js"
     }
   }

--- a/packages/builder/builder-shared/src/index.ts
+++ b/packages/builder/builder-shared/src/index.ts
@@ -32,3 +32,4 @@ export * from './css';
 export * from './minimize';
 export * from './core-js';
 export * from './progress';
+export * from './prettyTime';

--- a/packages/builder/builder-shared/src/prettyTime.ts
+++ b/packages/builder/builder-shared/src/prettyTime.ts
@@ -1,14 +1,21 @@
 import basePrettyTime from '../compiled/pretty-time';
 import chalk from '@modern-js/utils/chalk';
 
-const TIME_REGEXP = /(\d+)([a-zA-Z]+)/;
+const TIME_REGEXP = /([\d.]+)([a-zA-Z]+)/;
 
-export const prettyTime = (time: number | [number, number], digits: number) => {
+export const prettyTime = (time: number | [number, number], digits = 1) => {
   const timeStr: string = basePrettyTime(time, digits);
 
   return timeStr.replace(TIME_REGEXP, (match, p1, p2) => {
     if (p1 && p2) {
-      return `${chalk.bold(p1)} ${p2}`;
+      let time = p1;
+
+      // remove digits of ms time
+      if (p2 === 'ms') {
+        time = Number(time).toFixed(0);
+      }
+
+      return `${chalk.bold(time)} ${p2}`;
     }
     return chalk.bold(match);
   });

--- a/packages/builder/builder-shared/src/prettyTime.ts
+++ b/packages/builder/builder-shared/src/prettyTime.ts
@@ -1,0 +1,11 @@
+import basePrettyTime from '../compiled/pretty-time';
+import chalk from '@modern-js/utils/chalk';
+
+export const prettyTime = (time: number | [number, number], digits: number) => {
+  const timeStr: string = basePrettyTime(time, digits);
+
+  return timeStr.replace(
+    /(\d+)([a-zA-Z]+)/,
+    (match, p1, p2) => `${chalk.bold(p1)} ${p2}`,
+  );
+};

--- a/packages/builder/builder-shared/src/prettyTime.ts
+++ b/packages/builder/builder-shared/src/prettyTime.ts
@@ -1,11 +1,15 @@
 import basePrettyTime from '../compiled/pretty-time';
 import chalk from '@modern-js/utils/chalk';
 
+const TIME_REGEXP = /(\d+)([a-zA-Z]+)/;
+
 export const prettyTime = (time: number | [number, number], digits: number) => {
   const timeStr: string = basePrettyTime(time, digits);
 
-  return timeStr.replace(
-    /(\d+)([a-zA-Z]+)/,
-    (match, p1, p2) => `${chalk.bold(p1)} ${p2}`,
-  );
+  return timeStr.replace(TIME_REGEXP, (match, p1, p2) => {
+    if (p1 && p2) {
+      return `${chalk.bold(p1)} ${p2}`;
+    }
+    return chalk.bold(match);
+  });
 };

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
@@ -1,6 +1,6 @@
 import webpack from 'webpack';
 import { logger } from '@modern-js/utils/logger';
-import prettyTime from '@modern-js/builder-shared/pretty-time';
+import { prettyTime } from '@modern-js/builder-shared';
 import { bus, createFriendlyPercentage } from './helpers';
 import { createNonTTYLogger } from './helpers/nonTty';
 import type { Props } from './helpers/type';

--- a/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
+++ b/packages/builder/builder-webpack-provider/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
@@ -85,7 +85,7 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
     compiler.hooks.done.tap(this.name, stat => {
       if (startTime) {
         this.hasCompileErrors = stat.hasErrors();
-        this.compileTime = prettyTime(process.hrtime(startTime), 0);
+        this.compileTime = prettyTime(process.hrtime(startTime));
         startTime = null;
 
         if (!this.hasCompileErrors) {

--- a/packages/builder/builder/src/plugins/fileSize.ts
+++ b/packages/builder/builder/src/plugins/fileSize.ts
@@ -135,9 +135,11 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
 
   const totalSizeLabel = `${chalk.bold.blue('Total size:')}  ${filesize(
     totalSize,
+    { round: 1 },
   )}`;
   const gzippedSizeLabel = `${chalk.bold.blue('Gzipped size:')}  ${filesize(
     totalGzipSize,
+    { round: 1 },
   )}`;
   logger.log(`\n  ${totalSizeLabel}\n  ${gzippedSizeLabel}\n`);
 }

--- a/packages/document/main-doc/docs/en/components/debug-app.mdx
+++ b/packages/document/main-doc/docs/en/components/debug-app.mdx
@@ -6,7 +6,7 @@ $ pnpm run dev
 > modern dev
 
 info    Starting dev server...
-ready   Client compiled in 50ms
+ready   Client compiled in 50 ms
 
   > Local:    http://localhost:8080/
   > Network:  http://192.168.0.1:8080/

--- a/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
@@ -92,7 +92,7 @@ $ pnpm run build
 > modern build
 
 info    Staring production build...
-ready   Client compiled in 50ms
+ready   Client compiled in 50 ms
 info    Production file sizes:
 
   File                                      Size         Gzipped

--- a/packages/document/main-doc/docs/zh/components/debug-app.mdx
+++ b/packages/document/main-doc/docs/zh/components/debug-app.mdx
@@ -6,7 +6,7 @@ $ pnpm run dev
 > modern dev
 
 info    Starting dev server...
-ready   Client compiled in 50ms
+ready   Client compiled in 50 ms
 
   > Local:    http://localhost:8080/
   > Network:  http://192.168.0.1:8080/

--- a/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
@@ -92,7 +92,7 @@ $ pnpm run build
 > modern build
 
 info    Staring production build...
-ready   Client compiled in 50ms
+ready   Client compiled in 50 ms
 info    Production file sizes:
 
   File                                      Size         Gzipped


### PR DESCRIPTION
## Summary

<img width="581" alt="Screenshot 2023-09-21 at 11 11 51" src="https://github.com/web-infra-dev/modern.js/assets/7237365/e9830981-9d5f-4ccd-b240-6d5ff1b2fea9">


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8639748</samp>

This pull request improves the time logs format for the builder by refactoring the `prettyTime` function and exporting it from the main entry point of the `@modern-js/builder-shared` package. It also updates the imports of `prettyTime` in the other packages that depend on it and adds a changeset file to document the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8639748</samp>

*  Add a changeset file to document the changes to three packages: `@modern-js/builder-webpack-provider`, `@modern-js/builder-rspack-provider`, and `@modern-js/builder-shared` ([link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-16f157a8868056b2a2d7fb1086558c6bad5ec39916576a3d23d36c7d8607d62cR1-R9))
*  Refactor the `prettyTime` function to export it from the main entry point of the `@modern-js/builder-shared` package instead of a subdirectory ([link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L4-R8), [link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L97-L100), [link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L151-L153), [link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L215), [link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-057faf79ac89dea7fb92b571ce15153429a02e0ef592e56170404c7a5ac319e5R35), [link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-b37e5fb8c8109c56fa9b9a837517fde37af30fb9f27d14bb90999154811c14c9L3-R3))
*  Improve the time logs format for the builder by adding color formatting using `chalk` to the `prettyTime` function ([link](https://github.com/web-infra-dev/modern.js/pull/4702/files?diff=unified&w=0#diff-82753a1d4b978105181818922dac8643da628c65a15cb8ec45ca52b637fc7241R1-R15))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
