### PR TITLE
fix(ssr): routerManifest may be a undefined

### DIFF
--- a/.changeset/poor-comics-arrive.md
+++ b/.changeset/poor-comics-arrive.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(ssr): routerManifest may be a undefined
+fix(ssr): routerManifest 可能是个 undefined

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
@@ -45,9 +45,7 @@ class LoadableCollector implements Collector {
 
   private get existsAssets(): string[] | undefined {
     const { routeManifest, entryName } = this.options;
-    return routeManifest?.routeAssets?.[entryName]?.assets as
-      | string[]
-      | undefined;
+    return routeManifest?.routeAssets?.[entryName]?.assets;
   }
 
   collect(comopnent: ReactElement): ReactElement {

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
@@ -43,6 +43,13 @@ class LoadableCollector implements Collector {
     this.options = options;
   }
 
+  private get existsAssets(): string[] | undefined {
+    const { routeManifest, entryName } = this.options;
+    return routeManifest?.routeAssets?.[entryName]?.assets as
+      | string[]
+      | undefined;
+  }
+
   collect(comopnent: ReactElement): ReactElement {
     const { stats, entryName } = this.options;
 
@@ -99,8 +106,7 @@ class LoadableCollector implements Collector {
   }
 
   private async emitScriptAssets(chunks: ChunkAsset[]) {
-    const { template, config, nonce, result, routeManifest, entryName } =
-      this.options;
+    const { template, config, nonce, result } = this.options;
     const { chunksMap } = result;
     const { scriptLoading = 'defer', enableInlineScripts } = config;
 
@@ -120,10 +126,9 @@ class LoadableCollector implements Collector {
       chunks
         .filter(chunk => {
           const jsChunkReg = new RegExp(`<script .*src="${chunk.url!}".*>`);
-          const existsAssets = routeManifest?.routeAssets?.[entryName]
-            ?.assets as string[];
           return (
-            !jsChunkReg.test(template) && !existsAssets.includes(chunk.path!)
+            !jsChunkReg.test(template) &&
+            !this.existsAssets?.includes(chunk.path!)
           );
         })
         .map(chunk => {
@@ -145,8 +150,6 @@ class LoadableCollector implements Collector {
       template,
       result: { chunksMap },
       config: { enableInlineStyles },
-      entryName,
-      routeManifest,
     } = this.options;
 
     const atrributes = attributesToString(this.generateAttributes());
@@ -155,10 +158,10 @@ class LoadableCollector implements Collector {
       chunks
         .filter(chunk => {
           const cssChunkReg = new RegExp(`<link .*href="${chunk.url!}".*>`);
-          const existsAssets = routeManifest?.routeAssets?.[entryName]
-            ?.assets as string[];
+
           return (
-            !cssChunkReg.test(template) && !existsAssets.includes(chunk.path!)
+            !cssChunkReg.test(template) &&
+            !this.existsAssets?.includes(chunk.path!)
           );
         })
         .map(chunk => {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1ae257</samp>

This pull request fixes some SSR bugs in the `@modern-js/runtime` package and refactors the `LoadableCollector` class. It also adds a changeset file to document the patch version update and the bilingual description of the changes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a1ae257</samp>

*  Add a changeset file to document the patch version update and the bug fixes for the `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-3c0bc6f05054e1df59ca6e7ef89625b1e1d8ee02ebe8284358f158b16db71ee5R1-R6))
*  Add a private getter method `existsAssets` to the `LoadableCollector` class to return an array of asset paths that are already included in the `routeManifest` object or undefined ([link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409R46-R52))
*  Use the `existsAssets` method to simplify the logic of filtering out the redundant assets in the `emitScriptAssets` and `emitStyleAssets` methods of the `LoadableCollector` class ([link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L102-R109), [link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L123-R131), [link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L148-L149), [link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L158-R164))
*  Remove the unused variables `routeManifest` and `entryName` from the destructuring assignment of the `this.options` object in the `emitScriptAssets` and `emitStyleAssets` methods of the `LoadableCollector` class ([link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L102-R109), [link](https://github.com/web-infra-dev/modern.js/pull/4857/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L148-L149))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
