### PR TITLE
fix(module-tools): move init watcher from onStart hook to createCompiler

### DIFF
--- a/.changeset/red-dolphins-return.md
+++ b/.changeset/red-dolphins-return.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): move init watcher from onStart hook to createCompiler
+fix(module-tools): 将 init watcher 从 onStart 钩子移动到 createCompiler 中

--- a/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
@@ -9,7 +9,6 @@ import { loaderMap } from '../../constants/loader';
 import { debugResolve } from '../../debug';
 import type { SideEffects, ICompiler } from '../../types';
 import { writeFile } from './write-file';
-import { initWatcher } from './watch';
 
 /**
  * esbuld's external will keep import statement as import|require statement, which
@@ -40,10 +39,6 @@ export const adapterPlugin = (compiler: ICompiler): Plugin => {
   return {
     name: 'esbuild:adapter',
     setup(build) {
-      build.onStart(() => {
-        context.watch && initWatcher(compiler);
-      });
-
       build.onResolve({ filter: /.*/ }, async args => {
         if (args.kind === 'url-token') {
           return {

--- a/packages/solutions/module-tools/src/builder/esbuild/index.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/index.ts
@@ -30,6 +30,7 @@ import { TransformContext } from './transform';
 import { SourcemapContext } from './sourcemap';
 import { createRenderChunkHook, createTransformHook } from './hook';
 import { createResolver } from './resolve';
+import { initWatcher } from './watch';
 
 export class EsbuildCompiler implements ICompiler {
   instance?: BuildContext;
@@ -102,6 +103,9 @@ export class EsbuildCompiler implements ICompiler {
   }
 
   async init() {
+    if (this.context.watch) {
+      initWatcher(this);
+    }
     const internal = await getInternalList(this.context);
     const user = this.config.hooks;
     this.hookList = [...user, ...internal];


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87199a3</samp>

This pull request improves the file watching and rebuilding functionality for the `@modern-js/module-tools` package by using the esbuild adapter plugin. It also adds a changeset file to document the patch version update and the fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87199a3</samp>

* Move the initialization of the file watcher from `adapter.ts` to `index.ts` to improve the esbuild builder module ([link](https://github.com/web-infra-dev/modern.js/pull/4733/files?diff=unified&w=0#diff-a99e93a85a25f2e6a158276b6dda938ff69960872fbcf2c32e40e74f236f32e7L12), [link](https://github.com/web-infra-dev/modern.js/pull/4733/files?diff=unified&w=0#diff-a99e93a85a25f2e6a158276b6dda938ff69960872fbcf2c32e40e74f236f32e7L43-L46), [link](https://github.com/web-infra-dev/modern.js/pull/4733/files?diff=unified&w=0#diff-d6189887fb409f30bf3b5e8e4a063f0057cd58e07bd24165b0bf5c4fde675fa9R33), [link](https://github.com/web-infra-dev/modern.js/pull/4733/files?diff=unified&w=0#diff-d6189887fb409f30bf3b5e8e4a063f0057cd58e07bd24165b0bf5c4fde675fa9R300-R302))
* Add a changeset file to document the patch version update and the fix message for the `@modern-js/module-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4733/files?diff=unified&w=0#diff-c2ddbcb5afce60446d8886722c6f967046ad58075142936893d73aed66837c36R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
