### PR TITLE
fix(module-tools): catch rebaseUrl error which break the build

### DIFF
--- a/.changeset/giant-penguins-poke.md
+++ b/.changeset/giant-penguins-poke.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): catch rebaseUrl error which break the build
+fix(module-tools): 捕获会破坏整个构建的 rebaseUrl 错误

--- a/packages/solutions/module-tools/src/builder/feature/style/utils.ts
+++ b/packages/solutions/module-tools/src/builder/feature/style/utils.ts
@@ -66,20 +66,25 @@ export async function rebaseUrls(
   if (!cssUrlRE.test(content)) {
     return { file };
   }
-  const rebased = await rewriteCssUrls(
-    content,
-    path.extname(file).slice(1),
-    url => {
-      if (url.startsWith('/')) {
-        return url;
-      }
-      return resolver(url, fileDir);
-    },
-  );
-  return {
-    file,
-    contents: rebased,
-  };
+  try {
+    // FIXME: use ast match instead of reg match
+    const rebased = await rewriteCssUrls(
+      content,
+      path.extname(file).slice(1),
+      url => {
+        if (url.startsWith('/')) {
+          return url;
+        }
+        return resolver(url, fileDir);
+      },
+    );
+    return {
+      file,
+      contents: rebased,
+    };
+  } catch (e) {
+    return { file };
+  }
 }
 
 export function rewriteCssUrls(


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 245eaea</samp>

This pull request fixes a bug in the `@modern-js/module-tools` package that could cause the build process to fail when rebasing CSS URLs. It also adds a changeset file to document the patch version update and the fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 245eaea</samp>

*  Document the patch version update and the fix message for the `@modern-js/module-tools` package in a changeset file ([link](https://github.com/web-infra-dev/modern.js/pull/4802/files?diff=unified&w=0#diff-c5d9c920f4cb7e299ba2ed121bbb5b048affa86b017ad705081b690a895d1b5aR1-R6))
*  Catch any errors from rebasing the URLs in the CSS files and add a FIXME comment to suggest an AST-based solution ([link](https://github.com/web-infra-dev/modern.js/pull/4802/files?diff=unified&w=0#diff-969e44e1fcd0fe0f91feab7f20633aeca949ec1e38d35306999261d536dc7f50L69-R87))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
