### PR TITLE
docs: add esbuild isolated modules links

### DIFF
--- a/packages/document/module-doc/docs/en/guide/advance/in-depth-about-build.md
+++ b/packages/document/module-doc/docs/en/guide/advance/in-depth-about-build.md
@@ -26,7 +26,7 @@ They have their own benefits.
 - bundleless maintains the original file structure and is more conducive to debugging and tree shaking.
 
 :::warning
-bundleless is a single file compilation mode, so for type references and exports you need to add the `type` field, e.g. `import type { A } from '. /types`
+bundleless is a single-file compilation mode, so for referencing and exporting types, you need to add the `type` keyword. For example, `import type { A } from './types'`. Please refer to the [esbuild documentation](https://esbuild.github.io/content-types/#isolated-modules) for more information.
 :::
 
 In `buildConfig` you can specify whether the current build task is bundle or bundleless by using [`buildConfig.buildType`](/en/api/config/build-config#buildtype).

--- a/packages/document/module-doc/docs/zh/guide/advance/in-depth-about-build.md
+++ b/packages/document/module-doc/docs/zh/guide/advance/in-depth-about-build.md
@@ -26,7 +26,7 @@ sidebar_position: 1
 - bundleless 则是可以保持原有的文件结构，更有利于调试和 tree shaking。
 
 :::warning
-bundleless 是单文件编译模式，因此对于类型的引用和导出你需要加上 `type` 字段， 例如 `import type { A } from './types`
+bundleless 是单文件编译模式，因此对于类型的引用和导出你需要加上 `type` 字段， 例如 `import type { A } from './types`，背景参考 [esbuild 文档](https://esbuild.github.io/content-types/#isolated-modules)。
 :::
 
 在 `buildConfig` 中可以通过 [`buildConfig.buildType`](/api/config/build-config#buildtype) 来指定当前构建任务是 bundle 还是 bundleless。


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68e8985</samp>

Updated the warning message in the `in-depth-about-build.md` file for both English and Chinese documentation to include a link to the esbuild documentation. This change helps users understand the isolated modules feature and the use of the `type` keyword for bundleless mode.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 68e8985</samp>

*  Update warning message about bundleless mode and `type` keyword in English and Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4801/files?diff=unified&w=0#diff-8eb479c99689dc1073e91bf9c7e830785792286a4d7e70967e650b1a71d2e571L29-R29), [link](https://github.com/web-infra-dev/modern.js/pull/4801/files?diff=unified&w=0#diff-81499f5d7ce55a454ea9ed297c8453a107c47b7a1a4f22d3b1302fa72076ec59L29-R29))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
