### PR TITLE
docs(module-tools): fix plugin-tailwindcss version mismatch

### DIFF
--- a/packages/document/module-doc/docs/en/guide/best-practices/use-tailwindcss.mdx
+++ b/packages/document/module-doc/docs/en/guide/best-practices/use-tailwindcss.mdx
@@ -19,18 +19,7 @@ To use [Tailwind CSS](https://tailwindcss.com/) in Modern.js Module, you can fol
 ? Please select the feature name: Enable Tailwind CSS
 ```
 
-After successful initialization, you will see the following additions to the `package.json` file:
-
-```json title="./package.json"
-{
-  "dependencies": {
-    "tailwindcss": "^3.0.0"
-  },
-  "devDependencies": {
-    "@modern-js/plugin-tailwindcss": "^2.0.0"
-  }
-}
-```
+After successful initialization, you will see that the `package.json` has added dependencies for `tailwindcss` and `@modern-js/plugin-tailwindcss`.
 
 2. Register the Tailwind plugin in `modern.config.ts`:
 

--- a/packages/document/module-doc/docs/zh/guide/best-practices/use-tailwindcss.mdx
+++ b/packages/document/module-doc/docs/zh/guide/best-practices/use-tailwindcss.mdx
@@ -19,18 +19,7 @@ Modern.js Module 支持使用 Tailwind CSS 开发组件样式。
 ? 请选择功能名称 启用 「Tailwind CSS」 支持
 ```
 
-成功开启后，会看到 `package.json` 中新增了依赖：
-
-```json title="./package.json"
-{
-  "dependencies": {
-    "tailwindcss": "^3.0.0"
-  },
-  "devDependencies": {
-    "@modern-js/plugin-tailwindcss": "^2.0.0"
-  }
-}
-```
+成功开启后，你会看到 `package.json` 中新增了 `tailwindcss` 和 `@modern-js/plugin-tailwindcss` 依赖。
 
 2. 在 `modern.config.ts` 中注册 Tailwind 插件:
 


### PR DESCRIPTION
## Summary

Fix plugin-tailwindcss version mismatch, the plugin version is different in Modern.js and EdenX, so we just remove the version.

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0873de8</samp>

Updated the documentation on using Tailwind CSS with Modern.js to simplify the dependency installation instructions and omit the version numbers. Applied the same change to both the English and Chinese versions of the guide.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0873de8</samp>

*  Simplify the documentation on how to use Tailwind CSS with Modern.js by omitting the exact version numbers of the dependencies and only showing the package names ([link](https://github.com/web-infra-dev/modern.js/pull/4939/files?diff=unified&w=0#diff-7a56032bce67d74c36d3e517ded7a275517e58c8fa53d09b5376252ef5f2f351L22-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4939/files?diff=unified&w=0#diff-96b986301e1663af7ec2ef2868dc256b48a88b202b5d82c851b6e6af9b15dc0cL22-R23))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
