### PR TITLE
chore(storybook): enhance docs and auto detect builder provider

### DIFF
--- a/.changeset/sharp-beds-pretend.md
+++ b/.changeset/sharp-beds-pretend.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/storybook-builder': patch
+---
+
+chore(storybook): enhance docs and auto detect builder provider
+
+chore(storybook): 改进文档，自动判断的 builder provider

--- a/packages/document/builder-doc/docs/en/guide/advanced/storybook.md
+++ b/packages/document/builder-doc/docs/en/guide/advanced/storybook.md
@@ -14,9 +14,12 @@ You can switch between Webpack and Rspack smoothly in Modern.js builder, for tho
 
 ## Quick Start
 
-### Using in Modern.js projects
+Before getting started, the current Storybook supports building using either Webpack or Rspack as the underlying tool. Depending on your needs, install any of the following packages:
 
-#### Not using legacy Storybook plugin(@modern-js/plugin-storybook)
+- @modern-js/builder-webpack-provider: Use Webpack for building with better compatibility.
+- @modern-js/builder-rspack-provider: Use Rspack for building with super fast startup speed (recommended).
+
+### Using in Modern.js projects, Not using legacy Storybook plugin(@modern-js/plugin-storybook)
 
 If your current project is already a Modern.js project and you haven't used any old version Storybook plugins, you can directly enable the Storybook feature by using the following command:
 
@@ -32,7 +35,9 @@ This command will create a template for Storybook, including:
 - Creating example story components.
 - Updating package.json to add dependencies @storybook/addon-essentials and @modern-js/storybook, as well as creating Storybook-related scripts.
 
-#### Using legacy Storybook plugin(@modern-js/plugin-storybook)
+To start, run `npm run storybook`.
+
+### Migrate from @modern-js/plugin-storybook
 
 If you are using an older version of the Storybook plugin, you can still run the command above to create templates and modify the package.json. You can also upgrade manually.
 
@@ -54,6 +59,19 @@ Update dependencies like @storybook/addon-\* to major version 7.
 
 Finally, follow the official Storybook documentation to make the necessary updates for some breaking changes, such as changes in story writing and MDX syntax. You can refer to the migration guide at [storybook migrate doc](https://storybook.js.org/docs/react/migration-guide).
 
+Addon some scripts in your package.json
+
+```json
+{
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+  }
+}
+```
+
+To Start, run `npm run storybook`
+
 ### Native Storybook users
 
 Modern.js Builder only support Storybook 7, so you need to upgrade from Storybook version 6 to version 7, please follow the steps outlined in the official Storybook documentation at [storybook migrate doc](https://storybook.js.org/docs/react/migration-guide).
@@ -72,12 +90,6 @@ export default config;
 The default config file path is `modern.config.(j|t)s`, for the detail config, see [builder config](https://modernjs.dev/builder/guide/basic/builder-config.html).
 
 If the original project includes configurations for Babel, they need to be written in the modern configuration. Most Babel configurations have already been included in Modern.js.
-
-## Using Webpack or Rspack
-
-Currently, Storybook supports building with either Webpack or Rspack as the underlying bundler. Depending on your needs, install @modern-js/builder-webpack-provider or @modern-js/builder-rspack-provider.
-
-After installation, proceed with the corresponding [configuration](/guide/advanced/storybook#bundler).
 
 ## Enable Rspack build
 
@@ -206,6 +218,14 @@ const config = defineConfig({
 
 export default config;
 ```
+
+## Storybook addon compatibility
+
+Due to the current version of Storybook in the document being version 7, please select the addon for Storybook V7.
+
+When an addon does not require additional Babel or Webpack configurations, it can be used directly, such as @storybook/addon-essentials.
+
+For some addons that require dependencies on Babel plugins and Webpack configurations, such as @storybook/addon-coverage, only @modern-js/builder-webpack-provider supports them.
 
 ## Benefits
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/storybook.md
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/storybook.md
@@ -14,11 +14,14 @@
 
 ## 快速开始
 
-### 在 Modern.js 项目中使用
+在开始之前，当前 Storybook 支持底层使用 Webpack 或是 Rspack 进行构建，根据你的需求安装下列任何一个包：
 
-#### 没有使用过 Storybook 插件(@modern-js/plugin-storybook)
+- @modern-js/builder-webpack-provider： 使用 Webpack 构建，更好的兼容性
+- @modern-js/builder-rspack-provider：使用 Rspack 构建，极致的启动速度（推荐）
 
-如果当前项目已经是 Modern.js 项目，并且没有使用旧版本 Storybook 插件， 则可以直接使用如下命令开启 Storybook 功能。
+### 在 Modern.js 项目中使用, 没有使用过 Storybook 插件(@modern-js/plugin-storybook)
+
+如果没有使用旧版本 Storybook 插件， 情直接使用如下命令开启 Storybook 功能。
 
 ```bash
 $ npx modern new
@@ -30,11 +33,13 @@ $ npx modern new
 
 - 创建配置文件夹 `.storybook`，以及默认配置文件 `.storybook/main.ts`
 - 创建 stories 组件示例
-- 更新 package.json，新增依赖 @storybook/addon-essential 和 @modern-js/storybook，以及创建 storybook 相关脚本。
+- 更新 package.json，新增依赖 @storybook/addon-essential 和 @modern-js/storybook，以及创建 storybook 相关脚本
 
-#### 正在使用旧版本 Storybook 插件(@modern-js/plugin-storybook)
+运行 `npm run storybook` 即可启动 Storybook 预览。
 
-若正使用旧版本 Storybook 插件，那么你仍然可以运行上方的命令，来创建模版以及修改 package.json，也可以手动升级。
+### 从 @modern-js/plugin-storybook 迁移
+
+你仍然可以运行上方的命令，来创建模版以及修改 package.json，也可以手动升级。
 
 若你在旧版本对 storybook 进行了一些自定义配置，需要将配置文件 `root/config/storybook/main.(j|t)s` 移动到 `root/.storybook/main.(j|t)s`。
 
@@ -54,7 +59,20 @@ export default config;
 
 最后按照 Storybook 官网文档，对一些 breaking change 做相应的更新，例如 stories 的写法，MDX 的写法等，参考[storybook 迁移文档](https://storybook.js.org/docs/react/migration-guide)。
 
-### 当前项目是 Storybook 项目，没有使用 Modern.js
+在项目的 package.json 中添加相应的命令
+
+```json
+{
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+  }
+}
+```
+
+使用 `npm run storybook` 即可启动
+
+### 原生 Storybook 项目，没有使用 Modern.js
 
 若当前 Storybook 版本还是 6，需要先按照 Storybook 官网文档升级到版本 7 ，参考[storybook 迁移文档](https://storybook.js.org/docs/react/migration-guide)。
 
@@ -72,10 +90,6 @@ export default config;
 Modern.js 的配置文件默认为 `modern.config.(j|t)s`，配置请查看 [builder 配置](https://modernjs.dev/builder/guide/basic/builder-config.html)。
 
 若原来项目中包含了 Babel 等配置，需要对应的写在 modern 配置中，大部分 Babel 配置已经包含进了 Modern.js。
-
-## 使用 Webpack 或 Rspack
-
-当前 Storybook 支持底层使用 Webpack 或是 Rspack 进行构建，根据你的需求安装 @modern-js/builder-webpack-provider 或 @modern-js/builder-rspack-provider。
 
 安装完成后进行相应的[配置](/guide/advanced/storybook#bundler)。
 
@@ -205,6 +219,14 @@ const config = defineConfig({
 
 export default config;
 ```
+
+## Storybook addon 兼容性
+
+由于当前文档中的 Storybook 版本为 7，因此请选择 storybook V7 的 addon。
+
+当 addon 不需要额外的 Babel 或 Webpack 配置时，可以直接使用，如 @storybook/addon-essentials。
+
+部分 addon 需要依赖 babel 插件和 Webpack 配置时，如 @storybook/addon-coverage，只能使用 @modern-js/builder-webpack-provider 才有支持。
 
 ## 收益
 

--- a/packages/storybook/builder/package.json
+++ b/packages/storybook/builder/package.json
@@ -93,6 +93,18 @@
     "@types/webpack-hot-middleware": "^2.25.6",
     "typescript": "^5.2.2"
   },
+  "peerDependencies": {
+    "@modern-js/builder-webpack-provider": "workspace:^2.40.0",
+    "@modern-js/builder-rspack-provider": "workspace:^2.40.0"
+  },
+  "peerDependenciesMeta": {
+    "@modern-js/builder-webpack-provider": {
+      "optional": true
+    },
+    "@modern-js/builder-rspack-provider": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",

--- a/packages/storybook/builder/src/core.ts
+++ b/packages/storybook/builder/src/core.ts
@@ -11,7 +11,7 @@ export async function getCompiler(
   builderOptions: BuilderOptions,
   options: Options,
 ): Promise<Compiler> {
-  const bundler = builderOptions.bundler || 'webpack';
+  const { bundler } = builderOptions;
 
   const { presets } = options;
 
@@ -33,7 +33,15 @@ export async function getCompiler(
   );
 
   if (!provider) {
-    throw new Error(`@modern-js/builder-${bundler}-provider not found `);
+    if (bundler) {
+      throw new Error(
+        `You choose to use ${bundler}, but @modern-js/builder-${bundler}-provider not found in your project, please install it`,
+      );
+    } else {
+      throw new Error(
+        `Please install one provider first, try install @modern-js/builder-rspack-provider or @modern-js/builder-webpack-provider first`,
+      );
+    }
   }
 
   const builder = await createBuilder(provider, {


### PR DESCRIPTION
## Summary

- enhance docs
- auto detect builder provider if user not set explictly

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 848b889</samp>

*  Add a changeset file to document the changes to the packages @modern-js/builder-doc and @modern-js/storybook-builder ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-fde15cc3a9bab3f375190fd44b282e39c575aba4b51b90d624a4272842d80cd0R1-R8))
  - Adding a paragraph to explain the bundler options for Storybook in the Quick Start section ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d8462f8d5a7ee66ef224948ec8bc119a2e58dd982fd0714d4575c34afa6d4125L17-R23), [link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dL17-R25))
  - Renaming and updating the sections for migrating from the legacy Storybook plugin or using native Storybook projects ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d8462f8d5a7ee66ef224948ec8bc119a2e58dd982fd0714d4575c34afa6d4125L35-R41), [link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d8462f8d5a7ee66ef224948ec8bc119a2e58dd982fd0714d4575c34afa6d4125R62-R74), [link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d8462f8d5a7ee66ef224948ec8bc119a2e58dd982fd0714d4575c34afa6d4125L76-L81), [link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dL33-R43), [link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dL57-R76), [link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dL76-L79))
  - Adding a paragraph to explain the compatibility issues of Storybook addons with different providers in the ConfigFile section ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d8462f8d5a7ee66ef224948ec8bc119a2e58dd982fd0714d4575c34afa6d4125R222-R229), [link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dR223-R230))
  - Fixing a typo in the Chinese documentation ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-fbaef7cc93daf838dfddb1fb6570129d723275cb961f22d56ad6290811cfd91dL17-R25))
  - Simplifying the assignment of the bundler variable by using destructuring ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d14ccbdf163a4c757552d040dfa1e8c1141edff82490a6dc18a0b95d744c7ff2L14-R14))
  - Modifying the error message thrown when the provider is not found to give more specific instructions ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d14ccbdf163a4c757552d040dfa1e8c1141edff82490a6dc18a0b95d744c7ff2L36-R44))
  - Importing the types of the provider packages for Webpack and Rspack ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d1d1c4ea2e63bd7a984783ef58d5f19cc325d18b18c0a0e7b74d4924f16db2a8R5-R6))
  - Changing the type of the bundler parameter and the return type of the requireResolve function ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d1d1c4ea2e63bd7a984783ef58d5f19cc325d18b18c0a0e7b74d4924f16db2a8L22-R26))
  - Adding an else if branch to handle the case when the bundler is 'rspack' in the getProvider function ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d1d1c4ea2e63bd7a984783ef58d5f19cc325d18b18c0a0e7b74d4924f16db2a8L33-R35))
  - Adding an else branch to implement the auto detection of the provider when the bundler is undefined in the getProvider function ([link](https://github.com/web-infra-dev/modern.js/pull/4965/files?diff=unified&w=0#diff-d1d1c4ea2e63bd7a984783ef58d5f19cc325d18b18c0a0e7b74d4924f16db2a8L40-R48))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
