### PR TITLE
feat(plugin-runtime): support ssr inline assets

### DIFF
--- a/.changeset/kind-stingrays-knock.md
+++ b/.changeset/kind-stingrays-knock.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': minor
+---
+
+feat(plugin-runtime): support ssr inline assets
+feat(plugin-runtime): 支持 SSR 内联 css, scripts 资源

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -201,6 +201,7 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
             config => config.name === 'client',
           )?.output?.chunkLoadingGlobal;
           const config = api.useResolvedConfigContext();
+          const { enableInlineScripts, enableInlineStyles } = config.output;
           const { crossorigin, scriptLoading } = config.html;
           const disablePrerender =
             typeof config.server?.ssr === 'object'
@@ -215,6 +216,14 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
               scriptLoading,
               chunkLoadingGlobal,
               disablePrerender,
+              enableInlineScripts:
+                typeof enableInlineScripts === 'function'
+                  ? undefined
+                  : enableInlineScripts,
+              enableInlineStyles:
+                typeof enableInlineStyles === 'function'
+                  ? undefined
+                  : enableInlineStyles,
             }),
           });
         }

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/render.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/render.ts
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 
 export interface Collector {
   collect: (comopnent: ReactElement) => ReactElement;
-  effect: () => void;
+  effect: () => void | Promise<void>;
 }
 
 class Render {
@@ -20,7 +20,7 @@ class Render {
     return this;
   }
 
-  finish(): string {
+  async finish(): Promise<string> {
     // collectors do collect
     const App = this.collectors.reduce(
       (pre, collector) => collector.collect(pre),
@@ -31,9 +31,7 @@ class Render {
     const html = ReactDomServer.renderToString(App);
 
     // collectors do effect
-    this.collectors.forEach(component => {
-      component.effect();
-    });
+    await Promise.all(this.collectors.map(component => component.effect()));
 
     return html;
   }

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/types.ts
@@ -20,6 +20,8 @@ export { RuntimeContext, RenderLevel };
 export type SSRPluginConfig = {
   crossorigin?: boolean | 'anonymous' | 'use-credentials';
   scriptLoading?: 'defer' | 'blocking' | 'module';
+  enableInlineStyles?: boolean | RegExp;
+  enableInlineScripts?: boolean | RegExp;
   disablePrerender?: boolean;
   chunkLoadingGlobal?: string;
 } & Exclude<ServerUserConfig['ssr'], boolean>;

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/utils.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/utils.ts
@@ -1,30 +1,9 @@
-import type { ChunkExtractor } from '@loadable/server';
-
 export const CSS_CHUNKS_PLACEHOLDER = '<!--<?- chunksMap.css ?>-->';
 
 export const SSR_DATA_JSON_ID = '__MODERN_SSR_DATA__';
 
 export const ROUTER_DATA_JSON_ID = '__MODERN_ROUTER_DATA__';
 
-export function getLoadableScripts(extractor: ChunkExtractor) {
-  const check = (scripts: string) =>
-    (scripts || '').includes('__LOADABLE_REQUIRED_CHUNKS___ext');
-
-  const scripts = extractor.getScriptTags();
-
-  if (!check(scripts)) {
-    return '';
-  }
-
-  return (
-    scripts
-      .split('</script>')
-      // The first two scripts are essential for Loadable.
-      .slice(0, 2)
-      .map(i => `${i}</script>`)
-      .join('')
-  );
-}
 export function attributesToString(attributes: Record<string, any>) {
   // Iterate through the properties and convert them into a string, only including properties that are not undefined.
   return Object.entries(attributes).reduce((str, [key, value]) => {

--- a/packages/runtime/plugin-runtime/tests/ssr/serverRender/renderToString/render.test.ts
+++ b/packages/runtime/plugin-runtime/tests/ssr/serverRender/renderToString/render.test.ts
@@ -4,7 +4,7 @@ import { createStyledCollector } from '../../../../src/ssr/serverRender/renderTo
 import App from '../../fixtures/string-ssr/App';
 
 describe('test render', () => {
-  it('should render styledComponent correctly', () => {
+  it('should render styledComponent correctly', async () => {
     const result = {
       chunksMap: {
         js: '',
@@ -13,7 +13,7 @@ describe('test render', () => {
       renderLevel: 2,
     };
     const Apps = createElement(App);
-    const html = createRender(Apps)
+    const html = await createRender(Apps)
       .addCollector(createStyledCollector(result))
       .finish();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7837,6 +7837,21 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
 
+  tests/integration/ssr/fixtures/inline:
+    dependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^18
+        version: 18.2.0
+      react-dom:
+        specifier: ^18
+        version: 18.2.0(react@18.2.0)
+
   tests/integration/ssr/fixtures/preload:
     dependencies:
       '@modern-js/app-tools':

--- a/tests/integration/ssr/fixtures/inline/modern.config.ts
+++ b/tests/integration/ssr/fixtures/inline/modern.config.ts
@@ -1,0 +1,15 @@
+import { applyBaseConfig } from '../../../../utils/applyBaseConfig';
+
+process.env.BUNDLER = 'webpack';
+export default applyBaseConfig({
+  server: {
+    ssr: true,
+  },
+  output: {
+    enableInlineStyles: true,
+    enableInlineScripts: /page\./,
+  },
+  runtime: {
+    router: true,
+  },
+});

--- a/tests/integration/ssr/fixtures/inline/package.json
+++ b/tests/integration/ssr/fixtures/inline/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "ssr-inline",
+  "version": "2.9.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "serve": "modern serve"
+  },
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18",
+    "@modern-js/runtime": "workspace:*",
+    "@modern-js/app-tools": "workspace:*"
+  }
+}

--- a/tests/integration/ssr/fixtures/inline/src/routes/index.css
+++ b/tests/integration/ssr/fixtures/inline/src/routes/index.css
@@ -1,0 +1,117 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: PingFang SC, Hiragino Sans GB, Microsoft YaHei, Arial, sans-serif;
+  background: linear-gradient(to bottom, transparent, #fff) #eceeef;
+}
+
+p {
+  margin: 0;
+}
+
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  box-sizing: border-box;
+}
+
+.container-box {
+  min-height: 100vh;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-top: 10px;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.title {
+  display: flex;
+  margin: 4rem 0 4rem;
+  align-items: center;
+  font-size: 4rem;
+  font-weight: 600;
+}
+
+.logo {
+  width: 3.6rem;
+  margin: 0 1.6rem;
+}
+
+.name {
+  background: -webkit-linear-gradient(315deg, #788ec9 25%, #5978c0);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.description {
+  text-align: center;
+  line-height: 1.5;
+  font-size: 1.3rem;
+  color: #1b3a42;
+  margin-bottom: 5rem;
+}
+
+.code {
+  background: #fafafa;
+  border-radius: 12px;
+  padding: 0.6rem 0.9rem;
+  font-size: 1.05rem;
+  font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
+    Bitstream Vera Sans Mono, Courier New, monospace;
+}
+
+.container-box .grid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1100px;
+  margin-top: 3rem;
+}
+
+.card {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100px;
+  color: inherit;
+  text-decoration: none;
+  transition: 0.15s ease;
+  width: 45%;
+}
+
+.card:hover,
+.card:focus {
+  transform: scale(1.05);
+}
+
+.card h2 {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.card p {
+  opacity: 0.6;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-top: 1rem;
+}
+
+.arrow-right {
+  width: 1.3rem;
+  margin-left: 0.5rem;
+  margin-top: 3px;
+}

--- a/tests/integration/ssr/fixtures/inline/src/routes/layout.jsx
+++ b/tests/integration/ssr/fixtures/inline/src/routes/layout.jsx
@@ -1,0 +1,11 @@
+// eslint-disable-next-line no-unused-vars
+import { Outlet } from '@modern-js/runtime/router';
+
+export default function Layout() {
+  return (
+    <div>
+      Root layout
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/ssr/fixtures/inline/src/routes/page.jsx
+++ b/tests/integration/ssr/fixtures/inline/src/routes/page.jsx
@@ -1,0 +1,84 @@
+import './index.css';
+
+const Index = (): JSX.Element => (
+  <div className="container-box">
+    <main>
+      <div className="title">
+        Welcome to
+        <img
+          className="logo"
+          src="https://lf3-static.bytednsdoc.com/obj/eden-cn/nuvshpqnulg/eden-x-logo.png"
+          alt="EdenX Logo"
+        />
+        <p className="name">EdenX</p>
+      </div>
+      <p className="description">
+        Get started by editing <code className="code">src/routes/page.tsx</code>
+      </p>
+      <div className="grid">
+        <a
+          href="https://modernjs.dev/guides/get-started/quick-start.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="card"
+        >
+          <h2>
+            Guide
+            <img
+              className="arrow-right"
+              src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            />
+          </h2>
+          <p>Follow the guides to use all features of EdenX.</p>
+        </a>
+        <a
+          href="https://modernjs.dev/tutorials/foundations/introduction"
+          target="_blank"
+          className="card"
+          rel="noreferrer"
+        >
+          <h2>
+            Tutorials
+            <img
+              className="arrow-right"
+              src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            />
+          </h2>
+          <p>Learn to use EdenX to create your first application.</p>
+        </a>
+        <a
+          href="https://modernjs.dev/configure/app/usage"
+          target="_blank"
+          className="card"
+          rel="noreferrer"
+        >
+          <h2>
+            Config
+            <img
+              className="arrow-right"
+              src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            />
+          </h2>
+          <p>Find all configuration items provided by EdenX.</p>
+        </a>
+        <a
+          href="https://code.byted.org/webinfra/edenx"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="card"
+        >
+          <h2>
+            GitLab
+            <img
+              className="arrow-right"
+              src="https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/arrow-right.svg"
+            />
+          </h2>
+          <p>View the source code of EdenX, feel free to contribute.</p>
+        </a>
+      </div>
+    </main>
+  </div>
+);
+
+export default Index;

--- a/tests/integration/ssr/tests/inline.test.ts
+++ b/tests/integration/ssr/tests/inline.test.ts
@@ -1,0 +1,51 @@
+import dns from 'node:dns';
+import path, { join } from 'path';
+import puppeteer, { Browser, Page } from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchOptions,
+  modernBuild,
+  modernServe,
+} from '../../../utils/modernTestUtils';
+
+const fixtureDir = path.resolve(__dirname, '../fixtures');
+
+dns.setDefaultResultOrder('ipv4first');
+
+describe('Inline SSR', () => {
+  let app: any;
+  let appPort: number;
+  let page: Page;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    const appDir = join(fixtureDir, 'inline');
+    appPort = await getPort();
+
+    await modernBuild(appDir);
+    app = await modernServe(appDir, appPort);
+
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  test('should inline style & js', async () => {
+    await page.goto(`http://localhost:${appPort}`);
+
+    const content = await page.content();
+
+    expect(content).toMatch('.card:hover');
+
+    expect(content).toMatch('t.jsx)("code",');
+  });
+
+  afterAll(async () => {
+    if (browser) {
+      browser.close();
+    }
+    if (app) {
+      await killApp(app);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 20fbd9e</samp>

This pull request adds a new feature to the `@modern-js/runtime` package that allows inlining some script and style assets in the HTML output for SSR rendering. It modifies the `SSRPluginConfig` type, the `ssrPlugin` and `renderToString` functions, and the `RenderToString` and `Render` classes to support the feature. It also adds a test case for the feature in the `tests/integration/ssr` folder, using a fixture app with some configuration options and components. It updates the `.changeset` folder with a markdown file that describes the changes and the version update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 20fbd9e</samp>

*  Add a markdown file to the `.changeset` folder with the changelog and version information for the `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-b166fcd96d22993f8d9ee640cbdf58af3a5ca272247818067c6e419ade5f27b7R1-R6))
*  Add two configuration options for enabling the inline assets feature for the style and script assets in the `SSRPluginConfig` type ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-7bb2b37d7c4c35db7a1d3fbfbd76ed3192cc5ca45a0a749df4661179ad395c32R23-R24))
*  Destructure the configuration options from the `config.output` object and pass them to the `renderToString` function in the `ssrPlugin` function ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5R204), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-bc883842568ba0f6294665702da2a6e3084013a4913e4969cdb767ce9fa157d5R219-R226))
*  Declare and assign a `routeManifest` property to store the route assets information in the `RenderToString` class ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR89-R90), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR100))
*  Change the `renderToString` and `render` methods of the `RenderToString` class to return promises instead of strings and add `await` keywords before the asynchronous function calls ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL126-R129), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL178-R181), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL188-R191), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR201))
*  Pass the `routeManifest` property to the `createLoadableCollector` function in the `renderToString` method of the `RenderToString` class ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eR201))
*  Import some modules and types for the inline assets feature and define some helper functions for filtering and checking the chunk assets in the `loadable.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L1-R2), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409R16-R36))
*  Change the `effect` method of the `LoadableCollector` class to return a promise and replace the original logic of emitting the loadable assets with two separate methods for emitting the script and style assets ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L39-R61), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L45-R158))
*  Add an optional parameter for extra attributes to the `generateAttributes` method of the `LoadableCollector` class ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L104-R171))
*  Add an optional property for the route manifest to the `LoadableCollectorOptions` interface ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409R177))
*  Change the `effect` method of the `Collector` interface and the `finish` method of the `Render` class to return promises and use `Promise.all` to wait for the collectors' effects in the `render.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-2a60a4207bff6c27e1554b1c312fdecade17a7a27a49bf5bf4fb7c05d4a82e93L6-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-2a60a4207bff6c27e1554b1c312fdecade17a7a27a49bf5bf4fb7c05d4a82e93L23-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-2a60a4207bff6c27e1554b1c312fdecade17a7a27a49bf5bf4fb7c05d4a82e93L34-R34))
*  Add a fixture folder for the inline SSR test case with a configuration file, a package file, a style file, a layout component and a page component ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-780a5c7bdb12407d5eb7cfc0ffb6bb1da72ee9e9a9f09f409cf36c495392ac8aR1-R15), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-b03c46ccaaa87c2a92fd19ca3afb0846700b2401e39e2ebfe17e74cf8e9fcfd3R1-R16), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-210a4504953e6e645546bec728744ac8d363192225acb08f41d79caeaac82ddcR1-R117), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-e83e29e6ae2f5811605b153884789ef1d5337371bed4a112d939569ca8aab628R1-R11), [link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-e381f69a502a13d9de9737f12ff00c5e53423faf96cfc8d5012e198a2ba759f0R1-R84))
*  Add a test file for the inline SSR feature that builds, serves and asserts the app with the inline style and script elements ([link](https://github.com/web-infra-dev/modern.js/pull/4735/files?diff=unified&w=0#diff-7d9f76db8fd9f5965f908a66d22b3789d758511a7056adc66b3fdcad1b2b79b3R1-R51))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
