### PR TITLE
fix(builder-cli): load provider based on package.json

### DIFF
--- a/.changeset/wild-zoos-type.md
+++ b/.changeset/wild-zoos-type.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': patch
+---
+
+fix(builder-cli): load provider based on package.json
+
+fix(builder-cli): 优先基于 package.json 加载 provider

--- a/packages/builder/builder/src/cli/provider.ts
+++ b/packages/builder/builder/src/cli/provider.ts
@@ -1,13 +1,27 @@
 import { RSPACK_PROVIDER, WEBPACK_PROVIDER } from '@modern-js/builder-shared';
-import { isPackageInstalled } from '@modern-js/utils';
+import { fs, isPackageInstalled } from '@modern-js/utils';
+import path from 'path';
 
 export function getProviderType() {
   const root = process.cwd();
+  const pkgJsonPath = path.join(root, 'package.json');
+  const pkgJson = fs.readJSONSync(pkgJsonPath);
+  const deps = {
+    ...pkgJson.dependencies,
+    ...pkgJson.devDependencies,
+  };
+
+  // Judging based on package.json, this is more accurate
+  if (deps[RSPACK_PROVIDER]) {
+    return 'rspack';
+  }
+  if (deps[WEBPACK_PROVIDER]) {
+    return 'webpack';
+  }
 
   if (isPackageInstalled(RSPACK_PROVIDER, root)) {
     return 'rspack';
   }
-
   if (isPackageInstalled(WEBPACK_PROVIDER, root)) {
     return 'webpack';
   }


### PR DESCRIPTION
## Summary

The `isPackageInstalled` method may get incorrect result in monorepo, so we prefer to load provider based on package.json.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
