### PR TITLE
docs(module-plugin-vue): add more limitation about module vue

### DIFF
--- a/packages/document/module-doc/docs/en/guide/basic/command-preview.md
+++ b/packages/document/module-doc/docs/en/guide/basic/command-preview.md
@@ -20,6 +20,7 @@ Options:
   --platform [platform] Build artifacts for all or specified platforms
   --no-dts disables DTS type file generation and type checking
   --no-clear disables automatic clearing of output directories
+  -c, --config <config>  Specify the path to the config file (default: "modern.config.j(t)s")
   -h, --help Show information about the current command
 ```
 

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-vue.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-vue.mdx
@@ -3,7 +3,11 @@
 The Vue plugin provides support for building Vue 3 components. The plugin internally integrates [esbuild-plugin-vue3](https://github.com/pipe01/esbuild-plugin-vue3) and [@vue/babel-plugin-jsx](https://github.com/vuejs/babel-plugin-jsx)。
 
 :::warning
-The current implementation of this plugin integrates directly with the community plugin and therefore does not support writing jsx/tsx in sfc.
+Notice that we have some limitation:
+
+1. The current implementation of this plugin integrates directly with the community plugin and therefore does not support writing jsx/tsx in sfc.
+2. If you want to generate d.ts for the components, please use the official recommendation [vue-tsc](https://www.npmjs.com/package/vue-tsc).
+3. Only support bundle, we recommend to set input to `['src/**/*.vue']` or `['src/index.ts']`.
 :::
 
 ## Quick start
@@ -24,6 +28,10 @@ import { modulePluginVue } from '@modern-js/plugin-module-vue';
 
 export default defineConfig({
   plugins: [moduleTools(), modulePluginVue()],
+  buildType: 'bundle',
+  format: 'esm',
+  input: ['src/index.vue'],
+  dts: false,
 });
 ```
 

--- a/packages/document/module-doc/docs/zh/guide/basic/command-preview.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/command-preview.md
@@ -20,6 +20,7 @@ Options:
   --platform [platform]  构建所有或者指定平台的产物
   --no-dts               关闭 DTS 类型文件生成和类型检查
   --no-clear             关闭自动清除产物输出目录的行为
+  -c, --config <config>  指定配置文件（default: "modern.config.j(t)s"）
   -h, --help             展示当前命令的信息
 ```
 

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-vue.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-vue.mdx
@@ -3,7 +3,11 @@
 Vue 插件提供了对 Vue 3 组件构建的支持，插件内部集成了 [esbuild-plugin-vue3](https://github.com/pipe01/esbuild-plugin-vue3) 和 [@vue/babel-plugin-jsx](https://github.com/vuejs/babel-plugin-jsx)。
 
 :::warning
-目前此插件的实现是直接集成社区插件，因此不支持在 sfc 里写 jsx/tsx.
+请注意，此插件仍有一些用法限制：
+
+1. 目前此插件的实现是直接集成社区插件，因此不支持在 sfc 里写 jsx/tsx。
+2. 如果要为组件生成 d.ts，请使用官方推荐方式 [vue-tsc](https://www.npmjs.com/package/vue-tsc)。
+3. 仅支持打包场景，推荐将 input 设置为 `['src/**/*.vue']` 或者 `['src/index.ts']`。
 :::
 
 ## 快速开始
@@ -24,6 +28,10 @@ import { modulePluginVue } from '@modern-js/plugin-module-vue';
 
 export default defineConfig({
   plugins: [moduleTools(), modulePluginVue()],
+  buildType: 'bundle',
+  format: 'esm',
+  input: ['src/index.vue'],
+  dts: false,
 });
 ```
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3847fb6</samp>

Improved the documentation of the `plugin-vue` for both English and Chinese users. Added more details and examples on how to use the plugin and what to avoid.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3847fb6</samp>

*  Update warning message in plugin-vue documentation to include more details about the limitations of the plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4910/files?diff=unified&w=0#diff-95da3c338681ec6386923b61ddc1fb5e7d75ccced662855b66dee49da3a60bc2L6-R9), [link](https://github.com/web-infra-dev/modern.js/pull/4910/files?diff=unified&w=0#diff-372f224d8909b5cbf0e7553b93221d20bf07761302a3184623e2a25b0b8c1159L6-R9))
*  Modify example configuration in plugin-vue documentation to reflect the recommended settings for input, buildType, format, and dts ([link](https://github.com/web-infra-dev/modern.js/pull/4910/files?diff=unified&w=0#diff-95da3c338681ec6386923b61ddc1fb5e7d75ccced662855b66dee49da3a60bc2R30-R33), [link](https://github.com/web-infra-dev/modern.js/pull/4910/files?diff=unified&w=0#diff-372f224d8909b5cbf0e7553b93221d20bf07761302a3184623e2a25b0b8c1159R30-R33))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
