### PR TITLE
docs: fix broken dicebear avatar api url

### DIFF
--- a/packages/document/main-doc/docs/en/tutorials/first-app/c01-start.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c01-start.mdx
@@ -38,7 +38,7 @@ We delete the original sample code and replace it with a simple point of contact
 const getAvatar = (users: Array<{ name: string; email: string }>) =>
   users.map(user => ({
     ...user,
-    avatar: `https://avatars.dicebear.com/v2/identicon/${user.name}.svg`,
+    avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${user.name}`,
   }));
 
 const mockData = getAvatar([

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c03-css.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c03-css.mdx
@@ -178,7 +178,7 @@ import Item from '../components/Item';
 const getAvatar = (users: Array<{ name: string, email: string }>) =>
   users.map(user => ({
     ...user,
-    avatar: `https://avatars.dicebear.com/v2/identicon/${user.name}.svg`,
+    avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${user.name}`,
   }));
 
 const mockData = getAvatar([

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c04-routes.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c04-routes.mdx
@@ -42,7 +42,7 @@ import Item from '../../components/Item';
 const getAvatar = (users: Array<{ name: string; email: string }>) =>
   users.map(user => ({
     ...user,
-    avatar: `https://avatars.dicebear.com/v2/identicon/${user.name}.svg`,
+    avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${user.name}`,
   }));
 
 const getMockArchivedData = () =>

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c05-loader.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c05-loader.mdx
@@ -37,7 +37,7 @@ export const loader = async (): Promise<LoaderData> => {
     const firstName = name.firstName();
     return {
       name: firstName,
-      avatar: `https://avatars.dicebear.com/api/identicon/${firstName}.svg`,
+      avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${firstName}`,
       email: internet.email(),
     };
   });

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c06-model.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c06-model.mdx
@@ -212,7 +212,7 @@ export const loader = async (): Promise<LoaderData> => {
     const firstName = name.firstName();
     return {
       name: firstName,
-      avatar: `https://avatars.dicebear.com/api/identicon/${firstName}.svg`,
+      avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${firstName}`,
       email: internet.email(),
       archived: false,
     };

--- a/packages/document/main-doc/docs/en/tutorials/first-app/c07-container.mdx
+++ b/packages/document/main-doc/docs/en/tutorials/first-app/c07-container.mdx
@@ -30,7 +30,7 @@ export const loader = async (): Promise<LoaderData> => {
     const firstName = name.firstName();
     return {
       name: firstName,
-      avatar: `https://avatars.dicebear.com/api/identicon/${firstName}.svg`,
+      avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${firstName}`,
       email: internet.email(),
     };
   });

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c01-start.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c01-start.mdx
@@ -38,7 +38,7 @@ import DebugApp from "@site-docs/components/debug-app"
 const getAvatar = (users: Array<{ name: string; email: string }>) =>
   users.map(user => ({
     ...user,
-    avatar: `https://avatars.dicebear.com/v2/identicon/${user.name}.svg`,
+    avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${user.name}`,
   }));
 
 const mockData = getAvatar([

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c03-css.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c03-css.mdx
@@ -177,7 +177,7 @@ import Item from '../components/Item';
 const getAvatar = (users: Array<{ name: string, email: string }>) =>
   users.map(user => ({
     ...user,
-    avatar: `https://avatars.dicebear.com/v2/identicon/${user.name}.svg`,
+    avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${user.name}`,
   }));
 
 const mockData = getAvatar([

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c04-routes.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c04-routes.mdx
@@ -42,7 +42,7 @@ import Item from '../../components/Item';
 const getAvatar = (users: Array<{ name: string; email: string }>) =>
   users.map(user => ({
     ...user,
-    avatar: `https://avatars.dicebear.com/v2/identicon/${user.name}.svg`,
+    avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${user.name}`,
   }));
 
 const getMockArchivedData = () =>

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c05-loader.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c05-loader.mdx
@@ -37,7 +37,7 @@ export const loader = async (): Promise<LoaderData> => {
     const firstName = name.firstName();
     return {
       name: firstName,
-      avatar: `https://avatars.dicebear.com/api/identicon/${firstName}.svg`,
+      avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${firstName}`,
       email: internet.email(),
     };
   });

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c06-model.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c06-model.mdx
@@ -209,7 +209,7 @@ export const loader async (): Promise<LoaderData> => {
     const firstName = name.firstName();
     return {
       name: firstName,
-      avatar: `https://avatars.dicebear.com/api/identicon/${firstName}.svg`,
+      avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${firstName}`,
       email: internet.email(),
       archived: false,
     };

--- a/packages/document/main-doc/docs/zh/tutorials/first-app/c07-container.mdx
+++ b/packages/document/main-doc/docs/zh/tutorials/first-app/c07-container.mdx
@@ -30,7 +30,7 @@ export const loader = async (): Promise<LoaderData> => {
     const firstName = name.firstName();
     return {
       name: firstName,
-      avatar: `https://avatars.dicebear.com/api/identicon/${firstName}.svg`,
+      avatar: `https://api.dicebear.com/7.x/pixel-art/svg?seed=${firstName}`,
       email: internet.email(),
     };
   });


### PR DESCRIPTION
## Summary

The old api is not working anymore. Dicebear updated their api format. 

## Related Issue

N/A.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
