### PR TITLE
chore: use pnpm@8.9 in corepack

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,3 @@ registry = 'https://registry.npmjs.org/'
 
 link-workspace-packages=false
 strict-peer-dependencies=false
-resolution-mode=highest

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "engines": {
     "node": ">=14.17.6",
-    "pnpm": ">=8.0.0 <=8.6.1"
+    "pnpm": ">=8.7.0 <9"
   },
-  "packageManager": "pnpm@8.6.1",
+  "packageManager": "pnpm@8.9.0",
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"


### PR DESCRIPTION
This PR brings:

- Ensure to use `﻿pnpm@>=8.7` to adopt the highest resolution by default.
- Experiment with `﻿pnpm@8.9` in CI to evaluate if it can reduce the linking time by CoW during installation.