### PR TITLE
fix(plugin-garfish): only override assetPrefix default value

### DIFF
--- a/.changeset/red-hairs-knock.md
+++ b/.changeset/red-hairs-knock.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix(plugin-garfish): only override assetPrefix default value
+
+fix(plugin-garfish): 只对 assetPrefix 的默认值进行覆盖

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -177,8 +177,17 @@ export const garfishPlugin = ({
               const resolveOptions = useResolvedConfigContext();
               if (resolveOptions?.deploy?.microFrontend) {
                 chain.output.libraryTarget('umd');
-                if (
+
+                const DEFAULT_ASSET_PREFIX = '/';
+
+                // Only override assetPrefix when using the default asset prefix,
+                // this allows user or other plugins to set asset prefix.
+                const isUsingDefaultAssetPrefix =
                   !useConfig.dev?.assetPrefix &&
+                  resolveOptions.dev?.assetPrefix === DEFAULT_ASSET_PREFIX;
+
+                if (
+                  isUsingDefaultAssetPrefix &&
                   resolveOptions?.server?.port &&
                   env === 'development'
                 ) {

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -182,9 +182,11 @@ export const garfishPlugin = ({
 
                 // Only override assetPrefix when using the default asset prefix,
                 // this allows user or other plugins to set asset prefix.
+                const resolvedAssetPrefix = resolveOptions.dev?.assetPrefix;
                 const isUsingDefaultAssetPrefix =
                   !useConfig.dev?.assetPrefix &&
-                  resolveOptions.dev?.assetPrefix === DEFAULT_ASSET_PREFIX;
+                  (!resolvedAssetPrefix ||
+                    resolvedAssetPrefix === DEFAULT_ASSET_PREFIX);
 
                 if (
                   isUsingDefaultAssetPrefix &&


### PR DESCRIPTION
## Summary

If some other Modern.js plugin is configuring the `dev.assetPrefix` option, the garfish plugin should not override it.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f388648</samp>

This pull request fixes a bug in the `@modern-js/plugin-garfish` package that caused the assetPrefix to be overridden incorrectly when using the microFrontend deploy option. It adds a changeset file and a condition to check the assetPrefix value before overriding it.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f388648</samp>

* Fix assetPrefix override logic in plugin-garfish ([link](https://github.com/web-infra-dev/modern.js/pull/4725/files?diff=unified&w=0#diff-10bba10d09124276d7e6033e0d3df831808249eb1577603c39e2369625917694L180-R190))
* Add changeset file to document patch update for `@modern-js/plugin-garfish` package ([link](https://github.com/web-infra-dev/modern.js/pull/4725/files?diff=unified&w=0#diff-34ad924f28beb445c9092e1114333a6b705ee11d458d4e034870c1e11df6271aR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
