### PR TITLE
docs(module-tools): add tip how to use hook to register module plugin

### DIFF
--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.mdx
@@ -28,6 +28,7 @@ export default defineConfig({
 :::tip
 You can also configure the registration via hooks, for example,
 if you need to bundle two files A and B at the same time and only need to use babel when bundle A:
+
 ```ts
 import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { getBabelHook } from '@modern-js/plugin-module-babel';
@@ -38,14 +39,18 @@ const babelHook = getBabelHook({
 
 export default defineConfig({
   plugins: [moduleTools()],
-  buildConfig: [{
-    hooks: [babelHook],
-    input: ['src/a.ts']
-  }, {
-    input: ['src/b.ts']
-  }],
+  buildConfig: [
+    {
+      hooks: [babelHook],
+      input: ['src/a.ts'],
+    },
+    {
+      input: ['src/b.ts'],
+    },
+  ],
 });
 ```
+
 :::
 
 ## Config

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.mdx
@@ -25,7 +25,6 @@ export default defineConfig({
 });
 ```
 
-:::tip
 You can also configure the registration via hooks, for example,
 if you need to bundle two files A and B at the same time and only need to use babel when bundle A:
 
@@ -50,8 +49,6 @@ export default defineConfig({
   ],
 });
 ```
-
-:::
 
 ## Config
 

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-babel.mdx
@@ -25,6 +25,29 @@ export default defineConfig({
 });
 ```
 
+:::tip
+You can also configure the registration via hooks, for example,
+if you need to bundle two files A and B at the same time and only need to use babel when bundle A:
+```ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { getBabelHook } from '@modern-js/plugin-module-babel';
+
+const babelHook = getBabelHook({
+  // babel options
+});
+
+export default defineConfig({
+  plugins: [moduleTools()],
+  buildConfig: [{
+    hooks: [babelHook],
+    input: ['src/a.ts']
+  }, {
+    input: ['src/b.ts']
+  }],
+});
+```
+:::
+
 ## Config
 
 See [babel options](https://babeljs.io/docs/options).

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.mdx
@@ -31,6 +31,7 @@ export default defineConfig({
 :::tip
 You can also configure registration via hooks, for example,
 if you have multiple build configurations at the same time and only need to inject the polyfill when bundle:
+
 ```ts
 import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { getPolyfillHook } from '@modern-js/plugin-module-polyfill';
@@ -39,14 +40,18 @@ const polyfillHook = getPolyfillHook();
 
 export default defineConfig({
   plugins: [moduleTools()],
-  buildConfig: [{
-    buildType: 'bundle',
-    hooks: [polyfillHook],
-  }, {
-    buildType: 'bundleless',
-  }]
+  buildConfig: [
+    {
+      buildType: 'bundle',
+      hooks: [polyfillHook],
+    },
+    {
+      buildType: 'bundleless',
+    },
+  ],
 });
 ```
+
 :::
 
 ## Config

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.mdx
@@ -28,7 +28,6 @@ export default defineConfig({
 });
 ```
 
-:::tip
 You can also configure registration via hooks, for example,
 if you have multiple build configurations at the same time and only need to inject the polyfill when bundle:
 
@@ -51,8 +50,6 @@ export default defineConfig({
   ],
 });
 ```
-
-:::
 
 ## Config
 

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-polyfill.mdx
@@ -28,6 +28,27 @@ export default defineConfig({
 });
 ```
 
+:::tip
+You can also configure registration via hooks, for example,
+if you have multiple build configurations at the same time and only need to inject the polyfill when bundle:
+```ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { getPolyfillHook } from '@modern-js/plugin-module-polyfill';
+
+const polyfillHook = getPolyfillHook();
+
+export default defineConfig({
+  plugins: [moduleTools()],
+  buildConfig: [{
+    buildType: 'bundle',
+    hooks: [polyfillHook],
+  }, {
+    buildType: 'bundleless',
+  }]
+});
+```
+:::
+
 ## Config
 
 - **Type**

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.mdx
@@ -25,6 +25,28 @@ export default defineConfig({
 });
 ```
 
+:::tip
+你也可以通过 hooks 配置注册，例如你同时需要打包 A，B 两个文件，并只需要在打包 A 时使用 babel：
+```ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { getBabelHook } from '@modern-js/plugin-module-babel';
+
+const babelHook = getBabelHook({
+  // babel options
+});
+
+export default defineConfig({
+  plugins: [moduleTools()],
+  buildConfig: [{
+    hooks: [babelHook],
+    input: ['src/a.ts']
+  }, {
+    input: ['src/b.ts']
+  }],
+});
+```
+:::
+
 ## 配置
 
 See [Babel options](https://babeljs.io/docs/options)

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.mdx
@@ -25,7 +25,6 @@ export default defineConfig({
 });
 ```
 
-:::tip
 你也可以通过 hooks 配置注册，例如你同时需要打包 A，B 两个文件，并只需要在打包 A 时使用 babel：
 
 ```ts
@@ -49,8 +48,6 @@ export default defineConfig({
   ],
 });
 ```
-
-:::
 
 ## 配置
 

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-babel.mdx
@@ -27,6 +27,7 @@ export default defineConfig({
 
 :::tip
 你也可以通过 hooks 配置注册，例如你同时需要打包 A，B 两个文件，并只需要在打包 A 时使用 babel：
+
 ```ts
 import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { getBabelHook } from '@modern-js/plugin-module-babel';
@@ -37,14 +38,18 @@ const babelHook = getBabelHook({
 
 export default defineConfig({
   plugins: [moduleTools()],
-  buildConfig: [{
-    hooks: [babelHook],
-    input: ['src/a.ts']
-  }, {
-    input: ['src/b.ts']
-  }],
+  buildConfig: [
+    {
+      hooks: [babelHook],
+      input: ['src/a.ts'],
+    },
+    {
+      input: ['src/b.ts'],
+    },
+  ],
 });
 ```
+
 :::
 
 ## 配置

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.mdx
@@ -28,7 +28,6 @@ export default defineConfig({
 });
 ```
 
-:::tip
 你也可以通过 hooks 配置注册，例如你同时具有多份构建配置，并只需要在 bundle 构建时注入 polyfill：
 
 ```ts
@@ -50,8 +49,6 @@ export default defineConfig({
   ],
 });
 ```
-
-:::
 
 ## 配置
 

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.mdx
@@ -28,6 +28,26 @@ export default defineConfig({
 });
 ```
 
+:::tip
+你也可以通过 hooks 配置注册，例如你同时具有多份构建配置，并只需要在 bundle 构建时注入 polyfill：
+```ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { getPolyfillHook } from '@modern-js/plugin-module-polyfill';
+
+const polyfillHook = getPolyfillHook();
+
+export default defineConfig({
+  plugins: [moduleTools()],
+  buildConfig: [{
+    buildType: 'bundle',
+    hooks: [polyfillHook],
+  }, {
+    buildType: 'bundleless',
+  }]
+});
+```
+:::
+
 ## 配置
 
 - **类型：**

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-polyfill.mdx
@@ -30,6 +30,7 @@ export default defineConfig({
 
 :::tip
 你也可以通过 hooks 配置注册，例如你同时具有多份构建配置，并只需要在 bundle 构建时注入 polyfill：
+
 ```ts
 import { moduleTools, defineConfig } from '@modern-js/module-tools';
 import { getPolyfillHook } from '@modern-js/plugin-module-polyfill';
@@ -38,14 +39,18 @@ const polyfillHook = getPolyfillHook();
 
 export default defineConfig({
   plugins: [moduleTools()],
-  buildConfig: [{
-    buildType: 'bundle',
-    hooks: [polyfillHook],
-  }, {
-    buildType: 'bundleless',
-  }]
+  buildConfig: [
+    {
+      buildType: 'bundle',
+      hooks: [polyfillHook],
+    },
+    {
+      buildType: 'bundleless',
+    },
+  ],
 });
 ```
+
 :::
 
 ## 配置


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 644bc45</samp>

This pull request updates the documentation of the plugin-babel and plugin-polyfill modules in both English and Chinese. It adds tip sections that explain how to use hooks to customize babel options and polyfill injection for different input files and build types. These changes improve the usability and performance of the module-tools plugin.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 644bc45</samp>

*  Add tip sections to the plugin-babel and plugin-polyfill modules documentation to show how to use hooks for customizing babel options and polyfill injection ([link](https://github.com/web-infra-dev/modern.js/pull/4761/files?diff=unified&w=0#diff-015ddbea17a1131278f5090202ea12232fa99a22e366d3460519bdf7c35437d6R28-R50), [link](https://github.com/web-infra-dev/modern.js/pull/4761/files?diff=unified&w=0#diff-344f8be82c1c135925e0bddf30da496f29274891202911ea6dbf755adc8d7dbfR31-R51), [link](https://github.com/web-infra-dev/modern.js/pull/4761/files?diff=unified&w=0#diff-d32cb4722df8f07e22ac50a5961a377e073b47e8e92e576782959ba9fcc39106R28-R49), [link](https://github.com/web-infra-dev/modern.js/pull/4761/files?diff=unified&w=0#diff-d2bd9626458d50f293568f18448746c71c2e858452e9894ccdf1477f754f05b7R31-R50))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
