### PR TITLE
fix: remake server ssr logger msg

### DIFF
--- a/.changeset/dirty-ligers-roll.md
+++ b/.changeset/dirty-ligers-roll.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: remake server ssr logger msg
+fix: 重写 ssr server 日志信息

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToStream/index.ts
@@ -33,12 +33,12 @@ export const render = ({ App, context }: ServerRenderOptions) => {
         }
 
         const cost = end();
-        tracker.trackTiming(SSRTimings.SSR_RENDER_SHELL, cost);
+        tracker.trackTiming(SSRTimings.RENDER_SHELL, cost);
       },
       onAllReady() {
         // calculate streaming ssr cost
         const cost = end();
-        tracker.trackTiming(SSRTimings.SSR_RENDER_TOTAL, cost);
+        tracker.trackTiming(SSRTimings.RENDER_HTML, cost);
       },
       onShellError(e) {
         // Don't log error in `onShellError` callback, since it has been logged in `onError` callback

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/entry.ts
@@ -162,17 +162,17 @@ export default class Entry {
 
   private async prefetch(context: RuntimeContext) {
     let prefetchData;
-    const end = time();
 
     try {
-      prefetchData = await prefetch(this.App, context, this.pluginConfig);
+      prefetchData = await prefetch(
+        this.App,
+        context,
+        this.pluginConfig,
+        this.tracker,
+      );
       this.result.renderLevel = RenderLevel.SERVER_PREFETCH;
-      const prefetchCost = end();
-
-      this.tracker.trackTiming(SSRTimings.SSR_PREFETCH, prefetchCost);
     } catch (e) {
       this.result.renderLevel = RenderLevel.CLIENT_RENDER;
-      this.tracker.trackError(SSRErrors.PREFETCH, e as Error);
     }
 
     return prefetchData || {};
@@ -204,7 +204,7 @@ export default class Entry {
         .finish();
 
       const cost = end();
-      this.tracker.trackTiming(SSRTimings.SSR_RENDER_HTML, cost);
+      this.tracker.trackTiming(SSRTimings.RENDER_HTML, cost);
       this.result.renderLevel = RenderLevel.SERVER_RENDER;
     } catch (e) {
       this.tracker.trackError(SSRErrors.RENDER_HTML, e as Error);

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/index.ts
@@ -1,8 +1,6 @@
 import { run } from '@modern-js/runtime-utils/node';
-import { time } from '@modern-js/runtime-utils/time';
 import { ServerRenderOptions } from '../types';
 import { PreRender } from '../../react/prerender';
-import { SSRTimings } from '../tracker';
 import SSREntry from './entry';
 
 export const render = ({
@@ -20,11 +18,7 @@ export const render = ({
     });
     entry.metrics.emitCounter('app.visit.count', 1);
 
-    const end = time();
     const html = await entry.renderToHtml(context);
-    const cost = end();
-
-    entry.tracker.trackTiming(SSRTimings.SSR_RENDER_TOTAL, cost);
 
     const cacheConfig = PreRender.config();
     if (cacheConfig) {

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/tracker.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/tracker.ts
@@ -3,14 +3,15 @@ import type { BaseSSRServerContext } from '@modern-js/types';
 export type SSRTracker = ReturnType<typeof createSSRTracker>;
 
 export enum SSRTimings {
-  SSR_RENDER_TOTAL,
-  SSR_PREFETCH,
-  SSR_RENDER_HTML,
-  SSR_RENDER_SHELL,
+  PRERENDER,
+  RENDER_HTML,
+  RENDER_SHELL,
+  USE_LOADER,
 }
 
 export enum SSRErrors {
-  PREFETCH,
+  PRERENDER,
+  USE_LOADER,
   RENDER_HTML,
   RENDER_STREAM,
   RENDER_SHELL,
@@ -24,10 +25,15 @@ const errors: Record<
     logger?: string;
   }
 > = {
-  [SSRErrors.PREFETCH]: {
-    reporter: 'SSR Error - App Prefetch Render',
-    logger: 'App Prefetch Render',
-    metrics: 'app.prefetch.render.error',
+  [SSRErrors.PRERENDER]: {
+    reporter: 'SSR Error - App Prerender',
+    logger: 'App Prerender',
+    metrics: 'app.prerender.error',
+  },
+  [SSRErrors.USE_LOADER]: {
+    reporter: 'SSR Error - App run useLoader',
+    logger: 'App run useLoader',
+    metrics: 'app.useloader.error',
   },
   [SSRErrors.RENDER_HTML]: {
     reporter: 'SSR Error - App Render To HTML',
@@ -53,26 +59,25 @@ const timings: Record<
     logger?: string;
   }
 > = {
-  [SSRTimings.SSR_PREFETCH]: {
-    reporter: 'ssr-prefetch',
-    serverTiming: 'ssr-prefetch',
-    metrics: 'app.prefeth.cost',
-    logger: 'App Prefetch cost = %d ms',
+  [SSRTimings.PRERENDER]: {
+    reporter: 'ssr-prerender',
+    serverTiming: 'ssr-prerender',
+    metrics: 'app.prerender.cost',
+    logger: 'App Prerender cost = %d ms',
   },
-  [SSRTimings.SSR_RENDER_HTML]: {
+  [SSRTimings.RENDER_HTML]: {
     reporter: 'ssr-render-html',
     serverTiming: 'ssr-render-html',
     metrics: 'app.render.html.cost',
     logger: 'App Render To HTML cost = %d ms',
   },
-  [SSRTimings.SSR_RENDER_TOTAL]: {
-    reporter: 'ssr-render-total',
-    serverTiming: 'ssr-render-total',
-    metrics: 'app.render.cost',
-    logger: 'App Render Total cost = %d ms',
-  },
-  [SSRTimings.SSR_RENDER_SHELL]: {
+  [SSRTimings.RENDER_SHELL]: {
     reporter: 'ssr-render-shell',
+  },
+  [SSRTimings.USE_LOADER]: {
+    reporter: 'use-loader',
+    serverTiming: 'use-loader',
+    logger: 'App run useLoader cost = %d ms',
   },
 };
 

--- a/packages/runtime/plugin-runtime/tests/ssr/serverRender/tracker.test.ts
+++ b/packages/runtime/plugin-runtime/tests/ssr/serverRender/tracker.test.ts
@@ -60,18 +60,16 @@ describe('tracker', () => {
 
   it('track ssr error', () => {
     const error = new Error('mock error');
-    tracker.trackError(SSRErrors.PREFETCH, error);
+    tracker.trackError(SSRErrors.PRERENDER, error);
 
-    expect(reporter.errors).toEqual([
-      ['SSR Error - App Prefetch Render', error],
-    ]);
-    expect(logger.errors).toEqual([['App Prefetch Render', error]]);
-    expect(metrics.errors.get('app.prefetch.render.error')).toEqual(1);
+    expect(reporter.errors).toEqual([['SSR Error - App Prerender', error]]);
+    expect(logger.errors).toEqual([['App Prerender', error]]);
+    expect(metrics.errors.get('app.prerender.error')).toEqual(1);
   });
 
   it('track ssr timing', () => {
     const cost = 13;
-    tracker.trackTiming(SSRTimings.SSR_RENDER_HTML, cost);
+    tracker.trackTiming(SSRTimings.RENDER_HTML, cost);
 
     expect(serverTiming.serverTimings).toEqual([['ssr-render-html', cost]]);
     expect(logger.timings).toEqual([['App Render To HTML cost = %d ms', cost]]);


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 462d270</samp>

This pull request improves the SSR performance and error tracking in the `@modern-js/runtime` package. It refactors the `prefetch` and `renderToHtml` methods in the `SSREntry` class and removes unnecessary code from the `renderToString` and `renderToStream` files. It also updates the naming and configuration of the `SSRTimings` and `SSRErrors` enums in the `tracker.ts` file and the corresponding test cases. It adds a changeset file to document the patch version update and the fix messages.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 462d270</samp>

*  Add a changeset file to document the patch version update and the fix messages for the `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-834e6a7653a47107ffee3b8cc4210224936bc5558f3f40022a29fde64d6699b8R1-R6))
*  Import modules and types from `@modern-js/runtime-utils` and `./serverRender/tracker` in `prefetch.tsx` to measure and track the SSR performance and errors ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-f101a2b994f6a9674089eb10c342b7770ff8cda675ea6a24c36a7bff4b55bdb2L4-R8))
*  Add a `tracker` parameter to the `prefetch` function in `prefetch.tsx` and use it to record the timings and errors of the prerendering and useLoader steps ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-f101a2b994f6a9674089eb10c342b7770ff8cda675ea6a24c36a7bff4b55bdb2R15), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-f101a2b994f6a9674089eb10c342b7770ff8cda675ea6a24c36a7bff4b55bdb2L18-R45), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-f101a2b994f6a9674089eb10c342b7770ff8cda675ea6a24c36a7bff4b55bdb2L39-R72))
*  Rename the `SSRTimings` enums in `renderToStream/index.ts`, `renderToString/entry.ts` and `serverRender/tracker.ts` to make the naming consistent and avoid confusion ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-3cd0efac6151a1e235d4e28e4c92ec98da7b610907a65a6e1b2b9bca9b361b05L36-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL207-R207), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-7ea1309b8e8110ce1dfe7b8aea05c03b99bfbfa5317f07e2b719bacf8c26498aL6-R14))
*  Remove the redundant `time` and `tracker` logic from the `renderToString/entry.ts` and `renderToString/index.ts` files and delegate the tracking responsibility to the `prefetch` function and the `SSREntry` class ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-352b83cd645505525fd5003e97448913b8ad6c4578237700bd1d9b8c7581cb1eL165-R175), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-57fccd878d7aa5b0589b6ce04ee36b219f78d7e22ac6ad57602f7670a905993bL2-R3), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-57fccd878d7aa5b0589b6ce04ee36b219f78d7e22ac6ad57602f7670a905993bL23-R22))
*  Add a new `SSRTimings.USE_LOADER` and `SSRErrors.USE_LOADER` enum in `serverRender/tracker.ts` to track the useLoader performance and errors ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-7ea1309b8e8110ce1dfe7b8aea05c03b99bfbfa5317f07e2b719bacf8c26498aL6-R14), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-7ea1309b8e8110ce1dfe7b8aea05c03b99bfbfa5317f07e2b719bacf8c26498aL27-R37), [link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-7ea1309b8e8110ce1dfe7b8aea05c03b99bfbfa5317f07e2b719bacf8c26498aL56-R68))
*  Remove the unused `SSRTimings.SSR_RENDER_TOTAL` entry from the `timingConfig` object in `serverRender/tracker.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-7ea1309b8e8110ce1dfe7b8aea05c03b99bfbfa5317f07e2b719bacf8c26498aL68-R81))
*  Update the test cases for the `tracker.ts` file to reflect the changes in the enums and the tracking logic ([link](https://github.com/web-infra-dev/modern.js/pull/4922/files?diff=unified&w=0#diff-b2152fbb51e6340d9d588ff74f89bb15962f389a19165bb56eae22bfd0ba13bfL63-R72))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
