### PR TITLE
fix: import('node:xx') would compile failed when target = webworker

### DIFF
--- a/.changeset/strange-glasses-retire.md
+++ b/.changeset/strange-glasses-retire.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: import('node:xx') would compile failed when target = webworker
+fix: import('node:xx') 将在 target = webworker 时构建失败

--- a/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/serverRender/renderToString/loadable.ts
@@ -35,8 +35,8 @@ const checkIsInline = (
 
 const readAsset = async (chunk: ChunkAsset) => {
   // working node env
-  const fs = await import('node:fs/promises');
-  const path = await import('node:path');
+  const fs = await import('fs/promises');
+  const path = await import('path');
 
   // only working in 'production' env
   // we need ensure the assetsDir is same as ssr bundles.


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95382a7</samp>

This pull request fixes two issues with importing node modules in web worker environments for the `@modern-js/runtime` package. It also updates the changelog and adds a Chinese translation for the fixes.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95382a7</samp>

* Fix import errors for node modules in web worker environments ([link](https://github.com/web-infra-dev/modern.js/pull/4934/files?diff=unified&w=0#diff-87cc87d978f521b77dbd80f1d2ffe5ab366a5df51ad6f2efaf9edf0ea4f65409L38-R39), [link](https://github.com/web-infra-dev/modern.js/pull/4934/files?diff=unified&w=0#diff-13933d5de362b1bf4e5a7445deb1d36b3fe24c6f97f0381b96b8d17ca7dd4bedR1-R6))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
