### PR TITLE
fix(devtools): missing `exports` from package files

### DIFF
--- a/packages/devtools/client/package.json
+++ b/packages/devtools/client/package.json
@@ -15,7 +15,8 @@
     "node": ">=14.0.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "exports"
   ],
   "main": "./dist/html/client/index.html",
   "exports": {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 279df0c</samp>

Updated `package.json` to include `exports` folder for devtools client package. This enables using ES modules instead of CommonJS modules in the modern.js project.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 279df0c</samp>

* Include `exports` folder in `files` field of `package.json` to enable module exports for devtools client package ([link](https://github.com/web-infra-dev/modern.js/pull/4924/files?diff=unified&w=0#diff-ee0bdc3f92472c79376377721c0e8c205228ee40cc94ffd50d4feb71deba0c2eL18-R19))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
