### PR TITLE
ci: split module test and add workflow

### DIFF
--- a/.github/workflows/test-module-Linux.yml
+++ b/.github/workflows/test-module-Linux.yml
@@ -1,0 +1,32 @@
+name: Module Tools Test (Linux)
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+jobs:
+  module-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Install Pnpm
+        run: corepack enable
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Test
+        run: cd ./tests && pnpm run test:module-tools

--- a/.github/workflows/test-module-Windows.yml
+++ b/.github/workflows/test-module-Windows.yml
@@ -1,0 +1,40 @@
+name: Module Tools Test (Windows)
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on pull request events but only for the main branch
+  push:
+    branches: [main]
+
+  merge_group:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  module-windows:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Install Pnpm
+        run: corepack enable
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Test
+        run: cd ./tests && pnpm run test:module-tools

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -3,7 +3,10 @@ module.exports = {
   preset: 'jest-puppeteer',
   rootDir: __dirname,
   setupFilesAfterEnv: ['./utils/jest.setup.js'],
-  testMatch: ['<rootDir>/integration/**/*.(spec|test).[tj]s?(x)'],
+  testMatch: [
+    '<rootDir>/integration/**/*.(spec|test).[tj]s?(x)',
+    '!**/module/**/*.(spec|test).[tj]s?(x)',
+  ],
   testPathIgnorePatterns: [
     '/node_modules/',
     '/api-service-koa/api/',


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4bbc85b</samp>

This pull request adds end-to-end tests for the `module` package using jest. It creates a new GitHub workflow file `.github/workflows/test-module.yml` and updates the jest configuration file `tests/jest.config.js` to include the `module` source code.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4bbc85b</samp>

* Add a GitHub workflow to run end-to-end tests for the module tools package ([link](https://github.com/web-infra-dev/modern.js/pull/4887/files?diff=unified&w=0#diff-6edc3e4912aeaaf0120b2601fcd211f0c00c0cbab77766b427fe35b14a92b561R1-R42))
* Configure jest for the end-to-end tests ([link](https://github.com/web-infra-dev/modern.js/pull/4887/files?diff=unified&w=0#diff-9687aa3bc256f0f578d1be71c9423c2a932447fed9ab1c162b0baa1e7947f7f1R12))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
