### PR TITLE
fix: can't get rspack util in tools.rspack

### DIFF
--- a/.changeset/modern-berries-live.md
+++ b/.changeset/modern-berries-live.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+hotfix(rspack-provider): can't get rspack util in tools.rspack

--- a/packages/builder/builder-rspack-provider/src/core/rspackConfig.ts
+++ b/packages/builder/builder-rspack-provider/src/core/rspackConfig.ts
@@ -41,7 +41,7 @@ async function getConfigUtils(
   chainUtils: ModifyChainUtils,
 ): Promise<ModifyRspackConfigUtils> {
   const { merge } = await import('@modern-js/builder-shared/webpack-merge');
-  const { default: rspack } = await import('@rspack/core');
+  const rspack = await import('@rspack/core');
 
   return {
     ...chainUtils,


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d67cc83</samp>

This pull request fixes a bug in the `@modern-js/builder-rspack-provider` package that prevented accessing the rspack utility. It also updates the import syntax for the `@rspack/core` module and adds a changeset file for the patch version update.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d67cc83</samp>

* Add a changeset file to document the patch version update and the bug fix for `@modern-js/builder-rspack-provider` ([link](https://github.com/web-infra-dev/modern.js/pull/4950/files?diff=unified&w=0#diff-44caabe8580a34b9169c69230fb22bbfd5b535391fabe17725f45f2ca359552fR1-R5))
* Simplify the import of `@rspack/core` by using the default export in `rspackConfig.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4950/files?diff=unified&w=0#diff-b3814db8920aea3983c051ad3f77b0bc59cfcc0f982a6046e8635a21d76ee8ccL44-R44))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
