### PR TITLE
fix: update rspress workflow token

### DIFF
--- a/.github/workflows/update-rspress.yml
+++ b/.github/workflows/update-rspress.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
           branch: 'feat-update-rspress-version'
           title: 'feat: update rspress version'
           body: 'feat: update rspress version'


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99417ef</samp>

Added `token` parameter to checkout action in `update-rspress.yml` workflow. This allows the workflow to push changes to the `rspress` branch using a custom secret.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99417ef</samp>

*  Add `token` parameter to `actions/checkout@v2` step to enable pushing to `rspress` branch ([link](https://github.com/web-infra-dev/modern.js/pull/4852/files?diff=unified&w=0#diff-82c82c334f07616e850d3b97aaaa7f731cddcbff579c462d806839c883c4811dR46))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
