### PR TITLE
feat: release action trigger rsbuild update-modern workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,3 +137,12 @@ jobs:
           -H 'Authorization: Bearer ${{ secrets.REPO_SCOPED_TOKEN }}' \
           -d '{"ref": "main", "inputs": {"version": "latest"}}' \
           https://api.github.com/repos/web-infra-dev/rspress/actions/workflows/release-pull-request-with-modernjs.yml/dispatches
+
+      - name: Trigger Rsbuild Update Modern
+        if: ${{github.event.inputs.version == 'latest'}}
+        run: |
+          curl -X POST \
+          -H 'Content-Type: application/json' \
+          -H 'Authorization: Bearer ${{ secrets.REPO_SCOPED_TOKEN }}' \
+          -d '{"ref": "main"}' \
+          https://api.github.com/repos/web-infra-dev/rsbuild/actions/workflows/update-modern.yml/dispatches


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e897df1</samp>

Add a step to `.github/workflows/release.yml` to update rsbuild-modern package when releasing a stable version of modern.js. This ensures that web projects that depend on rsbuild-modern can use the latest features and fixes of modern.js.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e897df1</samp>

*  Add a step to trigger Rsbuild Update Modern workflow on stable releases ([link](https://github.com/web-infra-dev/modern.js/pull/4828/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R140-R148))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
