### PR TITLE
chore: upgrade react-router and remix

### DIFF
--- a/.changeset/stale-donkeys-deliver.md
+++ b/.changeset/stale-donkeys-deliver.md
@@ -1,0 +1,10 @@
+---
+'@modern-js/plugin-data-loader': patch
+'@modern-js/plugin-garfish': patch
+'@modern-js/runtime': patch
+'@modern-js/runtime-utils': patch
+'@modern-js/plugin-ssg': patch
+---
+
+chore: upgrade react-router and remix
+chore: 更新 react-router 和 remix

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -7,9 +7,9 @@ import {
 } from '@remix-run/node';
 import {
   createStaticHandler,
-  ErrorResponse,
   UNSAFE_DEFERRED_SYMBOL as DEFERRED_SYMBOL,
   type UNSAFE_DeferredData as DeferredData,
+  isRouteErrorResponse,
 } from '@modern-js/runtime-utils/remix-router';
 import { transformNestedRoutes } from '@modern-js/runtime-utils/browser';
 import { isPlainObject } from '@modern-js/utils/lodash';
@@ -162,7 +162,10 @@ export const handleRequest = async ({
     });
 
     if (isResponse(response) && isRedirectResponse(response.status)) {
-      response = convertModernRedirectResponse(response.headers, basename);
+      response = convertModernRedirectResponse(
+        response.headers as unknown as Headers,
+        basename,
+      );
     } else if (isPlainObject(response) && DEFERRED_SYMBOL in response) {
       const deferredData = response[DEFERRED_SYMBOL] as DeferredData;
       const body = createDeferredReadableStream(deferredData, request.signal);
@@ -191,7 +194,7 @@ export const handleRequest = async ({
           });
     }
   } catch (error) {
-    const message = error instanceof ErrorResponse ? error.data : String(error);
+    const message = isRouteErrorResponse(error) ? error.data : String(error);
     if (error instanceof Error) {
       logger?.error(error);
     } else {

--- a/packages/cli/plugin-ssg/package.json
+++ b/packages/cli/plugin-ssg/package.json
@@ -91,7 +91,7 @@
     "jest": "^29",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.17.0",
     "typescript": "^5"
   },
   "sideEffects": false,

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -104,7 +104,7 @@
     "jest-fetch-mock": "^3.0.3",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.17.0",
     "typescript": "^5"
   },
   "sideEffects": false,

--- a/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
@@ -7,7 +7,7 @@ import type {
   SSRMode,
 } from '@modern-js/types';
 import {
-  ErrorResponse,
+  UNSAFE_ErrorResponseImpl as ErrorResponseImpl,
   type StaticHandlerContext,
   type Router,
 } from '@modern-js/runtime-utils/remix-router';
@@ -175,7 +175,7 @@ export function deserializeErrors(
     // Hey you!  If you change this, please change the corresponding logic in
     // serializeErrors
     if (val && val.__type === 'RouteErrorResponse') {
-      serialized[key] = new ErrorResponse(
+      serialized[key] = new ErrorResponseImpl(
         val.status,
         val.statusText,
         val.data,

--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -119,8 +119,8 @@
   "dependencies": {
     "@modern-js/utils": "workspace:*",
     "serialize-javascript": "^6.0.0",
-    "react-router-dom": "6.15.0",
-    "@remix-run/router": "1.8.0",
+    "react-router-dom": "6.17.0",
+    "@remix-run/router": "1.10.0",
     "@swc/helpers": "0.5.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1171,8 +1171,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       react-router-dom:
-        specifier: ^6.8.1
-        version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.17.0
+        version: 6.17.0(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -3330,8 +3330,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       react-router-dom:
-        specifier: ^6.8.1
-        version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.17.0
+        version: 6.17.0(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: ^5
         version: 5.0.4
@@ -5098,14 +5098,14 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@remix-run/router':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.10.0
+        version: 1.10.0
       '@swc/helpers':
         specifier: 0.5.1
         version: 0.5.1
       react-router-dom:
-        specifier: 6.15.0
-        version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.17.0
+        version: 6.17.0(react-dom@18.2.0)(react@18.2.0)
       serialize-javascript:
         specifier: ^6.0.0
         version: 6.0.1
@@ -5881,8 +5881,8 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
       react-router-dom:
-        specifier: ^6.8.1
-        version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.17.0
+        version: 6.17.0(react-dom@18.2.0)(react@18.2.0)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -14493,14 +14493,14 @@ packages:
       stream-slice: 0.1.2
     dev: false
 
+  /@remix-run/router@1.10.0:
+    resolution: {integrity: sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==}
+    engines: {node: '>=14.0.0'}
+
   /@remix-run/router@1.3.2:
     resolution: {integrity: sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==}
     engines: {node: '>=14'}
     dev: false
-
-  /@remix-run/router@1.8.0:
-    resolution: {integrity: sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==}
-    engines: {node: '>=14.0.0'}
 
   /@remix-run/server-runtime@1.13.0:
     resolution: {integrity: sha512-gjIW3XCeIlOt3rrOZMD6HixQydRgs1SwYjP99ZAVruG2+gNq/tL2OusMFYTLvtWrybt215tPROyF/6iTLsaO3g==}
@@ -14852,7 +14852,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
       react-lazy-with-preload: 2.2.1
-      react-router-dom: 6.15.0(react-dom@18.2.0)(react@18.2.0)
+      react-router-dom: 6.17.0(react-dom@18.2.0)(react@18.2.0)
       react-syntax-highlighter: 15.5.0(react@18.2.0)
       rehype-autolink-headings: 6.1.1
       rehype-external-links: 2.0.1
@@ -29375,17 +29375,17 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
-  /react-router-dom@6.15.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==}
+  /react-router-dom@6.17.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.8.0
+      '@remix-run/router': 1.10.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.15.0(react@18.2.0)
+      react-router: 6.17.0(react@18.2.0)
 
   /react-router@5.3.4(react@18.2.0):
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
@@ -29404,13 +29404,13 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
-  /react-router@6.15.0(react@18.2.0):
-    resolution: {integrity: sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==}
+  /react-router@6.17.0(react@18.2.0):
+    resolution: {integrity: sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.8.0
+      '@remix-run/router': 1.10.0
       react: 18.2.0
 
   /react-side-effect@2.1.2(react@18.2.0):

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -12,7 +12,7 @@
     "lodash": "^4.17.21",
     "react": "^18",
     "react-dom": "^18",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "6.17.0",
     "vue": "^3.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3acb7d8</samp>

Updated the code to use the latest version of `@remix-run/router` and its new API. Bumped the `react-router-dom` dependency version across several packages to match the peer dependency requirement of `@remix-run/router`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3acb7d8</samp>

*  Update `react-router-dom` dependency version to `6.17.0` in several packages to match the peer dependency requirement of `@remix-run/router` and use the latest features and bug fixes ([link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-e846ee504d15ad0546aba89589fd6c87fea9c4ab12bb6ce61815770a4466ba07L94-R94), [link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-e096c3e0345e1b9606770a2fcc3f4ff9ac8deddb1a361935de73fa2761b9aa7cL107-R107), [link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-560fbea092d0619f8d5ff773b4836125abef98396c8924530851e4979761764fL122-R123), [link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-283456d349870a43f9269898463ae8e4041fd489a775c83b2aa27776d895b137L15-R15))
* Update `@remix-run/router` dependency version to `1.10.0` in `packages/toolkit/runtime-utils/package.json` to use the new features and bug fixes ([link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-560fbea092d0619f8d5ff773b4836125abef98396c8924530851e4979761764fL122-R123))
* Replace `ErrorResponse` type with `UNSAFE_ErrorResponseImpl` as the imported name in `packages/cli/plugin-data-loader/src/runtime/index.ts` and `packages/runtime/plugin-garfish/src/router/runtime/utils.tsx`, because the `ErrorResponse` type was renamed and exported as an internal implementation detail ([link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL10-R12), [link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L10-R10))
* Add `isRouteErrorResponse` function as a public API to check if an error is an instance of `ErrorResponse`, and use it instead of `error instanceof ErrorResponse` in `packages/cli/plugin-data-loader/src/runtime/index.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL10-R12), [link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL194-R197))
* Cast `response.headers` to `unknown` and then to `Headers` in `packages/cli/plugin-data-loader/src/runtime/index.ts`, to avoid TypeScript errors when calling the `convertModernRedirectResponse` function, which expects a `Headers` argument, because the `response` type was changed from `Response` to `Response | RouteResponse` in the `@remix-run/router` package, and the `RouteResponse` type does not have a `headers` property ([link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-f9da7a857e3fdfbcd54347f5d566dd980f03b59099c61ec0f38941505cf0b4feL165-R168))
* Replace `ErrorResponse` constructor with `ErrorResponseImpl` as the imported name in `packages/runtime/plugin-garfish/src/router/runtime/utils.tsx`, for the same reason as above ([link](https://github.com/web-infra-dev/modern.js/pull/4873/files?diff=unified&w=0#diff-68d33c0330ce6ad71e2f784749c8749d053abdbac5823f9b400a010e1e60bb32L178-R178))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
