### PR TITLE
chore: fix tiny typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Modern.js is an open source web engineering system from ByteDance, including mul
 The following solutions and libraries are available within the Modern.js ecosystem:
 
 - 🦀 [Rspack](https://github.com/web-infra-dev/rspack): A fast Rust-based web bundler.
-- 🐬 [Rsbuild](https://github.com/web-infra-dev/rsbuild)：An Rspack-based build tool for the web, rebranded from Modern.js Builder.
+- 🐬 [Rsbuild](https://github.com/web-infra-dev/rsbuild): An Rspack-based build tool for the web, rebranded from Modern.js Builder.
 - 🐹 [Rspress](https://github.com/web-infra-dev/rspress): A fast Rspack-based static site generator.
 - 🐟 [Garfish](https://github.com/web-infra-dev/garfish): A powerful micro front-end framework.
 - 🦆 [Reduck](https://github.com/web-infra-dev/reduck): A redux-based state management library.
-- 🐴 [SWC Plugins](https://github.com/web-infra-dev/swc-plugins)：Built-in SWC plugins for Modern.js.
+- 🐴 [SWC Plugins](https://github.com/web-infra-dev/swc-plugins): Built-in SWC plugins for Modern.js.
 
 ## Benchmark
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following solutions and libraries are available within the Modern.js ecosyst
 - 🐬 [Rsbuild](https://github.com/web-infra-dev/rsbuild): An Rspack-based build tool for the web, rebranded from Modern.js Builder.
 - 🐹 [Rspress](https://github.com/web-infra-dev/rspress): A fast Rspack-based static site generator.
 - 🐟 [Garfish](https://github.com/web-infra-dev/garfish): A powerful micro front-end framework.
-- 🦆 [Reduck](https://github.com/web-infra-dev/reduck): A redux-based state management library.
+- 🦆 [Reduck](https://github.com/web-infra-dev/reduck): An redux-based state management library.
 - 🐴 [SWC Plugins](https://github.com/web-infra-dev/swc-plugins): Built-in SWC plugins for Modern.js.
 
 ## Benchmark


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55c9761</samp>

This pull request fixes a formatting issue in the `README.md` file of the web-infra-dev/modern.js repository. It replaces a full-width colon with a half-width one after Rsbuild in the list of tools.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55c9761</samp>

* Replace full-width colon with half-width colon for consistency in Rsbuild list item ([link](https://github.com/web-infra-dev/modern.js/pull/4847/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R42))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
