### PR TITLE
fix(builder): babel addIncludes & addExcludes not take effect

### DIFF
--- a/.changeset/spicy-trains-end.md
+++ b/.changeset/spicy-trains-end.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): babel addIncludes & addExcludes not take effect
+
+fix(builder): babel addIncludes & addExcludes 方法不生效

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -102,7 +102,7 @@ export const builderPluginBabel = (): BuilderPlugin => ({
             config.tools.babel,
             {
               ...getBabelUtils(baseBabelConfig),
-              babelUtils,
+              ...babelUtils,
             },
           );
 

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -874,6 +874,9 @@ exports[`plugins/babel > should set include/exclude 1`] = `
   "module": {
     "rules": [
       {
+        "exclude": [
+          "src/**/*.js",
+        ],
         "include": [
           {
             "and": [
@@ -883,6 +886,7 @@ exports[`plugins/babel > should set include/exclude 1`] = `
               },
             ],
           },
+          "src/**/*.ts",
         ],
         "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
         "use": [


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31ce277</samp>

This pull request fixes a babel-loader bug in the `builder-webpack-provider` package and adds a changeset file to document the patch update. The changeset file also provides a bilingual description of the change for the users.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31ce277</samp>

* Fix babel-loader configuration bug in `builderPluginBabel` function ([link](https://github.com/web-infra-dev/modern.js/pull/4830/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL105-R105))
* Add changeset file for patch update of `@modern-js/builder-webpack-provider` package ([link](https://github.com/web-infra-dev/modern.js/pull/4830/files?diff=unified&w=0#diff-9c736629364a5aae7f4fdecf5c779e873ca6175714b5548579149b48ea36b719R1-R7))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
