### PR TITLE
chore: use github runner for integration test CI

### DIFF
--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   integration-test-linux:
     # The type of runner that the job will run on
-    runs-on: ${{ fromJSON(vars.SELF_LINUX_LABELS || '"ubuntu-latest"') }}
+    runs-on: "ubuntu-latest"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Noticed that some dependencies are missing from our Linux machine: https://github.com/web-infra-dev/modern.js/actions/runs/6649078621/job/18067041899#step:12:21