### PR TITLE
fix: module-tools doc

### DIFF
--- a/packages/document/module-doc/docs/en/api/plugin-api/plugin-hooks.md
+++ b/packages/document/module-doc/docs/en/api/plugin-api/plugin-hooks.md
@@ -27,15 +27,14 @@ export const myPlugin = (): CliPlugin<ModuleTools> => ({
 
   setup() {
     return {
-      beforeBuild(options: Options): Return {
-        return options.config;
+      beforeBuild(options: Options): void {
       }
     }
   },
 });
 ```
 
-Parameters and return value types.
+Parameters value types.
 
 ```ts
 type Options = { options: { config: BuildConfig; cliOptions: BuildCommandOptions } }
@@ -48,8 +47,6 @@ export interface BuildCommandOptions {
   tsconfig: string;
   watch?: boolean;
 }
-
-type Return = BuildConfig;
 ```
 
 > `BuildConfig` type reference [API configuration](en/api/)

--- a/packages/document/module-doc/docs/zh/api/plugin-api/plugin-hooks.md
+++ b/packages/document/module-doc/docs/zh/api/plugin-api/plugin-hooks.md
@@ -27,15 +27,14 @@ export const myPlugin = (): CliPlugin<ModuleTools> => ({
 
   setup() {
     return {
-      beforeBuild(options: Options): Return {
-        return options.config;
+      beforeBuild(options: Options): void {
       },
     };
   },
 });
 ```
 
-参数和返回值类型：
+参数类型：
 
 ```ts
 type Options = {
@@ -50,8 +49,6 @@ export interface BuildCommandOptions {
   tsconfig: string;
   watch?: boolean;
 }
-
-type Return = BuildConfig;
 ```
 
 > `BuildConfig` 类型参考 [API 配置](/api/)


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

更新文档。

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4599126</samp>

Simplified a plugin hook in the module-doc package. Updated the documentation for the `beforeBuild` hook in `plugin-hooks.md`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

module-tools的beforeBuild执行后并没有返回值。
<img width="531" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/51100990/183d2316-b6f9-48a2-b566-7399113e8cfe">

我尝试用tools文档构建plugin时被误导了。

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4599126</samp>

*  Change the return type of the `beforeBuild` hook to `void` and update the documentation accordingly ([link](https://github.com/web-infra-dev/modern.js/pull/4952/files?diff=unified&w=0#diff-a8594a87455ab6bdbe8457d973e0a2a88b127b7cc3734b2f7b65768a4e1976e8L30-R30), [link](https://github.com/web-infra-dev/modern.js/pull/4952/files?diff=unified&w=0#diff-a8594a87455ab6bdbe8457d973e0a2a88b127b7cc3734b2f7b65768a4e1976e8L38-R37), [link](https://github.com/web-infra-dev/modern.js/pull/4952/files?diff=unified&w=0#diff-a8594a87455ab6bdbe8457d973e0a2a88b127b7cc3734b2f7b65768a4e1976e8L53-L54))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
