### PR TITLE
fix: even if the page component exists, we should not keep the page c…

### DIFF
--- a/.changeset/wise-eggs-breathe.md
+++ b/.changeset/wise-eggs-breathe.md
@@ -2,5 +2,5 @@
 '@modern-js/app-tools': patch
 ---
 
-fix: Even if the page component exists, we should not keep the layout component
-fix: 即使页面组件存在，也不应该保留 layout component
+fix: Even if the page component exists, we should not create the empty layout component
+fix: 即使页面组件存在，也不应该创建一个空的 layout component

--- a/.changeset/wise-eggs-breathe.md
+++ b/.changeset/wise-eggs-breathe.md
@@ -2,5 +2,5 @@
 '@modern-js/app-tools': patch
 ---
 
-fix: Even if the page component exists, we should not keep the page component
-fix: 即使页面组件存在，也不应该保留 page component
+fix: Even if the page component exists, we should not keep the layout component
+fix: 即使页面组件存在，也不应该保留 layout component

--- a/.changeset/wise-eggs-breathe.md
+++ b/.changeset/wise-eggs-breathe.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: Even if the page component exists, we should not keep the page component
+fix: 即使页面组件存在，也不应该保留 page component

--- a/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
+++ b/packages/solutions/app-tools/src/analyze/nestedRoutes.ts
@@ -78,14 +78,12 @@ export const optimizeRoute = (
   }
 
   const { children } = routeTree;
-  const hasPage = children.some(child => child.index);
   if (
     !routeTree._component &&
     !routeTree.error &&
     !routeTree.loading &&
     !routeTree.config &&
-    !routeTree.clientData &&
-    !hasPage
+    !routeTree.clientData
   ) {
     const newRoutes = children.map(child => {
       const routePath = `${routeTree.path ? routeTree.path : ''}${

--- a/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
+++ b/packages/solutions/app-tools/tests/analyze/__snapshots__/nestedRoutes.test.ts.snap
@@ -12,17 +12,9 @@ exports[`nested routes walk 1`] = `
             "_component": "@_modern_js_src/__auth/__shop/layout.tsx",
             "children": [
               {
-                "children": [
-                  {
-                    "_component": "@_modern_js_src/__auth/__shop/item/page.tsx",
-                    "children": undefined,
-                    "id": "__auth/__shop/item/page",
-                    "index": true,
-                    "type": "nested",
-                  },
-                ],
-                "id": "__auth/__shop/item/layout",
-                "isRoot": false,
+                "_component": "@_modern_js_src/__auth/__shop/item/page.tsx",
+                "children": undefined,
+                "id": "__auth/__shop/item/page",
                 "path": "item",
                 "type": "nested",
               },
@@ -32,17 +24,9 @@ exports[`nested routes walk 1`] = `
             "type": "nested",
           },
           {
-            "children": [
-              {
-                "_component": "@_modern_js_src/__auth/login/page.tsx",
-                "children": undefined,
-                "id": "__auth/login/page",
-                "index": true,
-                "type": "nested",
-              },
-            ],
-            "id": "__auth/login/layout",
-            "isRoot": false,
+            "_component": "@_modern_js_src/__auth/login/page.tsx",
+            "children": undefined,
+            "id": "__auth/login/page",
             "path": "login",
             "type": "nested",
           },
@@ -67,18 +51,10 @@ exports[`nested routes walk 1`] = `
             "type": "nested",
           },
           {
-            "children": [
-              {
-                "_component": "@_modern_js_src/user/[id]/page.tsx",
-                "children": undefined,
-                "data": "<ROOT>/tests/analyze/fixtures/nested-routes/user/[id]/page.data.ts",
-                "id": "user/(id)/page",
-                "index": true,
-                "type": "nested",
-              },
-            ],
-            "id": "user/(id)/layout",
-            "isRoot": false,
+            "_component": "@_modern_js_src/user/[id]/page.tsx",
+            "children": undefined,
+            "data": "<ROOT>/tests/analyze/fixtures/nested-routes/user/[id]/page.data.ts",
+            "id": "user/(id)/page",
             "path": ":id",
             "type": "nested",
           },

--- a/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
+++ b/packages/solutions/app-tools/tests/analyze/nestedRoutes.test.ts
@@ -163,17 +163,10 @@ describe('nested routes', () => {
           _component: 'layoutB',
           children: [
             {
-              id: 'c',
-              type: 'nested',
+              id: 'd',
               path: 'c',
-              children: [
-                {
-                  id: 'd',
-                  type: 'nested',
-                  _component: 'pageD',
-                  index: true,
-                },
-              ],
+              _component: 'pageD',
+              type: 'nested',
             },
           ],
         },


### PR DESCRIPTION
…omponent

In the [previous version](https://github.com/web-infra-dev/modern.js/pull/4484), because of the needs of the admin solution, we retained the redundant layout component, and now we remove this behavior.

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 565282c</samp>

This pull request improves the `@modern-js/app-tools` package by simplifying the nested routes analysis and optimization logic. It also updates the test case and the changeset file for the package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 565282c</samp>

* Add a changeset file to describe the patch version update and the fixes for the `@modern-js/app-tools` package ([link](https://github.com/web-infra-dev/modern.js/pull/4925/files?diff=unified&w=0#diff-03aa04466269c94324a950758cb24e7a9106880b3c0e6db75ab9885e62f0e7f8R1-R6))
* Remove the `hasPage` variable and condition from the nested routes analysis and optimization logic in `nestedRoutes.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4925/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL81),[link](https://github.com/web-infra-dev/modern.js/pull/4925/files?diff=unified&w=0#diff-89756710513f64f72aaf997fdd2a0179fd26970e9d18e579b4648498933ce1cdL87-R86))
* Update and simplify the test case for the nested routes analysis and optimization in `nestedRoutes.test.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4925/files?diff=unified&w=0#diff-b9f08e190da885b9aeebef0f55d68a4b8e57c4c46ed5deb768eb5afad999d463L166-R169))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
