### PR TITLE
fix(module-tools): remove baseUrl in tsconfig path plugin

### DIFF
--- a/.changeset/giant-squids-doubt.md
+++ b/.changeset/giant-squids-doubt.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): remove baseUrl in tsconfig path plugin, respect custom tsconfig
+fix(module-tools): 移除 tsconfig path 插件里的 baseUrl 配置，尊重自定义 tsconfig 里的配置

--- a/packages/solutions/module-tools/src/builder/esbuild/resolve.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/resolve.ts
@@ -19,7 +19,6 @@ function createEnhancedResolve(options: ResolverOptions): {
   if (fs.existsSync(tsconfig)) {
     plugins.push(
       new TsconfigPathsPlugin({
-        baseUrl: options.root,
         configFile: tsconfig,
       }),
     );


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 346b17d</samp>

This pull request fixes two issues related to the tsconfig path plugin in the `@modern-js/module-tools` package. It removes the `baseUrl` option from the plugin constructor in `resolve.ts` and adds a changeset file to document the patch version update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 346b17d</samp>

* Fix tsconfig path plugin issues for `@modern-js/module-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4794/files?diff=unified&w=0#diff-77b0eede26f9d941f45e0045277dbc9cbb3c10af534fe158d5d407f326dfac81R1-R6))
  - Remove `baseUrl` option from plugin constructor to avoid conflicts with custom tsconfig files ([link](https://github.com/web-infra-dev/modern.js/pull/4794/files?diff=unified&w=0#diff-185ad5af2c9ddfb773a93dd1d77f9c812009c3730f55d8c373420b7687fe0f72L22))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
