### PR TITLE
chore(deps): bump @babel/core to v7.23.2

### DIFF
--- a/.changeset/fair-kids-judge.md
+++ b/.changeset/fair-kids-judge.md
@@ -1,0 +1,21 @@
+---
+'@modern-js/babel-plugin-module-resolver': patch
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+'@modern-js-app/eslint-config': patch
+'@modern-js/builder-shared': patch
+'@modern-js/plugin-data-loader': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/babel-compiler': patch
+'@modern-js/builder-plugin-vue2': patch
+'@modern-js/builder-plugin-swc': patch
+'@modern-js/builder-plugin-vue': patch
+'@modern-js/plugin-bff': patch
+'@modern-js/server': patch
+'@modern-js/server-utils': patch
+---
+
+chore(deps): bump @babel/core to v7.23.2
+
+chore(deps): 升级 @babel/core 至 v7.23.2

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-transform-modules-commonjs": "^7.22.15",
     "@commitlint/cli": "^17.6.3",
     "@commitlint/config-conventional": "^17.6.3",

--- a/packages/builder/builder-rspack-provider/package.json
+++ b/packages/builder/builder-rspack-provider/package.json
@@ -50,7 +50,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/server": "workspace:*",
     "@modern-js/types": "workspace:*",

--- a/packages/builder/builder-shared/package.json
+++ b/packages/builder/builder-shared/package.json
@@ -160,7 +160,7 @@
     }
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/types": "^7.22.15",
     "@babel/parser": "^7.22.15",
     "@modern-js/prod-server": "workspace:*",

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -88,7 +88,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/preset-react": "^7.22.15",
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/inspector-webpack-plugin": "1.0.6",

--- a/packages/builder/plugin-swc/package.json
+++ b/packages/builder/plugin-swc/package.json
@@ -59,7 +59,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.22.15",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.22.15",

--- a/packages/builder/plugin-vue/package.json
+++ b/packages/builder/plugin-vue/package.json
@@ -44,7 +44,7 @@
     "vue-loader": "^17.2.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",

--- a/packages/builder/plugin-vue2/package.json
+++ b/packages/builder/plugin-vue2/package.json
@@ -44,7 +44,7 @@
     "vue-loader": "^15.10.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-webpack-provider": "workspace:*",
     "@modern-js/builder-rspack-provider": "workspace:*",

--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -62,7 +62,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@modern-js/bff-core": "workspace:*",
     "@modern-js/create-request": "workspace:*",
     "@modern-js/server-utils": "workspace:*",

--- a/packages/cli/plugin-data-loader/package.json
+++ b/packages/cli/plugin-data-loader/package.json
@@ -61,7 +61,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@modern-js/utils": "workspace:*",
     "@modern-js/runtime-utils": "workspace:*",
     "@remix-run/node": "^1.12.0",

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -22,7 +22,7 @@
     "check": "eslint-find-rules --unused index.js"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/eslint-plugin": "^7.22.10",
     "@rsbuild/babel-preset": "0.0.7",

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -153,7 +153,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/types": "^7.22.15",
     "cookie": "0.5.0",
     "@loadable/babel-plugin": "5.15.3",

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -116,7 +116,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.22.15",
     "@babel/preset-react": "^7.22.15",
     "@modern-js-reduck/plugin-auto-actions": "^1.1.10",

--- a/packages/server/babel-plugin-module-resolver/package.json
+++ b/packages/server/babel-plugin-module-resolver/package.json
@@ -45,7 +45,7 @@
     "@swc/helpers": "0.5.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.22.15",
     "@babel/preset-env": "^7.22.15",

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -45,7 +45,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/register": "^7.22.15",
     "@modern-js/prod-server": "workspace:*",
     "@modern-js/server-utils": "workspace:*",

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -38,7 +38,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/preset-env": "^7.22.15",
     "@babel/preset-react": "^7.22.15",

--- a/packages/toolkit/compiler/babel/package.json
+++ b/packages/toolkit/compiler/babel/package.json
@@ -37,7 +37,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
   .:
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/plugin-transform-modules-commonjs':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@commitlint/cli':
         specifier: ^17.6.3
         version: 17.6.3
@@ -153,11 +153,11 @@ importers:
   packages/builder/builder-rspack-provider:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/preset-typescript':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
@@ -232,8 +232,8 @@ importers:
   packages/builder/builder-shared:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/parser':
         specifier: ^7.22.15
         version: 7.23.0
@@ -297,10 +297,10 @@ importers:
     devDependencies:
       '@babel/preset-env':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@babel/preset-typescript':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@scripts/vitest-config':
         specifier: workspace:*
         version: link:../../../scripts/vitest-config
@@ -329,11 +329,11 @@ importers:
   packages/builder/builder-webpack-provider:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/preset-react':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
@@ -574,17 +574,17 @@ importers:
   packages/builder/plugin-swc:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/preset-env':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@babel/preset-react':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@babel/preset-typescript':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@modern-js/builder-shared':
         specifier: workspace:*
         version: link:../builder-shared
@@ -651,14 +651,14 @@ importers:
         version: 0.5.1
       '@vue/babel-plugin-jsx':
         specifier: 1.1.1
-        version: 1.1.1(@babel/core@7.23.0)
+        version: 1.1.1(@babel/core@7.23.2)
       vue-loader:
         specifier: ^17.2.2
         version: 17.2.2(webpack@5.88.1)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@modern-js/builder':
         specifier: workspace:*
         version: link:../builder
@@ -694,14 +694,14 @@ importers:
         version: 0.5.1
       '@vue/babel-preset-jsx':
         specifier: ^1.4.0
-        version: 1.4.0(@babel/core@7.23.0)
+        version: 1.4.0(@babel/core@7.23.2)
       vue-loader:
         specifier: ^15.10.1
         version: 15.10.1(css-loader@6.7.1)(webpack@5.88.1)
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@modern-js/builder':
         specifier: workspace:*
         version: link:../builder
@@ -822,8 +822,8 @@ importers:
   packages/cli/plugin-bff:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@modern-js/bff-core':
         specifier: workspace:*
         version: link:../../server/bff-core
@@ -881,7 +881,7 @@ importers:
         version: 3.5.1
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -941,8 +941,8 @@ importers:
   packages/cli/plugin-data-loader:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@modern-js/runtime-utils':
         specifier: workspace:*
         version: link:../../toolkit/runtime-utils
@@ -1006,7 +1006,7 @@ importers:
         version: 6.2.3
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -3191,11 +3191,11 @@ importers:
   packages/review/eslint-config-app:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/eslint-parser':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)(eslint@8.28.0)
+        version: 7.22.15(@babel/core@7.23.2)(eslint@8.28.0)
       '@babel/eslint-plugin':
         specifier: ^7.22.10
         version: 7.22.10(@babel/eslint-parser@7.22.15)(eslint@8.28.0)
@@ -3410,7 +3410,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -3418,14 +3418,14 @@ importers:
   packages/runtime/plugin-runtime:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/types':
         specifier: ^7.22.15
         version: 7.23.0
       '@loadable/babel-plugin':
         specifier: 5.15.3
-        version: 5.15.3(@babel/core@7.23.0)
+        version: 5.15.3(@babel/core@7.23.2)
       '@loadable/component':
         specifier: 5.15.3
         version: 5.15.3(react@18.2.0)
@@ -3555,7 +3555,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -3566,14 +3566,14 @@ importers:
   packages/runtime/plugin-testing:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/preset-env':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@babel/preset-react':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@jest/types':
         specifier: ^29.5.0
         version: 29.5.0
@@ -3621,7 +3621,7 @@ importers:
         version: 5.14.5
       babel-jest:
         specifier: ^29.5.0
-        version: 29.5.0(@babel/core@7.23.0)
+        version: 29.5.0(@babel/core@7.23.2)
       enhanced-resolve:
         specifier: 5.12.0
         version: 5.12.0
@@ -3642,7 +3642,7 @@ importers:
         version: 6.2.3
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       yargs:
         specifier: ^17.0.1
         version: 17.7.1
@@ -3703,17 +3703,17 @@ importers:
         version: 1.22.4
     devDependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/plugin-syntax-dynamic-import':
         specifier: ^7.8.3
-        version: 7.8.3(@babel/core@7.23.0)
+        version: 7.8.3(@babel/core@7.23.2)
       '@babel/plugin-transform-modules-commonjs':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@babel/preset-env':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@scripts/build':
         specifier: workspace:*
         version: link:../../../scripts/build
@@ -3811,7 +3811,7 @@ importers:
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -3851,7 +3851,7 @@ importers:
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -4322,11 +4322,11 @@ importers:
   packages/server/server:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/register':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@modern-js/prod-server':
         specifier: workspace:*
         version: link:../prod-server
@@ -4416,20 +4416,20 @@ importers:
   packages/server/utils:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@babel/plugin-proposal-decorators':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@babel/preset-env':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@babel/preset-react':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@babel/preset-typescript':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@modern-js/babel-compiler':
         specifier: workspace:*
         version: link:../../toolkit/compiler/babel
@@ -4447,7 +4447,7 @@ importers:
         version: 0.5.1
       babel-plugin-transform-typescript-metadata:
         specifier: ^0.3.2
-        version: 0.3.2(@babel/core@7.23.0)
+        version: 0.3.2(@babel/core@7.23.2)
     devDependencies:
       '@modern-js/server-core':
         specifier: workspace:*
@@ -4472,7 +4472,7 @@ importers:
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
+        version: 29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -4914,8 +4914,8 @@ importers:
   packages/toolkit/compiler/babel:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../utils
@@ -4925,10 +4925,10 @@ importers:
     devDependencies:
       '@babel/plugin-transform-classes':
         specifier: ^7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
       '@babel/preset-typescript':
         specifier: ^7.22.15
-        version: 7.23.0(@babel/core@7.23.0)
+        version: 7.23.0(@babel/core@7.23.2)
       '@scripts/build':
         specifier: workspace:*
         version: link:../../../../scripts/build
@@ -5331,8 +5331,8 @@ importers:
   scripts/prebundle:
     dependencies:
       '@babel/core':
-        specifier: ^7.22.15
-        version: 7.23.0
+        specifier: ^7.23.2
+        version: 7.23.2
       '@modern-js/tsconfig':
         specifier: workspace:*
         version: link:../../packages/review/tsconfig
@@ -5432,7 +5432,7 @@ importers:
         version: 10.4.13(postcss@8.4.31)
       babel-loader:
         specifier: 9.1.3
-        version: 9.1.3(@babel/core@7.23.0)(webpack@5.88.1)
+        version: 9.1.3(@babel/core@7.23.2)(webpack@5.88.1)
       babel-plugin-lodash:
         specifier: 3.3.4
         version: 3.3.4
@@ -7095,6 +7095,10 @@ importers:
 
   tests/integration/module/fixtures/build/asset/svgr: {}
 
+  tests/integration/module/fixtures/build/autoExtension/type-commonjs: {}
+
+  tests/integration/module/fixtures/build/autoExtension/type-module: {}
+
   tests/integration/module/fixtures/build/autoExternal:
     dependencies:
       path-browserify:
@@ -7162,6 +7166,8 @@ importers:
 
   tests/integration/module/fixtures/build/resolve/with-mainFields: {}
 
+  tests/integration/module/fixtures/build/shims: {}
+
   tests/integration/module/fixtures/build/sideEffects: {}
 
   tests/integration/module/fixtures/build/sourceDir: {}
@@ -7226,7 +7232,7 @@ importers:
     devDependencies:
       '@babel/preset-env':
         specifier: 7.22.15
-        version: 7.22.15(@babel/core@7.23.0)
+        version: 7.22.15(@babel/core@7.23.2)
 
   tests/integration/module/plugins/node-polyfill: {}
 
@@ -8626,15 +8632,38 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
-  /@babel/eslint-parser@7.22.15(@babel/core@7.23.0)(eslint@8.28.0):
+  /@babel/core@7.23.2:
+    resolution: {integrity: sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.23.0
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
+      '@babel/helpers': 7.23.2
+      '@babel/parser': 7.23.0
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.2
+      '@babel/types': 7.23.0
+      convert-source-map: 2.0.0
+      debug: 4.3.4(supports-color@9.3.1)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/eslint-parser@7.22.15(@babel/core@7.23.2)(eslint@8.28.0):
     resolution: {integrity: sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.28.0
       eslint-visitor-keys: 2.1.0
@@ -8648,7 +8677,7 @@ packages:
       '@babel/eslint-parser': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@babel/eslint-parser': 7.22.15(@babel/core@7.23.0)(eslint@8.28.0)
+      '@babel/eslint-parser': 7.22.15(@babel/core@7.23.2)(eslint@8.28.0)
       eslint: 8.28.0
       eslint-rule-composer: 0.3.0
     dev: false
@@ -8684,30 +8713,30 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.23.0):
+  /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.22.15
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.0)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.0):
+  /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -8728,12 +8757,12 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.23.0):
+  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4(supports-color@9.3.1)
@@ -8797,6 +8826,20 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+    dev: false
+
+  /@babel/helper-module-transforms@7.23.0(@babel/core@7.23.2):
+    resolution: {integrity: sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -8812,24 +8855,24 @@ packages:
     resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.23.0):
+  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.23.2):
     resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.10
 
-  /@babel/helper-replace-supers@7.22.20(@babel/core@7.23.0):
+  /@babel/helper-replace-supers@7.22.20(@babel/core@7.23.2):
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.22.15
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -8881,6 +8924,17 @@ packages:
       '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@babel/helpers@7.23.2:
+    resolution: {integrity: sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.2
+      '@babel/types': 7.23.0
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/highlight@7.22.13:
     resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
@@ -8897,73 +8951,73 @@ packages:
     dependencies:
       '@babel/types': 7.23.0
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-FB9iYlz7rURmRJyXRKEnalYPPdn87H5no108cyuQQyMwlpJ2SJtpIUBI27kdTin956pz+LPypkPVPUTlxOmrsg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-Hyph9LseGvAeeXzikV88bczhsrLrIZqDPxO+sSmAunMPaGrBGhfMWzCPYTtiW9t+HzSE2wtV8e5cc5P6r1xMDQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.22.15(@babel/core@7.23.0)
+      '@babel/plugin-transform-optional-chaining': 7.22.15(@babel/core@7.23.2)
 
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.0):
+  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-proposal-decorators@7.23.0(@babel/core@7.23.0):
+  /@babel/plugin-proposal-decorators@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-kYsT+f5ARWF6AdFmqoEEp+hpqxEB8vGmRWfw2aj78M2vTwS2uHW91EF58iFm1Z9U8Y/RrLu2XKJn46P9ca1b0w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.0)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/plugin-syntax-decorators': 7.22.10(@babel/core@7.23.0)
+      '@babel/plugin-syntax-decorators': 7.22.10(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-proposal-export-default-from@7.22.17(@babel/core@7.23.0):
+  /@babel/plugin-proposal-export-default-from@7.22.17(@babel/core@7.23.2):
     resolution: {integrity: sha512-cop/3quQBVvdz6X5SJC6AhUv3C9DrVTM06LUEXimEdWAhCSyOJIr9NiZDU9leHZ0/aiG0Sh7Zmvaku5TWYNgbA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-default-from': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-export-default-from': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.0):
+  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.12.9):
@@ -8978,160 +9032,160 @@ packages:
       '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.12.9)
     dev: false
 
-  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.0):
+  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-proposal-partial-application@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-proposal-partial-application@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-3FKlTrBXzQ9MGfZijsGns7CZUh6ur/NA94Aw9mYKKhL3BoHaY+nF2fWeOaGfQis+VKfLy3pw5DQjjXXFGh11Rw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-partial-application': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-partial-application': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-proposal-pipeline-operator@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-proposal-pipeline-operator@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-tk81rXNA4T/AQc4zFhIIJp9OSmY8rmy46G7LXiPm4+/X8A0A0f9ri6yjEIj3fYqZQYrQnX9uuWXppPGsEesYtg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-pipeline-operator': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-pipeline-operator': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.0):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
 
-  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.0):
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.0):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.2):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-decorators@7.22.10(@babel/core@7.23.0):
+  /@babel/plugin-syntax-decorators@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-z1KTVemBjnz+kSEilAsI4lbkPOl5TvJH7YDSY1CTIzvLWJ+KHXp+mRe8VPmfnyvqOPqar1V2gid2PleKzRUstQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-export-default-from@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-export-default-from@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-ODAqWWXB/yReh/jVQDag/3/tl6lgBueQkk/TcfW/59Oykm4c8a55XloX0CTk2k2VJiFWMgHby9xNX29IbCv9dQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.23.0):
+  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-KwvoWDeNKPETmozyFE0P2rOLqh39EoQHNjqizrI5B8Vt0ZNS7M56s7dAiAqbYfiAYOuIzIh96z3iR2ktgu3tEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.0):
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9):
@@ -9151,29 +9205,39 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: false
 
-  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.0):
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.23.2):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.0):
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.2):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9):
@@ -9185,66 +9249,66 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.0):
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-partial-application@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-partial-application@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-Nqljda6NhbZDP42ET/WzoxFHcv5wpfLPrdImbc3GR30x2FVS2dSVYIGCtgJKUi5beaQLPIzeu9uuDiap6svjMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-pipeline-operator@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-pipeline-operator@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-7yuGXd+h8gpR14FnPDTTCd5TfC/1B9njNZJT29GJ7UFF/WVbzkZy7728DynrENqgImqj5xyPTQAo8si9n3QVJQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.0):
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.23.0):
@@ -9255,367 +9319,377 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: false
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.0):
+  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.23.2):
+    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-async-generator-functions@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-async-generator-functions@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-jBm1Es25Y+tVoTi5rfd5t1KLmL8ogLKpXszboWOTTtGFGz2RKnQe2yn7HbZ+kb/B8N0FVSGQo874NSlOU1T4+w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.23.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.23.2)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.23.0)
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-block-scoping@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-block-scoping@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-G1czpdJBZCtngoK1sJgloLiOHUnkb/bLZwqVZD8kXmq0ZnVfTTWUcs9OWtp0mBtYJ+4LQY1fllqBkOIPhXmFmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-nDkQ0NfkOhPTq8YCLiWNxp1+f9fCobEjCb0n8WdbNUBc4IB5V7P1QnX9IjpSoquKrXF5SKojHleVNs2vGeHCHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-classes@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-classes@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-VbbC3PGjBdE0wAWDdHM9G8Gm977pnYI0XpqMd6LrKISj8/DJXEsWqgRuTYaNE9Bv0JGhTZUzHDlMk18IpOuoqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.0)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
 
-  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.15
 
-  /@babel/plugin-transform-destructuring@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-destructuring@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-HzG8sFl1ZVGTme74Nw+X01XsUTqERVQ6/RLHo3XjGRzm7XD6QTtfS3NJotVgCGy8BzkDqRjRBD8dAyJn5TuvSQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-dynamic-import@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-dynamic-import@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-g/21plo58sfteWjaO0ZNVb+uEOkJNjAaHhbejrnBmu011l/eNDScmkbjCC3l4FKb10ViaGU4aOkFznSu2zRHgA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-export-namespace-from@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-export-namespace-from@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-xa7aad7q7OiT8oNZ1mU7NrISjlSkVdMbNxn9IuLZyL9AJEhs1Apba3I+u5riX1dIkdptP5EKDG5XDPByWxtehw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-flow-strip-types@7.18.6(@babel/core@7.23.0):
+  /@babel/plugin-transform-flow-strip-types@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-wE0xtA7csz+hw4fKPwxmu5jnzAsXPIO57XnRwzXP3T19jWh1BODnPGoG9xKYwvAwusP7iUktHayRFbMPGtODaQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-for-of@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-for-of@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-me6VGeHsx30+xh9fbDLLPi0J1HzmeIIyenoOQHuw2D4m2SAU3NrspX5XxJLBpqn5yrLzrlw2Iy3RA//Bx27iOA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-json-strings@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-json-strings@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-CxT5tCqpA9/jXFlme9xIBCc5RPtdDq3JpkkhgHQqtDdiTnTI0jtZ0QzXhr5DILeYifDPp2wvY2ad+7+hLMW5Pw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-logical-assignment-operators@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-logical-assignment-operators@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-qQwRTP4+6xFCDV5k7gZBF3C31K34ut0tbEcTKxlX/0KXxm9GLcO14p570aWxFvVzx6QAfPgq7gaeIHXJC8LswQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-modules-commonjs@7.23.0(@babel/core@7.23.0):
+  /@babel/plugin-transform-modules-commonjs@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-32Xzss14/UVc7k9g775yMIvkVK8xwKE0DPdP5JTapr3+Z9w4tzeOuLNY6BXDQR6BdnzIlXnCGAzsk/ICHBLVWQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
-  /@babel/plugin-transform-modules-systemjs@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-modules-systemjs@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-rIqHmHoMEOhI3VkVf5jQ15l539KrwhzqcBO6wdCNWPWc/JWt9ILNYNUssbRpeq0qWns8svuw8LnMNCvWBIJ8wA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.20
 
-  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-YZWOw4HxXrotb5xsjMJUDlLgcDXSfO9eCmdl1bgW4+/lAGdkjaEvOnQ4p5WKKdUgSzO39dgPl0pTnfxm0OAXcg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-numeric-separator@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-numeric-separator@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-3dzU4QGPsILdJbASKhF/V2TVP+gJya1PsueQCxIPCEcerqF21oEcrob4mzjsp2Py/1nLfF5m+xYNMDpmA8vffg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-object-rest-spread@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-object-rest-spread@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-fEB+I1+gAmfAyxZcX1+ZUwLeAuuf8VIg67CTznZE0MqVFumWkh8xWtn58I4dxdVf080wn7gzWoF8vndOViJe9Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.20
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.0)
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-optional-catch-binding@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-optional-catch-binding@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-rli0WxesXUeCJnMYhzAglEjLWVDF6ahb45HuprcmQuLidBJFWjNnOzssk2kuc6e33FlLaiZhG/kUIzUMWdBKaQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-optional-chaining@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-optional-chaining@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-ngQ2tBhq5vvSJw2Q2Z9i7ealNkpDMU0rGWnHPKqRZO0tzZ5tlaoz4hDvhXioOoaE0X2vfNss1djwg0DXlfu30A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
 
   /@babel/plugin-transform-parameters@7.22.15(@babel/core@7.12.9):
     resolution: {integrity: sha512-hjk7qKIqhyzhhUvRT683TYQOFa/4cQKwQy7ALvTpODswN40MljzNDa0YldevS6tGbxwaEKVn502JmY0dP7qEtQ==}
@@ -9627,472 +9701,472 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-parameters@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-parameters@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-hjk7qKIqhyzhhUvRT683TYQOFa/4cQKwQy7ALvTpODswN40MljzNDa0YldevS6tGbxwaEKVn502JmY0dP7qEtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-PPjh4gyrQnGe97JTalgRGMuU4icsZFnWkzicB/fUtzlKUqvsWBKEpPPfr5a2JiyirZkHxnAqkQMO5Z5B2kK3fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-private-property-in-object@7.22.11(@babel/core@7.23.0):
+  /@babel/plugin-transform-private-property-in-object@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-sSCbqZDBKHetvjSwpyWzhuHkmW5RummxJBVbYLkGkaiTOWGxml7SXt0iWa03bzxFIx7wOj3g/ILRd0RcJKBeSQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-react-constant-elements@7.22.3(@babel/core@7.23.0):
+  /@babel/plugin-transform-react-constant-elements@7.22.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-b5J6muxQYp4H7loAQv/c7GO5cPuRA6H5hx4gO+/Hn+Cu9MRQU0PNiUoWq1L//8sq6kFSNxGXFb2XTaUfa9y+Pg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
     dev: false
 
-  /@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
       '@babel/types': 7.23.0
     dev: false
 
-  /@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.23.0):
+  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
 
-  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-runtime@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-runtime@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-tEVLhk8NRZSmwQ0DJtxxhTrCht1HVo8VaMzYT4w6lwyKBuHsgoioAUA7/6eT2fRfc5/23fuGdlwIxXhRVgWr4g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.0)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.0)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.2)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.2)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-typescript@7.22.15(@babel/core@7.23.0):
+  /@babel/plugin-transform-typescript@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-1uirS0TnijxvQLnlv5wQBwOX3E1wCFX7ITv+9pBV2wKEk4K+M5tqDaoNXnTH8tjEIYHLO98MwiTWO04Ggz4XuA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.2)
 
-  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.23.0):
+  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-HCCIb+CbJIAE6sXn5CjFQXMwkCClcOfPCzTlilJ8cUatfzwHlWQkbtV0zD338u9dZskwvuOYTuuaMaA8J5EI5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.23.0):
+  /@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-lhMfi4FC15j13eKrh3DnYHjpGj6UKQHtNKTbtc1igvAhRy4+kLhV07OpLcsN0VgDEw/MjAvJO4BdMJsHwMhzCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/preset-env@7.22.15(@babel/core@7.23.0):
+  /@babel/preset-env@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-tZFHr54GBkHk6hQuVA8w4Fmq+MSPsfvMG0vPnOYyTnJpyfMqybL8/MbNCPRT9zc2KBO2pe4tq15g6Uno4Jpoag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.20
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.0)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-async-generator-functions': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-block-scoping': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-classes': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-destructuring': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-dynamic-import': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-for-of': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-json-strings': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-systemjs': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-numeric-separator': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-optional-chaining': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.23.0)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.0)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.2)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.2)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-async-generator-functions': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-block-scoping': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-classes': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-destructuring': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-dynamic-import': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-for-of': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-json-strings': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-systemjs': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-numeric-separator': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-chaining': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.23.2)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.2)
       '@babel/types': 7.23.0
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.0)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.0)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.2)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.2)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.2)
       core-js-compat: 3.32.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/preset-env@7.22.20(@babel/core@7.23.0):
+  /@babel/preset-env@7.22.20(@babel/core@7.23.2):
     resolution: {integrity: sha512-11MY04gGC4kSzlPHRfvVkNAZhUxOvm7DCJ37hPDnUENwe06npjIRAfInEMTGSb4LZK5ZgDFkv5hw0lGebHeTyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.20
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.0)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-async-generator-functions': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-block-scoping': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-classes': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-destructuring': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-dynamic-import': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-for-of': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-json-strings': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-systemjs': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-numeric-separator': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-optional-chaining': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.23.0)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.23.0)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.23.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.0)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.2)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.2)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-async-generator-functions': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-block-scoping': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-classes': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-destructuring': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-dynamic-import': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-for-of': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-json-strings': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-systemjs': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-numeric-separator': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-chaining': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.23.2)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.23.2)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.23.2)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.2)
       '@babel/types': 7.23.0
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.0)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.0)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.2)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.2)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.2)
       core-js-compat: 3.32.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/preset-flow@7.18.6(@babel/core@7.23.0):
+  /@babel/preset-flow@7.18.6(@babel/core@7.23.2):
     resolution: {integrity: sha512-E7BDhL64W6OUqpuyHnSroLnqyRTcG6ZdOBl1OKI/QK/HJfplqK/S3sq1Cckx7oTodJ5yOXyfw7rEADJ6UjoQDQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
-      '@babel/plugin-transform-flow-strip-types': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-flow-strip-types': 7.18.6(@babel/core@7.23.2)
     dev: false
 
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.0):
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.2):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.23.0
       esutils: 2.0.3
 
-  /@babel/preset-react@7.22.15(@babel/core@7.23.0):
+  /@babel/preset-react@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-Csy1IJ2uEh/PecCBXXoZGAZBeCATTuePzCSB7dLYWS0vOEj6CNpjxIhW4duWwZodBNueH7QO14WbGn8YyeuN9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
-      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@babel/preset-typescript@7.23.0(@babel/core@7.23.0):
+  /@babel/preset-typescript@7.23.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-6P6VVa/NM/VlAYj5s2Aq/gdVg8FSENCg3wlZ6Qau9AcPaoF5LbN1nyGlR9DTRIw9PpxI94e+ReydsJHcjwAweg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.0)
-      '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.23.0)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.23.2)
 
-  /@babel/register@7.22.15(@babel/core@7.23.0):
+  /@babel/register@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-V3Q3EqoQdn65RCgTLwauZaTfd1ShhwPmbBv+1dkZV/HpCGMKVyn6oFcRlI7RaKqiDQjX2Qd3AuoEguBgdjIKlg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -11839,7 +11913,7 @@ packages:
     resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.19
       babel-plugin-istanbul: 6.1.1
@@ -11962,14 +12036,14 @@ packages:
       '@lezer/common': 1.0.4
     dev: false
 
-  /@loadable/babel-plugin@5.15.3(@babel/core@7.23.0):
+  /@loadable/babel-plugin@5.15.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-kwEsPxCk8vnwbTfbA4lHqT5t0u0czCQTnCcmOaTjxT5lCn7yZCBTBa9D7lHs+MLM2WyPsZlee3Qh0TTkMMi5jg==}
     engines: {node: '>=8'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
     dev: false
 
   /@loadable/component@5.15.2(react@18.2.0):
@@ -14522,14 +14596,14 @@ packages:
   /@rsbuild/babel-preset@0.0.7:
     resolution: {integrity: sha512-U8XzLq+FBAryfBiDzTGrWrZyEcqwVnpg5q/Af1jYBBI7o6/xaBHJcgvCmvyk1JvbciQCUGrwWthWau5qc1CJPA==}
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-proposal-decorators': 7.23.0(@babel/core@7.23.0)
-      '@babel/plugin-proposal-export-default-from': 7.22.17(@babel/core@7.23.0)
-      '@babel/plugin-proposal-partial-application': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-proposal-pipeline-operator': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-runtime': 7.22.15(@babel/core@7.23.0)
-      '@babel/preset-env': 7.22.20(@babel/core@7.23.0)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-proposal-decorators': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-proposal-export-default-from': 7.22.17(@babel/core@7.23.2)
+      '@babel/plugin-proposal-partial-application': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-proposal-pipeline-operator': 7.22.15(@babel/core@7.23.2)
+      '@babel/plugin-transform-runtime': 7.22.15(@babel/core@7.23.2)
+      '@babel/preset-env': 7.22.20(@babel/core@7.23.2)
+      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.2)
       '@babel/runtime': 7.23.2
       '@babel/types': 7.23.0
       '@rsbuild/shared': 0.0.7
@@ -15394,8 +15468,8 @@ packages:
     resolution: {integrity: sha512-qKIJs8gqXTy0eSEbt0OW5nsJqiV/2+N1eWoiBiIxoZ+8b0ACXIAUcE/N6AsEDUqIq8AMK7lebqjEfIAt2Sp7Mg==}
     hasBin: true
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/preset-env': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/preset-env': 7.22.15(@babel/core@7.23.2)
       '@babel/types': 7.23.0
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.5.1
@@ -15450,8 +15524,8 @@ packages:
   /@storybook/codemod@7.5.1:
     resolution: {integrity: sha512-PqHGOz/CZnRG9pWgshezCacu524CrXOJrCOwMUP9OMpH0Jk/NhBkHaBZrB8wMjn5hekTj0UmRa/EN8wJm9CCUQ==}
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/preset-env': 7.22.15(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/preset-env': 7.22.15(@babel/core@7.23.2)
       '@babel/types': 7.23.0
       '@storybook/csf': 0.1.1
       '@storybook/csf-tools': 7.5.1
@@ -15819,101 +15893,101 @@ packages:
       '@types/express': 4.17.13
       file-system-cache: 2.3.0
 
-  /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-plugin-transform-react-native-svg@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-transform-react-native-svg@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-UKrY3860AQICgH7g+6h2zkoxeVEPLYwX/uAjmqo4PIq2FIHppwhIqZstIyTz0ZtlwreKR41O3W3BzsBBiJV2Aw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
     engines: {node: '>=12'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /@svgr/babel-preset@8.0.0(@babel/core@7.23.0):
+  /@svgr/babel-preset@8.0.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-KLcjiZychInVrhs86OvcYPLTFu9L5XV2vj0XAaE1HwE3J3jLmIzRY8ttdeAg/iFyp8nhavJpafpDZTt+1LIpkQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.23.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.23.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.23.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.23.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.23.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.23.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.0.0(@babel/core@7.23.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.23.2)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.23.2)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.23.2)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.23.2)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.23.2)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.23.2)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.0.0(@babel/core@7.23.2)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.23.2)
     dev: false
 
   /@svgr/core@8.0.0:
     resolution: {integrity: sha512-aJKtc+Pie/rFYsVH/unSkDaZGvEeylNv/s2cP+ta9/rYWxRVvoV/S4Qw65Kmrtah4CBK5PM6ISH9qUH7IJQCng==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/core': 7.23.0
-      '@svgr/babel-preset': 8.0.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@svgr/babel-preset': 8.0.0(@babel/core@7.23.2)
       camelcase: 6.3.0
       cosmiconfig: 8.1.3
       snake-case: 3.0.4
@@ -15935,8 +16009,8 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
     dependencies:
-      '@babel/core': 7.23.0
-      '@svgr/babel-preset': 8.0.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@svgr/babel-preset': 8.0.0(@babel/core@7.23.2)
       '@svgr/core': 8.0.0
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -15960,11 +16034,11 @@ packages:
     resolution: {integrity: sha512-zSoeKcbCmfMXjA11uDuCJb+1LWNb3vy6Qw/VHj0Nfcl3UuqwuoZWknHsBIhCWvi4wU9vPui3aq054qjVyZqY4A==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-transform-react-constant-elements': 7.22.3(@babel/core@7.23.0)
-      '@babel/preset-env': 7.22.15(@babel/core@7.23.0)
-      '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-constant-elements': 7.22.3(@babel/core@7.23.2)
+      '@babel/preset-env': 7.22.15(@babel/core@7.23.2)
+      '@babel/preset-react': 7.22.15(@babel/core@7.23.2)
+      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.2)
       '@svgr/core': 8.0.0
       '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0)
       '@svgr/plugin-svgo': 8.0.1(@svgr/core@8.0.0)
@@ -17196,11 +17270,11 @@ packages:
     resolution: {integrity: sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==}
     dev: false
 
-  /@vue/babel-plugin-jsx@1.1.1(@babel/core@7.23.0):
+  /@vue/babel-plugin-jsx@1.1.1(@babel/core@7.23.2):
     resolution: {integrity: sha512-j2uVfZjnB5+zkcbc/zsOc0fSNGCMMjaEXP52wdwdIfn0qjFfEYpYZBFKFg+HHnQeJCVrjOeO0YxgaL7DMrym9w==}
     dependencies:
       '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
       '@babel/template': 7.22.15
       '@babel/traverse': 7.22.15
       '@babel/types': 7.23.0
@@ -17213,21 +17287,21 @@ packages:
       - supports-color
     dev: false
 
-  /@vue/babel-plugin-transform-vue-jsx@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-plugin-transform-vue-jsx@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-Fmastxw4MMx0vlgLS4XBX0XiBbUFzoMGeVXuMV08wyOfXdikAFqBTuYPR0tlk+XskL19EzHc39SgjrPGY23JnA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
       '@vue/babel-helper-vue-jsx-merge-props': 1.4.0
       html-tags: 2.0.0
       lodash.kebabcase: 4.1.1
       svg-tags: 1.0.0
     dev: false
 
-  /@vue/babel-preset-jsx@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-preset-jsx@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-QmfRpssBOPZWL5xw7fOuHNifCQcNQC1PrOo/4fu6xlhlKJJKSA3HqX92Nvgyx8fqHZTUGMPHmFA+IDqwXlqkSA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -17236,75 +17310,75 @@ packages:
       vue:
         optional: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@vue/babel-helper-vue-jsx-merge-props': 1.4.0
-      '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.0)
-      '@vue/babel-sugar-composition-api-inject-h': 1.4.0(@babel/core@7.23.0)
-      '@vue/babel-sugar-composition-api-render-instance': 1.4.0(@babel/core@7.23.0)
-      '@vue/babel-sugar-functional-vue': 1.4.0(@babel/core@7.23.0)
-      '@vue/babel-sugar-inject-h': 1.4.0(@babel/core@7.23.0)
-      '@vue/babel-sugar-v-model': 1.4.0(@babel/core@7.23.0)
-      '@vue/babel-sugar-v-on': 1.4.0(@babel/core@7.23.0)
+      '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.2)
+      '@vue/babel-sugar-composition-api-inject-h': 1.4.0(@babel/core@7.23.2)
+      '@vue/babel-sugar-composition-api-render-instance': 1.4.0(@babel/core@7.23.2)
+      '@vue/babel-sugar-functional-vue': 1.4.0(@babel/core@7.23.2)
+      '@vue/babel-sugar-inject-h': 1.4.0(@babel/core@7.23.2)
+      '@vue/babel-sugar-v-model': 1.4.0(@babel/core@7.23.2)
+      '@vue/babel-sugar-v-on': 1.4.0(@babel/core@7.23.2)
     dev: false
 
-  /@vue/babel-sugar-composition-api-inject-h@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-sugar-composition-api-inject-h@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-VQq6zEddJHctnG4w3TfmlVp5FzDavUSut/DwR0xVoe/mJKXyMcsIibL42wPntozITEoY90aBV0/1d2KjxHU52g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@vue/babel-sugar-composition-api-render-instance@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-sugar-composition-api-render-instance@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-6ZDAzcxvy7VcnCjNdHJ59mwK02ZFuP5CnucloidqlZwVQv5CQLijc3lGpR7MD3TWFi78J7+a8J56YxbCtHgT9Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@vue/babel-sugar-functional-vue@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-sugar-functional-vue@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-lTEB4WUFNzYt2In6JsoF9sAYVTo84wC4e+PoZWSgM6FUtqRJz7wMylaEhSRgG71YF+wfLD6cc9nqVeXN2rwBvw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@vue/babel-sugar-inject-h@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-sugar-inject-h@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-muwWrPKli77uO2fFM7eA3G1lAGnERuSz2NgAxuOLzrsTlQl8W4G+wwbM4nB6iewlKbwKRae3nL03UaF5ffAPMA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
     dev: false
 
-  /@vue/babel-sugar-v-model@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-sugar-v-model@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-0t4HGgXb7WHYLBciZzN5s0Hzqan4Ue+p/3FdQdcaHAb7s5D9WZFGoSxEZHrR1TFVZlAPu1bejTKGeAzaaG3NCQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
       '@vue/babel-helper-vue-jsx-merge-props': 1.4.0
-      '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.0)
+      '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.2)
       camelcase: 5.3.1
       html-tags: 2.0.0
       svg-tags: 1.0.0
     dev: false
 
-  /@vue/babel-sugar-v-on@1.4.0(@babel/core@7.23.0):
+  /@vue/babel-sugar-v-on@1.4.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-m+zud4wKLzSKgQrWwhqRObWzmTuyzl6vOP7024lrpeJM4x2UhQtRDLgYjXAw9xBXjCwS0pP9kXjg91F9ZNo9JA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
-      '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
+      '@vue/babel-plugin-transform-vue-jsx': 1.4.0(@babel/core@7.23.2)
       camelcase: 5.3.1
     dev: false
 
@@ -18246,39 +18320,39 @@ packages:
   /b-validate@1.4.4:
     resolution: {integrity: sha512-E2tnSnxxKDyxP1G+TMTbVHA8XajfHHOJKeWm9YVRISSPtzTL7ZP/7tIYp01b+O83L5R/6i31+Su+vCOJBnQWFQ==}
 
-  /babel-core@7.0.0-bridge.0(@babel/core@7.23.0):
+  /babel-core@7.0.0-bridge.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
     dev: false
 
-  /babel-jest@29.5.0(@babel/core@7.23.0):
+  /babel-jest@29.5.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@jest/transform': 29.5.0
       '@types/babel__core': 7.20.2
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.5.0(@babel/core@7.23.0)
+      babel-preset-jest: 29.5.0(@babel/core@7.23.2)
       chalk: 4.1.2
       graceful-fs: 4.2.10
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  /babel-loader@9.1.3(@babel/core@7.23.0)(webpack@5.88.1):
+  /babel-loader@9.1.3(@babel/core@7.23.2)(webpack@5.88.1):
     resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
       webpack: '>=5'
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
       webpack: 5.88.1(esbuild@0.17.19)
@@ -18360,14 +18434,14 @@ packages:
       resolve: 1.22.4
     dev: false
 
-  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.23.0):
+  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.22.20
-      '@babel/core': 7.23.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.23.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -18384,24 +18458,24 @@ packages:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.23.0):
+  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.23.2):
     resolution: {integrity: sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.23.2)
       core-js-compat: 3.32.1
     transitivePeerDependencies:
       - supports-color
 
-  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.23.0):
+  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.23.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -18423,7 +18497,7 @@ packages:
     resolution: {integrity: sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==}
     dev: true
 
-  /babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.23.0):
+  /babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
     peerDependencies:
       '@babel/core': ^7
@@ -18432,38 +18506,38 @@ packages:
       '@babel/traverse':
         optional: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.0):
+  /babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.2):
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.2)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.2)
 
-  /babel-preset-jest@29.5.0(@babel/core@7.23.0):
+  /babel-preset-jest@29.5.0(@babel/core@7.23.2):
     resolution: {integrity: sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       babel-plugin-jest-hoist: 29.5.0
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.0)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.2)
 
   /babel-walk@3.0.0-canary-5:
     resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
@@ -23739,7 +23813,7 @@ packages:
     resolution: {integrity: sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/parser': 7.23.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
@@ -23895,11 +23969,11 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@jest/test-sequencer': 29.5.0
       '@jest/types': 29.5.0
       '@types/node': 14.18.35
-      babel-jest: 29.5.0(@babel/core@7.23.0)
+      babel-jest: 29.5.0(@babel/core@7.23.2)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.3.1
@@ -23934,11 +24008,11 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@jest/test-sequencer': 29.5.0
       '@jest/types': 29.5.0
       '@types/node': 18.11.17
-      babel-jest: 29.5.0(@babel/core@7.23.0)
+      babel-jest: 29.5.0(@babel/core@7.23.2)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.3.1
@@ -24231,10 +24305,10 @@ packages:
     resolution: {integrity: sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/generator': 7.23.0
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.2)
       '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
       '@jest/expect-utils': 29.5.0
@@ -24242,7 +24316,7 @@ packages:
       '@jest/types': 29.5.0
       '@types/babel__traverse': 7.18.5
       '@types/prettier': 2.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.0)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.2)
       chalk: 4.1.2
       expect: 29.5.0
       graceful-fs: 4.2.10
@@ -24413,17 +24487,17 @@ packages:
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/parser': 7.23.0
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.0)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.0)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.0)
-      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.0)
-      '@babel/preset-env': 7.22.15(@babel/core@7.23.0)
-      '@babel/preset-flow': 7.18.6(@babel/core@7.23.0)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
-      '@babel/register': 7.22.15(@babel/core@7.23.0)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.23.0)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.2)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.2)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.2)
+      '@babel/preset-env': 7.22.15(@babel/core@7.23.2)
+      '@babel/preset-flow': 7.18.6(@babel/core@7.23.2)
+      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.2)
+      '@babel/register': 7.22.15(@babel/core@7.23.2)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.23.2)
       chalk: 4.1.2
       flow-parser: 0.219.4
       graceful-fs: 4.2.10
@@ -29132,7 +29206,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@babel/generator': 7.23.0
       ast-types: 0.14.2
       commander: 2.20.3
@@ -31730,7 +31804,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-jest@29.1.0(@babel/core@7.23.0)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4):
+  /ts-jest@29.1.0(@babel/core@7.23.2)(@jest/types@29.5.0)(babel-jest@29.5.0)(esbuild@0.17.19)(jest@29.5.0)(typescript@5.0.4):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -31751,9 +31825,9 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.2
       '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.23.0)
+      babel-jest: 29.5.0(@babel/core@7.23.2)
       bs-logger: 0.2.6
       esbuild: 0.17.19
       fast-json-stable-stringify: 2.1.0

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -9,7 +9,7 @@
     "start": "pnpm build && node ./dist/index.js"
   },
   "dependencies": {
-    "@babel/core": "^7.22.15",
+    "@babel/core": "^7.23.2",
     "@modern-js/tsconfig": "workspace:*",
     "@scripts/build": "workspace:*",
     "@types/node": "^14",


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31434f8</samp>

This pull request updates the `@babel/core` dependency to the latest version (v7.23.2) in all the packages and scripts that use it. This is part of the dependency update for the whole monorepo. It also adds a changeset file to document and automate the versioning and publishing of the affected packages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31434f8</samp>

*  Add a changeset file to document the dependency update ([link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-de166a77802c79215f2394e8f4ecf7ce43682c5335bf8b217b50a93694a0427dR1-R21))
*  Update `@babel/core` dependency to v7.23.2 in the root `package.json` and in 16 packages that use it for transpiling, bundling, or linting the code ([link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L69-R69), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-0dfad59d3b9faa8b69b516527ff7dcc43db019040e3499dfa12a7b716d2e7ab7L53-R53), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-fddf5e8ef6a1c41374dc69b604fbc5fbd1bc944f335e853797d9badbd5455fa9L163-R163), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-3497897bafd468150e9ba75f0d2843fcd2cc7995518584f7fa73e853a153f1a1L91-R91), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-34ed68e35fc7b09be4c7b86093bb347bb44eb062dc6ad1961198c212ccf433caL62-R62), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-20b86993f9aae2ac83068c66050acfcec56d9946db911512edbc4deab556a2ebL47-R47), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-86f750c8fbfdaab1c896607398ab06fbd4ad6d1c442c8d185a027557152c0068L47-R47), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-ff81a1a711e2b04cc1c3f89e2cbe0f0b8075a6d8143cbf3e9d0339142ec9c6f5L65-R65), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-3b460c782e2166fc1f074472a38e5c65963dacdf5b16f19339e76fcadb42ad07L64-R64), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-d61007e6a4f882d26ca3f691465e069175887da72988065c1aed67b34a6f2ac6L25-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-a90f331e2d4e9320efe81c8af64349df4b94c4c63c247993e91f00bcfc1a8561L156-R156), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-5c42de52a46deaf73848ff3a1094d026cbf6b5a8049348d450d9641a7866d59bL119-R119), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-68919b1058e03ed865adbeced195327d5f22c54d5c36804770dfafd56e8bd9f0L48-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-4e5229a5eda5177170934d4faa8f34e6413ab98d6652b8173bbc236a97251b31L48-R48), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-dc7b8927f3df002c4c4ca7546fd0ff7c1333be87d78108370effc1fca0bccb17L41-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-a3e220b9aa3578cce7cf042c9c5d1c436287501843eb64b932a5ed0bcabffa37L40-R40), [link](https://github.com/web-infra-dev/modern.js/pull/4861/files?diff=unified&w=0#diff-6303d99950f4c2d7dd64bda8fa0082189d738c530edba3d835accc7b1d56f3c6L12-R12))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
