### PR TITLE
fix(module-tools): output can rewrite in watch mode

### DIFF
--- a/.changeset/hungry-planes-fix.md
+++ b/.changeset/hungry-planes-fix.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix: output don't update in watch mode
+fix: watch 模式下产物不更新

--- a/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
@@ -39,6 +39,9 @@ export const adapterPlugin = (compiler: ICompiler): Plugin => {
   return {
     name: 'esbuild:adapter',
     setup(build) {
+      build.onStart(async () => {
+        compiler.outputChunk = new Map();
+      });
       build.onResolve({ filter: /.*/ }, async args => {
         if (args.kind === 'url-token') {
           return {


### PR DESCRIPTION

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23d3bb2</samp>

This pull request fixes a bug in the `@modern-js/module-tools` package that prevented the output files from updating in watch mode. It adds a changeset file to document the fix and updates the `writeFile` function in the `esbuild` builder module.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23d3bb2</samp>

*  Add a changeset file to document the fixes for `@modern-js/module-tools` ([link](https://github.com/web-infra-dev/modern.js/pull/4771/files?diff=unified&w=0#diff-a569c976dc1964b1599a51cd618016c474a6f658a2f5614335ff697daaeb18b7R1-R6))
*  Fix the output files not updating in watch mode by creating a new map object from the output chunk object in the `writeFile` function of the `esbuild` builder module ([link](https://github.com/web-infra-dev/modern.js/pull/4771/files?diff=unified&w=0#diff-738f9d3096a69d42de894401d0c88f2c1f705346fd278007ce346d25e6ed7857L68-R68))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
