### PR TITLE
docs: correct content about disableHtmlFolder API

### DIFF
--- a/.changeset/curly-snakes-rule.md
+++ b/.changeset/curly-snakes-rule.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-doc': patch
+---
+
+fix: correct content about disableHtmlFolder API
+fix: 更正 disableHtmlFolder API 的内容

--- a/packages/document/builder-doc/docs/en/guide/basic/output-files.md
+++ b/packages/document/builder-doc/docs/en/guide/basic/output-files.md
@@ -134,8 +134,10 @@ export default {
       css: '',
       html: '',
     },
-    disableHtmlFolder: true,
   },
+  html: {
+    disableHtmlFolder: true,
+  }
 };
 ```
 

--- a/packages/document/builder-doc/docs/zh/guide/basic/output-files.md
+++ b/packages/document/builder-doc/docs/zh/guide/basic/output-files.md
@@ -134,6 +134,8 @@ export default {
       css: '',
       html: '',
     },
+  },
+  html: {
     disableHtmlFolder: true,
   },
 };


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1de9e9f</samp>

This pull request fixes the documentation and the changeset file for the `@modern-js/builder-doc` package. It corrects the usage of the `disableHtmlFolder` option in the English and Chinese guides, and adds a changeset file to describe the fixes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1de9e9f</samp>

*  Add a changeset file to document the fixes to the `@modern-js/builder-doc` package ([link](https://github.com/web-infra-dev/modern.js/pull/4807/files?diff=unified&w=0#diff-54cd6d9d2131e3c5d31273ffabc2ef3e5eec24b39c4b2f4c4dbef602d894f1dcR1-R6))
*  Fix the `disableHtmlFolder` API documentation in the English and Chinese guides ([link](https://github.com/web-infra-dev/modern.js/pull/4807/files?diff=unified&w=0#diff-165f3992dbf15453c6e537b89966fb4ae29f92d41f0c43dff19535a4f2edeee5L137-R140), [link](https://github.com/web-infra-dev/modern.js/pull/4807/files?diff=unified&w=0#diff-98e305adfaa93997336ce9b33d5fe713e07c4d2353ca4eacadc847d4d3e62c73R137-R138))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
