### PR TITLE
fix: modify the priority order of `source` field and the webpack default mainFields

### DIFF
--- a/.changeset/neat-ligers-train.md
+++ b/.changeset/neat-ligers-train.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder': patch
+---
+
+fix(builder): Modify the priority order of `source` field and the webpack default mainFields
+fix(builder): 修改 source 和 webpack 默认的 mainFields 的优先级顺序

--- a/packages/builder/builder/src/plugins/sourceBuild.ts
+++ b/packages/builder/builder/src/plugins/sourceBuild.ts
@@ -108,7 +108,9 @@ export function builderPluginSourceBuild(
             // webpack.js.org/configuration/module/#ruleresolve
             chain.module
               .rule(useTsLoader ? CHAIN_ID.RULE.TS : CHAIN_ID.RULE.JS)
-              .resolve.mainFields.merge(['...', sourceField]);
+              // source > webpack default mainFiedls.
+              // when source is not exist, other mainFields will effect.
+              .resolve.mainFields.merge([sourceField, '...']);
 
             // webpack chain not support resolve.conditionNames
             chain.module


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 083483a</samp>

This pull request fixes the priority order of the `source` field in the `@modern-js/builder` package. It updates the `sourceBuild.ts` file and the changelog for a patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 083483a</samp>

* Fix the priority order of the `source` field and the webpack default mainFields in `@modern-js/builder` package ([link](https://github.com/web-infra-dev/modern.js/pull/4889/files?diff=unified&w=0#diff-d398fabb54647edd1f8cb54f3d0db470898056b22f1b780ea4cac0e9832fb2f3L111-R113), [link](https://github.com/web-infra-dev/modern.js/pull/4889/files?diff=unified&w=0#diff-4d37ba101c41911c167aedaa64d3fb2609a90319ff69d54af81a8f934cca9534R1-R6))
  - Put the `sourceField` first in the `mainFields` array in the `builderPluginSourceBuild` function in `sourceBuild.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4889/files?diff=unified&w=0#diff-d398fabb54647edd1f8cb54f3d0db470898056b22f1b780ea4cac0e9832fb2f3L111-R113))
  - Add a comment to explain why the `resolve.conditionNames` property is not used ([link](https://github.com/web-infra-dev/modern.js/pull/4889/files?diff=unified&w=0#diff-d398fabb54647edd1f8cb54f3d0db470898056b22f1b780ea4cac0e9832fb2f3L111-R113))
  - Update the changelog with a patch version and a summary of the fix in both English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4889/files?diff=unified&w=0#diff-4d37ba101c41911c167aedaa64d3fb2609a90319ff69d54af81a8f934cca9534R1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
