### PR TITLE
fix: release install command to update lock file

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -49,7 +49,7 @@ jobs:
         run: RSBUILD_VERSION=nightly pnpm run update-rsbuild
 
       - name: Install Dependencies && Build
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Release
         uses: web-infra-dev/actions@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         run: pnpm run update-rsbuild
 
       - name: Install Dependencies && Build
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Release
         uses: web-infra-dev/actions@v2


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60b37ff</samp>

Added `--no-frozen-lockfile` option to `pnpm install` commands in both release workflows. This allows testing and releasing the latest dependencies.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60b37ff</samp>

*  Allow pnpm to update lockfile when installing dependencies for release workflows ([link](https://github.com/web-infra-dev/modern.js/pull/4792/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L52-R52), [link](https://github.com/web-infra-dev/modern.js/pull/4792/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L117-R117))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
