### PR TITLE
chore: separate module testing

### DIFF
--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -67,4 +67,5 @@ jobs:
 
       - name: Test
         if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        run: cd ./tests && pnpm run test
+        # Run the module-tools tests separately to avoid OOM
+        run: cd ./tests && pnpm run test && pnpm run test:module-tools

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -73,4 +73,5 @@ jobs:
 
       - name: Test
         if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        run: cd ./tests && pnpm run test
+        # Run the module-tools tests separately to avoid OOM
+        run: cd ./tests && pnpm run test && pnpm run test:module-tools

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -3,7 +3,10 @@ module.exports = {
   preset: 'jest-puppeteer',
   rootDir: __dirname,
   setupFilesAfterEnv: ['./utils/jest.setup.js'],
-  testMatch: ['<rootDir>/integration/**/*.(spec|test).[tj]s?(x)'],
+  testMatch: [
+    '<rootDir>/integration/**/*.(spec|test).[tj]s?(x)',
+    '!**/module/**',
+  ],
   testPathIgnorePatterns: [
     '/node_modules/',
     '/api-service-koa/api/',


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25c7304</samp>

This pull request splits the module-tools tests from the other integration tests in the GitHub Actions workflows for Linux and Windows, and updates the jest configuration to avoid running them twice. This improves the test performance and prevents out-of-memory errors.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25c7304</samp>

* Split the integration tests into two groups: module-tools tests and other tests, to avoid out-of-memory errors on GitHub Actions runners ([link](https://github.com/web-infra-dev/modern.js/pull/4892/files?diff=unified&w=0#diff-7896e19a8235639ab480580bdbc872913d7c654b533a7360d7b58a7bcbe32f9dL70-R71), [link](https://github.com/web-infra-dev/modern.js/pull/4892/files?diff=unified&w=0#diff-0140bd37d64c64518fe24fe1d94ea665cfae9e6da21a3ff99117c6b4f2076b91L76-R77))
* Exclude the module tests from the default testMatch pattern in `jest.config.js`, to prevent jest from running them twice ([link](https://github.com/web-infra-dev/modern.js/pull/4892/files?diff=unified&w=0#diff-9687aa3bc256f0f578d1be71c9423c2a932447fed9ab1c162b0baa1e7947f7f1L6-R9))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
