### PR TITLE
fix(docs): docs reference

### DIFF
--- a/.changeset/spicy-hounds-warn.md
+++ b/.changeset/spicy-hounds-warn.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/main-doc': patch
+---
+
+fix(storybook-docs): fix document reference

--- a/packages/document/builder-doc/docs/en/guide/advanced/storybook.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/storybook.md
@@ -50,11 +50,11 @@ export default config;
 
 Update dependencies like @storybook/addon-\* to major version 7.
 
-Finally, follow the official Storybook documentation to make the necessary updates for some breaking changes, such as changes in story writing and MDX syntax. You can refer to the migration guide at https://storybook.js.org/docs/react/migration-guide.
+Finally, follow the official Storybook documentation to make the necessary updates for some breaking changes, such as changes in story writing and MDX syntax. You can refer to the migration guide at [storybook migrate doc](https://storybook.js.org/docs/react/migration-guide).
 
 ### Native Storybook users
 
-Modern.js Builder only support Storybook 7, so you need to upgrade from Storybook version 6 to version 7, please follow the steps outlined in the official Storybook documentation at https://storybook.js.org/docs/react/migration-guide.
+Modern.js Builder only support Storybook 7, so you need to upgrade from Storybook version 6 to version 7, please follow the steps outlined in the official Storybook documentation at [storybook migrate doc](https://storybook.js.org/docs/react/migration-guide).
 
 To install @modern-js/storybook as the framework for Storybook, if you have interest in Rspack, install `@modern-js/builder-provider-rspack`, otherwise you should install `@modern-js/builder-provider-webpack`. Rspack is super fast compared to Webpack.
 
@@ -67,7 +67,7 @@ const config = {
 export default config;
 ```
 
-The default config file is `modern.config.(j|t)s`, for the detail config, see [builder config](/guide/basic/builder-config.html).
+The default config file is `modern.config.(j|t)s`, for the detail config, see [builder config](https://modernjs.dev/builder/guide/basic/builder-config.html).
 
 If the original project includes configurations for Babel, they need to be written in the modern configuration. Most Babel configurations have already been included in Modern.js.
 

--- a/packages/document/builder-doc/docs/en/guide/debug/debug-mode.md
+++ b/packages/document/builder-doc/docs/en/guide/debug/debug-mode.md
@@ -54,7 +54,7 @@ module.exports = {
 };
 ```
 
-For a complete introduction to Builder config, please see the [Builder Config](/guide/basic/builder-config.html) chapter.
+For a complete introduction to Builder config, please see the [Builder Config](https://modernjs.dev/builder/guide/basic/builder-config.html) chapter.
 
 ## Webpack Config File
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/storybook.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/storybook.md
@@ -50,11 +50,11 @@ export default config;
 
 升级 @storybook/addon-\* 系列依赖，升级到 7 版本。
 
-最后按照 Storybook 官网文档，对一些 breaking change 做相应的更新，例如 stories 的写法，MDX 的写法等，参考 https://storybook.js.org/docs/react/migration-guide。
+最后按照 Storybook 官网文档，对一些 breaking change 做相应的更新，例如 stories 的写法，MDX 的写法等，参考[storybook 迁移文档](https://storybook.js.org/docs/react/migration-guide)。
 
 ### 当前项目是 Storybook 项目，没有使用 Modern.js
 
-若当前 Storybook 版本还是 6，需要先按照 Storybook 官网文档升级到版本 7 ，参考 https://storybook.js.org/docs/react/migration-guide。
+若当前 Storybook 版本还是 6，需要先按照 Storybook 官网文档升级到版本 7 ，参考[storybook 迁移文档](https://storybook.js.org/docs/react/migration-guide)。
 
 安装 @modern-js/storybook，作为 storybook 的 framework。若想要使用 Rspack 作为构建工具，安装 @modern-js/builder-provider-rspack，若要使用 Webpack 作为构建工具，则安装 @modern-js/builder-provider-webpack。
 
@@ -67,7 +67,7 @@ const config = {
 export default config;
 ```
 
-Modern.js 的配置文件默认为 `modern.config.(j|t)s`，配置请查看 [builder 配置](/guide/basic/builder-config.html)。
+Modern.js 的配置文件默认为 `modern.config.(j|t)s`，配置请查看 [builder 配置](https://modernjs.dev/builder/guide/basic/builder-config.html)。
 
 若原来项目中包含了 Babel 等配置，需要对应的写在 modern 配置中，大部分 Babel 配置已经包含进了 Modern.js。
 

--- a/packages/document/builder-doc/docs/zh/guide/debug/debug-mode.md
+++ b/packages/document/builder-doc/docs/zh/guide/debug/debug-mode.md
@@ -54,7 +54,7 @@ module.exports = {
 };
 ```
 
-关于 Builder 配置项的完整介绍，请查看 [Builder 配置项](/guide/basic/builder-config.html) 章节。
+关于 Builder 配置项的完整介绍，请查看 [Builder 配置项](https://modernjs.dev/builder/guide/basic/builder-config.html) 章节。
 
 ## webpack 配置文件
 

--- a/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
@@ -2,7 +2,11 @@
 sidebar_position: 12
 ---
 
-# Using Storybook
+# Using StorybookV6
+
+:::warning
+This document is for users of the old version Storybook V6 and will be deprecated in the future. If you want to upgrade from an older version or if you are a new user who wants to try new storybook, please refer to the [new documentation here](https://modernjs.dev/builder/guide/advanced/storybook.html).
+:::
 
 [Storybook](https://storybook.js.org/) is a tool dedicated to component debugging, providing around component development.
 

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
@@ -5,7 +5,7 @@ sidebar_position: 12
 # 使用 StorybookV6
 
 :::warning
-该教程是用于老版本 StorybookV6 用户，并且会在以后弃用，想要从旧版本插件升级或新用户想要尝试请查看[新文档](https://modernjs.dev/builder/guide/storybook.html)
+该教程是用于老版本 StorybookV6 用户，并且会在以后弃用，想要从旧版本插件升级或新用户想要尝试请查看[新文档](https://modernjs.dev/builder/guide/advanced/storybook.html)
 :::
 
 


### PR DESCRIPTION
## Summary

fix doc references

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4584d9</samp>

This pull request improves the documentation for using Storybook with the `builder-doc` and `main-doc` packages. It fixes link issues, enhances readability and accessibility, and adds deprecation warnings for the old version of Storybook. It also adds a changeset file for the `@modern-js/main-doc` package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4584d9</samp>

*  Add a changeset file to indicate a patch release and describe the document reference fix ([link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-610ede8db430859f9fdb4c7473751cf70c12731dcf673d9fa7d0483743b81223R1-R5))
*  Update the documents for using Storybook to use links instead of plain URLs for the migration guide and absolute URLs instead of relative URLs for the builder config, in both English and Chinese versions ([link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-d8462f8d5a7ee66ef224948ec8bc119a2e58dd982fd0714d4575c34afa6d4125L53-R57), [link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-d8462f8d5a7ee66ef224948ec8bc119a2e58dd982fd0714d4575c34afa6d4125L70-R70), [link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dL53-R57), [link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dL70-R70))
*  Update the documents for the debug mode to use absolute URLs instead of relative URLs for the builder config, in both English and Chinese versions ([link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-a689ea73ee83b1e26e0a64ad075d101b0b6aaa151a1408c7a7e775131c7b15aaL57-R57), [link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-259d6785c5c8af590f3b23ffd8c2671b18a680029df9918824698e86539c33aaL57-R57))
*  Add a warning to the documents for using the old version Storybook V6 and provide a link to the new version Storybook V7, in both English and Chinese versions (`using-storybook.mdx` files, [link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-035db2ac24c8b7d4a7e94f94ac046804a4786d5688eadb9b3538920ab557c8a3L5-R10), [link](https://github.com/web-infra-dev/modern.js/pull/4869/files?diff=unified&w=0#diff-a47ea9bca5870e6377cdd9e866aa7f90e8069297b59d3c83ef3d12b87cbfe7f6L8-R8))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
