### PR TITLE
fix(plugin-testing): failed to run tests with decorators

### DIFF
--- a/.changeset/dirty-apes-roll.md
+++ b/.changeset/dirty-apes-roll.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/plugin-testing': patch
+---
+
+fix(plugin-testing): failed to run tests with decorators
+
+fix(plugin-testing): 修复无法运行带有 decorator 的测试用例的问题

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -75,19 +75,23 @@ export const builderPluginBabel = (): BuilderPlugin => ({
             },
           };
 
+          const decoratorConfig = {
+            version: config.output.enableLatestDecorators
+              ? '2018-09'
+              : 'legacy',
+          } as const;
+
           const baseBabelConfig =
             isServer || isServiceWorker
-              ? getBabelConfigForNode()
+              ? getBabelConfigForNode({
+                  pluginDecorators: decoratorConfig,
+                })
               : getBabelConfigForWeb({
                   presetEnv: {
                     targets: browserslist,
                     useBuiltIns: getUseBuiltIns(config),
                   },
-                  pluginDecorators: {
-                    version: config.output.enableLatestDecorators
-                      ? '2018-09'
-                      : 'legacy',
-                  },
+                  pluginDecorators: decoratorConfig,
                 });
 
           applyPluginImport(baseBabelConfig, config.source.transformImport);

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -212,6 +212,12 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
               "compact": false,
               "configFile": false,
               "plugins": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [
@@ -278,6 +284,12 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
               "compact": false,
               "configFile": false,
               "plugins": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -2149,6 +2149,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               "compact": true,
               "configFile": false,
               "plugins": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [
@@ -2254,6 +2260,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               "compact": true,
               "configFile": false,
               "plugins": [
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [

--- a/packages/runtime/plugin-testing/src/base/config/transformer/babelTransformer.ts
+++ b/packages/runtime/plugin-testing/src/base/config/transformer/babelTransformer.ts
@@ -2,7 +2,14 @@ import babelJest from 'babel-jest';
 
 const babelTransformer = (babelJest.createTransformer as any)?.({
   presets: [
-    require.resolve('@rsbuild/babel-preset/node'),
+    [
+      require.resolve('@rsbuild/babel-preset/node'),
+      {
+        pluginDecorators: {
+          version: 'legacy',
+        },
+      },
+    ],
     require.resolve('@babel/preset-react'),
   ],
   configFile: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8267,6 +8267,21 @@ importers:
         specifier: ^5
         version: 5.0.4
 
+  tests/integration/testing-plugin:
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../packages/solutions/app-tools
+      '@modern-js/plugin-testing':
+        specifier: workspace:*
+        version: link:../../../packages/runtime/plugin-testing
+      '@types/jest':
+        specifier: ^29
+        version: 29.2.6
+      '@types/node':
+        specifier: ^14
+        version: 14.18.35
+
   tests/integration/write-to-dist:
     dependencies:
       '@modern-js/runtime':

--- a/tests/integration/testing-plugin/modern.config.ts
+++ b/tests/integration/testing-plugin/modern.config.ts
@@ -1,0 +1,6 @@
+import { testingPlugin } from '@modern-js/plugin-testing';
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  plugins: [testingPlugin()],
+});

--- a/tests/integration/testing-plugin/package.json
+++ b/tests/integration/testing-plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "@e2e/testing-plugin",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "modern test"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/plugin-testing": "workspace:*",
+    "@types/jest": "^29",
+    "@types/node": "^14"
+  }
+}

--- a/tests/integration/testing-plugin/src/index.ts
+++ b/tests/integration/testing-plugin/src/index.ts
@@ -1,0 +1,10 @@
+function seal(constructor: unknown) {
+  Object.seal(constructor);
+}
+
+@seal
+export class DummyClass {
+  public method() {
+    // Method implementation
+  }
+}

--- a/tests/integration/testing-plugin/tests/index.test.ts
+++ b/tests/integration/testing-plugin/tests/index.test.ts
@@ -1,0 +1,7 @@
+import { DummyClass } from '../src';
+
+describe('basic test', () => {
+  test('should compile legacy decorator correctly', () => {
+    expect(new DummyClass()).toEqual({});
+  });
+});

--- a/tests/integration/testing-plugin/tests/tsconfig.json
+++ b/tests/integration/testing-plugin/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "paths": {},
+    "types": ["node", "jest"]
+  }
+}

--- a/tests/integration/testing-plugin/tsconfig.json
+++ b/tests/integration/testing-plugin/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "target": "ES5",
+    "experimentalDecorators": true,
+    "types": ["jest"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b67171b</samp>

This pull request adds support for the legacy decorator syntax in the `@modern-js/plugin-testing` package and the `@modern-js/builder-webpack-provider` plugin. It also adds an integration test project that uses the legacy decorator syntax and verifies that it can run tests with the `modern test` command. It updates the relevant files and adds a changeset to document the patch updates.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b67171b</samp>

*  Add a changeset file to document the patch updates and the fix for the plugin-testing package ([link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-ddf8d10ef5b1f5ad8ca8d5377cf98148ef9c1bdf4410d6b126d511fff628dca0R1-R8))
*  Enable running tests with legacy decorator syntax by adding the `pluginDecorators` option to the babel transformer and preset functions ([link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL78-R88), [link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL86-R94), [link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-bbadaf480f80ba20b903dafd7dbf55a487867d8cb3741abb1746971638d6ac47L5-R12))
*  Create a test project in the `testing-plugin` folder that uses the `@modern-js/plugin-testing` package and the legacy decorator syntax ([link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-75ecd31f312c49d846c165e62a674fdc3b7a8bce95902002db5f78173028e197R1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-c5147609194fde0a6dda1e332f786125e968973aca56a132372d2ea566baaaeeR1-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-2e5267bd26862446ba6042b70a2032f8f8b6b600cb2e449f238179ee64678cfbR1-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-1606dcbd6c7d0b83c85961d27fdca7737eab2991ca1b25e5c9bfd85821faac06R1-R7), [link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-f0954d5b84e8a9de03085847d44fcef102dc477ff36a70fbf1e20da725e7ac89R1-R12), [link](https://github.com/web-infra-dev/modern.js/pull/4840/files?diff=unified&w=0#diff-201020abe4e82e023c767abcba2867523613a98601d417044994f1952bac3299R1-R15))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
