### PR TITLE
fix: modify the generated routes code, compatible with loadable and swc

### DIFF
--- a/.changeset/giant-suns-punch.md
+++ b/.changeset/giant-suns-punch.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: modify the generated routes code, compatible with loadable and swc
+fix: 修改生成的 routes 代码，兼容 loadable 和 swc

--- a/packages/solutions/app-tools/src/analyze/templates.ts
+++ b/packages/solutions/app-tools/src/analyze/templates.ts
@@ -342,19 +342,19 @@ export const fileSystemRoutes = async ({
       if (route._component) {
         if (splitRouteChunks) {
           if (route.isRoot) {
-            lazyImport = `async function(){const routeModule = await import('${route._component}'); if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule;return routeModule;}`;
+            lazyImport = `() => import('${route._component}').then(routeModule => {if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule; return routeModule; }) `;
             rootLayoutCode = `import RootLayout from '${route._component}'`;
             component = `RootLayout`;
           } else if (ssrMode === 'string') {
-            lazyImport = `async function(){const routeModule = await import(/* webpackChunkName: "${route.id}" */  '${route._component}'); if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule;return routeModule;}`;
+            lazyImport = `() => import(/* webpackChunkName: "${route.id}" */  '${route._component}').then(routeModule => {if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule; return routeModule; }) `;
             component = `loadable(${lazyImport})`;
           } else {
             // csr and streaming
-            lazyImport = `async function(){const routeModule = await import(/* webpackChunkName: "${route.id}" */  '${route._component}'); if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule;return routeModule;}`;
+            lazyImport = `() => import(/* webpackChunkName: "${route.id}" */  '${route._component}').then(routeModule => {if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule; return routeModule; }) `;
             component = `lazy(${lazyImport})`;
           }
         } else {
-          lazyImport = `async function(){const routeModule = await import(/* webpackMode: "eager" */ '${route._component}'); if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule;return routeModule;}`;
+          lazyImport = `() => import(/* webpackMode: "eager" */  '${route._component}').then(routeModule => {if(typeof document !== "undefined") window.${ROUTE_MODULES}["${route.id}"] = routeModule; return routeModule; }) `;
           if (ssrMode === 'string') {
             component = `loadable(${lazyImport})`;
           } else {

--- a/packages/solutions/app-tools/tests/analyze/__snapshots__/templates.test.ts.snap
+++ b/packages/solutions/app-tools/tests/analyze/__snapshots__/templates.test.ts.snap
@@ -52,21 +52,21 @@ import loader_1 from "@_modern_js_src/routes/layout.loader.ts";
               "id": "user/[id]/page",
               "loader": loader_0,
               "type": "nested",
-              "lazyImport": async function(){const routeModule = await import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx'); if(typeof document !== "undefined") window._routeModules["user/[id]/page"] = routeModule;return routeModule;},
-              "component": lazy(async function(){const routeModule = await import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx'); if(typeof document !== "undefined") window._routeModules["user/[id]/page"] = routeModule;return routeModule;}),
+              "lazyImport": () => import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx').then(routeModule => {if(typeof document !== "undefined") window._routeModules["user/[id]/page"] = routeModule; return routeModule; }) ,
+              "component": lazy(() => import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx').then(routeModule => {if(typeof document !== "undefined") window._routeModules["user/[id]/page"] = routeModule; return routeModule; }) ),
               "shouldRevalidate": createShouldRevalidate("user/[id]/page")
             }
           ],
           "lazyImport": null
         }
       ],
-      "lazyImport": async function(){const routeModule = await import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx'); if(typeof document !== "undefined") window._routeModules["user/layout"] = routeModule;return routeModule;},
-      "component": lazy(async function(){const routeModule = await import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx'); if(typeof document !== "undefined") window._routeModules["user/layout"] = routeModule;return routeModule;}),
+      "lazyImport": () => import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx').then(routeModule => {if(typeof document !== "undefined") window._routeModules["user/layout"] = routeModule; return routeModule; }) ,
+      "component": lazy(() => import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx').then(routeModule => {if(typeof document !== "undefined") window._routeModules["user/layout"] = routeModule; return routeModule; }) ),
       "shouldRevalidate": createShouldRevalidate("user/layout")
     }
   ],
-  "lazyImport": async function(){const routeModule = await import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx'); if(typeof document !== "undefined") window._routeModules["layout"] = routeModule;return routeModule;},
-  "component": lazy(async function(){const routeModule = await import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx'); if(typeof document !== "undefined") window._routeModules["layout"] = routeModule;return routeModule;})
+  "lazyImport": () => import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx').then(routeModule => {if(typeof document !== "undefined") window._routeModules["layout"] = routeModule; return routeModule; }) ,
+  "component": lazy(() => import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx').then(routeModule => {if(typeof document !== "undefined") window._routeModules["layout"] = routeModule; return routeModule; }) )
 },
 ];
   

--- a/tests/integration/routes/src/three/routes/user/[id]/page.tsx
+++ b/tests/integration/routes/src/three/routes/user/[id]/page.tsx
@@ -9,7 +9,7 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 }) => {
   const revalidate = nextUrl.searchParams.get('revalidate');
   const flag = revalidate !== 'false';
-  if (revalidate) {
+  if (typeof revalidate === 'string') {
     return flag;
   }
   return defaultShouldRevalidate;

--- a/tests/integration/routes/tests/index.test.ts
+++ b/tests/integration/routes/tests/index.test.ts
@@ -555,9 +555,11 @@ const supportShouldRevalidateInSSR = async (
   appPort: number,
 ) => {
   expect(errors.length).toBe(0);
-  await page.goto(`http://localhost:${appPort}/three/user/111`, {
+  await page.goto(`http://localhost:${appPort}/three`, {
     waitUntil: ['networkidle0'],
   });
+  await page.click('.should-revalidate');
+  await new Promise(resolve => setTimeout(resolve, 300));
   const rootElm = await page.$('#root');
   const text = await page.evaluate(el => el?.textContent, rootElm);
   expect(text?.includes('param is 111')).toBeTruthy();


### PR DESCRIPTION
## Summary

Currently, our swc plugin for loadable only supports  arrow function, so this PR modify the generated routes code to arrow function.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eee439</samp>

This pull request fixes some compatibility and testing issues for the `@modern-js/app-tools` package, which provides tools for building modern web applications. It updates the routes code generation to work with `loadable` and `swc`, adds a type check for the `shouldRevalidate` hook, and improves the integration test for the same hook.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3eee439</samp>

*  Add a changeset file to describe the patch version update and the fixes for the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4833/files?diff=unified&w=0#diff-7f5955d29bb27e62b4c727d55e79e24c23775be06c9c2ca7d0c41da67b809d4cR1-R6))
*  Modify the `fileSystemRoutes` function to use arrow function syntax for the `lazyImport` variable and remove the `await` keyword from the import expression, to make the code compatible with swc and loadable ([link](https://github.com/web-infra-dev/modern.js/pull/4833/files?diff=unified&w=0#diff-dbfb9b73a9abfe46cea1f0f8a12245ca44db2fa24d49d3641c8e1ce883d3fa44L345-R357))
*  Add a type check for the `revalidate` variable in the `shouldRevalidate` hook, to handle the case when the parameter is not provided in the query string ([link](https://github.com/web-infra-dev/modern.js/pull/4833/files?diff=unified&w=0#diff-1b0c68104761c36b68fa542dc745ff5389eb82be32bc04e501430a4984d4e320L12-R12))
*  Update the `supportShouldRevalidateInSSR` test case to navigate to the `/three` page first, click on the `.should-revalidate` link, and add a delay to wait for the revalidation to complete, to make the test more realistic and robust ([link](https://github.com/web-infra-dev/modern.js/pull/4833/files?diff=unified&w=0#diff-a706802b24849d0e19f24d8b93af40f32a74278238ca698f1a17f1f8fc364444L558-R562))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
