### PR TITLE
fix: should not filter mf entrys when compiler is rspack

### DIFF
--- a/.changeset/yellow-suits-applaud.md
+++ b/.changeset/yellow-suits-applaud.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: should not filter mf entrys when compiler is rspack
+fix: 不应该过滤 mf entry，当 compiler 是 rspack 的时候

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -106,6 +106,7 @@ export class RouterPlugin {
     }
 
     const { webpack } = compiler;
+    const isRspack = webpack.rspackVersion;
     const { Compilation, sources } = webpack;
     const { RawSource } = sources;
 
@@ -205,22 +206,28 @@ export class RouterPlugin {
           };
 
           const entryNames = Array.from(compilation.entrypoints.keys());
-          const orignalEntryIds = Object.keys(compilation.options.entry).map(
-            entryName => {
-              const chunk = compilation.namedChunks.get(
-                entryName,
-              ) as webpack.Chunk;
-              if (chunk) {
-                return chunk.id;
-              }
-              return entryName;
-            },
-          );
-          const entryChunks = this.getEntryChunks(compilation, chunks).filter(
-            chunk => orignalEntryIds.includes(chunk.id as string),
-          );
-          const entryChunkFiles = this.getEntryChunkFiles(entryChunks);
+          let entryChunks = [];
+          if (isRspack) {
+            entryChunks = this.getEntryChunks(compilation, chunks);
+          } else {
+            const orignalEntryIds = Object.keys(compilation.options.entry).map(
+              entryName => {
+                const chunk = compilation.namedChunks.get(
+                  entryName,
+                ) as webpack.Chunk;
+                if (chunk) {
+                  return chunk.id;
+                }
+                return entryName;
+              },
+            );
 
+            entryChunks = this.getEntryChunks(compilation, chunks).filter(
+              chunk => orignalEntryIds.includes(chunk.id as string),
+            );
+          }
+
+          const entryChunkFiles = this.getEntryChunkFiles(entryChunks);
           const entryChunkFileIds = entryChunks.map(chunk => chunk.id);
           for (let i = 0; i < entryChunkFiles.length; i++) {
             const entryName = entryNames[i];


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
