### PR TITLE
fix(module): change transform options to make sourcemap correct

### DIFF
--- a/.changeset/green-bags-remember.md
+++ b/.changeset/green-bags-remember.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-module-babel': patch
+'@modern-js/module-tools': patch
+---
+
+fix: sourcemap
+fix: 修复 sourcemap

--- a/packages/module/plugin-module-babel/src/index.ts
+++ b/packages/module/plugin-module-babel/src/index.ts
@@ -16,7 +16,6 @@ export const getBabelHook = (options?: BabelTransformOptions) => ({
       if (isJsExt(args.path) || isJsLoader(args.loader)) {
         const result = await require('@babel/core').transformAsync(args.code, {
           filename: args.path,
-          sourceFileName: args.path,
           sourceMaps: Boolean(compiler.config.sourceMap),
           sourceType: 'unambiguous',
           inputSourceMap: false,

--- a/packages/solutions/module-tools/src/builder/feature/swc.ts
+++ b/packages/solutions/module-tools/src/builder/feature/swc.ts
@@ -1,3 +1,4 @@
+import { basename } from 'path';
 import type { TransformConfig, JscTarget } from '@modern-js/swc-plugins';
 import { Compiler } from '@modern-js/swc-plugins';
 import type { ICompiler, Source, TsTarget, ITsconfig } from '../../types';
@@ -78,7 +79,6 @@ export const swcTransform = (userTsconfig: ITsconfig) => ({
           const { target, jsx } = compiler.config;
 
           const swcCompilerOptions: TransformConfig = {
-            filename: path,
             sourceMaps: Boolean(compiler.config.sourceMap),
             inputSourceMap: false,
             swcrc: false,
@@ -119,7 +119,10 @@ export const swcTransform = (userTsconfig: ITsconfig) => ({
           };
 
           const swcCompiler = new Compiler(swcCompilerOptions);
-          const result = await swcCompiler.transform(path, source.code);
+          const result = await swcCompiler.transform(
+            basename(path),
+            source.code,
+          );
           return {
             ...source,
             code: result.code,
@@ -148,7 +151,6 @@ export const swcRenderChunk = {
               ? umdModuleName(chunk.fileName)
               : umdModuleName;
           const swcCompiler = new Compiler({
-            filename: name,
             sourceMaps: Boolean(compiler.config.sourceMap),
             inputSourceMap: false,
             swcrc: false,

--- a/tests/integration/module/fixtures/build/sourceMap/__snapshots__/sourceMap.test.ts.snap
+++ b/tests/integration/module/fixtures/build/sourceMap/__snapshots__/sourceMap.test.ts.snap
@@ -39,3 +39,28 @@ export const debug = str => addPrefix('DEBUG:', str);
   "version": 3,
 }
 `;
+
+exports[`sourcemap usage sourcemap with swc 1`] = `
+{
+  "mappings": ";;;;;;;;;;;;;;;;;;;AAAA;;;;;;;ACAO,IAAMA,YAAY,CAACC,QAAQC,QAAQ,GAAGD,UAAUC;;;ADEhD,IAAMC,QAAQD,SAAOF,UAAU,UAAUE;",
+  "names": [
+    "addPrefix",
+    "prefix",
+    "str",
+    "debug",
+  ],
+  "sources": [
+    "../../src/index.js",
+    "../../src/utils.js",
+  ],
+  "sourcesContent": [
+    "import { addPrefix } from './utils';
+
+export const debug = str => addPrefix('DEBUG:', str);
+",
+    "export const addPrefix = (prefix, str) => \`\${prefix}:\${str}\`;
+",
+  ],
+  "version": 3,
+}
+`;

--- a/tests/integration/module/fixtures/build/sourceMap/sourceMap.test.ts
+++ b/tests/integration/module/fixtures/build/sourceMap/sourceMap.test.ts
@@ -22,6 +22,24 @@ describe('sourcemap usage', () => {
     expect(JSON.parse(content)).toMatchSnapshot();
   });
 
+  it('sourcemap with swc', async () => {
+    const configFile = path.join(fixtureDir, './swc.ts');
+    await runCli({
+      argv: ['build'],
+      configFile,
+      appDirectory: fixtureDir,
+    });
+    const distSourceMapFilePath = path.join(
+      fixtureDir,
+      './dist/swc/index.js.map',
+    );
+    expect(await fs.pathExists(distSourceMapFilePath)).toBe(true);
+    const content = fs.readFileSync(distSourceMapFilePath, 'utf-8');
+    const map = JSON.parse(content);
+    expect(map).toMatchSnapshot();
+    expect(map.sources[0]).toBe('../../src/index.js');
+  });
+
   it('sourcemap is false', async () => {
     const configFile = path.join(fixtureDir, './false.ts');
     await runCli({

--- a/tests/integration/module/fixtures/build/sourceMap/swc.ts
+++ b/tests/integration/module/fixtures/build/sourceMap/swc.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    sourceMap: true,
+    outDir: './dist/swc',
+    transformLodash: true,
+  },
+});

--- a/tests/integration/module/plugins/babel/babel.test.ts
+++ b/tests/integration/module/plugins/babel/babel.test.ts
@@ -15,6 +15,11 @@ describe('plugin-babel', () => {
       path.resolve(__dirname, 'dist/index.js'),
       'utf8',
     );
+    const map = fs.readFileSync(
+      path.resolve(__dirname, 'dist/index.js.map'),
+      'utf8',
+    );
     expect(outFile).toContain('_regeneratorRuntime');
+    expect(JSON.parse(map).sources[0]).toBe('../src/index.js');
   });
 });

--- a/tests/integration/module/plugins/babel/modern.config.ts
+++ b/tests/integration/module/plugins/babel/modern.config.ts
@@ -4,6 +4,7 @@ import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 export default defineConfig({
   buildConfig: {
     input: ['./src/index.js'],
+    sourceMap: true,
   },
 
   plugins: [


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a3ac02</samp>

This pull request fixes the sourcemap generation for the module builder and the babel plugin by using only the file name instead of the full file path. It also updates the changeset file and the documentation to reflect the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a3ac02</samp>

*  Remove `sourceFileName` and `filename` options from babel and swc transformations to fix sourcemap issue ([link](https://github.com/web-infra-dev/modern.js/pull/4765/files?diff=unified&w=0#diff-f8fa9c790144a806bdbf089a240f9b7765ad0acef0a27750a763b8598f1ac110L19), [link](https://github.com/web-infra-dev/modern.js/pull/4765/files?diff=unified&w=0#diff-13578b7cc93a2e5d81f173da770a28a035eb13ea36a6efa8612752e5c289ac47L81), [link](https://github.com/web-infra-dev/modern.js/pull/4765/files?diff=unified&w=0#diff-13578b7cc93a2e5d81f173da770a28a035eb13ea36a6efa8612752e5c289ac47L122-R125), [link](https://github.com/web-infra-dev/modern.js/pull/4765/files?diff=unified&w=0#diff-13578b7cc93a2e5d81f173da770a28a035eb13ea36a6efa8612752e5c289ac47L151))
*  Import `basename` function from `path` module and use it to pass file name instead of file path to swc compiler ([link](https://github.com/web-infra-dev/modern.js/pull/4765/files?diff=unified&w=0#diff-13578b7cc93a2e5d81f173da770a28a035eb13ea36a6efa8612752e5c289ac47R1), [link](https://github.com/web-infra-dev/modern.js/pull/4765/files?diff=unified&w=0#diff-13578b7cc93a2e5d81f173da770a28a035eb13ea36a6efa8612752e5c289ac47L122-R125))
*  Update changeset file to indicate patch-level changes for `@modern-js/plugin-module-babel` and `@modern-js/module-tools` packages and add brief description in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4765/files?diff=unified&w=0#diff-5271766f5f092ca6c89ca598dc394b012446cbe006c752de54d35607e28c04c7R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
