### PR TITLE
fix(ssr): only node runtime read assets from fs

### DIFF
--- a/.changeset/tough-days-clean.md
+++ b/.changeset/tough-days-clean.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(ssr): only node runtime read assets from fs.
+fix(ssr): 只有在 node 运行时才从文件系统中读取资源


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a2ea50</samp>

This pull request fixes a compatibility issue with SSR and improves the browser runtime performance by using dynamic imports and conditional `fs` usage in `loadable.ts`. It also adds a changeset file for the `@modern-js/runtime` package to document the patch version update and the fix message.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a2ea50</samp>

* Fix a bug that caused errors when bundling `@modern-js/runtime` for the web by removing unnecessary import of `fs` from `node:fs/promises` and moving it to dynamic imports for node runtime only ([link](https://github.com/web-infra-dev/modern.js/pull/4884/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L1), [link](https://github.com/web-infra-dev/modern.js/pull/4884/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409R36-R38), [link](https://github.com/web-infra-dev/modern.js/pull/4884/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L132-R136), [link](https://github.com/web-infra-dev/modern.js/pull/4884/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L170-R175))
* Add a changeset file to document the patch version update and the fix message for the `@modern-js/runtime` package in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4884/files?diff=unified&w=0#diff-b03f25fffedba52d369757ae920cdece5e113f81f48f8df3ad4703d04051fd6eR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
