### PR TITLE
fix(main-doc): fixed ports in MFE docs

### DIFF
--- a/.changeset/tame-jokes-cheer.md
+++ b/.changeset/tame-jokes-cheer.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/main-doc': patch
+---
+
+fix(main-doc): fixed wrong ports in MFE docs

--- a/packages/document/main-doc/docs/en/guides/topic-detail/micro-frontend/c03-main-app.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/micro-frontend/c03-main-app.mdx
@@ -44,12 +44,12 @@ defineConfig(App, {
         return [
           {
             name: 'Table',
-            entry: 'http://localhost:8001',
+            entry: 'http://localhost:8081',
             // activeWhen: '/table'
           },
           {
             name: 'Dashboard',
-            entry: 'http://localhost:8002',
+            entry: 'http://localhost:8082',
             // activeWhen: '/dashboard'
           },
         ];

--- a/packages/document/main-doc/docs/zh/components/micro-runtime-config.mdx
+++ b/packages/document/main-doc/docs/zh/components/micro-runtime-config.mdx
@@ -5,11 +5,11 @@ defineConfig(App, {
   masterApp: {
     apps: [{
       name: 'Table',
-      entry: 'http://localhost:8001',
+      entry: 'http://localhost:8081',
       // activeWhen: '/table'
     }, {
       name: 'Dashboard',
-      entry: 'http://localhost:8002'
+      entry: 'http://localhost:8082'
       // activeWhen: '/dashboard'
     }]
   },

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/micro-frontend/c03-main-app.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/micro-frontend/c03-main-app.mdx
@@ -44,12 +44,12 @@ defineConfig(App, {
         return [
           {
             name: 'Table',
-            entry: 'http://localhost:8001',
+            entry: 'http://localhost:8081',
             // activeWhen: '/table'
           },
           {
             name: 'Dashboard',
-            entry: 'http://localhost:8002',
+            entry: 'http://localhost:8082',
             // activeWhen: '/dashboard'
           },
         ];


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 32ad10f</samp>

This pull request fixes the port numbers for the micro-frontends in the English and Chinese documentation. It also adds a changeset file to document and automate the release process.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 32ad10f</samp>

*  Add changeset file for release automation ([link](https://github.com/web-infra-dev/modern.js/pull/4722/files?diff=unified&w=0#diff-75dbd3beaead7081475217b430c2ee7160d244d030db7f4f77e4958cbf2a8468R1-R5))
*  Fix wrong port numbers for micro-frontends in documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4722/files?diff=unified&w=0#diff-d9ce747e4e710807775ad2318adbc14e5306ab37bf255203cb58095af52f7ed8L47-R52), [link](https://github.com/web-infra-dev/modern.js/pull/4722/files?diff=unified&w=0#diff-da6421c56fe048f3718d5272683b33546ca6875e7a6fec900d5e3d4e159cce50L8-R12), [link](https://github.com/web-infra-dev/modern.js/pull/4722/files?diff=unified&w=0#diff-debb9dd08ff7c463d3d5778c4191705ed5ca0edc32e460844f1936d971d0f0b6L47-R52))

## Related Issue

[Link to issue](https://github.com/web-infra-dev/modern.js/issues/3505)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
