### PR TITLE
fix(plugin-runtime): Document.tsx should work normal with title tag render

### DIFF
--- a/.changeset/chilled-swans-eat.md
+++ b/.changeset/chilled-swans-eat.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(plugin-runtime): `Document.tsx` should work fine when user config `html.title` or `html.titleByEntries`
+fix(plugin-runtime): `Document.tsx` 正常工作当用户配置 `html.title` or `html.titleByEntries` 的时候

--- a/packages/runtime/plugin-runtime/src/document/DocumentStructureContext.tsx
+++ b/packages/runtime/plugin-runtime/src/document/DocumentStructureContext.tsx
@@ -6,6 +6,7 @@ type DocumentStructureContextProps = {
   hasSetLinks?: boolean;
   hasSetBody?: boolean;
   hasSetRoot?: boolean;
+  hasSetTitle?: boolean;
   docChild?: ReactNode;
 };
 
@@ -16,4 +17,5 @@ export const DocumentStructureContext =
     hasSetBody: false,
     hasSetRoot: false,
     hasSetLinks: false,
+    hasSetTitle: false,
   });

--- a/packages/runtime/plugin-runtime/src/document/Head.tsx
+++ b/packages/runtime/plugin-runtime/src/document/Head.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import { DocumentStructureContext } from './DocumentStructureContext';
 import { Scripts } from './Scripts';
 import { Links } from './Links';
+import { Title } from './Title';
 import {
   DOCUMENT_META_PLACEHOLDER,
   HEAD_PARTICALS_SEPARATOR,
@@ -10,23 +11,26 @@ import {
 } from './constants';
 
 export function Head(props: { children?: any }) {
-  const { hasSetScripts, hasSetLinks } = useContext(DocumentStructureContext);
+  const { hasSetScripts, hasSetLinks, hasSetTitle } = useContext(
+    DocumentStructureContext,
+  );
   const { children, ...rest } = props;
   // todo: verify the children
   return (
     <head {...rest}>
       {/* configuration by config.output.meta */}
-      {`${TOP_PARTICALS_SEPARATOR}`}
-      {`${DOCUMENT_META_PLACEHOLDER}`}
+      {TOP_PARTICALS_SEPARATOR}
+      {DOCUMENT_META_PLACEHOLDER}
+      {!hasSetTitle && <Title />}
       {!hasSetLinks && <Links />}
       {/* Scripts must have as default. If not, place in Head */}
       {!hasSetScripts && <Scripts />}
-      {`${HEAD_PARTICALS_SEPARATOR}`}
+      {HEAD_PARTICALS_SEPARATOR}
       {children}
     </head>
   );
 }
 
 export function DefaultHead() {
-  return <head>{`${DOCUMENT_META_PLACEHOLDER}`}</head>;
+  return <head>{DOCUMENT_META_PLACEHOLDER}</head>;
 }

--- a/packages/runtime/plugin-runtime/src/document/Html.tsx
+++ b/packages/runtime/plugin-runtime/src/document/Html.tsx
@@ -53,6 +53,7 @@ export function Html(props: { children: any[] }) {
   const hasSetLinks = Boolean(findTargetElement('Links', children));
   const hasSetBody = Boolean(findTargetChild('Body', children));
   const hasSetRoot = Boolean(findTargetElement('Root', children));
+  const hasSetTitle = Boolean(findTargetElement('title', children));
   const notMissMustChild = [
     hasSetHead,
     hasSetBody,
@@ -96,6 +97,7 @@ export function Html(props: { children: any[] }) {
           hasSetLinks,
           hasSetRoot,
           hasSetBody,
+          hasSetTitle,
           docChild: children,
         }}
       >

--- a/packages/runtime/plugin-runtime/src/document/Title.tsx
+++ b/packages/runtime/plugin-runtime/src/document/Title.tsx
@@ -1,0 +1,5 @@
+import { DOCUMENT_TITLE_PLACEHOLDER } from './constants';
+
+export function Title() {
+  return <title>{DOCUMENT_TITLE_PLACEHOLDER}</title>;
+}

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -25,6 +25,7 @@ import {
   DOCUMENT_COMMENT_PLACEHOLDER_END,
   DOCUMENT_STYLE_PLACEHOLDER_START,
   DOCUMENT_STYLE_PLACEHOLDER_END,
+  DOCUMENT_TITLE_PLACEHOLDER,
   TOP_PARTICALS_SEPARATOR,
   HEAD_PARTICALS_SEPARATOR,
   BODY_PARTICALS_SEPARATOR,
@@ -224,6 +225,13 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
             .join(''),
         ].join('');
 
+        const titles = [
+          templateParameters.title,
+          htmlWebpackPlugin.tags.headTags
+            .filter((item: any) => item.tagName === 'title')
+            .join(''),
+        ].join('');
+
         // if the Document.tsx has a functional script, replace to convert it
         if (
           html.includes(DOCUMENT_SCRIPT_PLACEHOLDER_START) &&
@@ -281,7 +289,8 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
           .replace(
             DOCUMENT_SSRDATASCRIPT_PLACEHOLDER,
             PLACEHOLDER_REPLACER_MAP[DOCUMENT_SSRDATASCRIPT_PLACEHOLDER],
-          );
+          )
+          .replace(DOCUMENT_TITLE_PLACEHOLDER, titles);
         return finalHtml;
       };
     };

--- a/packages/runtime/plugin-runtime/src/document/constants.ts
+++ b/packages/runtime/plugin-runtime/src/document/constants.ts
@@ -2,6 +2,7 @@ import { HTML_CHUNKSMAP_SEPARATOR } from '@modern-js/utils/universal/constants';
 
 export const DOC_EXT = ['jsx', 'tsx', 'ts', 'js'];
 export const DOCUMENT_META_PLACEHOLDER = encodeURIComponent('<%= meta %>');
+export const DOCUMENT_TITLE_PLACEHOLDER = encodeURIComponent('<%= title %>');
 export const HTML_SEPARATOR = '<!--<?- html ?>-->';
 export const HEAD_PARTICALS_SEPARATOR = encodeURIComponent(
   '<!--<?- partials.head ?>-->',

--- a/packages/runtime/plugin-runtime/tests/document/index.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/index.test.tsx
@@ -27,7 +27,7 @@ describe('plugin-document', () => {
     );
     const docHtml = ReactDomServer.renderToString(document);
     expect(docHtml).toEqual(
-      `<html><head>%3C!--%3C%3F-%20partials.top%20%3F%3E--%3E<!-- -->%3C%25%3D%20meta%20%25%3E<!-- -->%3C!--%20chunk%20links%20placeholder%20--%3E<!-- -->%3C!--%20chunk%20scripts%20placeholder%20--%3E<!-- -->%3C!--%3C%3F-%20partials.head%20%3F%3E--%3E</head><body><div id="root">%3C!--%3C%3F-%20html%20%3F%3E--%3E</div>%3C!--%3C%3F-%20partials.body%20%3F%3E--%3E<!-- -->%3C!--%3C%3F-%20chunksMap.js%20%3F%3E--%3E<!-- -->%3C!--%3C%3F-%20SSRDataScript%20%3F%3E--%3E</body></html>`,
+      `<html><head>%3C!--%3C%3F-%20partials.top%20%3F%3E--%3E<!-- -->%3C%25%3D%20meta%20%25%3E<title>%3C%25%3D%20title%20%25%3E</title>%3C!--%20chunk%20links%20placeholder%20--%3E<!-- -->%3C!--%20chunk%20scripts%20placeholder%20--%3E<!-- -->%3C!--%3C%3F-%20partials.head%20%3F%3E--%3E</head><body><div id=\"root\">%3C!--%3C%3F-%20html%20%3F%3E--%3E</div>%3C!--%3C%3F-%20partials.body%20%3F%3E--%3E<!-- -->%3C!--%3C%3F-%20chunksMap.js%20%3F%3E--%3E<!-- -->%3C!--%3C%3F-%20SSRDataScript%20%3F%3E--%3E</body></html>`,
     );
   });
 
@@ -91,5 +91,30 @@ describe('plugin-document', () => {
     const docHtml = ReactDomServer.renderToString(document);
 
     expect(docHtml.includes(`<h1>title: </h1><div id="abc">`)).toBeTruthy();
+  });
+
+  it('should render title successful', () => {
+    const document = (
+      <DocumentContext.Provider
+        value={{
+          templateParams: {
+            title: 'aaaa',
+          },
+        }}
+      >
+        <Html>
+          <Head></Head>
+          <Body>
+            <Root rootId="abc"></Root>
+            <Scripts></Scripts>
+          </Body>
+        </Html>
+      </DocumentContext.Provider>
+    );
+    const docHtml = ReactDomServer.renderToString(document);
+
+    expect(
+      docHtml.includes(`<title>%3C%25%3D%20title%20%25%3E</title>`),
+    ).toBeTruthy();
   });
 });

--- a/tests/integration/app-document/modern.config.ts
+++ b/tests/integration/app-document/modern.config.ts
@@ -39,6 +39,7 @@ export default applyBaseConfig({
   },
   html: {
     favicon: './static/a.icon',
+    title: 'test-title',
   },
   plugins: [routerPlugin(), tmpTest()],
 });

--- a/tests/integration/app-document/tests/index.test.ts
+++ b/tests/integration/app-document/tests/index.test.ts
@@ -150,6 +150,14 @@ describe('test dev and build', () => {
         ),
       ).toBe(true);
     });
+
+    test('should has title in Head', async () => {
+      const htmlWithDoc = fs.readFileSync(
+        path.join(appDir, 'dist', 'html/sub/index.html'),
+        'utf-8',
+      );
+      expect(htmlWithDoc.includes('<title>test-title</title>')).toBe(true);
+    });
   });
 
   describe('test dev', () => {


### PR DESCRIPTION
fix(plugin-runtime): Document.tsx should work normal when user config html.title or html.titleByEntries

## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 72e99f7</samp>

This pull request improves the document title handling in the `@modern-js/runtime` package. It adds a new `Title` component that uses a `DOCUMENT_TITLE_PLACEHOLDER` constant to render the title element. It also allows the user to configure the title via the `html` options or use a custom title element from the document.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 72e99f7</samp>

*  Add a changeset file to document the patch version update and bug fixes for the `@modern-js/runtime` package ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-3f1255352591734a713e58d27fd65db6fea2c33024b2ce02c6b8481df74cf6f5R1-R6))
*  Add a new constant `DOCUMENT_TITLE_PLACEHOLDER` to represent the template expression for the document title ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-1a1cc0259df40308359daa495e6b88cc3bba9bdfec132dbeaded71ea428b8492R5))
*  Import the `DOCUMENT_TITLE_PLACEHOLDER` constant to the `documentPlugin` file and the `Title` component file ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-0e55b04e20002e2fb2749b80f99d441529beb49561d648172696a765aa8afa67R28), [link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-daf985ace4367348335b3512fc7053ca56d727135a3eaa5aa745b3786e98b1fbR1-R5))
*  Add a new variable `titles` in the `documentPlugin` function to concatenate the user-configured title and the custom title element from the document ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-0e55b04e20002e2fb2749b80f99d441529beb49561d648172696a765aa8afa67R228-R234))
*  Replace the `DOCUMENT_TITLE_PLACEHOLDER` in the final HTML with the `titles` variable in the `documentPlugin` function ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-0e55b04e20002e2fb2749b80f99d441529beb49561d648172696a765aa8afa67L284-R293))
*  Add a new property `hasSetTitle` to the `DocumentStructureContextProps` type and the `DocumentStructureContext` provider to indicate whether the document has a custom title element or not ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-500101c6ae36b06f1ee654919c29be185c90705feb275d930f1b46987e81cd94R9), [link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-500101c6ae36b06f1ee654919c29be185c90705feb275d930f1b46987e81cd94R20))
*  Pass the `hasSetTitle` property to the `DocumentStructureContext` provider in the `Html` component function, based on the result of the `findTargetElement` helper function ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-49cef652dccc4c76ffab70c6eb943e62f7c449602d6da36dda7af85e4560c02cR56), [link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-49cef652dccc4c76ffab70c6eb943e62f7c449602d6da36dda7af85e4560c02cR100))
*  Destructure the `hasSetTitle` property from the `DocumentStructureContext` in the `Head` component function ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-518d21577d0beb3523093dd8bf7bf6f51af83286422384761dfc8e8ba49a7c5bL13-R16))
*  Add a conditional rendering of the `Title` component in the `Head` component function, based on the `hasSetTitle` property ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-518d21577d0beb3523093dd8bf7bf6f51af83286422384761dfc8e8ba49a7c5bL19-R28))
*  Remove the unnecessary template literals from the `DefaultHead` component function ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-518d21577d0beb3523093dd8bf7bf6f51af83286422384761dfc8e8ba49a7c5bL31-R35))
*  Add a new file for the `Title` component, which renders a title element with the `DOCUMENT_TITLE_PLACEHOLDER` as its content ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-daf985ace4367348335b3512fc7053ca56d727135a3eaa5aa745b3786e98b1fbR1-R5))
*  Update the first test case in the `document/index.test.tsx` file to include the `Title` component with the `DOCUMENT_TITLE_PLACEHOLDER` in the expected output ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-58438d895d20c5a03968777e10317f727253aafd490098fb2b7646d7e255a5faL30-R30))
*  Add a new test case in the `document/index.test.tsx` file to check that the `Title` component renders the `DOCUMENT_TITLE_PLACEHOLDER` successfully when the document has a custom title element ([link](https://github.com/web-infra-dev/modern.js/pull/4961/files?diff=unified&w=0#diff-58438d895d20c5a03968777e10317f727253aafd490098fb2b7646d7e255a5faR95-R119))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
