### PR TITLE
feat(builder): use jiti to load config

### DIFF
--- a/.changeset/five-suits-learn.md
+++ b/.changeset/five-suits-learn.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': patch
+---
+
+feat(builder): use jiti to load config
+
+feat(builder): 使用 jiti 来加载配置

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -62,10 +62,10 @@
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/monorepo-utils": "workspace:*",
-    "@modern-js/node-bundle-require": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@svgr/webpack": "8.0.1",
-    "@swc/helpers": "0.5.1"
+    "@swc/helpers": "0.5.1",
+    "jiti": "^1.20.0"
   },
   "devDependencies": {
     "@modern-js/builder-webpack-provider": "workspace:*",

--- a/packages/builder/builder/src/cli/config.ts
+++ b/packages/builder/builder/src/cli/config.ts
@@ -1,7 +1,7 @@
+import jiti from 'jiti';
 import { join } from 'path';
 import { findExists } from '@modern-js/utils';
 import { existsSync } from '@modern-js/utils/fs-extra';
-import { bundleRequire } from '@modern-js/node-bundle-require';
 import type { BuilderEntry, BuilderPlugin } from '@modern-js/builder-shared';
 import type { BuilderConfig as WebpackBuilderConfig } from '@modern-js/builder-webpack-provider';
 import type { BuilderConfig as RspackBuilderConfig } from '@modern-js/builder-rspack-provider';
@@ -22,8 +22,8 @@ export async function loadConfig(): Promise<BuilderConfig> {
   const configFile = join(process.cwd(), 'builder.config.ts');
 
   if (existsSync(configFile)) {
-    const mod = await bundleRequire(configFile);
-    return mod.default || mod;
+    const loadConfig = jiti(__filename, { interopDefault: true });
+    return loadConfig(configFile);
   }
 
   return {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       '@modern-js/monorepo-utils':
         specifier: workspace:*
         version: link:../../toolkit/monorepo-utils
-      '@modern-js/node-bundle-require':
-        specifier: workspace:*
-        version: link:../../toolkit/node-bundle-require
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
@@ -93,6 +90,9 @@ importers:
       '@swc/helpers':
         specifier: 0.5.1
         version: 0.5.1
+      jiti:
+        specifier: ^1.20.0
+        version: 1.20.0
     devDependencies:
       '@modern-js/builder-rspack-provider':
         specifier: workspace:*
@@ -25677,8 +25677,8 @@ packages:
       - ts-node
     dev: true
 
-  /jiti@1.19.3:
-    resolution: {integrity: sha512-5eEbBDQT/jF1xg6l36P+mWGGoH9Spuy0PCdSr2dtWRDGC6ph/w9ZCL4lmESW8f8F7MwT3XKescfP0wnZWAKL9w==}
+  /jiti@1.20.0:
+    resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
     hasBin: true
 
   /jju@1.4.0:
@@ -33262,7 +33262,7 @@ packages:
       fast-glob: 3.3.0
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.19.3
+      jiti: 1.20.0
       lilconfig: 2.1.0
       micromatch: 4.0.5
       normalize-path: 3.0.0


### PR DESCRIPTION
## Summary

Ref: https://github.com/web-infra-dev/rspack/pull/3222

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7051ec8</samp>

This pull request updates the `@modern-js/builder` package to use `jiti` for loading config files. This enhances the performance and compatibility of the builder CLI with different file formats.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7051ec8</samp>

*  Add jiti dependency and use it to load config files for builder CLI ([link](https://github.com/web-infra-dev/modern.js/pull/4754/files?diff=unified&w=0#diff-9cf8545b55c9e3ca88938fac70f48ca84c6f0a1337da7e022df9cc950f831f19L65-R68), [link](https://github.com/web-infra-dev/modern.js/pull/4754/files?diff=unified&w=0#diff-72faeddaedd71d8dd22524ea9ab83fd80ec914976f3eab7601ba628086d3a1a4L1-R4), [link](https://github.com/web-infra-dev/modern.js/pull/4754/files?diff=unified&w=0#diff-72faeddaedd71d8dd22524ea9ab83fd80ec914976f3eab7601ba628086d3a1a4L25-R26))
* Add changeset file to document patch update of `@modern-js/builder` package ([link](https://github.com/web-infra-dev/modern.js/pull/4754/files?diff=unified&w=0#diff-a0fc207bb6683ac6c758e203c51c1f2dbf3c3b98606145f43e19c4bb74a3b35dR1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
