### PR TITLE
chore(workflow): temporarily manually upgrade Rsbuild

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -45,11 +45,13 @@ jobs:
       - name: Install Dependencies && Build
         run: pnpm install
 
-      - name: Update Rsbuild Nightly Version
-        run: RSBUILD_VERSION=nightly pnpm run update-rsbuild
+      # Temporarily manually upgrade Rsbuild
 
-      - name: Install Dependencies && Build
-        run: pnpm install --no-frozen-lockfile
+      # - name: Update Rsbuild Nightly Version
+      #   run: RSBUILD_VERSION=nightly pnpm run update-rsbuild
+
+      # - name: Install Dependencies && Build
+      #   run: pnpm install --no-frozen-lockfile
 
       - name: Release
         uses: web-infra-dev/actions@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,11 +110,13 @@ jobs:
       - name: Install Dependencies && Build
         run: pnpm install
 
-      - name: Update Rsbuild Nightly Version
-        run: pnpm run update-rsbuild
+      # Temporarily manually upgrade Rsbuild
 
-      - name: Install Dependencies && Build
-        run: pnpm install --no-frozen-lockfile
+      # - name: Update Rsbuild Nightly Version
+      #   run: pnpm run update-rsbuild
+
+      # - name: Install Dependencies && Build
+      #   run: pnpm install --no-frozen-lockfile
 
       - name: Release
         uses: web-infra-dev/actions@v2


### PR DESCRIPTION
## Summary

Temporarily manually upgrade Rsbuild.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab2209b</samp>

Comment out some steps in the `.github/workflows/release.yml` and `.github/workflows/release-nightly.yml` workflows to avoid errors caused by the latest Rsbuild version. This is a temporary workaround until Rsbuild is fixed.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab2209b</samp>

*  Comment out steps to update Rsbuild Nightly Version and install dependencies and build with no frozen lockfile in the nightly release workflow to avoid errors caused by the latest Rsbuild version ([link](https://github.com/web-infra-dev/modern.js/pull/4899/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L48-R55))
*  Apply the same change to the stable release workflow to keep the workflows consistent ([link](https://github.com/web-infra-dev/modern.js/pull/4899/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L113-R120))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
