### PR TITLE
docs(builder): fix dead links

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/en/guide/faq/exceptions.md
@@ -258,9 +258,9 @@ export default {
 
 In addition to the reasons mentioned above, there is another possibility that can cause Babel compilation to hang, which is when Babel compiles a large JS file exceeding 10,000 lines (usually a large file in the node_modules directory that is compiled using `source.include`).
 
-When Babel compiles large files, the built-in babel-plugin-styled-components in Modern.js can cause the compilation to hang. There is already a [relevant issue]((https://github.com/styled-components/babel-plugin-styled-components/issues/374)) in the community .
+When Babel compiles large files, the built-in babel-plugin-styled-components in Modern.js can cause the compilation to hang. There is already a [relevant issue](https://github.com/styled-components/babel-plugin-styled-components/issues/374) in the community .
 
-In the future, Modern.js will consider removing the built-in babel-plugin-styled-components. In the current version, you can set [tools.styledComponents](/configure/app/tools/styled-components.html) to `false` to remove this plugin.
+In the future, Modern.js will consider removing the built-in babel-plugin-styled-components. In the current version, you can set [tools.styledComponents](/api/config-tools.html#toolsstyledcomponents) to `false` to remove this plugin.
 
 ```ts title="modern.config.ts"
 export default {

--- a/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
+++ b/packages/document/builder-doc/docs/zh/guide/faq/exceptions.md
@@ -260,7 +260,7 @@ export default {
 
 当 Babel 编译大文件时，Modern.js 内置的 babel-plugin-styled-components 会卡死，社区中已有 [相关 issue](https://github.com/styled-components/babel-plugin-styled-components/issues/374)。
 
-未来 Modern.js 会考虑移除内置的 babel-plugin-styled-components。在当前版本里，你可以将 [tools.styledComponents](/configure/app/tools/styled-components.html) 设置为 `false` 来移除该插件。
+未来 Modern.js 会考虑移除内置的 babel-plugin-styled-components。在当前版本里，你可以将 [tools.styledComponents](/api/config-tools.html#toolsstyledcomponents) 设置为 `false` 来移除该插件。
 
 ```ts title="modern.config.ts"
 export default {


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 25a38cb</samp>

This pull request fixes a broken link and updates the documentation of the `tools.styledComponents` option in the FAQ section of the `builder-doc` package. It applies the changes to both the English and Chinese versions of the document.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 25a38cb</samp>

* Fix broken link to community issue and update link to tools.styledComponents option in English FAQ document ([link](https://github.com/web-infra-dev/modern.js/pull/4927/files?diff=unified&w=0#diff-e973d8362ca617a8bab5334833fc15ebff93d5823ae87ab98597eb0a7935fe81L261-R263))
* Update link to tools.styledComponents option in Chinese FAQ document to match new API structure ([link](https://github.com/web-infra-dev/modern.js/pull/4927/files?diff=unified&w=0#diff-61e9b6308f8819db84914f183dd09d9d0a5995e2102aff1170697d54aa53c62bL263-R263))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
