### PR TITLE
fix(utils): bump rslog@1.1.0 to fix color support detection

### DIFF
--- a/.changeset/twelve-zoos-sort.md
+++ b/.changeset/twelve-zoos-sort.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+fix(utils): bump rslog@1.1.0 to fix color support detection
+
+fix(utils): 升级 rslog@1.1.0 并修复 color 支持检测

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -217,7 +217,7 @@
   "dependencies": {
     "caniuse-lite": "^1.0.30001520",
     "lodash": "^4.17.21",
-    "rslog": "^1.0.0",
+    "rslog": "^1.1.0",
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5218,8 +5218,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       rslog:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@modern-js/types':
         specifier: workspace:*
@@ -14459,7 +14459,7 @@ packages:
       '@modern-js/builder': link:packages/builder/builder
       '@modern-js/builder-rspack-provider': link:packages/builder/builder-rspack-provider
       chalk: 4.1.2
-      rslog: 1.0.0
+      rslog: 1.1.0
       unified: 10.1.2
     dev: true
 
@@ -31748,8 +31748,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rslog@1.0.0:
-    resolution: {integrity: sha512-yTulfJJIYHBftErlZZXHdZuFA8275spDcTrCs8JIXIh+wRIRgi6RGoT8MAnB8H6NIEvJbMUP14Mo1t7hCw4k1g==}
+  /rslog@1.1.0:
+    resolution: {integrity: sha512-wtTijPuwUhyVG7YvnIVzlefhlto4qJ9vm42ewwJtqrOBP/vKdZCIyfiYm0odVCR3ajR1CIUqaloIzbqhlbyaZA==}
     engines: {node: '>=14.17.6'}
 
   /rspack-manifest-plugin@5.0.0-alpha0(webpack@5.88.1):


### PR DESCRIPTION
## Summary

Ref: https://github.com/rspack-contrib/rslog/releases/tag/v1.1.0

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c92d56b</samp>

This pull request updates the `@modern-js/utils` package to fix a logging issue with color support detection. It adds a changeset file and updates the `rslog` dependency version in the `package.json` file.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c92d56b</samp>

* Patch `@modern-js/utils` package to fix color support detection for `rslog` dependency (.changeset/twelve-zoos-sort.md, [link](https://github.com/web-infra-dev/modern.js/pull/4786/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L220-R220))
* Update `rslog` version to `1.1.0` in `package.json` of `@modern-js/utils` ([link](https://github.com/web-infra-dev/modern.js/pull/4786/files?diff=unified&w=0#diff-0801e4274ee8cfc5154b2775f3ed84ad407a0d44fc0b1524e794f9786073c478L220-R220))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
