### PR TITLE
chore(app-tools): remove afterDev hook judgment to ensure environment…

### DIFF
--- a/.changeset/large-schools-ring.md
+++ b/.changeset/large-schools-ring.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+chore(app-tools): remove afterDev hook tty judgment to ensure development and testing environments are consistent
+chore(app-tools): 移除 afterDev hook tty 判断来确保开发、测试环境行为一致

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -190,12 +190,10 @@ export default ({
 
           builder.onDevCompileDone(async ({ isFirstCompile }) => {
             const hookRunners = api.useHookRunners();
-            if (process.stdout.isTTY || isFirstCompile) {
-              hookRunners.afterDev({ isFirstCompile });
+            hookRunners.afterDev({ isFirstCompile });
 
-              if (isFirstCompile) {
-                printInstructions(hookRunners, appContext, normalizedConfig);
-              }
+            if (isFirstCompile) {
+              printInstructions(hookRunners, appContext, normalizedConfig);
             }
           });
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6f8d56</samp>

This pull request removes the `process.stdout.isTTY` check from the `afterDev` hook in the `@modern-js/app-tools` package, so that the hook is always run and displays some information and tips after the development server is started. This improves the consistency and predictability of the development and testing environments.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6f8d56</samp>

* Remove TTY check before running `afterDev` hook to display information and tips after development server is compiled ([link](https://github.com/web-infra-dev/modern.js/pull/4768/files?diff=unified&w=0#diff-08de4d272da3558877a7cb513b2101a7e5ce5d1669655890ab7cfff090e2c00eR1-R6),[link](https://github.com/web-infra-dev/modern.js/pull/4768/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L193-R196))
  * Update changelog for `@modern-js/app-tools` package with patch version bump and change description in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4768/files?diff=unified&w=0#diff-08de4d272da3558877a7cb513b2101a7e5ce5d1669655890ab7cfff090e2c00eR1-R6))
  * Delete `process.stdout.isTTY` condition from `onDevCompileDone` callback in `analyze` module of `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4768/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L193-R196))
  * Keep `isFirstCompile` flag to control if information and tips are printed only once or every time code changes ([link](https://github.com/web-infra-dev/modern.js/pull/4768/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L193-R196))
  * Ensure consistency and predictability of development and testing environments by always running `afterDev` hook regardless of output device ([link](https://github.com/web-infra-dev/modern.js/pull/4768/files?diff=unified&w=0#diff-08de4d272da3558877a7cb513b2101a7e5ce5d1669655890ab7cfff090e2c00eR1-R6),[link](https://github.com/web-infra-dev/modern.js/pull/4768/files?diff=unified&w=0#diff-c9c4ee1419dfa997f254f0c64a909255e47cd07a1c50a287c441bebfe8decba1L193-R196))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
