### PR TITLE
docs(main): no longer add link to Builder

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/dev/asset-prefix.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/asset-prefix.mdx
@@ -4,10 +4,6 @@ sidebar_label: assetPrefix
 
 # dev.assetPrefix
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.assetPrefix](https://modernjs.dev/builder/en/api/config-dev.html#devassetprefix).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/assetPrefix.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/dev/before-start-url.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/before-start-url.mdx
@@ -4,10 +4,6 @@ sidebar_label: beforeStartUrl
 
 # dev.beforeStartUrl
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.beforeStartUrl](https://modernjs.dev/builder/en/api/config-dev.html#devbeforestarturl).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/beforeStartUrl.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/dev/hmr.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/hmr.mdx
@@ -4,10 +4,6 @@ sidebar_label: hmr
 
 # dev.hmr
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.hmr](https://modernjs.dev/builder/en/api/config-dev.html#devhmr).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/hmr.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/dev/host.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/host.mdx
@@ -4,10 +4,6 @@ sidebar_label: host
 
 # dev.host
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.host](https://modernjs.dev/builder/en/api/config-dev.html#devhost).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/host.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/dev/https.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/https.mdx
@@ -4,10 +4,6 @@ sidebar_label: https
 
 # dev.https
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.https](https://modernjs.dev/builder/en/api/config-dev.html#devhttps).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/https.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/dev/port.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/port.mdx
@@ -4,10 +4,6 @@ sidebar_label: port
 
 # dev.port
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.port](https://modernjs.dev/builder/en/api/config-dev.html#devport).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/port.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/dev/progress-bar.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/progress-bar.mdx
@@ -4,10 +4,6 @@ sidebar_label: progressBar
 
 # dev.progressBar
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.progressBar](https://modernjs.dev/builder/en/api/config-dev.html#devprogressbar).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/progressBar.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/dev/start-url.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/dev/start-url.mdx
@@ -4,10 +4,6 @@ sidebar_label: startUrl
 
 # dev.startUrl
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [dev.startUrl](https://modernjs.dev/builder/en/api/config-dev.html#devstarturl).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/dev/startUrl.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/experiments/lazy-compilation.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/experiments/lazy-compilation.mdx
@@ -4,10 +4,6 @@ sidebar_label: lazyCompilation
 
 # experiments.lazyCompilation
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [experiments.lazyCompilation](https://modernjs.dev/builder/en/api/config-experiments.html#experimentslazycompilation).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/experiments/lazyCompilation.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/experiments/source-build.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/experiments/source-build.mdx
@@ -4,10 +4,6 @@ sidebar_label: sourceBuild
 
 # experiments.sourceBuild
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [experiments.sourceBuild](https://modernjs.dev/builder/en/api/config-experiments.html#experimentssourcebuild).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/experiments/sourceBuild.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/app-icon.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/app-icon.mdx
@@ -4,10 +4,6 @@ sidebar_label: appIcon
 
 # html.appIcon
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.appIcon](https://modernjs.dev/builder/en/api/config-html.html#htmlappicon).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/appIcon.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/crossorigin.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/crossorigin.mdx
@@ -4,10 +4,6 @@ sidebar_label: crossorigin
 
 # html.crossorigin
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.crossorigin](https://modernjs.dev/builder/en/api/config-html.html#htmlcrossorigin).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/crossorigin.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/disable-html-folder.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/disable-html-folder.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableHtmlFolder
 
 # html.disableHtmlFolder
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.disableHtmlFolder](https://modernjs.dev/builder/en/api/config-html.html#htmldisablehtmlfolder).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/disableHtmlFolder.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/favicon-by-entries.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/favicon-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: faviconByEntries
 
 # html.faviconByEntries
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.faviconByEntries](https://modernjs.dev/builder/en/api/config-html.html#htmlfaviconbyentries).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/faviconByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/favicon.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/favicon.mdx
@@ -4,10 +4,6 @@ sidebar_label: favicon
 
 # html.favicon
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.favicon](https://modernjs.dev/builder/en/api/config-html.html#htmlfavicon).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/favicon.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/inject-by-entries.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/inject-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: injectByEntries
 
 # html.injectByEntries
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.injectByEntries](https://modernjs.dev/builder/en/api/config-html.html#htmlinjectbyentries).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/injectByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/inject.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/inject.mdx
@@ -4,10 +4,6 @@ sidebar_label: inject
 
 # html.inject
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.inject](https://modernjs.dev/builder/en/api/config-html.html#htmlinject).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/inject.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/meta-by-entries.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/meta-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: metaByEntries
 
 # html.metaByEntries
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.metaByEntries](https://modernjs.dev/builder/en/api/config-html.html#htmlmetabyentries).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/metaByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/meta.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/meta.mdx
@@ -4,10 +4,6 @@ sidebar_label: meta
 
 # html.meta
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.meta](https://modernjs.dev/builder/en/api/config-html.html#htmlmeta).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/meta.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/mount-id.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/mount-id.mdx
@@ -4,10 +4,6 @@ sidebar_label: mountId
 
 # html.mountId
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.mountId](https://modernjs.dev/builder/en/api/config-html.html#htmlmountid).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/mountId.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/script-loading.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/script-loading.mdx
@@ -4,10 +4,6 @@ sidebar_label: scriptLoading
 
 # html.scriptLoading
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.scriptLoading](https://modernjs.dev/builder/en/api/config-html.html#htmlscriptloading).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/scriptLoading.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/tags-by-entries.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/tags-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: tagsByEntries
 
 # html.tagsByEntries
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.tagsByEntries](https://modernjs.dev/builder/en/api/config-html.html#htmltagsbyentries).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/tagsByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/tags.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/tags.mdx
@@ -4,10 +4,6 @@ sidebar_label: tags
 
 # html.tags
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.tags](https://modernjs.dev/builder/en/api/config-html.html#htmltags).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/tags.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/template-by-entries.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/template-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: templateByEntries
 
 # html.templateByEntries
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.templateByEntries](https://modernjs.dev/builder/en/api/config-html.html#htmltemplatebyentries).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/templateByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/template-parameters-by-entries.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/template-parameters-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: templateParametersByEntries
 
 # html.templateParametersByEntries
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.templateParametersByEntries](https://modernjs.dev/builder/en/api/config-html.html#htmltemplateparametersbyentries).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/templateParametersByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/template-parameters.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/template-parameters.mdx
@@ -4,10 +4,6 @@ sidebar_label: templateParameters
 
 # html.templateParameters
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.templateParameters](https://modernjs.dev/builder/en/api/config-html.html#htmltemplateparameters).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/templateParameters.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/template.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/template.mdx
@@ -4,10 +4,6 @@ sidebar_label: template
 
 # html.template
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.template](https://modernjs.dev/builder/en/api/config-html.html#htmltemplate).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/template.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/title-by-entries.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/title-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: titleByEntries
 
 # html.titleByEntries
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.titleByEntries](https://modernjs.dev/builder/en/api/config-html.html#htmltitlebyentries).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/titleByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/html/title.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/html/title.mdx
@@ -4,10 +4,6 @@ sidebar_label: title
 
 # html.title
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [html.title](https://modernjs.dev/builder/en/api/config-html.html#htmltitle).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/html/title.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/asset-prefix.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/asset-prefix.mdx
@@ -4,10 +4,6 @@ sidebar_label: assetPrefix
 
 # output.assetPrefix
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.assetPrefix](https://modernjs.dev/builder/en/api/config-output.html#outputassetprefix).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/assetPrefix.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/assets-retry.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/assets-retry.mdx
@@ -4,10 +4,6 @@ sidebar_label: assetsRetry
 
 # output.assetsRetry
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.assetsRetry](https://modernjs.dev/builder/en/api/config-output.html#outputassetsretry).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/assetsRetry.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/charset.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/charset.mdx
@@ -4,10 +4,6 @@ sidebar_label: charset
 
 # output.charset
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.charset](https://modernjs.dev/builder/en/api/config-output.html#outputcharset).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/charset.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/clean-dist-path.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/clean-dist-path.mdx
@@ -4,10 +4,6 @@ sidebar_label: cleanDistPath
 
 # output.cleanDistPath
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.cleanDistPath](https://modernjs.dev/builder/en/api/config-output.html#outputcleandistpath).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/cleanDistPath.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/convert-to-rem.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/convert-to-rem.mdx
@@ -4,10 +4,6 @@ sidebar_label: convertToRem
 
 # output.convertToRem
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.convertToRem](https://modernjs.dev/builder/en/api/config-output.html#outputconverttorem).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/convertToRem.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/copy.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/copy.mdx
@@ -4,10 +4,6 @@ sidebar_label: copy
 
 # output.copy
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.copy](https://modernjs.dev/builder/en/api/config-output.html#outputcopy).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/copy.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/css-module-local-ident-name.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/css-module-local-ident-name.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssModuleLocalIdentName
 
 # output.cssModuleLocalIdentName
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.cssModuleLocalIdentName](https://modernjs.dev/builder/en/api/config-output.html#outputcssmodulelocalidentname).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/cssModuleLocalIdentName.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/css-modules.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/css-modules.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssModules
 
 # output.cssModules
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.cssModules](https://modernjs.dev/builder/en/api/config-output.html#outputcssmodules).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/cssModules.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/data-uri-limit.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/data-uri-limit.mdx
@@ -4,10 +4,6 @@ sidebar_label: dataUriLimit
 
 # output.dataUriLimit
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.dataUriLimit](https://modernjs.dev/builder/en/api/config-output.html#outputdataurilimit).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/dataUriLimit.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-css-extract.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-css-extract.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableCssExtract
 
 # output.disableCssExtract
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableCssExtract](https://modernjs.dev/builder/en/api/config-output.html#outputdisablecssextract).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableCssExtract.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-css-module-extension.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-css-module-extension.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableCssModuleExtension
 
 # output.disableCssModuleExtension
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableCssModuleExtension](https://modernjs.dev/builder/en/api/config-output.html#outputdisablecssmoduleextension).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableCssModuleExtension.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-filename-hash.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-filename-hash.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableFilenameHash
 
 # output.disableFilenameHash
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableFilenameHash](https://modernjs.dev/builder/en/api/config-output.html#outputdisablefilenamehash).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableFilenameHash.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-inline-runtime-chunk.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-inline-runtime-chunk.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableInlineRuntimeChunk
 
 # output.disableInlineRuntimeChunk
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableInlineRuntimeChunk](https://modernjs.dev/builder/en/api/config-output.html#outputdisableinlineruntimechunk).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableInlineRuntimeChunk.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-minimize.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-minimize.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableMinimize
 
 # output.disableMinimize
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableMinimize](https://modernjs.dev/builder/en/api/config-output.html#outputdisableminimize).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableMinimize.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-source-map.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-source-map.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableSourceMap
 
 # output.disableSourceMap
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableSourceMap](https://modernjs.dev/builder/en/api/config-output.html#outputdisablesourcemap).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableSourceMap.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-svgr.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-svgr.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableSvgr
 
 # output.disableSvgr
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableSvgr](https://modernjs.dev/builder/en/api/config-output.html#outputdisablesvgr).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableSvgr.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-ts-checker.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-ts-checker.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableTsChecker
 
 # output.disableTsChecker
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.disableTsChecker](https://modernjs.dev/builder/en/api/config-output.html#outputdisabletschecker).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/disableTsChecker.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/dist-path.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/dist-path.mdx
@@ -4,10 +4,6 @@ sidebar_label: distPath
 
 # output.distPath
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.distPath](https://modernjs.dev/builder/en/api/config-output.html#outputdistpath).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/distPath.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/enable-asset-fallback.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/enable-asset-fallback.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableAssetFallback
 
 # output.enableAssetFallback
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.enableAssetFallback](https://modernjs.dev/builder/en/api/config-output.html#outputenableassetfallback).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/enableAssetFallback.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/enable-asset-manifest.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/enable-asset-manifest.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableAssetManifest
 
 # output.enableAssetManifest
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.enableAssetManifest](https://modernjs.dev/builder/en/api/config-output.html#outputenableassetmanifest).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/enableAssetManifest.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/enable-css-module-tsdeclaration.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/enable-css-module-tsdeclaration.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableCssModuleTSDeclaration
 
 # output.enableCssModuleTSDeclaration
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.enableCssModuleTSDeclaration](https://modernjs.dev/builder/en/api/config-output.html#outputenablecssmoduletsdeclaration).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/enableCssModuleTSDeclaration.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/enable-inline-scripts.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/enable-inline-scripts.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableInlineScripts
 
 # output.enableInlineScripts
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.enableInlineScripts](https://modernjs.dev/builder/en/api/config-output.html#outputenableinlinescripts).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/enableInlineScripts.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/enable-inline-styles.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/enable-inline-styles.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableInlineStyles
 
 # output.enableInlineStyles
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.enableInlineStyles](https://modernjs.dev/builder/en/api/config-output.html#outputenableinlinestyles).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/enableInlineStyles.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/enable-latest-decorators.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/enable-latest-decorators.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableLatestDecorators
 
 # output.enableLatestDecorators
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.enableLatestDecorators](https://modernjs.dev/builder/en/api/config-output.html#outputenablelatestdecorators).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/enableLatestDecorators.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/externals.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/externals.mdx
@@ -4,10 +4,6 @@ sidebar_label: externals
 
 # output.externals
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.externals](https://modernjs.dev/builder/en/api/config-output.html#outputexternals).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/externals.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/filename.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/filename.mdx
@@ -4,10 +4,6 @@ sidebar_label: filename
 
 # output.filename
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.filename](https://modernjs.dev/builder/en/api/config-output.html#outputfilename).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/filename.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/legal-comments.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/legal-comments.mdx
@@ -4,10 +4,6 @@ sidebar_label: legalComments
 
 # output.legalComments
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.legalComments](https://modernjs.dev/builder/en/api/config-output.html#outputlegalcomments).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/legalComments.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/override-browserslist.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/override-browserslist.mdx
@@ -4,10 +4,6 @@ sidebar_label: overrideBrowserslist
 
 # output.overrideBrowserslist
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.overrideBrowserslist](https://modernjs.dev/builder/en/api/config-output.html#outputoverridebrowserslist).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/overrideBrowserslist.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/polyfill.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/polyfill.mdx
@@ -4,10 +4,6 @@ sidebar_label: polyfill
 
 # output.polyfill
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.polyfill](https://modernjs.dev/builder/en/api/config-output.html#outputpolyfill).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/polyfill.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/output/svg-default-export.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/svg-default-export.mdx
@@ -4,10 +4,6 @@ sidebar_label: svgDefaultExport
 
 # output.svgDefaultExport
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [output.svgDefaultExport](https://modernjs.dev/builder/en/api/config-output.html#outputsvgdefaultexport).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/output/svgDefaultExport.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/build-cache.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/build-cache.mdx
@@ -4,10 +4,6 @@ sidebar_label: buildCache
 
 # performance.buildCache
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.buildCache](https://modernjs.dev/builder/en/api/config-performance.html#performancebuildcache).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/buildCache.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/bundle-analyze.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/bundle-analyze.mdx
@@ -4,10 +4,6 @@ sidebar_label: bundleAnalyze
 
 # performance.bundleAnalyze
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.bundleAnalyze](https://modernjs.dev/builder/en/api/config-performance.html#performancebundleanalyze).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/bundleAnalyze.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/chunk-split.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/chunk-split.mdx
@@ -4,10 +4,6 @@ sidebar_label: chunkSplit
 
 # performance.chunkSplit
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.chunkSplit](https://modernjs.dev/builder/en/api/config-performance.html#performancechunksplit).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/chunkSplit.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/dns-prefetch.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/dns-prefetch.mdx
@@ -4,10 +4,6 @@ sidebar_label: dnsPrefetch
 
 # performance.dnsPrefetch
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.dnsPrefetch](https://modernjs.dev/builder/en/api/config-performance.html#performancednsprefetch).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/dnsPrefetch.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/preconnect.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/preconnect.mdx
@@ -4,10 +4,6 @@ sidebar_label: preconnect
 
 # performance.preconnect
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.preconnect](https://modernjs.dev/builder/en/api/config-performance.html#performancepreconnect).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/preconnect.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/prefetch.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/prefetch.mdx
@@ -4,10 +4,6 @@ sidebar_label: prefetch
 
 # performance.prefetch
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.prefetch](https://modernjs.dev/builder/en/api/config-performance.html#performanceprefetch).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/prefetch.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/preload.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/preload.mdx
@@ -4,10 +4,6 @@ sidebar_label: preload
 
 # performance.preload
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.preload](https://modernjs.dev/builder/en/api/config-performance.html#performancepreload).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/preload.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/print-file-size.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/print-file-size.mdx
@@ -4,10 +4,6 @@ sidebar_label: printFileSize
 
 # performance.printFileSize
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.printFileSize](https://modernjs.dev/builder/en/api/config-performance.html#performanceprintfilesize).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/printFileSize.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/profile.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/profile.mdx
@@ -4,10 +4,6 @@ sidebar_label: profile
 
 # performance.profile
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.profile](https://modernjs.dev/builder/en/api/config-performance.html#performanceprofile).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/profile.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/remove-console.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/remove-console.mdx
@@ -4,10 +4,6 @@ sidebar_label: removeConsole
 
 # performance.removeConsole
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.removeConsole](https://modernjs.dev/builder/en/api/config-performance.html#performanceremoveconsole).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/removeConsole.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/remove-moment-locale.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/remove-moment-locale.mdx
@@ -4,10 +4,6 @@ sidebar_label: removeMomentLocale
 
 # performance.removeMomentLocale
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.removeMomentLocale](https://modernjs.dev/builder/en/api/config-performance.html#performanceremovemomentlocale).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/removeMomentLocale.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/performance/transform-lodash.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/transform-lodash.mdx
@@ -4,10 +4,6 @@ sidebar_label: transformLodash
 
 # performance.transformLodash
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [performance.transformLodash](https://modernjs.dev/builder/en/api/config-performance.html#performancetransformlodash).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/performance/transformLodash.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/security/check-syntax.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/security/check-syntax.mdx
@@ -4,10 +4,6 @@ sidebar_label: checkSyntax
 
 # security.checkSyntax
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [security.checkSyntax](https://modernjs.dev/builder/en/api/config-security.html#securitychecksyntax).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/security/checkSyntax.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/security/nonce.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/security/nonce.mdx
@@ -4,10 +4,6 @@ sidebar_label: nonce
 
 # security.nonce
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [security.nonce](https://modernjs.dev/builder/en/api/config-security.html#securitynonce).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/security/nonce.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/security/sri.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/security/sri.mdx
@@ -4,10 +4,6 @@ sidebar_label: sri
 
 # security.sri
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [security.sri](https://modernjs.dev/builder/en/api/config-security.html#securitysri).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/security/sri.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/alias-strategy.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/alias-strategy.mdx
@@ -4,10 +4,6 @@ sidebar_label: aliasStrategy
 
 # source.aliasStrategy
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.aliasStrategy](https://modernjs.dev/builder/en/api/config-source.html#sourcealiasstrategy).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/aliasStrategy.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/alias.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/alias.mdx
@@ -4,10 +4,6 @@ sidebar_label: alias
 
 # source.alias
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.alias](https://modernjs.dev/builder/en/api/config-source.html#sourcealias).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/alias.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/compile-js-data-uri.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/compile-js-data-uri.mdx
@@ -4,10 +4,6 @@ sidebar_label: compileJsDataURI
 
 # source.compileJsDataURI
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.compileJsDataURI](https://modernjs.dev/builder/en/api/config-source.html#sourcecompilejsdatauri).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/compileJsDataURI.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/define.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/define.mdx
@@ -4,10 +4,6 @@ sidebar_label: define
 
 # source.define
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.define](https://modernjs.dev/builder/en/api/config-source.html#sourcedefine).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/define.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/exclude.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/exclude.mdx
@@ -4,10 +4,6 @@ sidebar_label: exclude
 
 # source.exclude
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.exclude](https://modernjs.dev/builder/en/api/config-source.html#sourceexclude).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/exclude.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/global-vars.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/global-vars.mdx
@@ -4,10 +4,6 @@ sidebar_label: globalVars
 
 # source.globalVars
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.globalVars](https://modernjs.dev/builder/en/api/config-source.html#sourceglobalvars).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/globalVars.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/include.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/include.mdx
@@ -4,10 +4,6 @@ sidebar_label: include
 
 # source.include
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.include](https://modernjs.dev/builder/en/api/config-source.html#sourceinclude).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/include.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/module-scopes.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/module-scopes.mdx
@@ -4,10 +4,6 @@ sidebar_label: moduleScopes
 
 # source.moduleScopes
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.moduleScopes](https://modernjs.dev/builder/en/api/config-source.html#sourcemodulescopes).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/moduleScopes.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/pre-entry.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/pre-entry.mdx
@@ -4,10 +4,6 @@ sidebar_label: preEntry
 
 # source.preEntry
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.preEntry](https://modernjs.dev/builder/en/api/config-source.html#sourcepreentry).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/preEntry.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/resolve-extension-prefix.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/resolve-extension-prefix.mdx
@@ -4,10 +4,6 @@ sidebar_label: resolveExtensionPrefix
 
 # source.resolveExtensionPrefix
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.resolveExtensionPrefix](https://modernjs.dev/builder/en/api/config-source.html#sourceresolveextensionprefix).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/resolveExtensionPrefix.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/resolve-main-fields.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/resolve-main-fields.mdx
@@ -4,10 +4,6 @@ sidebar_label: resolveMainFields
 
 # source.resolveMainFields
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.resolveMainFields](https://modernjs.dev/builder/en/api/config-source.html#sourceresolvemainfields).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/resolveMainFields.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/source/transform-import.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/transform-import.mdx
@@ -4,10 +4,6 @@ sidebar_label: transformImport
 
 # source.transformImport
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [source.transformImport](https://modernjs.dev/builder/en/api/config-source.html#sourcetransformimport).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/source/transformImport.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/autoprefixer.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/autoprefixer.mdx
@@ -4,10 +4,6 @@ sidebar_label: autoprefixer
 
 # tools.autoprefixer
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.autoprefixer](https://modernjs.dev/builder/en/api/config-tools.html#toolsautoprefixer).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/autoprefixer.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/babel.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/babel.mdx
@@ -4,10 +4,6 @@ sidebar_label: babel
 
 # tools.babel
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.babel](https://modernjs.dev/builder/en/api/config-tools.html#toolsbabel).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/babel.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/css-extract.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/css-extract.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssExtract
 
 # tools.cssExtract
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.cssExtract](https://modernjs.dev/builder/en/api/config-tools.html#toolscssextract).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/cssExtract.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/css-loader.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/css-loader.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssLoader
 
 # tools.cssLoader
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.cssLoader](https://modernjs.dev/builder/en/api/config-tools.html#toolscssloader).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/cssLoader.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/dev-server.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/dev-server.mdx
@@ -4,10 +4,6 @@ sidebar_label: devServer
 
 # tools.devServer
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.devServer](https://modernjs.dev/builder/en/api/config-tools.html#toolsdevserver).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/devServer.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/html-plugin.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/html-plugin.mdx
@@ -4,10 +4,6 @@ sidebar_label: htmlPlugin
 
 # tools.htmlPlugin
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.htmlPlugin](https://modernjs.dev/builder/en/api/config-tools.html#toolshtmlplugin).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/htmlPlugin.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/inspector.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/inspector.mdx
@@ -4,10 +4,6 @@ sidebar_label: inspector
 
 # tools.inspector
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.inspector](https://modernjs.dev/builder/en/api/config-tools.html#toolsinspector).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/inspector.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/less.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/less.mdx
@@ -4,10 +4,6 @@ sidebar_label: less
 
 # tools.less
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.less](https://modernjs.dev/builder/en/api/config-tools.html#toolsless).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/less.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/minify-css.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/minify-css.mdx
@@ -4,10 +4,6 @@ sidebar_label: minifyCss
 
 # tools.minifyCss
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.minifyCss](https://modernjs.dev/builder/en/api/config-tools.html#toolsminifycss).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/minifyCss.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/postcss.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/postcss.mdx
@@ -4,10 +4,6 @@ sidebar_label: postcss
 
 # tools.postcss
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.postcss](https://modernjs.dev/builder/en/api/config-tools.html#toolspostcss).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/postcss.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/pug.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/pug.mdx
@@ -4,10 +4,6 @@ sidebar_label: pug
 
 # tools.pug
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.pug](https://modernjs.dev/builder/en/api/config-tools.html#toolspug).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/pug.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/rspack.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/rspack.mdx
@@ -4,10 +4,6 @@ sidebar_label: rspack
 
 # tools.rspack
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.rspack](https://modernjs.dev/builder/en/api/config-tools.html#toolsrspack).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/rspack.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/sass.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/sass.mdx
@@ -4,10 +4,6 @@ sidebar_label: sass
 
 # tools.sass
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.sass](https://modernjs.dev/builder/en/api/config-tools.html#toolssass).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/sass.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/style-loader.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/style-loader.mdx
@@ -4,10 +4,6 @@ sidebar_label: styleLoader
 
 # tools.styleLoader
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.styleLoader](https://modernjs.dev/builder/en/api/config-tools.html#toolsstyleloader).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/styleLoader.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/styled-components.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/styled-components.mdx
@@ -4,10 +4,6 @@ sidebar_label: styledComponents
 
 # tools.styledComponents
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.styledComponents](https://modernjs.dev/builder/en/api/config-tools.html#toolsstyledcomponents).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/styledComponents.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/terser.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/terser.mdx
@@ -4,10 +4,6 @@ sidebar_label: terser
 
 # tools.terser
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.terser](https://modernjs.dev/builder/en/api/config-tools.html#toolsterser).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/terser.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/ts-checker.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/ts-checker.mdx
@@ -4,10 +4,6 @@ sidebar_label: tsChecker
 
 # tools.tsChecker
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.tsChecker](https://modernjs.dev/builder/en/api/config-tools.html#toolstschecker).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/tsChecker.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/ts-loader.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/ts-loader.mdx
@@ -4,10 +4,6 @@ sidebar_label: tsLoader
 
 # tools.tsLoader
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.tsLoader](https://modernjs.dev/builder/en/api/config-tools.html#toolstsloader).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/tsLoader.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/webpack-chain.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/webpack-chain.mdx
@@ -4,10 +4,6 @@ sidebar_label: webpackChain
 
 # tools.webpackChain
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.webpackChain](https://modernjs.dev/builder/en/api/config-tools.html#toolswebpackchain).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/webpackChain.md';
 
 <Main />

--- a/packages/document/main-doc/docs/en/configure/app/tools/webpack.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/webpack.mdx
@@ -4,10 +4,6 @@ sidebar_label: webpack
 
 # tools.webpack
 
-:::tip
-This config is provided by Modern.js Builder, more detail can see [tools.webpack](https://modernjs.dev/builder/en/api/config-tools.html#toolswebpack).
-:::
-
 import Main from '@modern-js/builder-doc/docs/en/config/tools/webpack.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/asset-prefix.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/asset-prefix.mdx
@@ -4,10 +4,6 @@ sidebar_label: assetPrefix
 
 # dev.assetPrefix
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.assetPrefix](https://modernjs.dev/builder/api/config-dev.html#devassetprefix)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/assetPrefix.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/before-start-url.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/before-start-url.mdx
@@ -4,10 +4,6 @@ sidebar_label: beforeStartUrl
 
 # dev.beforeStartUrl
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.beforeStartUrl](https://modernjs.dev/builder/api/config-dev.html#devbeforestarturl)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/beforeStartUrl.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/hmr.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/hmr.mdx
@@ -4,10 +4,6 @@ sidebar_label: hmr
 
 # dev.hmr
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.hmr](https://modernjs.dev/builder/api/config-dev.html#devhmr)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/hmr.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/host.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/host.mdx
@@ -4,10 +4,6 @@ sidebar_label: host
 
 # dev.host
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.host](https://modernjs.dev/builder/api/config-dev.html#devhost)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/host.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/https.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/https.mdx
@@ -4,10 +4,6 @@ sidebar_label: https
 
 # dev.https
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.https](https://modernjs.dev/builder/api/config-dev.html#devhttps)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/https.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/port.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/port.mdx
@@ -4,10 +4,6 @@ sidebar_label: port
 
 # dev.port
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.port](https://modernjs.dev/builder/api/config-dev.html#devport)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/port.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/progress-bar.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/progress-bar.mdx
@@ -4,10 +4,6 @@ sidebar_label: progressBar
 
 # dev.progressBar
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.progressBar](https://modernjs.dev/builder/api/config-dev.html#devprogressbar)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/progressBar.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/dev/start-url.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/dev/start-url.mdx
@@ -4,10 +4,6 @@ sidebar_label: startUrl
 
 # dev.startUrl
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [dev.startUrl](https://modernjs.dev/builder/api/config-dev.html#devstarturl)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/dev/startUrl.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/experiments/lazy-compilation.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/experiments/lazy-compilation.mdx
@@ -4,10 +4,6 @@ sidebar_label: lazyCompilation
 
 # experiments.lazyCompilation
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [experiments.lazyCompilation](https://modernjs.dev/builder/api/config-experiments.html#experimentslazycompilation)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/experiments/lazyCompilation.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/experiments/source-build.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/experiments/source-build.mdx
@@ -4,10 +4,6 @@ sidebar_label: sourceBuild
 
 # experiments.sourceBuild
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [experiments.sourceBuild](https://modernjs.dev/builder/api/config-experiments.html#experimentssourcebuild)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/experiments/sourceBuild.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/app-icon.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/app-icon.mdx
@@ -4,10 +4,6 @@ sidebar_label: appIcon
 
 # html.appIcon
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.appIcon](https://modernjs.dev/builder/api/config-html.html#htmlappicon)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/appIcon.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/crossorigin.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/crossorigin.mdx
@@ -4,10 +4,6 @@ sidebar_label: crossorigin
 
 # html.crossorigin
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.crossorigin](https://modernjs.dev/builder/api/config-html.html#htmlcrossorigin)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/crossorigin.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/disable-html-folder.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/disable-html-folder.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableHtmlFolder
 
 # html.disableHtmlFolder
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.disableHtmlFolder](https://modernjs.dev/builder/api/config-html.html#htmldisablehtmlfolder)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/disableHtmlFolder.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/favicon-by-entries.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/favicon-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: faviconByEntries
 
 # html.faviconByEntries
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.faviconByEntries](https://modernjs.dev/builder/api/config-html.html#htmlfaviconbyentries)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/faviconByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/favicon.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/favicon.mdx
@@ -4,10 +4,6 @@ sidebar_label: favicon
 
 # html.favicon
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.favicon](https://modernjs.dev/builder/api/config-html.html#htmlfavicon)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/favicon.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/inject-by-entries.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/inject-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: injectByEntries
 
 # html.injectByEntries
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.injectByEntries](https://modernjs.dev/builder/api/config-html.html#htmlinjectbyentries)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/injectByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/inject.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/inject.mdx
@@ -4,10 +4,6 @@ sidebar_label: inject
 
 # html.inject
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.inject](https://modernjs.dev/builder/api/config-html.html#htmlinject)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/inject.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/meta-by-entries.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/meta-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: metaByEntries
 
 # html.metaByEntries
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.metaByEntries](https://modernjs.dev/builder/api/config-html.html#htmlmetabyentries)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/metaByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/meta.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/meta.mdx
@@ -4,10 +4,6 @@ sidebar_label: meta
 
 # html.meta
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.meta](https://modernjs.dev/builder/api/config-html.html#htmlmeta)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/meta.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/mount-id.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/mount-id.mdx
@@ -4,10 +4,6 @@ sidebar_label: mountId
 
 # html.mountId
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.mountId](https://modernjs.dev/builder/api/config-html.html#htmlmountid)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/mountId.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/script-loading.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/script-loading.mdx
@@ -4,10 +4,6 @@ sidebar_label: scriptLoading
 
 # html.scriptLoading
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.scriptLoading](https://modernjs.dev/builder/api/config-html.html#htmlscriptloading)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/scriptLoading.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/tags-by-entries.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/tags-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: tagsByEntries
 
 # html.tagsByEntries
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.tagsByEntries](https://modernjs.dev/builder/api/config-html.html#htmltagsbyentries)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/tagsByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/tags.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/tags.mdx
@@ -4,10 +4,6 @@ sidebar_label: tags
 
 # html.tags
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.tags](https://modernjs.dev/builder/api/config-html.html#htmltags)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/tags.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/template-by-entries.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/template-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: templateByEntries
 
 # html.templateByEntries
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.templateByEntries](https://modernjs.dev/builder/api/config-html.html#htmltemplatebyentries)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/templateByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/template-parameters-by-entries.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/template-parameters-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: templateParametersByEntries
 
 # html.templateParametersByEntries
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.templateParametersByEntries](https://modernjs.dev/builder/api/config-html.html#htmltemplateparametersbyentries)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/templateParametersByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/template-parameters.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/template-parameters.mdx
@@ -4,10 +4,6 @@ sidebar_label: templateParameters
 
 # html.templateParameters
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.templateParameters](https://modernjs.dev/builder/api/config-html.html#htmltemplateparameters)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/templateParameters.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/template.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/template.mdx
@@ -4,10 +4,6 @@ sidebar_label: template
 
 # html.template
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.template](https://modernjs.dev/builder/api/config-html.html#htmltemplate)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/template.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/title-by-entries.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/title-by-entries.mdx
@@ -4,10 +4,6 @@ sidebar_label: titleByEntries
 
 # html.titleByEntries
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.titleByEntries](https://modernjs.dev/builder/api/config-html.html#htmltitlebyentries)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/titleByEntries.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/html/title.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/html/title.mdx
@@ -4,10 +4,6 @@ sidebar_label: title
 
 # html.title
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [html.title](https://modernjs.dev/builder/api/config-html.html#htmltitle)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/html/title.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/asset-prefix.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/asset-prefix.mdx
@@ -4,10 +4,6 @@ sidebar_label: assetPrefix
 
 # output.assetPrefix
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.assetPrefix](https://modernjs.dev/builder/api/config-output.html#outputassetprefix)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/assetPrefix.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/assets-retry.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/assets-retry.mdx
@@ -4,10 +4,6 @@ sidebar_label: assetsRetry
 
 # output.assetsRetry
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.assetsRetry](https://modernjs.dev/builder/api/config-output.html#outputassetsretry)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/assetsRetry.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/charset.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/charset.mdx
@@ -4,10 +4,6 @@ sidebar_label: charset
 
 # output.charset
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.charset](https://modernjs.dev/builder/api/config-output.html#outputcharset)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/charset.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/clean-dist-path.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/clean-dist-path.mdx
@@ -4,10 +4,6 @@ sidebar_label: cleanDistPath
 
 # output.cleanDistPath
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.cleanDistPath](https://modernjs.dev/builder/api/config-output.html#outputcleandistpath)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/cleanDistPath.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/convert-to-rem.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/convert-to-rem.mdx
@@ -4,10 +4,6 @@ sidebar_label: convertToRem
 
 # output.convertToRem
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.convertToRem](https://modernjs.dev/builder/api/config-output.html#outputconverttorem)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/convertToRem.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/copy.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/copy.mdx
@@ -4,10 +4,6 @@ sidebar_label: copy
 
 # output.copy
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.copy](https://modernjs.dev/builder/api/config-output.html#outputcopy)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/copy.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/css-module-local-ident-name.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/css-module-local-ident-name.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssModuleLocalIdentName
 
 # output.cssModuleLocalIdentName
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.cssModuleLocalIdentName](https://modernjs.dev/builder/api/config-output.html#outputcssmodulelocalidentname)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/cssModuleLocalIdentName.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/css-modules.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/css-modules.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssModules
 
 # output.cssModules
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.cssModules](https://modernjs.dev/builder/api/config-output.html#outputcssmodules)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/cssModules.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/data-uri-limit.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/data-uri-limit.mdx
@@ -4,10 +4,6 @@ sidebar_label: dataUriLimit
 
 # output.dataUriLimit
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.dataUriLimit](https://modernjs.dev/builder/api/config-output.html#outputdataurilimit)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/dataUriLimit.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-css-extract.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-css-extract.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableCssExtract
 
 # output.disableCssExtract
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableCssExtract](https://modernjs.dev/builder/api/config-output.html#outputdisablecssextract)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableCssExtract.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-css-module-extension.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-css-module-extension.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableCssModuleExtension
 
 # output.disableCssModuleExtension
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableCssModuleExtension](https://modernjs.dev/builder/api/config-output.html#outputdisablecssmoduleextension)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableCssModuleExtension.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-filename-hash.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-filename-hash.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableFilenameHash
 
 # output.disableFilenameHash
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableFilenameHash](https://modernjs.dev/builder/api/config-output.html#outputdisablefilenamehash)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableFilenameHash.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-inline-runtime-chunk.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-inline-runtime-chunk.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableInlineRuntimeChunk
 
 # output.disableInlineRuntimeChunk
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableInlineRuntimeChunk](https://modernjs.dev/builder/api/config-output.html#outputdisableinlineruntimechunk)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableInlineRuntimeChunk.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-minimize.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-minimize.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableMinimize
 
 # output.disableMinimize
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableMinimize](https://modernjs.dev/builder/api/config-output.html#outputdisableminimize)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableMinimize.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-source-map.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-source-map.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableSourceMap
 
 # output.disableSourceMap
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableSourceMap](https://modernjs.dev/builder/api/config-output.html#outputdisablesourcemap)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableSourceMap.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-svgr.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-svgr.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableSvgr
 
 # output.disableSvgr
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableSvgr](https://modernjs.dev/builder/api/config-output.html#outputdisablesvgr)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableSvgr.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-ts-checker.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-ts-checker.mdx
@@ -4,10 +4,6 @@ sidebar_label: disableTsChecker
 
 # output.disableTsChecker
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.disableTsChecker](https://modernjs.dev/builder/api/config-output.html#outputdisabletschecker)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/disableTsChecker.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/dist-path.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/dist-path.mdx
@@ -4,10 +4,6 @@ sidebar_label: distPath
 
 # output.distPath
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.distPath](https://modernjs.dev/builder/api/config-output.html#outputdistpath)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/distPath.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-asset-fallback.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-asset-fallback.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableAssetFallback
 
 # output.enableAssetFallback
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.enableAssetFallback](https://modernjs.dev/builder/api/config-output.html#outputenableassetfallback)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/enableAssetFallback.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-asset-manifest.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-asset-manifest.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableAssetManifest
 
 # output.enableAssetManifest
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.enableAssetManifest](https://modernjs.dev/builder/api/config-output.html#outputenableassetmanifest)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/enableAssetManifest.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-css-module-tsdeclaration.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-css-module-tsdeclaration.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableCssModuleTSDeclaration
 
 # output.enableCssModuleTSDeclaration
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.enableCssModuleTSDeclaration](https://modernjs.dev/builder/api/config-output.html#outputenablecssmoduletsdeclaration)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/enableCssModuleTSDeclaration.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-scripts.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-scripts.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableInlineScripts
 
 # output.enableInlineScripts
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.enableInlineScripts](https://modernjs.dev/builder/api/config-output.html#outputenableinlinescripts)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/enableInlineScripts.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-styles.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-inline-styles.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableInlineStyles
 
 # output.enableInlineStyles
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.enableInlineStyles](https://modernjs.dev/builder/api/config-output.html#outputenableinlinestyles)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/enableInlineStyles.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/enable-latest-decorators.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/enable-latest-decorators.mdx
@@ -4,10 +4,6 @@ sidebar_label: enableLatestDecorators
 
 # output.enableLatestDecorators
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.enableLatestDecorators](https://modernjs.dev/builder/api/config-output.html#outputenablelatestdecorators)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/enableLatestDecorators.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/externals.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/externals.mdx
@@ -4,10 +4,6 @@ sidebar_label: externals
 
 # output.externals
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.externals](https://modernjs.dev/builder/api/config-output.html#outputexternals)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/externals.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/filename.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/filename.mdx
@@ -4,10 +4,6 @@ sidebar_label: filename
 
 # output.filename
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.filename](https://modernjs.dev/builder/api/config-output.html#outputfilename)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/filename.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/legal-comments.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/legal-comments.mdx
@@ -4,10 +4,6 @@ sidebar_label: legalComments
 
 # output.legalComments
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.legalComments](https://modernjs.dev/builder/api/config-output.html#outputlegalcomments)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/legalComments.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/override-browserslist.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/override-browserslist.mdx
@@ -4,10 +4,6 @@ sidebar_label: overrideBrowserslist
 
 # output.overrideBrowserslist
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.overrideBrowserslist](https://modernjs.dev/builder/api/config-output.html#outputoverridebrowserslist)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/overrideBrowserslist.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/polyfill.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/polyfill.mdx
@@ -4,10 +4,6 @@ sidebar_label: polyfill
 
 # output.polyfill
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.polyfill](https://modernjs.dev/builder/api/config-output.html#outputpolyfill)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/polyfill.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/output/svg-default-export.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/svg-default-export.mdx
@@ -4,10 +4,6 @@ sidebar_label: svgDefaultExport
 
 # output.svgDefaultExport
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [output.svgDefaultExport](https://modernjs.dev/builder/api/config-output.html#outputsvgdefaultexport)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/output/svgDefaultExport.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/build-cache.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/build-cache.mdx
@@ -4,10 +4,6 @@ sidebar_label: buildCache
 
 # performance.buildCache
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.buildCache](https://modernjs.dev/builder/api/config-performance.html#performancebuildcache)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/buildCache.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/bundle-analyze.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/bundle-analyze.mdx
@@ -4,10 +4,6 @@ sidebar_label: bundleAnalyze
 
 # performance.bundleAnalyze
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.bundleAnalyze](https://modernjs.dev/builder/api/config-performance.html#performancebundleanalyze)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/bundleAnalyze.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/chunk-split.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/chunk-split.mdx
@@ -4,10 +4,6 @@ sidebar_label: chunkSplit
 
 # performance.chunkSplit
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.chunkSplit](https://modernjs.dev/builder/api/config-performance.html#performancechunksplit)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/chunkSplit.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/dns-prefetch.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/dns-prefetch.mdx
@@ -4,10 +4,6 @@ sidebar_label: dnsPrefetch
 
 # performance.dnsPrefetch
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.dnsPrefetch](https://modernjs.dev/builder/api/config-performance.html#performancednsprefetch)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/dnsPrefetch.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/preconnect.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/preconnect.mdx
@@ -4,10 +4,6 @@ sidebar_label: preconnect
 
 # performance.preconnect
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.preconnect](https://modernjs.dev/builder/api/config-performance.html#performancepreconnect)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/preconnect.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/prefetch.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/prefetch.mdx
@@ -4,10 +4,6 @@ sidebar_label: prefetch
 
 # performance.prefetch
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.prefetch](https://modernjs.dev/builder/api/config-performance.html#performanceprefetch)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/prefetch.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/preload.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/preload.mdx
@@ -4,10 +4,6 @@ sidebar_label: preload
 
 # performance.preload
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.preload](https://modernjs.dev/builder/api/config-performance.html#performancepreload)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/preload.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/print-file-size.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/print-file-size.mdx
@@ -4,10 +4,6 @@ sidebar_label: printFileSize
 
 # performance.printFileSize
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.printFileSize](https://modernjs.dev/builder/api/config-performance.html#performanceprintfilesize)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/printFileSize.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/profile.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/profile.mdx
@@ -4,10 +4,6 @@ sidebar_label: profile
 
 # performance.profile
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.profile](https://modernjs.dev/builder/api/config-performance.html#performanceprofile)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/profile.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/remove-console.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/remove-console.mdx
@@ -4,10 +4,6 @@ sidebar_label: removeConsole
 
 # performance.removeConsole
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.removeConsole](https://modernjs.dev/builder/api/config-performance.html#performanceremoveconsole)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/removeConsole.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/remove-moment-locale.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/remove-moment-locale.mdx
@@ -4,10 +4,6 @@ sidebar_label: removeMomentLocale
 
 # performance.removeMomentLocale
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.removeMomentLocale](https://modernjs.dev/builder/api/config-performance.html#performanceremovemomentlocale)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/removeMomentLocale.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/performance/transform-lodash.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/transform-lodash.mdx
@@ -4,10 +4,6 @@ sidebar_label: transformLodash
 
 # performance.transformLodash
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [performance.transformLodash](https://modernjs.dev/builder/api/config-performance.html#performancetransformlodash)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/performance/transformLodash.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/security/check-syntax.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/security/check-syntax.mdx
@@ -4,10 +4,6 @@ sidebar_label: checkSyntax
 
 # security.checkSyntax
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [security.checkSyntax](https://modernjs.dev/builder/api/config-security.html#securitychecksyntax)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/security/checkSyntax.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/security/nonce.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/security/nonce.mdx
@@ -4,10 +4,6 @@ sidebar_label: nonce
 
 # security.nonce
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [security.nonce](https://modernjs.dev/builder/api/config-security.html#securitynonce)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/security/nonce.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/security/sri.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/security/sri.mdx
@@ -4,10 +4,6 @@ sidebar_label: sri
 
 # security.sri
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [security.sri](https://modernjs.dev/builder/api/config-security.html#securitysri)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/security/sri.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/alias-strategy.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/alias-strategy.mdx
@@ -4,10 +4,6 @@ sidebar_label: aliasStrategy
 
 # source.aliasStrategy
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.aliasStrategy](https://modernjs.dev/builder/api/config-source.html#sourcealiasstrategy)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/aliasStrategy.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/alias.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/alias.mdx
@@ -4,10 +4,6 @@ sidebar_label: alias
 
 # source.alias
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.alias](https://modernjs.dev/builder/api/config-source.html#sourcealias)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/alias.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/compile-js-data-uri.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/compile-js-data-uri.mdx
@@ -4,10 +4,6 @@ sidebar_label: compileJsDataURI
 
 # source.compileJsDataURI
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.compileJsDataURI](https://modernjs.dev/builder/api/config-source.html#sourcecompilejsdatauri)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/compileJsDataURI.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/define.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/define.mdx
@@ -4,10 +4,6 @@ sidebar_label: define
 
 # source.define
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.define](https://modernjs.dev/builder/api/config-source.html#sourcedefine)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/define.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/exclude.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/exclude.mdx
@@ -4,10 +4,6 @@ sidebar_label: exclude
 
 # source.exclude
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.exclude](https://modernjs.dev/builder/api/config-source.html#sourceexclude)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/exclude.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/global-vars.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/global-vars.mdx
@@ -4,10 +4,6 @@ sidebar_label: globalVars
 
 # source.globalVars
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.globalVars](https://modernjs.dev/builder/api/config-source.html#sourceglobalvars)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/globalVars.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/include.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/include.mdx
@@ -4,10 +4,6 @@ sidebar_label: include
 
 # source.include
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.include](https://modernjs.dev/builder/api/config-source.html#sourceinclude)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/include.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/module-scopes.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/module-scopes.mdx
@@ -4,10 +4,6 @@ sidebar_label: moduleScopes
 
 # source.moduleScopes
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.moduleScopes](https://modernjs.dev/builder/api/config-source.html#sourcemodulescopes)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/moduleScopes.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/pre-entry.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/pre-entry.mdx
@@ -4,10 +4,6 @@ sidebar_label: preEntry
 
 # source.preEntry
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.preEntry](https://modernjs.dev/builder/api/config-source.html#sourcepreentry)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/preEntry.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/resolve-extension-prefix.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/resolve-extension-prefix.mdx
@@ -4,10 +4,6 @@ sidebar_label: resolveExtensionPrefix
 
 # source.resolveExtensionPrefix
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.resolveExtensionPrefix](https://modernjs.dev/builder/api/config-source.html#sourceresolveextensionprefix)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/resolveExtensionPrefix.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/resolve-main-fields.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/resolve-main-fields.mdx
@@ -4,10 +4,6 @@ sidebar_label: resolveMainFields
 
 # source.resolveMainFields
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.resolveMainFields](https://modernjs.dev/builder/api/config-source.html#sourceresolvemainfields)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/resolveMainFields.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/source/transform-import.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/transform-import.mdx
@@ -4,10 +4,6 @@ sidebar_label: transformImport
 
 # source.transformImport
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [source.transformImport](https://modernjs.dev/builder/api/config-source.html#sourcetransformimport)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/source/transformImport.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/autoprefixer.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/autoprefixer.mdx
@@ -4,10 +4,6 @@ sidebar_label: autoprefixer
 
 # tools.autoprefixer
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.autoprefixer](https://modernjs.dev/builder/api/config-tools.html#toolsautoprefixer)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/autoprefixer.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/babel.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/babel.mdx
@@ -4,10 +4,6 @@ sidebar_label: babel
 
 # tools.babel
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.babel](https://modernjs.dev/builder/api/config-tools.html#toolsbabel)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/babel.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/css-extract.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/css-extract.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssExtract
 
 # tools.cssExtract
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.cssExtract](https://modernjs.dev/builder/api/config-tools.html#toolscssextract)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/cssExtract.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/css-loader.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/css-loader.mdx
@@ -4,10 +4,6 @@ sidebar_label: cssLoader
 
 # tools.cssLoader
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.cssLoader](https://modernjs.dev/builder/api/config-tools.html#toolscssloader)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/cssLoader.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/dev-server.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/dev-server.mdx
@@ -4,10 +4,6 @@ sidebar_label: devServer
 
 # tools.devServer
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.devServer](https://modernjs.dev/builder/api/config-tools.html#toolsdevserver)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/devServer.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/html-plugin.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/html-plugin.mdx
@@ -4,10 +4,6 @@ sidebar_label: htmlPlugin
 
 # tools.htmlPlugin
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.htmlPlugin](https://modernjs.dev/builder/api/config-tools.html#toolshtmlplugin)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/htmlPlugin.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/inspector.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/inspector.mdx
@@ -4,10 +4,6 @@ sidebar_label: inspector
 
 # tools.inspector
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.inspector](https://modernjs.dev/builder/api/config-tools.html#toolsinspector)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/inspector.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/less.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/less.mdx
@@ -4,10 +4,6 @@ sidebar_label: less
 
 # tools.less
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.less](https://modernjs.dev/builder/api/config-tools.html#toolsless)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/less.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/minify-css.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/minify-css.mdx
@@ -4,10 +4,6 @@ sidebar_label: minifyCss
 
 # tools.minifyCss
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.minifyCss](https://modernjs.dev/builder/api/config-tools.html#toolsminifycss)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/minifyCss.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/postcss.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/postcss.mdx
@@ -4,10 +4,6 @@ sidebar_label: postcss
 
 # tools.postcss
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.postcss](https://modernjs.dev/builder/api/config-tools.html#toolspostcss)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/postcss.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/pug.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/pug.mdx
@@ -4,10 +4,6 @@ sidebar_label: pug
 
 # tools.pug
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.pug](https://modernjs.dev/builder/api/config-tools.html#toolspug)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/pug.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/rspack.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/rspack.mdx
@@ -4,10 +4,6 @@ sidebar_label: rspack
 
 # tools.rspack
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.rspack](https://modernjs.dev/builder/api/config-tools.html#toolsrspack)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/rspack.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/sass.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/sass.mdx
@@ -4,10 +4,6 @@ sidebar_label: sass
 
 # tools.sass
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.sass](https://modernjs.dev/builder/api/config-tools.html#toolssass)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/sass.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/style-loader.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/style-loader.mdx
@@ -4,10 +4,6 @@ sidebar_label: styleLoader
 
 # tools.styleLoader
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.styleLoader](https://modernjs.dev/builder/api/config-tools.html#toolsstyleloader)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/styleLoader.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/styled-components.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/styled-components.mdx
@@ -4,10 +4,6 @@ sidebar_label: styledComponents
 
 # tools.styledComponents
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.styledComponents](https://modernjs.dev/builder/api/config-tools.html#toolsstyledcomponents)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/styledComponents.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/terser.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/terser.mdx
@@ -4,10 +4,6 @@ sidebar_label: terser
 
 # tools.terser
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.terser](https://modernjs.dev/builder/api/config-tools.html#toolsterser)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/terser.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/ts-checker.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/ts-checker.mdx
@@ -4,10 +4,6 @@ sidebar_label: tsChecker
 
 # tools.tsChecker
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.tsChecker](https://modernjs.dev/builder/api/config-tools.html#toolstschecker)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/tsChecker.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/ts-loader.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/ts-loader.mdx
@@ -4,10 +4,6 @@ sidebar_label: tsLoader
 
 # tools.tsLoader
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.tsLoader](https://modernjs.dev/builder/api/config-tools.html#toolstsloader)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/tsLoader.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/webpack-chain.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/webpack-chain.mdx
@@ -4,10 +4,6 @@ sidebar_label: webpackChain
 
 # tools.webpackChain
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.webpackChain](https://modernjs.dev/builder/api/config-tools.html#toolswebpackchain)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/webpackChain.md';
 
 <Main />

--- a/packages/document/main-doc/docs/zh/configure/app/tools/webpack.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/webpack.mdx
@@ -4,10 +4,6 @@ sidebar_label: webpack
 
 # tools.webpack
 
-:::tip
-该配置由 Modern.js Builder 提供，更多信息可参考 [tools.webpack](https://modernjs.dev/builder/api/config-tools.html#toolswebpack)。
-:::
-
 import Main from '@modern-js/builder-doc/docs/zh/config/tools/webpack.md';
 
 <Main />

--- a/packages/document/main-doc/scripts/config.ts
+++ b/packages/document/main-doc/scripts/config.ts
@@ -1,11 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
 
-const tip: Record<string, string> = {
-  zh: '该配置由 Modern.js Builder 提供，更多信息可参考',
-  en: 'This config is provided by Modern.js Builder, more detail can see',
-};
-
 export type Summary = {
   name: string;
   dirname: string;
@@ -16,21 +11,11 @@ export type Language = 'en' | 'zh';
 const createMarkdown = (summary: Summary, lng: Language) => {
   const { name, dirname } = summary;
 
-  const langPrefix = lng === 'zh' ? '' : `/${lng}`;
-
   return `---
 sidebar_label: ${name}
 ---
 
 # ${dirname}.${name}
-
-:::tip
-${
-  tip[lng]
-} [${dirname}.${name}](https://modernjs.dev/builder${langPrefix}/api/config-${dirname}.html#${dirname}${name.toLowerCase()})${
-    lng === 'en' ? '.' : '。'
-  }
-:::
 
 import Main from '@modern-js/builder-doc/docs/${lng}/config/${dirname}/${name}.md';
 


### PR DESCRIPTION
## Summary

No longer add link to Builder, we will gradually decouple Modern.js and Builder documentation.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a0e074</samp>

Removed tip sections that link to the Modern.js Builder documentation from various config files in the Modern.js documentation. This was done to avoid duplication and confusion, as the same information is already available in the `config-dev.mdx` and `config-experiments.mdx` files. This change was part of a pull request that aimed to refactor and simplify the Modern.js documentation structure and content.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a0e074</samp>

*  Removed tip sections that linked to Modern.js Builder documentation for various config options, as they were redundant and confusing ([link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-fb6df745f833dd0ef6fccb04dfd628e90ff531be511ebf03e0eed4c9668611b0L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-71bc3c46b6dc6237ff365f92ff651b4c72e6ce2717aa627bc314983a221ab9edL7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-982f61f247c0f869a6e7fae647fd2ee1bd45a88534aad78a68bd05bbc78682dbL7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-89a8a7483e4add85c168e70a4cf3bf22e75630ff73a1e2201c0de5e8475bcc62L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-4a82a6aa1c92cf9bdc0227b1f89e793f4f82566df301d63005fa2abca1868971L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-5452581560d8b2c48d2be454ece160d1639751dd256be27a45688614953d8917L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-6222423d2e7b08c3dd9410c6000b4ec0ae57c004bdce47bb79705e77f4f24f81L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-8c385700c05903317d2b0fa790addecde1d8b954728ce906171701c13534feb0L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-faeb41f52ffa7f07cd52bfecdb375999117695a862d6225635cb06fdbedc76b9L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-d04d4bc344b5d5aaf52e13b4437611314e51941448a85a8783dd11dd8e256da9L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-b9a94ea6bcc8f4a80b9889e1d87ce96420a1627ef000d1a9f3e625ad0a578d3cL7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-50c9980e9f7dbc6b01193d3f3d9afbf9637e4616501c203e14e21482d9b5a98fL7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-544269fa8b7a4893c046bed7373b4bb154f9e36245aeec0ecbdcc37803ca89fbL7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-42a61741b9a0f4d2ea5aad005a0f8fcc361187e81e6b38ecf7fe649c8ce29f52L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-ed5448c27dd036dcbffff11c8e64af5c68763cf009db84dfaf2b3e5b856e8513L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-e24b2a4d847d338275acdb811bb13bbcc2ff6f61282d89f6433f92e3ec906e72L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-74ee62d9e5097688972963a58ae4974665374c1b88c9b204da3c2055e7d3338bL7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-d6aeb8d0f62b232a94e9ef5adb8aba1e470ba276fa719dfe3ffa7cfcd0c7f11cL7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-c686be6c2e22fb10c5b149f3836a40305ccf8df7d9924ba09a4dfad8ebd1b244L7-L10), [link](https://github.com/web-infra-dev/modern.js/pull/4878/files?diff=unified&w=0#diff-db66dc41fbd19d334f6b1f25f41a15eda2befc1837e8771098fe9ff0df67efbdL7-L10)). These changes were part of a pull request that refactored and simplified the Modern.js documentation structure and content. The affected files were under the `packages/document/main-doc/docs/en/configure/app` directory, and had the `.mdx` extension.

## Related Issue

https://github.com/web-infra-dev/rsbuild/issues/66

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
