### PR TITLE
fix(app-tools): router plugin should filter mf entry

### DIFF
--- a/.changeset/fair-dolphins-give.md
+++ b/.changeset/fair-dolphins-give.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): router plugin should filter mf entry
+fix(app-tools): 路由插件需要过滤 MF 入口

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -205,7 +205,10 @@ export class RouterPlugin {
           };
 
           const entryNames = Array.from(compilation.entrypoints.keys());
-          const entryChunks = this.getEntryChunks(compilation, chunks);
+          const orignalEntryIds = Object.keys(compilation.options.entry);
+          const entryChunks = this.getEntryChunks(compilation, chunks).filter(
+            chunk => orignalEntryIds.includes(chunk.id as string),
+          );
           const entryChunkFiles = this.getEntryChunkFiles(entryChunks);
 
           const entryChunkFileIds = entryChunks.map(chunk => chunk.id);

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -205,7 +205,17 @@ export class RouterPlugin {
           };
 
           const entryNames = Array.from(compilation.entrypoints.keys());
-          const orignalEntryIds = Object.keys(compilation.options.entry);
+          const orignalEntryIds = Object.keys(compilation.options.entry).map(
+            entryName => {
+              const chunk = compilation.namedChunks.get(
+                entryName,
+              ) as webpack.Chunk;
+              if (chunk) {
+                return chunk.id;
+              }
+              return entryName;
+            },
+          );
           const entryChunks = this.getEntryChunks(compilation, chunks).filter(
             chunk => orignalEntryIds.includes(chunk.id as string),
           );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 67a1557</samp>

This pull request fixes a bug in the `RouterPlugin` of the `@modern-js/app-tools` package that caused conflicts with micro-frontend entry chunks. It also adds a changeset file to document the patch updates.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 67a1557</samp>

*  Filter out MF entry chunks from router manifest to avoid unnecessary requests and errors ([link](https://github.com/web-infra-dev/modern.js/pull/4773/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L208-R211))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
