### PR TITLE
fix(storybook-builder): add missing files

### DIFF
--- a/.changeset/small-sheep-travel.md
+++ b/.changeset/small-sheep-travel.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/storybook-builder': patch
+---
+
+fix(storybook-builder): add missing files
+fix(storybook-builder): 添加全 files

--- a/packages/storybook/builder/package.json
+++ b/packages/storybook/builder/package.json
@@ -16,7 +16,9 @@
     "test": "vitest run"
   },
   "files": [
-    "dist"
+    "dist",
+    "templates",
+    "preset.js"
   ],
   "exports": {
     ".": {

--- a/packages/storybook/builder/preset.js
+++ b/packages/storybook/builder/preset.js
@@ -1,2 +1,4 @@
 // This file is for some package that can't use exports field,
+// for example, framework needs to specify builder path using
+// abs path, when resolve abs path, exports is ignored
 module.exports = require('./dist/cjs/preset.js');


### PR DESCRIPTION
## Summary

Framework needs to specify builder root path for Storybook, so exports is ignored, we must keep preset.js at the root directory.
Templates is used to generate Storybook entry, so we need to keep them

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83072e1</samp>

This pull request fixes the storybook-builder package by adding missing files and a comment to explain a workaround. It also adds a changeset file to document the changes and the version bump.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83072e1</samp>

*  Add changeset file to document fixes to storybook-builder package ([link](https://github.com/web-infra-dev/modern.js/pull/4837/files?diff=unified&w=0#diff-5313af36a11062bd04c383757c4102a3b6e30d0da12ced58d9f5d695c8fd6fa4R1-R6))
*  Include missing files in storybook-builder package: `templates` and `preset.js` ([link](https://github.com/web-infra-dev/modern.js/pull/4837/files?diff=unified&w=0#diff-1d54535d7b406252bee2755120c26e35eef63f97c7ccab7a6b3538bc9213beacL19-R21))
*  Explain purpose of `preset.js` file in storybook-builder package: resolve absolute path of builder when using `exports` field ([link](https://github.com/web-infra-dev/modern.js/pull/4837/files?diff=unified&w=0#diff-d28a6d9ba5ccd83ecc13a022951430de19b3142d639218a2f653f18a8e115507R2-R3))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
