### PR TITLE
chore: bump rspress version

### DIFF
--- a/.changeset/nasty-trees-impress.md
+++ b/.changeset/nasty-trees-impress.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/builder': patch
+---
+
+chore: bump rspress


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42e60c0</samp>

Update `@modern-js/builder` to use the latest `rspress` version and fix bugs. This change improves the web development experience and performance of modern JavaScript projects.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42e60c0</samp>

* Update `@modern-js/builder` to use latest `rspress` version and add changelog entry ([link](https://github.com/web-infra-dev/modern.js/pull/4822/files?diff=unified&w=0#diff-757d975a32721366cc1f95e7f56e302f67a2022a32dc07775339df1cfb2af969R1-R5))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
