### PR TITLE
refactor: simpify `false.test.ts`

### DIFF
--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -13,17 +13,22 @@ on:
 jobs:
   integration-test-linux:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.SELF_LINUX_LABELS || '"ubuntu-latest"') }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Print runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        uses: pnpm/action-setup@v2
 
       - name: Check skip CI
         run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7152,11 +7152,7 @@ importers:
 
   tests/integration/module/fixtures/build/resolve/data-url: {}
 
-  tests/integration/module/fixtures/build/resolve/false:
-    devDependencies:
-      object-inspect:
-        specifier: 1.13.0
-        version: 1.13.0
+  tests/integration/module/fixtures/build/resolve/false: {}
 
   tests/integration/module/fixtures/build/resolve/node-protocol: {}
 

--- a/tests/integration/module/fixtures/build/resolve/false/browser-false/package.json
+++ b/tests/integration/module/fixtures/build/resolve/false/browser-false/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "browser-false",
+  "browser": {
+    "./util": false
+  }
+}

--- a/tests/integration/module/fixtures/build/resolve/false/index.ts
+++ b/tests/integration/module/fixtures/build/resolve/false/index.ts
@@ -1,3 +1,3 @@
-import xxx from 'object-inspect';
+import jjj from './browser-false/util';
 
-console.log('xxx:', xxx);
+console.log('jjj:', jjj); // the value of `jjj` should `{}`

--- a/tests/integration/module/fixtures/build/resolve/false/package.json
+++ b/tests/integration/module/fixtures/build/resolve/false/package.json
@@ -1,7 +1,4 @@
 {
   "name": "resolve-false",
-  "version": "1.0.0",
-  "devDependencies": {
-    "object-inspect": "1.13.0"
-  }
+  "version": "1.0.0"
 }


### PR DESCRIPTION
This PR introduces two changes:
- Use self-hosted runner for Linux integration tests
- Simply the `﻿resolve/false.test.ts` to see if they improve in Windows.

---

And there contains two case in the most failed ci recently:

- `module/build/resolve/false.test.ts` in windows.
- timeout in linux

(I think there's a 70% chance that the issue is **not** caused by nx.)

Regardless, let's proceed in trying to solve this problem