### PR TITLE
feat(generator): support module doc in new action

### DIFF
--- a/.changeset/young-llamas-attend.md
+++ b/.changeset/young-llamas-attend.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-doc-generator': minor
+'@modern-js/generator-common': minor
+---
+
+feat(generator): support module doc in new action
+feat(generator): 在 new 操作里支持模块文档功能

--- a/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
@@ -14,6 +14,24 @@ Thus with these capabilities, **Microgenerator can enable additional feature fun
 
 The microgenerator can be started via [`modern new`](/guide/basic/command-preview). The current Microgenerator features supported by the Modern.js Module are:
 
+## Develop Module Doc
+
+When we want to write documentation for out module project, we can enable the module doc feature. **will create `docs` directory and related files in the project directory, and add `"@modern-js/plugin-rspress"` dependency** in package.json.
+
+:::tip
+After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
+
+```ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [moduleTools(), modulePluginDoc()],
+});
+```
+
+:::
+
 ## Test
 
 When we want to test some modules, we can enable the test feature. When this feature is enabled, **a `tests` directory and related files will be created in the project directory, and a new `"@modern-js/plugin-testing"` dependency will be added to package.json**.

--- a/packages/document/module-doc/docs/en/guide/basic/use-module-doc.mdx
+++ b/packages/document/module-doc/docs/en/guide/basic/use-module-doc.mdx
@@ -1,0 +1,416 @@
+---
+sidebar_position: 5
+---
+
+# Developing Module documentation
+
+This chapter describes how to quickly build a static documentation site for a module project.
+
+## Before we start
+
+### Why we need to build a documentation site for a module
+
+1. a documentation site can help us to better organize the structure of the documentation.
+2. the documentation site has better presentation, such as the ability to execute functions in the page, render components.
+3. to make better use of AI search capabilities.
+
+### Preliminary preparation
+
+1. Enable the documentation feature via [micro-generator](/guide/basic/use-micro-generator).
+2. Read [Introduction to Rspress](https://rspress.dev/guide/start/introduction.html).
+
+After finishing the preparation work, we will build a documentation site for the module project based on Rspress.
+
+## Basic site structure
+
+The overall layout of the site consists of three parts: the navigation bar, the sidebar and the body part, which also includes the TOC (Table of contents found at the beginning of a book or document).
+
+The Rspress uses [File System Routing](https://rspress.dev/guide/basic/conventional-route.html), on which the module documentation is based, to automate the generation of the sidebar.
+For example, if you have the following file structure:
+
+```bash
+docs
+├── foo
+│ └── bar.md
+│ └── index.md
+└── foo.md
+└── index.md
+
+```
+
+Then the routing path for `foo/bar.md` will be `/foo/bar`, the routing path for `foo.md` will be `/foo`, and the routing path for `index.md` will be `/`.
+
+The specific mapping rules are as follows:
+
+| file-path       | routing-path |
+| --------------- | ------------ |
+| `index.md`      | `/`          |
+| `/foo.md`       | `/foo`       |
+| `/foo/index.md` | `/foo/`      |
+| `/foo/bar.md`   | `/foo/bar`   |
+
+The sidebars corresponding in turn to the above file paths and routing paths are shown below:
+
+<img src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rpauheh7nulwbm/edenx-module/docs-blog/autosidebar.png"></img>
+
+:::tip
+The text in each column of sidebar is determined by the primary title or directory name of the file. If you need to customize the sidebar, please configure [sidebar](https://rspress.dev/api/config/config-theme.html#sidebar)。
+:::
+
+## Writing Documentation
+
+Next, we can focus on writing the content of the document. In addition to the basic Markdown syntax, you may also need to understand the following advanced topics:
+
+- [Using MDX](https://rspress.dev/guide/basic/use-mdx.html)
+- [Using Assets](https://rspress.dev/guide/basic/static-assets.html)
+
+## Component preview
+
+Module documentation provides preview capabilities for component libraries. The contents in code blocks written in jsx and tsx will be parsed as React components.
+
+### Example
+
+Here is a complete example using the component preview feature:
+
+Assuming our project name is `demo` and we export a Button component.
+
+1. Add a new `docs/Button.mdx` file:
+
+````mdx title="Button.mdx"
+# Button
+
+## Basic Usage
+
+Buttons come in four sizes: small, medium, large
+
+```tsx
+import React from 'react';
+import { Button } from 'demo';
+
+export default () => {
+  return <Button size="large">Click Me</Button>;
+};
+```
+````
+
+2. In the `tsconfig.json`, configure aliases and point the package name to the current project directory, make the way document developers and users use components consistent:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "paths": {
+      "demo": ["."]
+    }
+  }
+}
+```
+
+3. In the `.gitignore`, add `docs_build/`:
+
+```bash title=".gitignore"
+docs_build/
+```
+
+Congratulations, you have finished writing a component document, execute `pnpm run dev` to see the result, remember to build the component library first to make sure the component product exists.
+
+### Mobile Preview
+
+Also, we support mobile preview mode, i.e. rendering mobile components using iframe, and set iframe position by `iframePosition`,
+support swipe preview and new page opening.
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools'.
+import { modulePluginDoc } from '@modern-js/plugin-rspress'.
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      /**
+       * Select the preview method
+       * @default web
+       */
+      previewMode: 'mobile',
+      /**
+       * Select iframe position
+       * @default 'follow'
+       */
+      iframePosition: 'fixed',
+    }),
+  ],
+});
+```
+
+:::tip
+If you only want to change the way a particular `jsx` and `tsx` block is previewed, you can use a different modifier to identify it:
+
+````mdx
+```jsx pure
+// The content here will not be rendered
+```
+
+```jsx web
+// Used to render desktop components
+```
+
+```jsx mobile
+// Used to render mobile components
+```
+````
+
+:::
+
+### Using external demos
+
+If our demo is very complex, then it is recommended to write the demo separately and then use the `code` tag in the mdx:
+
+```mdx
+<code src="/path/demo.tsx"></code>
+```
+
+## Using built-in components
+
+The plugin implements some built-in components internally so that you can develop module documentation more easily.
+
+### API
+
+Display the API content of the module.
+
+#### Parse file
+
+Before we can use the API component, we first need to specify the files to parse:
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      entries: {
+        Button: './src/button.tsx',
+      },
+      apiParseTool: 'react-docgen-typescript',
+    }),
+  ],
+});
+```
+
+#### Content generation
+
+Next, we'll see what kind of markdown content is generated based on the parsed file.
+
+Content can be generated with two different tools, [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) or [documentation](https://github.com/documentationjs/documentation):
+
+- `react-docgen-typescript` is targeted at component library scenarios and will only parse props to generate tables.
+
+```tsx
+export type ButtonProps = {
+  /**
+   * Whether to disable the button
+   */
+  disabled?: boolean;
+  /* * Whether to disable the button */ disabled?
+   * Type of Button
+   * @default 'default'
+   */
+  size?: 'mini' | 'small' | 'default' | 'large';
+}.
+export const Button = (props?: ButtonProps) => {};
+```
+
+The above is a standard writeup where `ButtonProps` will be extracted into the table and `Button` will be the title of the table.
+If you use the default export, the filename will be used as the form title. The generated content is as follows:
+
+```mdx
+### ButtonTest
+
+| property |          description          |                   type                   |   default   |
+| :------: | :---------------------------: | :--------------------------------------: | :---------: |
+| disabled | Whether to disable the button |                `boolean`                 |     `-`     |
+|   size   |        Type of Button         | `"mini" \|"small" \|"default" \|"large"` | `'default'` |
+```
+
+:::warning
+If React types are used in Props, you need to add the types in tsconfig.json, otherwise the types will not be resolved under the React namespace.
+```json
+{
+  "compilerOptions": {
+    "types": ["react"],
+  },
+}
+```
+:::
+
+- `documentation` is used in tool library scenarios to parse JSDoc annotations.
+
+```ts
+/**
+ * Greet function that returns a greeting message.
+ * @param {string} name - The name of the person to greet.
+ * @param {string} [greeting='Hello'] - The greeting to use.
+ * @returns {string} The greeting message.
+ */
+function greet(name: string, greeting = 'Hello') {
+  return `${greeting}, ${name}! `;
+}
+```
+
+The above is a greet function with a JSDoc annotation. The generated content is as follows:
+
+```md
+<! -- Generated by documentation.js. Update this documentation by updating the source code. -->
+
+## greet
+
+Greet function that returns a greeting message.
+
+### Parameters
+
+- `name` **[string][1]** The name of the person to greet.
+- `greeting` **[string][1]** The greeting to use. (optional, default `'Hello'`)
+
+Returns **[string][1]** The greeting message.
+
+[1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+```
+
+#### Using the component
+
+Next, you can use our built-in API components in your documentation by passing the `key` value into the `moduleName` property。
+
+```mdx title="Button.mdx"
+# Button
+
+## API
+
+<API moduleName="Button" />
+```
+
+### Overview
+
+Displays a list of modules that can be placed on the front page to display all modules.
+
+The Overview component has only one list property, which receives an array of objects, and the following properties of the objects
+
+| property |      description       |      type       | default |
+| :------: | :--------------------: | :-------------: | :-----: |
+|   icon   |          icon          | React.ReactNode |         |
+|   text   |   text(**required**)   |     string      |         |
+|   link   |   link(**required**)   |     string      |         |
+|  arrow   | whether to show arrows |     boolean     | `false` |
+
+## Plugin options
+
+### apiParseTool
+
+API parse tool.
+
+- Type:`'react-docgen-typescript' | 'documentation'`
+- Default: `'react-docgen-typescript'`
+
+### parseToolOptions
+
+API parse tool options.
+
+- Type:`ParseToolOptions`
+- Default: `{}`
+
+```ts
+type ParseToolOptions = {
+  // https://github.com/styleguidist/react-docgen-typescript#options
+  'react-docgen-typescript'?: ParserOptions;
+  // https://github.com/documentationjs/documentation/blob/master/docs/NODE_API.md#parameters-1
+  documentation?: DocumentationArgs;
+};
+```
+
+### entries
+
+Module names and relative paths for automatically generated documents.
+
+- Type:`Entries | ToolEntries`
+- Default: `{}`
+
+```ts
+type Entries = Record<string, string>;
+type ToolEntries = {
+  documentation: Entries;
+  'react-docgen-typescript': Entries;
+};
+```
+
+It also supports the use of different parsing tools for different files:
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      entries: {
+        documentation: {
+          Add: './src/utils/add.ts',
+        },
+        'react-docgen-typescript': {
+          Button: './src/components/button.tsx',
+        },
+      },
+    }),
+  ],
+});
+```
+
+### useModuleSidebar
+
+If you want to use[\_meta.json](https://rspress.dev/guide/basic/auto-nav-sidebar.html) to automate sidebar，you should set it `false`.
+
+- Type:`boolean`
+- Default: `true`
+
+### previewMode
+
+- Type:`'mobile' | 'web'`
+- Default: `'web'`
+
+In case of `web`, the component will be rendered directly in the page, otherwise it will be loaded through an iframe.
+
+### iframePosition
+
+- 类型：`'follow' | 'fixed'`
+- 默认值: `'follow'`
+
+When the value is `follow`, each code block will have an iframe showing its rendered view.
+When `fixed`, the iframe will be fixed to the right side of the page, showing the view of all the code blocks on the current page.
+
+### doc
+
+[Config](https://rspress.dev/api/index.html).
+
+## Advanced guide
+
+The above has covered the basics of developing module documentation, but this is not enough for developing a complete documentation station. Check out the [Rspress](https://rspress.dev) for an in-depth look at our documentation framework.
+You can modify the documentation framework configuration via the `doc` configuration.
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools'.
+import { modulePluginDoc } from '@modern-js/plugin-rspress'.
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      doc: {
+        // Customize the documentation site configuration
+      }
+    }),
+  ],
+});
+```
+
+import ReleaseModuleDoc from '@site-docs-en/components/release-module-doc';
+
+<ReleaseModuleDoc />

--- a/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
@@ -14,6 +14,24 @@ Modern.js Module 提供了微生成器工具，它可以为当前项目：
 
 可以通过 [`modern new`](/guide/basic/command-preview) 启动微生成器。目前 Modern.js Module 支持的微生成器功能有：
 
+## 开发模块文档
+
+当我们想要为模块编写文档的时候，可以启用模块文档功能。**会在项目目录下创建 `docs` 目录以及相关文件，在 package.json 中新增 `"@modern-js/plugin-rspress"` 依赖**。
+
+:::tip
+在成功开启后，会提示需要手动在配置中增加如下类似的代码。
+
+```ts
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [moduleTools(), modulePluginDoc()],
+});
+```
+
+:::
+
 ## Test 测试
 
 当我们想要对一些模块进行测试的时候，可以启用测试功能。启动该功能后，**会在项目目录下创建 `tests` 目录以及相关文件，在 package.json 中新增 `"@modern-js/plugin-testing"` 依赖**。

--- a/packages/document/module-doc/docs/zh/guide/basic/use-module-doc.mdx
+++ b/packages/document/module-doc/docs/zh/guide/basic/use-module-doc.mdx
@@ -1,0 +1,417 @@
+---
+sidebar_position: 5
+---
+
+# 开发模块文档
+
+本章介绍如何为模块项目快速搭建一个静态文档站点。
+
+## 开始之前
+
+### 为什么我们需要为模块搭建一个文档站点
+
+1. 文档站点可以帮助我们更好地组织文档的结构。
+2. 文档站点具有更好的表现形式，例如可以在页面中执行函数，渲染组件等。
+3. 可以更好地利用 AI 搜索的能力。
+
+### 前置准备
+
+1. 通过[微生成器](/guide/basic/use-micro-generator)开启文档功能。
+2. 阅读[Rspress 介绍](https://rspress.dev/zh/guide/start/introduction.html)。
+
+完成准备工作之后，接下来我们会基于 Rspress 为模块项目搭建一个文档站点。
+
+## 站点基本结构
+
+站点整体布局由三部分组成：导航栏、侧边栏以及正文部分，其中正文还包括了 TOC(Table of contents found at the beginning of a book or document)。
+
+Rspress 使用的是[文件系统路由](https://rspress.dev/zh/guide/basic/conventional-route.html)，模块文档基于此实现了侧边栏的自动生成。
+例如，如果你有以下的文件结构：
+
+```bash
+docs
+├── foo
+│   └── bar.md
+│   └── index.md
+└── foo.md
+└── index.md
+```
+
+那么 `foo/bar.md` 的路由路径会是 `/foo/bar`，`foo.md` 的路由路径会是 `/foo`，`index.md` 的路由路径会是 `/`。
+
+具体映射规则如下：
+
+| 文件路径        | 路由路径   |
+| --------------- | ---------- |
+| `index.md`      | `/`        |
+| `/foo.md`       | `/foo`     |
+| `/foo/index.md` | `/foo/`    |
+| `/foo/bar.md`   | `/foo/bar` |
+
+与上述文件路径和路由路径依次对应的侧边栏如下所示：
+
+<img src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rpauheh7nulwbm/edenx-module/docs-blog/autosidebar.png"></img>
+
+:::tip
+侧边栏每一栏的文本是由文件的一级标题或者目录名决定。如果你需要自定义侧边栏，请配置[sidebar](https://rspress.dev/zh/api/config/config-theme.html#sidebar)。
+:::
+
+## 编写文档
+
+接下来我们可以专注于文档内容的编写了。除了最基本的编写 markdown 以外，你可能还需要了解以下进阶内容：
+
+- [使用 MDX](https://rspress.dev/zh/guide/basic/use-mdx.html)
+- [使用静态资源](https://rspress.dev/zh/guide/basic/static-assets.html)
+
+## 组件预览
+
+模块文档为组件库提供了预览能力，`jsx`和`tsx`的代码块里的内容将会被解析为 React 组件。
+
+### 示例
+
+假设我们的项目名是`demo`，并导出了一个 Button 组件。
+
+1. 首先新增 `docs/Button.mdx` 文件：
+
+````mdx title="Button.mdx"
+# Button
+
+## 基本用法
+
+按钮分为： 小、中、大四种尺寸
+
+```tsx
+import React from 'react';
+import { Button } from 'demo';
+
+export default () => {
+  return <Button size="large">点我</Button>;
+};
+```
+````
+
+2. 在`tsconfig.json`里配置别名，将包名指向当前项目目录，使得文档开发者和用户使用组件方式一致：
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "paths": {
+      "demo": ["."]
+    }
+  }
+}
+```
+
+3. 在 `.gitignore` 文件下添加 `docs_build/`，文档产物将会生成在此目录下：
+
+```bash title=".gitignore"
+docs_build/
+```
+
+恭喜你，已经完成了一个组件文档的编写，执行`pnpm run dev`看看效果吧，记得先构建一下组件库，确保组件产物存在。
+
+### 移动端预览
+
+同时，我们也支持了移动端预览的方式，即使用 iframe 渲染移动端组件，并可以通过 `iframePosition` 设置 iframe 的位置，支持扫码预览以及新页面打开。
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      /**
+       * 选择预览方式
+       * @default web
+       */
+      previewMode: 'mobile',
+      /**
+       * 设置 iframe 的位置
+       * @default 'follow'
+       */
+      iframePosition: 'fixed',
+    }),
+  ],
+});
+```
+
+:::tip
+如果只想要改变某一个 `jsx` 和 `tsx` 代码块的预览方式，可以使用不同的修饰符进行标识：
+
+````mdx
+```jsx pure
+// 这里的内容不会被渲染
+```
+
+```jsx web
+// 用来渲染桌面端组件
+```
+
+```jsx mobile
+// 用来渲染移动端组件
+```
+````
+
+:::
+
+### 使用外部 demo
+
+如果我们的 demo 非常复杂，那么建议单独编写 demo，然后在 MDX 中使用 `code` 标签：
+
+```mdx
+<code src="/path/demo.tsx"></code>
+```
+
+## 使用内置组件
+
+插件内部实现了一部分内置组件，以便于你可以更轻松地开发模块文档。
+
+### API
+
+展示模块的 API 内容
+
+#### 解析文件
+
+在使用 API 组件之前，首先我们需要指定解析的文件：
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      entries: {
+        Button: './src/button.tsx',
+      },
+      apiParseTool: 'react-docgen-typescript',
+    }),
+  ],
+});
+```
+
+#### 内容生成
+
+接下来我们了解一下根据解析的文件会生成什么样的 markdown 内容。
+
+内容可以通过 [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) 或者 [documentation](https://github.com/documentationjs/documentation) 两个不同的工具生成：
+
+- `react-docgen-typescript`针对于组件库场景，仅会解析 props 生成表格。
+
+```tsx
+export type ButtonProps = {
+  /**
+   * Whether to disable the button
+   */
+  disabled?: boolean;
+  /**
+   * Type of Button
+   * @default 'default'
+   */
+  size?: 'mini' | 'small' | 'default' | 'large';
+};
+export const Button = (props?: ButtonProps) => {};
+```
+
+上面是一个标准写法，其中 `ButtonProps` 将被提取至表格中， `Button` 作为表格的标题。
+如果使用默认导出，文件名将作为表格标题。生成的内容如下：
+
+```mdx
+### ButtonTest
+
+|   属性   |             说明              |                    类型                     |   默认值    |
+| :------: | :---------------------------: | :-----------------------------------------: | :---------: |
+| disabled | Whether to disable the button |                  `boolean`                  |     `-`     |
+|   size   |        Type of Button         | `"mini" \| "small" \| "default" \| "large"` | `'default'` |
+```
+
+:::warning
+如果 Props 里使用了 React 的类型，你需要在 tsconfig.json 里添加 types ，否则会解析不到 React 命名空间下的类型。
+```json
+{
+  "compilerOptions": {
+    "types": ["react"],
+  },
+}
+```
+:::
+
+
+- `documentation`适用于工具库场景，用来解析 JSDoc 注释。
+
+```ts
+/**
+ * Greet function that returns a greeting message.
+ * @param {string} name - The name of the person to greet.
+ * @param {string} [greeting='Hello'] - The greeting to use.
+ * @returns {string} The greeting message.
+ */
+function greet(name: string, greeting = 'Hello') {
+  return `${greeting}, ${name}!`;
+}
+```
+
+上面是一个带有 JSDoc 注释的 greet 函数。生成的内容如下：
+
+```md
+<!-- Generated by documentation.js. Update this documentation by updating the source code. -->
+
+## greet
+
+Greet function that returns a greeting message.
+
+### Parameters
+
+- `name` **[string][1]** The name of the person to greet.
+- `greeting` **[string][1]** The greeting to use. (optional, default `'Hello'`)
+
+Returns **[string][1]** The greeting message.
+
+[1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+```
+
+#### 组件使用
+
+接下来，你便可以在文档里使用我们的内置 API 组件了，将`key`值传入`moduleName`属性里
+
+```mdx title="Button.mdx"
+# Button
+
+## API
+
+<API moduleName="Button" />
+```
+
+### Overview
+
+展示模块列表，可以放在首页用来展示所有模块。
+
+Overview 组件只有一个 list 属性，接收一个对象数组，下面是对象的属性
+
+| 属性  |      说明      |      类型       | 默认值  |
+| :---: | :------------: | :-------------: | :-----: |
+| icon  |      图标      | React.ReactNode |         |
+| text  | 文本(**必填**) |     string      |         |
+| link  | 链接(**必填**) |     string      |         |
+| arrow |  是否展示箭头  |     boolean     | `false` |
+
+## 插件配置
+
+### apiParseTool
+
+API 解析工具
+
+- 类型：`'react-docgen-typescript' | 'documentation'`
+- 默认值：`'react-docgen-typescript'`
+
+### parseToolOptions
+
+API 解析工具的参数
+
+- 类型：`ParseToolOptions`
+- 默认值：`{}`
+
+```ts
+type ParseToolOptions = {
+  // https://github.com/styleguidist/react-docgen-typescript#options
+  'react-docgen-typescript'?: ParserOptions;
+  // https://github.com/documentationjs/documentation/blob/master/docs/NODE_API.md#parameters-1
+  documentation?: DocumentationArgs;
+};
+```
+
+### entries
+
+自动生成文档的模块名称及相对路径
+
+- 类型：`Entries | ToolEntries`
+- 默认值：`{}`
+
+```ts
+type Entries = Record<string, string>;
+type ToolEntries = {
+  documentation: Entries;
+  'react-docgen-typescript': Entries;
+};
+```
+
+Entries 同时支持针对不同的文件使用不同的解析工具：
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      entries: {
+        documentation: {
+          Add: './src/utils/add.ts',
+        },
+        'react-docgen-typescript': {
+          Button: './src/components/button.tsx',
+        },
+      },
+    }),
+  ],
+});
+```
+
+### useModuleSidebar
+
+使用模块列表侧边栏。如果你想要使用[\_meta.json](https://rspress.dev/zh/guide/basic/auto-nav-sidebar.html)来自动化侧边栏，你需要关闭此选项。
+
+- 类型：`boolean`
+- 默认值：`true`
+
+### previewMode
+
+代码块预览方式。
+
+- 类型：`'mobile' | 'web'`
+- 默认值: `'web'`
+
+`web`时，代码块内容将会直接渲染在页面中，反之将会通过 iframe 加载。
+
+### iframePosition
+
+iframe 所处页面位置
+
+- 类型：`'follow' | 'fixed'`
+- 默认值: `'follow'`
+
+`follow`时，每一个代码块都会有一个 iframe 展示其渲染视图。
+`fixed`时，iframe 将会固定在页面右侧，展示当前页面所有代码块的视图。
+
+### doc
+
+[文档框架配置](https://rspress.dev/zh/api/index.html)
+
+## 进阶指南
+
+以上已经介绍完了开发模块文档的基本内容，但是这对于开发一个完整的文档站是不够的。查看[Rspress](https://rspress.dev)以深入了解我们的文档框架。
+你可以通过 `doc` 配置来修改文档框架配置。
+
+```ts title="modern.config.ts"
+import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import { modulePluginDoc } from '@modern-js/plugin-rspress';
+
+export default defineConfig({
+  plugins: [
+    moduleTools(),
+    modulePluginDoc({
+      doc: {
+        // 自定义文档站点配置
+      },
+    }),
+  ],
+});
+```
+
+import ReleaseModuleDoc from '@site-docs/components/release-module-doc';
+
+<ReleaseModuleDoc />

--- a/packages/generator/generator-cases/tests/__snapshots__/index.test.ts.snap
+++ b/packages/generator/generator-cases/tests/__snapshots__/index.test.ts.snap
@@ -130,6 +130,10 @@ exports[`test generator cases test getModuleNewCases 1`] = `
     "actionType": "function",
     "function": "runtimeApi",
   },
+  {
+    "actionType": "function",
+    "function": "module_doc",
+  },
 ]
 `;
 

--- a/packages/generator/generator-common/src/locale/en.ts
+++ b/packages/generator/generator-common/src/locale/en.ts
@@ -36,6 +36,7 @@ export const EN_LOCALE = {
       proxy: 'Enable Global Proxy',
       swc: 'Enable SWC Compile',
       rspack: 'Enable Rspack Build (experimental)',
+      module_doc: 'Enable Module Doc',
     },
     element: {
       self: 'Create Element',

--- a/packages/generator/generator-common/src/locale/zh.ts
+++ b/packages/generator/generator-common/src/locale/zh.ts
@@ -35,6 +35,7 @@ export const ZH_LOCALE = {
       proxy: '启用「全局代理」',
       swc: '启用「SWC 编译」',
       rspack: '启用「Rspack 构建」(实验性)',
+      module_doc: '启动「模块文档」功能',
     },
     element: {
       self: '创建工程元素',

--- a/packages/generator/generator-common/src/newAction/common/index.ts
+++ b/packages/generator/generator-common/src/newAction/common/index.ts
@@ -26,6 +26,7 @@ export enum ActionFunction {
   Proxy = 'proxy',
   SWC = 'swc',
   Rspack = 'rspack',
+  ModuleDoc = 'module_doc',
 }
 
 export enum ActionRefactor {
@@ -69,6 +70,8 @@ export const ActionFunctionText: Record<ActionFunction, () => string> = {
   [ActionFunction.Proxy]: () => i18n.t(localeKeys.action.function.proxy),
   [ActionFunction.SWC]: () => i18n.t(localeKeys.action.function.swc),
   [ActionFunction.Rspack]: () => i18n.t(localeKeys.action.function.rspack),
+  [ActionFunction.ModuleDoc]: () =>
+    i18n.t(localeKeys.action.function.module_doc),
 };
 
 export const ActionRefactorText: Record<ActionRefactor, () => string> = {

--- a/packages/generator/generator-common/src/newAction/module/index.ts
+++ b/packages/generator/generator-common/src/newAction/module/index.ts
@@ -14,6 +14,7 @@ export const ModuleActionFunctions = [
   ActionFunction.TailwindCSS,
   ActionFunction.StorybookV7,
   ActionFunction.RuntimeApi,
+  ActionFunction.ModuleDoc,
 ];
 
 export const ModuleActionTypesMap: Record<string, string[]> = {
@@ -69,6 +70,7 @@ export const ModuleActionFunctionsDevDependencies: Partial<
   [ActionFunction.Test]: '@modern-js/plugin-testing',
   [ActionFunction.RuntimeApi]: '@modern-js/runtime',
   [ActionFunction.TailwindCSS]: 'tailwindcss',
+  [ActionFunction.ModuleDoc]: '@modern-js/plugin-rspress',
 };
 
 export const ModuleActionFunctionsPeerDependencies: Partial<
@@ -90,9 +92,9 @@ export const ModuleNewActionGenerators: Partial<
   [ActionType.Function]: {
     [ActionFunction.Test]: '@modern-js/module-test-generator',
     [ActionFunction.TailwindCSS]: '@modern-js/tailwindcss-generator',
-    [ActionFunction.Storybook]: '@modern-js/storybook-generator',
     [ActionFunction.StorybookV7]: '@modern-js/storybook-next-generator',
     [ActionFunction.RuntimeApi]: '@modern-js/dependence-generator',
+    [ActionFunction.ModuleDoc]: '@modern-js/module-doc-generator',
   },
 };
 
@@ -101,7 +103,7 @@ export const ModuleNewActionPluginName: Partial<
 > = {
   [ActionType.Function]: {
     [ActionFunction.TailwindCSS]: 'tailwindcssPlugin',
-    [ActionFunction.Storybook]: 'storybookPlugin',
+    [ActionFunction.ModuleDoc]: 'modulePluginDoc',
     [ActionFunction.Test]: 'testPlugin',
   },
 };
@@ -112,6 +114,6 @@ export const ModuleNewActionPluginDependence: Partial<
   [ActionType.Function]: {
     [ActionFunction.Test]: '@modern-js/plugin-testing',
     [ActionFunction.TailwindCSS]: '@modern-js/plugin-tailwindcss',
-    [ActionFunction.Storybook]: '@modern-js/plugin-storybook',
+    [ActionFunction.ModuleDoc]: '@modern-js/plugin-rspress',
   },
 };

--- a/packages/generator/generators/module-doc-generator/.eslintrc.js
+++ b/packages/generator/generators/module-doc-generator/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['@modern-js'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json'],
+  },
+};

--- a/packages/generator/generators/module-doc-generator/CHANGELOG.md
+++ b/packages/generator/generators/module-doc-generator/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @modern-js/module-doc-generator

--- a/packages/generator/generators/module-doc-generator/README.md
+++ b/packages/generator/generators/module-doc-generator/README.md
@@ -1,0 +1,3 @@
+# @modern-js/module-doc-generator
+
+Modern.js 模块文档 生成器

--- a/packages/generator/generators/module-doc-generator/modern.config.js
+++ b/packages/generator/generators/module-doc-generator/modern.config.js
@@ -1,0 +1,5 @@
+const { generatorBuildConfig } = require('@scripts/build');
+
+module.exports = {
+  buildConfig: generatorBuildConfig,
+};

--- a/packages/generator/generators/module-doc-generator/package.json
+++ b/packages/generator/generators/module-doc-generator/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@modern-js/module-doc-generator",
+  "description": "A Progressive React Framework for modern web development.",
+  "homepage": "https://modernjs.dev",
+  "bugs": "https://github.com/web-infra-dev/modern.js/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/modern.js",
+    "directory": "packages/generator/generators/module-doc-generator"
+  },
+  "license": "MIT",
+  "keywords": [
+    "react",
+    "framework",
+    "modern",
+    "modern.js"
+  ],
+  "version": "3.2.11",
+  "jsnext:source": "./src/index.ts",
+  "main": "./src/index.ts",
+  "files": [
+    "/templates",
+    "/dist/index.js"
+  ],
+  "scripts": {
+    "prepublishOnly": "only-allow-pnpm",
+    "new": "modern-lib new",
+    "build": "modern-lib build",
+    "test": "jest --passWithNoTests"
+  },
+  "dependencies": {
+    "@modern-js/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@modern-js/codesmith": "2.3.0",
+    "@modern-js/codesmith-api-app": "2.3.0",
+    "@modern-js/codesmith-api-json": "2.3.0",
+    "@modern-js/dependence-generator": "workspace:*",
+    "@modern-js/generator-common": "workspace:*",
+    "@modern-js/generator-utils": "workspace:*",
+    "@modern-js/plugin-i18n": "workspace:*",
+    "@scripts/build": "workspace:*",
+    "@scripts/jest-config": "workspace:*",
+    "@types/jest": "^29",
+    "@types/node": "^14",
+    "jest": "^29",
+    "typescript": "^5"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "types": "./src/index.ts"
+}

--- a/packages/generator/generators/module-doc-generator/src/index.ts
+++ b/packages/generator/generators/module-doc-generator/src/index.ts
@@ -1,0 +1,69 @@
+import path from 'path';
+import { GeneratorContext, GeneratorCore } from '@modern-js/codesmith';
+import { AppAPI } from '@modern-js/codesmith-api-app';
+import {
+  getPackageManager,
+  getPackageManagerText,
+} from '@modern-js/generator-utils';
+import {
+  DependenceGenerator,
+  i18n as commonI18n,
+} from '@modern-js/generator-common';
+import { localeKeys, i18n } from './locale';
+
+const getGeneratorPath = (generator: string, distTag: string) => {
+  if (process.env.BYTED_CODESMITH_ENV === 'development') {
+    return path.dirname(require.resolve(generator));
+  } else if (distTag) {
+    return `${generator}@${distTag}`;
+  }
+  return generator;
+};
+
+const handleTemplateFile = async (
+  context: GeneratorContext,
+  appApi: AppAPI,
+  _generator: GeneratorCore,
+) => {
+  await appApi.forgeTemplate('templates/docs/**/*', undefined, resourceKey =>
+    resourceKey.replace('templates/', '').replace('.handlebars', ''),
+  );
+};
+
+export default async (context: GeneratorContext, generator: GeneratorCore) => {
+  const appApi = new AppAPI(context, generator);
+
+  const { locale } = context.config;
+  i18n.changeLanguage({ locale });
+  commonI18n.changeLanguage({ locale });
+  appApi.i18n.changeLanguage({ locale });
+
+  if (!(await appApi.checkEnvironment())) {
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
+
+  generator.logger.debug(`start run @modern-js/module-doc-generator`);
+  generator.logger.debug(`context=${JSON.stringify(context)}`);
+  generator.logger.debug(`context.data=${JSON.stringify(context.data)}`);
+
+  await handleTemplateFile(context, appApi, generator);
+
+  await appApi.runSubGenerator(
+    getGeneratorPath(DependenceGenerator, context.config.distTag),
+    undefined,
+    context.config,
+  );
+
+  const appDir = context.materials.default.basePath;
+  const packageManager =
+    context.config.packageManager || (await getPackageManager(appDir));
+
+  appApi.showSuccessInfo(
+    i18n.t(localeKeys.success, {
+      packageManager: getPackageManagerText(packageManager),
+    }),
+  );
+
+  generator.logger.debug(`forge @modern-js/module-doc-generator succeed `);
+};

--- a/packages/generator/generators/module-doc-generator/src/locale/en.ts
+++ b/packages/generator/generators/module-doc-generator/src/locale/en.ts
@@ -1,0 +1,4 @@
+export const EN_LOCALE = {
+  success: `Plugin dependency installed successfully! Please add the following code to`,
+  successTooltip: `After add code, you can run {packageManager} dev doc to run doc tools.`,
+};

--- a/packages/generator/generators/module-doc-generator/src/locale/index.ts
+++ b/packages/generator/generators/module-doc-generator/src/locale/index.ts
@@ -1,0 +1,9 @@
+import { I18n } from '@modern-js/plugin-i18n';
+import { ZH_LOCALE } from './zh';
+import { EN_LOCALE } from './en';
+
+const i18n = new I18n();
+
+const localeKeys = i18n.init('zh', { zh: ZH_LOCALE, en: EN_LOCALE });
+
+export { i18n, localeKeys };

--- a/packages/generator/generators/module-doc-generator/src/locale/zh.ts
+++ b/packages/generator/generators/module-doc-generator/src/locale/zh.ts
@@ -1,0 +1,4 @@
+export const ZH_LOCALE = {
+  success: `安装插件依赖成功！请添加如下代码至`,
+  successTooltip: `添加完成后，你可运行 {packageManager} dev doc 进行文档调试。`,
+};

--- a/packages/generator/generators/module-doc-generator/templates/docs/index.mdx.handlebars
+++ b/packages/generator/generators/module-doc-generator/templates/docs/index.mdx.handlebars
@@ -1,0 +1,1 @@
+# Hello world

--- a/packages/generator/generators/module-doc-generator/tsconfig.json
+++ b/packages/generator/generators/module-doc-generator/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {}
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2032,6 +2032,52 @@ importers:
         specifier: ^5
         version: 5.0.4
 
+  packages/generator/generators/module-doc-generator:
+    dependencies:
+      '@modern-js/utils':
+        specifier: workspace:*
+        version: link:../../../toolkit/utils
+    devDependencies:
+      '@modern-js/codesmith':
+        specifier: 2.3.0
+        version: 2.3.0
+      '@modern-js/codesmith-api-app':
+        specifier: 2.3.0
+        version: 2.3.0(@modern-js/codesmith@2.3.0)(typescript@5.2.2)
+      '@modern-js/codesmith-api-json':
+        specifier: 2.3.0
+        version: 2.3.0
+      '@modern-js/dependence-generator':
+        specifier: workspace:*
+        version: link:../dependence-generator
+      '@modern-js/generator-common':
+        specifier: workspace:*
+        version: link:../../generator-common
+      '@modern-js/generator-utils':
+        specifier: workspace:*
+        version: link:../../generator-utils
+      '@modern-js/plugin-i18n':
+        specifier: workspace:*
+        version: link:../../../cli/plugin-i18n
+      '@scripts/build':
+        specifier: workspace:*
+        version: link:../../../../scripts/build
+      '@scripts/jest-config':
+        specifier: workspace:*
+        version: link:../../../../scripts/jest-config
+      '@types/jest':
+        specifier: ^29
+        version: 29.2.6
+      '@types/node':
+        specifier: ^14
+        version: 14.18.35
+      jest:
+        specifier: ^29
+        version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.1)
+      typescript:
+        specifier: ^5
+        version: 5.2.2
+
   packages/generator/generators/module-generator:
     dependencies:
       '@modern-js/utils':
@@ -12298,6 +12344,29 @@ packages:
       - typescript
     dev: true
 
+  /@modern-js/codesmith-api-app@2.3.0(@modern-js/codesmith@2.3.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-oDkedFJaKSLR7gzjlUmHdkjs+zvEtvqApqdA9wnELlh4JGGAvvcr3N5x0fl0VXrAOFV+/pKMYK3DmWqj0IvIjg==}
+    peerDependencies:
+      '@modern-js/codesmith': ^2.3.0
+    dependencies:
+      '@modern-js/codesmith': 2.3.0
+      '@modern-js/codesmith-api-ejs': 2.3.0(@modern-js/codesmith@2.3.0)
+      '@modern-js/codesmith-api-fs': 2.3.0(@modern-js/codesmith@2.3.0)
+      '@modern-js/codesmith-api-git': 2.3.0(@modern-js/codesmith@2.3.0)
+      '@modern-js/codesmith-api-handlebars': 2.3.0(@modern-js/codesmith@2.3.0)
+      '@modern-js/codesmith-api-npm': 2.3.0
+      '@modern-js/codesmith-formily': 2.3.0(@modern-js/codesmith@2.3.0)(typescript@5.2.2)
+      '@modern-js/plugin-i18n': 2.37.2
+      '@modern-js/utils': 2.37.2
+      '@swc/helpers': 0.5.1
+      comment-json: 4.2.3
+      extra: 0.2.1
+      inquirer: 8.1.3
+    transitivePeerDependencies:
+      - debug
+      - typescript
+    dev: true
+
   /@modern-js/codesmith-api-ejs@2.2.5(@modern-js/codesmith@2.2.5):
     resolution: {integrity: sha512-hN4sJy+nnr2dPD/BwVLlNdYRQdTC1O2lltRBeEFYD43tD1yEagjWRtccAweoBIt379DsAqi2UKydsW5OvFge/Q==}
     peerDependencies:
@@ -12446,6 +12515,21 @@ packages:
     transitivePeerDependencies:
       - typescript
 
+  /@modern-js/codesmith-formily@2.3.0(@modern-js/codesmith@2.3.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-9YaG+iumS3+kyfwCKdGCKCWMgok0RyeZpwXWdz5Ky7qHuTzyz+QrUgvHs0L+KvY2akjGRZOX0dBbdr0srREvQA==}
+    peerDependencies:
+      '@modern-js/codesmith': ^2.3.0
+    dependencies:
+      '@formily/json-schema': 2.2.24(typescript@5.2.2)
+      '@formily/validator': 2.2.24
+      '@modern-js/codesmith': 2.3.0
+      '@modern-js/utils': 2.39.2
+      '@swc/helpers': 0.5.1
+      inquirer: 8.2.5
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
   /@modern-js/codesmith@2.2.5:
     resolution: {integrity: sha512-crlaJqKT8iSLRTLOgTU7PCVWtXJ66ezM5CmKTRGdQYIEWx85Pmuj3lmupyXM3ecv4lhVzoonVs/nh3bS5ubeOQ==}
     dependencies:
@@ -12460,10 +12544,10 @@ packages:
   /@modern-js/codesmith@2.3.0:
     resolution: {integrity: sha512-jZtoOvyH8GtPJTtgnTBtamBbqOEryoMolSgjJDVjJwIQNREnt4tcUtXK2n9kTVVrTVIVqeFNe3gaaMZm0n+aQA==}
     dependencies:
-      '@modern-js/utils': 2.37.2
+      '@modern-js/utils': 2.39.2
       '@swc/helpers': 0.5.1
       axios: 0.21.4
-      tar: 6.1.13
+      tar: 6.2.0
     transitivePeerDependencies:
       - debug
 
@@ -26683,10 +26767,6 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /minipass@4.2.5:
-    resolution: {integrity: sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==}
-    engines: {node: '>=8'}
-
   /minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
@@ -32059,17 +32139,6 @@ packages:
       mkdirp: 1.0.4
       yallist: 4.0.0
     dev: true
-
-  /tar@6.1.13:
-    resolution: {integrity: sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==}
-    engines: {node: '>=10'}
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 4.2.5
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
 
   /tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eb6ba36</samp>

This pull request adds a new feature to generate module documentation using a microgenerator. It updates the `generator-common` package to support the new action and plugin, and adds a new `module-doc-generator` package that handles the template files and sub generator. It also updates the documentation and locale files for the new feature, and adds changeset and config files for the new package.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eb6ba36</samp>

*  Add a changeset file to describe the pull request ([link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-7448797a555530e75324d9cd1446597325fa390f80001b5e01dc89cf5af13188R1-R7))
*  Implement the module doc generator package, which creates a `docs` directory and adds a plugin dependency in the project ([link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-e2692af3e109b9e54028a3253d6a7027ca7d0d40dc00f0645f59281aabd5fc64R1-R8)-[link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-974ac8dd1184f5d1f57d8e0dbb1fedc3d9139afdb42992f11790d61f0da33315R1-R10))
*  Update the common and module new action files to include the module doc action function, label, generator, dependency, config, and plugin ([link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-20bcfc96c162bf4bca3ddecb9379f48ba2b50c21e1f9f382113579b15fb9d2bcR29), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-20bcfc96c162bf4bca3ddecb9379f48ba2b50c21e1f9f382113579b15fb9d2bcR73-R74), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-1540285b10292f60b7a9db94fd86fb48b914409486cd5049d973523520d9e8e9R17), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-1540285b10292f60b7a9db94fd86fb48b914409486cd5049d973523520d9e8e9R73), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-1540285b10292f60b7a9db94fd86fb48b914409486cd5049d973523520d9e8e9L93-R97), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-1540285b10292f60b7a9db94fd86fb48b914409486cd5049d973523520d9e8e9L104-R106), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-1540285b10292f60b7a9db94fd86fb48b914409486cd5049d973523520d9e8e9L115-R117))
*  Add the locale keys for the module doc function in the English and Chinese locale files ([link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-9128106b7c928653c9b19cc11610f7df25c8a05996deb2aa143f5d94c77aa5bfR39), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-b955240339c127f0958e1393148d105595a26333f50833adbaa7f062651d2eebR38))
*  Add the guide document sections for using the microgenerator to enable the module doc feature in English and Chinese ([link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-e31d78df76c58c9d5f68de0da1e01cd75cd95250101a115dbee77a67f66e9fbdR17-R34), [link](https://github.com/web-infra-dev/modern.js/pull/4971/files?diff=unified&w=0#diff-9b0c6fb145f09db5395653ad3fc34a340094a7ab9249699a691b4d213cea89a7R17-R34))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
