### PR TITLE
 fix(builder): apply babel-plugin-styled-components correctly

### DIFF
--- a/.changeset/fast-apricots-notice.md
+++ b/.changeset/fast-apricots-notice.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-webpack-provider': patch
+---
+
+fix(builder): apply babel-plugin-styled-components correctly
+
+fix(builder): 正确注册 babel-plugin-styled-components 插件

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -17,7 +17,11 @@ import type {
   NormalizedConfig,
   TransformImport,
 } from '../types';
-import { getBabelUtils } from '@modern-js/utils';
+import {
+  getBabelUtils,
+  isUseSSRBundle,
+  applyOptionsChain,
+} from '@modern-js/utils';
 
 export const getUseBuiltIns = (config: NormalizedConfig) => {
   const { polyfill } = config.output;
@@ -179,15 +183,11 @@ function applyPluginLodash(config: BabelConfig, transformLodash?: boolean) {
   }
 }
 
-async function applyPluginStyledComponents(
+function applyPluginStyledComponents(
   babelConfig: BabelConfig,
   builderConfig: NormalizedConfig,
   isProd: boolean,
 ) {
-  const { applyOptionsChain, isUseSSRBundle } = await import(
-    '@modern-js/utils'
-  );
-
   const styledComponentsOptions =
     builderConfig.tools.styledComponents !== false
       ? applyOptionsChain(

--- a/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -288,6 +288,15 @@ exports[`webpackConfig > should not have any pluginImport in Babel 1`] = `
               "<ROOT>/compiled/babel-plugin-lodash",
               {},
             ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+              {
+                "displayName": true,
+                "pure": false,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
+            ],
           ],
           "presets": [
             [
@@ -480,6 +489,15 @@ exports[`webpackConfig > should not set default pluginImport for Babel 1`] = `
             [
               "<ROOT>/compiled/babel-plugin-lodash",
               {},
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+              {
+                "displayName": true,
+                "pure": false,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
             ],
           ],
           "presets": [
@@ -694,6 +712,15 @@ exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
             [
               "<ROOT>/compiled/babel-plugin-lodash",
               {},
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+              {
+                "displayName": true,
+                "pure": false,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
             ],
           ],
           "presets": [

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -146,6 +146,15 @@ exports[`plugins/babel > should add rule to compile Data URI when enable source.
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
                 ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
               ],
               "presets": [
                 [
@@ -302,6 +311,15 @@ exports[`plugins/babel > should adjust browserslist when target is node 1`] = `
                 [
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
                 ],
               ],
               "presets": [
@@ -476,6 +494,15 @@ exports[`plugins/babel > should apply exclude condition when using source.exclud
                 [
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
                 ],
               ],
               "presets": [
@@ -662,6 +689,15 @@ exports[`plugins/babel > should override targets of babel-preset-env when using 
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
                 ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
               ],
               "presets": [
                 [
@@ -838,6 +874,15 @@ exports[`plugins/babel > should set babel-loader 1`] = `
                 [
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
                 ],
               ],
               "presets": [
@@ -1021,6 +1066,15 @@ exports[`plugins/babel > should set include/exclude 1`] = `
                 [
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
                 ],
               ],
               "presets": [

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/default.test.ts.snap
@@ -504,6 +504,15 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
                 ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
               ],
               "presets": [
                 [
@@ -1376,6 +1385,15 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                   {},
                 ],
                 [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": true,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
+                [
                   "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
                   {
                     "removeImport": true,
@@ -1502,18 +1520,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                   {},
                 ],
                 [
-                  "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
-                  {
-                    "removeImport": true,
-                  },
-                ],
-                [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
                   {
                     "displayName": true,
                     "pure": true,
                     "ssr": false,
                     "transpileTemplateLiterals": true,
+                  },
+                ],
+                [
+                  "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
+                  {
+                    "removeImport": true,
                   },
                 ],
               ],
@@ -2197,6 +2215,15 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   {},
                 ],
                 [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": true,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
+                [
                   "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
                   {
                     "removeImport": true,
@@ -2308,18 +2335,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   {},
                 ],
                 [
-                  "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
-                  {
-                    "removeImport": true,
-                  },
-                ],
-                [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
                   {
                     "displayName": true,
                     "pure": true,
                     "ssr": false,
                     "transpileTemplateLiterals": true,
+                  },
+                ],
+                [
+                  "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
+                  {
+                    "removeImport": true,
                   },
                 ],
               ],
@@ -2912,6 +2939,15 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   {},
                 ],
                 [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": true,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
+                [
                   "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
                   {
                     "removeImport": true,
@@ -3038,18 +3074,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   {},
                 ],
                 [
-                  "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
-                  {
-                    "removeImport": true,
-                  },
-                ],
-                [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
                   {
                     "displayName": true,
                     "pure": true,
                     "ssr": false,
                     "transpileTemplateLiterals": true,
+                  },
+                ],
+                [
+                  "<ROOT>/compiled/babel-plugin-transform-react-remove-prop-types/index.js",
+                  {
+                    "removeImport": true,
                   },
                 ],
               ],

--- a/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/builder/builder-webpack-provider/tests/plugins/__snapshots__/react.test.ts.snap
@@ -152,6 +152,15 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                   "<ROOT>/compiled/babel-plugin-lodash",
                   {},
                 ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
               ],
               "presets": [
                 [

--- a/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -96,18 +96,18 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
                   {},
                 ],
                 [
-                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
-                  {
-                    "transformOn": false,
-                  },
-                ],
-                [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
                   {
                     "displayName": true,
                     "pure": false,
                     "ssr": false,
                     "transpileTemplateLiterals": true,
+                  },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
+                  {
+                    "transformOn": false,
                   },
                 ],
               ],
@@ -187,6 +187,15 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
                 [
                   "<WORKSPACE>/packages/builder/builder-webpack-provider/compiled/babel-plugin-lodash",
                   {},
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
                 ],
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
@@ -341,10 +350,6 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                   {},
                 ],
                 [
-                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
-                  {},
-                ],
-                [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
                   {
                     "displayName": true,
@@ -352,6 +357,10 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                     "ssr": false,
                     "transpileTemplateLiterals": true,
                   },
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
+                  {},
                 ],
               ],
               "presets": [
@@ -430,6 +439,15 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                 [
                   "<WORKSPACE>/packages/builder/builder-webpack-provider/compiled/babel-plugin-lodash",
                   {},
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
                 ],
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",

--- a/packages/builder/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -186,6 +186,15 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
                   "<WORKSPACE>/packages/builder/builder-webpack-provider/compiled/babel-plugin-lodash",
                   {},
                 ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
               ],
               "presets": [
                 [
@@ -428,6 +437,15 @@ exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
                 [
                   "<WORKSPACE>/packages/builder/builder-webpack-provider/compiled/babel-plugin-lodash",
                   {},
+                ],
+                [
+                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
                 ],
               ],
               "presets": [


### PR DESCRIPTION
## Summary

The `applyPluginStyledComponents` method should not be an async function, otherwise it can not be executed correctly.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3f6167</samp>

This pull request fixes the integration of `babel-plugin-styled-components` with the `@modern-js/builder-webpack-provider` package. It improves the SSR support and the options handling for the plugin, and adds a changeset file to document the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3f6167</samp>

* Add a changeset file to document the patch update for the `@modern-js/builder-webpack-provider` package ([link](https://github.com/web-infra-dev/modern.js/pull/4894/files?diff=unified&w=0#diff-ebb52f4652d975838284b1ad941115cb4c29ab9df54e32435366cd3118b16508R1-R7))
* Simplify the `applyPluginStyledComponents` function in `packages/builder/builder-webpack-provider/src/plugins/babel.ts` by removing the dynamic import and the unused parameter ([link](https://github.com/web-infra-dev/modern.js/pull/4894/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL182-R190))
* Import and use `isUseSSRBundle` and `applyOptionsChain` from `@modern-js/utils` in `packages/builder/builder-webpack-provider/src/plugins/babel.ts` to check the SSR mode and apply the options for the `babel-plugin-styled-components` ([link](https://github.com/web-infra-dev/modern.js/pull/4894/files?diff=unified&w=0#diff-1d881eb21400957a6f782153fd8eba41c23944a2c91461b579296019ece0578aL20-R24))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
