### PR TITLE
fix(builder): babel not work when using addIncludes

### DIFF
--- a/packages/builder/builder-rspack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/babel.ts
@@ -61,7 +61,10 @@ export const builderPluginBabel = (): BuilderPlugin => ({
             babelUtils,
           );
 
-          const notModify = isEqual(baseConfig, userBabelConfig);
+          const notModify =
+            isEqual(baseConfig, userBabelConfig) &&
+            !includes?.length &&
+            !excludes?.length;
 
           if (notModify) {
             return {};


### PR DESCRIPTION
## Summary

假如rspack的配置为：
```javascript
babel: (config, { addIncludes, removePlugins }) => {
      addIncludes([xxx]);
},
```

下面的notModify会是true，这会导致最后babel没有配置
```javascript
const notModify =
  isEqual(baseConfig, userBabelConfig) &&
    !includes?.length &&
    !excludes?.length;

if (notModify) {
  return {};
}
```

所以应该加上 includes 和 excludes 的配置

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a957c70</samp>

Improve babel plugin performance by skipping transformation if no include or exclude patterns are given. Update `babel.ts` file in `builder-rspack-provider` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a957c70</samp>

*  Skip babel transformation if no include or exclude patterns are provided ([link](https://github.com/web-infra-dev/modern.js/pull/4717/files?diff=unified&w=0#diff-42b824b393afa60dd38acf7a5f7b290dd6ce10a0b5bc08b8ad937cf3c741ba65L64-R67))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
