### PR TITLE
fix: new modern plugin version not exist

### DIFF
--- a/.changeset/polite-boxes-camp.md
+++ b/.changeset/polite-boxes-camp.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/generator-utils': patch
+---
+
+fix: new modern plugin version not exist
+
+fix: 修复 new 命令开启插件，插件版本不存在问题

--- a/packages/generator/generator-utils/src/index.ts
+++ b/packages/generator/generator-utils/src/index.ts
@@ -11,7 +11,7 @@ import { Solution, SolutionToolsMap } from '@modern-js/generator-common';
 import { GeneratorContext } from '@modern-js/codesmith';
 import { stripAnsi } from './utils/stripAnsi';
 import { i18n, localeKeys } from './locale';
-import { getAvailableVersion } from './utils/package';
+import { getAvailableVersion, isPackageExist } from './utils/package';
 import { fileExist } from './utils/fsExist';
 
 export * from './utils';
@@ -118,7 +118,11 @@ export async function getModernPluginVersion(
     if (typeof modernVersion !== 'string') {
       return getLatetPluginVersion();
     }
-    return getAvailableVersion(packageName, modernVersion, registry);
+    const version = getAvailableVersion(packageName, modernVersion, registry);
+    if (!(await isPackageExist(`${packageName}@${version}`))) {
+      return getLatetPluginVersion(packageName);
+    }
+    return version;
   }
   return getLatetPluginVersion();
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13a0082</samp>

This pull request fixes a bug in the `@modern-js/generator-utils` package that caused incorrect versions for plugins to be generated. It also updates the changelog with a changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13a0082</samp>

*  Add a changeset file to document the patch update for `@modern-js/generator-utils` ([link](https://github.com/web-infra-dev/modern.js/pull/4858/files?diff=unified&w=0#diff-d3b1d0e372042006165e359ade9290a3eb22cdc96a6810d1623d491e19bb3723R1-R7))
*  Import and use `isPackageExist` function from `./utils/package` to check package and version availability in `packages/generator/generator-utils/src/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4858/files?diff=unified&w=0#diff-639082b01105f4182dae7fbf5dfec32abf73b3a90bb6d4c8dc91fbf44764d5c4L14-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4858/files?diff=unified&w=0#diff-639082b01105f4182dae7fbf5dfec32abf73b3a90bb6d4c8dc91fbf44764d5c4L121-R125))
*  Modify `getModernPluginVersion` function to fallback to the latest plugin version if the user-specified version does not exist ([link](https://github.com/web-infra-dev/modern.js/pull/4858/files?diff=unified&w=0#diff-639082b01105f4182dae7fbf5dfec32abf73b3a90bb6d4c8dc91fbf44764d5c4L121-R125))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
