### PR TITLE
types: fix stats chunk type for rspack-ecosystem-ci

### DIFF
--- a/.changeset/lovely-yaks-rule.md
+++ b/.changeset/lovely-yaks-rule.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+chore(builder): update stats type
+
+chore(builder): 更新 stats 类型

--- a/packages/builder/builder-shared/src/types/stats.ts
+++ b/packages/builder/builder-shared/src/types/stats.ts
@@ -33,7 +33,7 @@ export interface StatsAsset {
   type: string;
   name: string;
   size: number;
-  chunks?: Array<string | number>;
+  chunks?: Array<string | undefined | null>;
   chunkNames?: Array<string | number>;
   info: StatsAssetInfo;
 }
@@ -49,7 +49,7 @@ interface StatsModule {
   identifier?: string;
   name?: string;
   id?: string;
-  chunks?: Array<string>;
+  chunks?: Array<string | undefined | null>;
   size?: number;
 }
 


### PR DESCRIPTION
## Summary


<img width="1453" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/9b09b6dd-6a41-4290-b559-d6d12a9e745d">

https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/6819385524/job/18546640006

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ab8c17</samp>

This pull request fixes the types of `chunks` properties in `@modern-js/builder-shared` to match webpack stats. It also adds a changeset file for the patch update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ab8c17</samp>

*  Add changeset file for patch update of `@modern-js/builder-shared` package (.changeset/lovely-yaks-rule.md)
*  Allow `undefined` and `null` values for `chunks` property in `StatsAsset` and `StatsModule` interfaces to match webpack stats object ([link](https://github.com/web-infra-dev/modern.js/pull/4938/files?diff=unified&w=0#diff-fdd219918f4a3c190114fd8ca34ee17f1d98c0a1b18de17b10602bf9e7164711L36-R36),[link](https://github.com/web-infra-dev/modern.js/pull/4938/files?diff=unified&w=0#diff-fdd219918f4a3c190114fd8ca34ee17f1d98c0a1b18de17b10602bf9e7164711L52-R52))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
