### PR TITLE
feat: add forceCSR for worker server

### DIFF
--- a/.changeset/mighty-icons-arrive.md
+++ b/.changeset/mighty-icons-arrive.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': minor
+---
+
+feat: add forceCSR options for worker server
+feat: 在 worker server 新增 forceCSR 参数和判断 csr=1 降级

--- a/packages/server/prod-server/src/workerServer.ts
+++ b/packages/server/prod-server/src/workerServer.ts
@@ -102,6 +102,9 @@ export type Manifest = {
    */
   pages: Record<string, Page>;
   routes: ModernRouteInterface[];
+  options?: {
+    forceCSR?: boolean;
+  };
 };
 
 const RESPONSE_NOTFOUND = new ReturnResponse('404: Page not found', 404);
@@ -126,7 +129,7 @@ const middlewarePipeline = createAsyncPipeline<
 
 export const createHandler = (manifest: Manifest) => {
   const routeMgr = new RouteMatchManager();
-  const { pages, routes } = manifest;
+  const { pages, routes, options: manifestOpts = {} } = manifest;
   routeMgr.reset(routes);
   return async (options: HandlerOptions): Promise<ReturnResponse> => {
     const { request, loadableStats, routeManifest } = options;
@@ -139,6 +142,10 @@ export const createHandler = (manifest: Manifest) => {
 
     const entryName = pageMatch.spec.urlPath;
     const page = pages[entryName];
+    if (manifestOpts.forceCSR && url.searchParams.get('csr') === '1') {
+      return createResponse(page.template);
+    }
+
     const logger = createLogger({ level: 'warn' });
     const metrics = defaultMetrics as any;
     const reporter = defaultReporter;


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73d161a</samp>

This pull request adds a new feature to the `@modern-js/prod-server` package that allows enabling client-side rendering for certain pages and requests on the worker server. This feature is controlled by a `forceCSR` option in the manifest file and a `csr` query parameter in the URL.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 73d161a</samp>

*  Add a `forceCSR` option and a `csr=1` query parameter to enable client-side rendering fallback for the worker server (`@modern-js/prod-server` package) ([link](https://github.com/web-infra-dev/modern.js/pull/4923/files?diff=unified&w=0#diff-0bca7f48e38b535fe08f706a9e1063b3a64a52d3e6d1fb2fff8e8e3c1e73e7adR1-R6), [link](https://github.com/web-infra-dev/modern.js/pull/4923/files?diff=unified&w=0#diff-cdf7d4afc78d8820e416cce7f0a2e443fc7a2355523088ff9c066ec09459936cR105-R107), [link](https://github.com/web-infra-dev/modern.js/pull/4923/files?diff=unified&w=0#diff-cdf7d4afc78d8820e416cce7f0a2e443fc7a2355523088ff9c066ec09459936cL129-R132), [link](https://github.com/web-infra-dev/modern.js/pull/4923/files?diff=unified&w=0#diff-cdf7d4afc78d8820e416cce7f0a2e443fc7a2355523088ff9c066ec09459936cR145-R148))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
