### PR TITLE
fix: adjust module template tsconfig

### DIFF
--- a/packages/generator/generators/module-generator/templates/base-template/package.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/base-template/package.json.handlebars
@@ -44,8 +44,6 @@
   "devDependencies": {
     "@modern-js/module-tools": "{{modernVersion}}",
     "@modern-js/eslint-config": "{{modernVersion}}",
-    "@modern-js/tsconfig": "{{modernVersion}}",
-    "@modern-js-app/eslint-config": "{{modernVersion}}",
     {{#if isTs}}
     "typescript": "~5.0.4",
     "@types/jest": "~29.2.4",

--- a/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/tsconfig.json.handlebars
@@ -1,13 +1,23 @@
 {
-  "extends": "@modern-js/tsconfig/base",
-  "declaration": true,
   "compilerOptions": {
-    "baseUrl": "./",
+    "allowJs": true,
+    "baseUrl": ".",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["DOM", "ESNext"],
+    "moduleResolution": "node",
     "paths": {
       "@/*": ["./src/*"]
     },
-    "isolatedModules": true
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "strict": true
   },
-  "include": ["src"],
-  "exclude": ["**/node_modules"]
+  "exclude": ["**/node_modules"],
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a74e82</samp>

Updated `tsconfig.json` for TypeScript template to use custom compiler options and enable JSX, JSON modules, and strict mode. This change aligns with modern.js framework conventions and improves the module generator.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a74e82</samp>

* Replace the base config with custom compiler options in `tsconfig.json` ([link](https://github.com/web-infra-dev/modern.js/pull/4890/files?diff=unified&w=0#diff-a082369268bcf3a4214502bbd1f252021dcff571dcf5e0cf237ad41ee8472399L2-R22))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
