### PR TITLE
fix(app-tools): align resolve.modules config in rspack mode

### DIFF
--- a/.changeset/perfect-dolphins-begin.md
+++ b/.changeset/perfect-dolphins-begin.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-shared': patch
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): align resolve.modules config in rspack mode
+
+fix(app-tools): 对齐 rspack 模式下的 resolve.modules 配置

--- a/packages/builder/builder-shared/src/types/bundlerConfig.ts
+++ b/packages/builder/builder-shared/src/types/bundlerConfig.ts
@@ -38,6 +38,7 @@ type RspackResolve = {
   conditionNames?: string[];
   alias?: Record<string, false | string | string[]>;
   tsConfigPath?: string;
+  modules?: string[];
   fallback?: Record<string, false | string>;
 };
 

--- a/packages/solutions/app-tools/src/builder/builder-webpack/adapterModern.ts
+++ b/packages/solutions/app-tools/src/builder/builder-webpack/adapterModern.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { BuilderPlugin } from '@modern-js/builder-shared';
 import type { BuilderPluginAPI } from '@modern-js/builder-webpack-provider';
 import { BuilderOptions } from '../shared';
@@ -16,11 +15,6 @@ export const builderPluginAdapterModern = (
     const { normalizedConfig: modernConfig, appContext } = options;
 
     api.modifyWebpackChain((chain, { CHAIN_ID }) => {
-      // compat modern-js v1
-      chain.resolve.modules
-        .add('node_modules')
-        .add(join(api.context.rootPath, 'node_modules'));
-
       // apply copy plugin
       if (chain.plugins.has(CHAIN_ID.PLUGIN.COPY)) {
         const defaultCopyPattern = createPublicPattern(

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { BuilderPlugin, BundlerChain } from '@modern-js/builder-shared';
 import type { BuilderPluginAPI } from '../types';
 
@@ -34,6 +35,12 @@ export const builderPluginAdapterBasic =
             .use('server-module-loader')
             .loader(require.resolve('../loaders/serverModuleLoader'));
         }
+
+        // compat modern-js v1
+        // this helps symlinked packages to resolve packages correctly, such as `react/jsx-runtime`.
+        chain.resolve.modules
+          .add('node_modules')
+          .add(path.join(api.context.rootPath, 'node_modules'));
       });
     },
   });


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 445b279</samp>

This pull request improves the webpack and rspack bundler modes for modern.js by removing unused code, adding missing configuration options, and fixing compatibility issues. It also adds a changeset file to document the patch updates for two affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 445b279</samp>

*  Add a changeset file to document the patch updates and the fix for the `resolve.modules` configuration in the `rspack` mode ([link](https://github.com/web-infra-dev/modern.js/pull/4762/files?diff=unified&w=0#diff-b640e6e3bdcb0a6a33368d056a91fa694cea49f4f7c16c6df74583400c9240e8R1-R8))
*  Add a new `modules` property to the `RspackResolve` type to allow specifying custom directories for module resolution ([link](https://github.com/web-infra-dev/modern.js/pull/4762/files?diff=unified&w=0#diff-7c4255fe8725aa72645e91fca27ec3e6257351046a3c8d55201ddc01c92c793eR41))
*  Remove the unused `join` import from the `adapterModern.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4762/files?diff=unified&w=0#diff-cbc46c31348c89a66f74badb7f3d7f0f41d0f8c6ba5cb58a636bdac612806912L1))
*  Remove the code that adds the `node_modules` directories to the `resolve.modules` option in the modern mode, as it is now handled by the `rspack` mode ([link](https://github.com/web-infra-dev/modern.js/pull/4762/files?diff=unified&w=0#diff-cbc46c31348c89a66f74badb7f3d7f0f41d0f8c6ba5cb58a636bdac612806912L19-L23))
*  Add the `path` import to the `adapterBasic.ts` file ([link](https://github.com/web-infra-dev/modern.js/pull/4762/files?diff=unified&w=0#diff-3c92eced88a6ce733ef5fc97a8bcc79c3b8d0c603c8c14a8c2590a822c58c2c6R1))
*  Add the code that adds the `node_modules` directories to the `resolve.modules` option in the basic mode, for compatibility with modern.js v1 ([link](https://github.com/web-infra-dev/modern.js/pull/4762/files?diff=unified&w=0#diff-3c92eced88a6ce733ef5fc97a8bcc79c3b8d0c603c8c14a8c2590a822c58c2c6R38-R43))

## Related Issue

https://github.com/web-infra-dev/rspack/pull/4290

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
