### PR TITLE
fix(browser-false): missing version field

### DIFF
--- a/tests/integration/module/fixtures/build/resolve/false/browser-false/package.json
+++ b/tests/integration/module/fixtures/build/resolve/false/browser-false/package.json
@@ -1,5 +1,6 @@
 {
   "name": "browser-false",
+  "version": "1.0.0",
   "browser": {
     "./util": false
   }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 919d116</samp>

Added `version` field to `package.json` file of `browser-false` package. This prepares the package for publishing and distribution as part of the modern.js framework.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 919d116</samp>

*  Add `version` field to `package.json` file with value `1.0.0` to prepare package for publishing ([link](https://github.com/web-infra-dev/modern.js/pull/4870/files?diff=unified&w=0#diff-70681e96c59ed4981941dafb570912f4a20a986fe4baa7a61ad477869d3b73b4R3))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
