### PR TITLE
fix(module-tools): add namespace when resolve result is false

### DIFF
--- a/.changeset/cold-timers-teach.md
+++ b/.changeset/cold-timers-teach.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): Add namespace when resolve result is false. Build failed in windows because `\empty-stub` is treated as a non-absolute path by esbuild.
+fix(module-tools): 当 resovle 的结果是 false 时，添加 namespace，因为在 windows 系统下，`\empty-stub` 会被 esbuild 当成一个非绝对路径导致构建失败。

--- a/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve, extname } from 'path';
+import { dirname, resolve, extname, sep } from 'path';
 import module from 'module';
 import { ImportKind, Loader, Plugin } from 'esbuild';
 import { fs, isString } from '@modern-js/utils';
@@ -194,8 +194,9 @@ export const adapterPlugin = (compiler: ICompiler): Plugin => {
           // we may get false when resolve browser field, in this case, we set it a empty object
           debugResolve('resolve false:', args);
           return {
-            path: '/empty-stub',
+            path: `${sep}empty-stub`,
             sideEffects: false,
+            namespace: 'resolve-false',
           };
         }
         const sideEffects = await getSideEffects(resultPath, isExternal);
@@ -220,18 +221,18 @@ export const adapterPlugin = (compiler: ICompiler): Plugin => {
           };
         }
 
+        if (args.namespace === 'resolve-false') {
+          return {
+            contents: 'module.exports = {}',
+          };
+        }
+
         if (args.suffix) {
           args.path += args.suffix;
         }
 
         if (args.namespace !== 'file') {
           return;
-        }
-
-        if (args.path === '/empty-stub') {
-          return {
-            contents: 'module.exports = {}',
-          };
         }
 
         compiler.addWatchFile(args.path);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5573c09</samp>

This pull request fixes a bug in the `@modern-js/module-tools` package that prevented building modules with esbuild on Windows. It adds a custom namespace property to the esbuild adapter plugin to handle false values as module paths, and updates the changeset file with the patch version and the bug description.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5573c09</samp>

*  Add a changeset file to describe the patch version update and bug fixes for `@modern-js/module-tools` ([link](https://github.com/web-infra-dev/modern.js/pull/4856/files?diff=unified&w=0#diff-84aa24e02d2e1d23ec03bfa33fcab5c4f3bdc31611717f14ae704292e49c15c7R1-R6))
*  Add a namespace property to the esbuild adapterPlugin to handle false values as module paths ([link](https://github.com/web-infra-dev/modern.js/pull/4856/files?diff=unified&w=0#diff-a99e93a85a25f2e6a158276b6dda938ff69960872fbcf2c32e40e74f236f32e7R199))
*  Return an empty module object when the adapterPlugin onLoad function receives a false value as a module path ([link](https://github.com/web-infra-dev/modern.js/pull/4856/files?diff=unified&w=0#diff-a99e93a85a25f2e6a158276b6dda938ff69960872fbcf2c32e40e74f236f32e7R224-R229))
*  Remove a redundant conditional branch from the adapterPlugin onLoad function that checked for '/empty-stub' ([link](https://github.com/web-infra-dev/modern.js/pull/4856/files?diff=unified&w=0#diff-a99e93a85a25f2e6a158276b6dda938ff69960872fbcf2c32e40e74f236f32e7L231-L236))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
