### PR TITLE
feat: config normalize after build

### DIFF
--- a/packages/solutions/module-tools/src/build.ts
+++ b/packages/solutions/module-tools/src/build.ts
@@ -15,23 +15,37 @@ export const build = async (
 
   const runner = api.useHookRunners();
 
-  debug('normalize build config');
+  debug('merge build config');
 
-  const { normalizeBuildConfig } = await import('./config/normalize');
-  const resolvedBuildConfig = await normalizeBuildConfig(api, context, options);
+  const { mergeBuildConfig, normalizeBuildConfig } = await import(
+    './config/normalize'
+  );
+  const mergedConfig = await mergeBuildConfig(api);
 
-  debug('normalize build config done');
+  debug('merge build config done');
 
-  debug('normalizedBuildConfig', resolvedBuildConfig);
+  debug('mergedConfig', mergedConfig);
 
   debug('run beforeBuild hooks');
 
   await runner.beforeBuild({
-    config: resolvedBuildConfig,
+    config: mergedConfig,
     cliOptions: options,
   });
 
   debug('run beforeBuild hooks done');
+
+  debug('normalize build config');
+
+  const resolvedBuildConfig = await normalizeBuildConfig(
+    mergedConfig,
+    context,
+    options,
+  );
+
+  debug('normalize build config done');
+
+  debug('normalizedBuildConfig', resolvedBuildConfig);
 
   const builder = await import('./builder');
   await builder.run({ cmdOptions: options, resolvedBuildConfig, context }, api);

--- a/packages/solutions/module-tools/src/config/normalize.ts
+++ b/packages/solutions/module-tools/src/config/normalize.ts
@@ -67,25 +67,10 @@ export const mergeConfig = (
 };
 
 export const normalizeBuildConfig = async (
-  api: PluginAPI<ModuleTools>,
+  mergedConfig: PartialBaseBuildConfig[],
   context: ModuleContext,
   buildCmdOptions: BuildCommandOptions,
 ): Promise<BaseBuildConfig[]> => {
-  let config = api.useConfigContext() as unknown as ModuleUserConfig;
-
-  if (isLegacyUserConfig(config as { legacy?: boolean })) {
-    const { createUserConfigFromLegacy } = await import(
-      './transformLegacyConfig'
-    );
-    config = await createUserConfigFromLegacy(config as ModuleLegacyUserConfig);
-  }
-
-  const { buildConfig, buildPreset } = config;
-
-  const configFromPreset = await presetToConfig(buildPreset);
-
-  const mergedConfig = mergeConfig(configFromPreset, buildConfig ?? {});
-
   validPartialBuildConfig(mergedConfig, context.appDirectory);
 
   const normalizedConfig = await Promise.all(
@@ -103,6 +88,27 @@ export const normalizeBuildConfig = async (
   );
 
   return normalizedConfig;
+};
+
+export const mergeBuildConfig = async (
+  api: PluginAPI<ModuleTools>,
+): Promise<PartialBaseBuildConfig[]> => {
+  let config = api.useConfigContext() as unknown as ModuleUserConfig;
+
+  if (isLegacyUserConfig(config as { legacy?: boolean })) {
+    const { createUserConfigFromLegacy } = await import(
+      './transformLegacyConfig'
+    );
+    config = await createUserConfigFromLegacy(config as ModuleLegacyUserConfig);
+  }
+
+  const { buildConfig, buildPreset } = config;
+
+  const configFromPreset = await presetToConfig(buildPreset);
+
+  const mergedConfig = mergeConfig(configFromPreset, buildConfig ?? {});
+
+  return mergedConfig;
 };
 
 export const transformToAbsPath = async (

--- a/packages/solutions/module-tools/src/hooks/build.ts
+++ b/packages/solutions/module-tools/src/hooks/build.ts
@@ -10,13 +10,13 @@ import type {
   BuildPlatformResult,
   WatchDtsHookContext,
   WatchJsHookContext,
-  BuildConfig,
   BaseBuildConfig,
+  PartialBaseBuildConfig,
 } from '../types';
 
 export const buildHooks = {
   beforeBuild: createParallelWorkflow<
-    { config: BuildConfig; cliOptions: BuildCommandOptions },
+    { config: PartialBaseBuildConfig[]; cliOptions: BuildCommandOptions },
     void
   >(),
   beforeBuildTask: createAsyncWaterfall<BaseBuildConfig>(),


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 32b2dba</samp>

Refactored the build config merging and normalization process in `module-tools` to improve performance and extensibility. Changed the `beforeBuild` hook context to use the merged config array instead of the normalized config object. Updated the `build` function in `build.ts` to use the new config structure and validation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 32b2dba</samp>

*  Simplify and improve the config merging and normalization logic for the `build` function in `build.ts` ([link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-20c58c09f062ae8a5282b8d8d25fb7ac467d0ca360ec4f5e079369e0e71051d0L18-R32), [link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-20c58c09f062ae8a5282b8d8d25fb7ac467d0ca360ec4f5e079369e0e71051d0R38-R49), [link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-8aa7727ba828087c3fa3ee640d59bd8addf83d27904d7917c8c0c59890ecfd93L70-R73), [link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-8aa7727ba828087c3fa3ee640d59bd8addf83d27904d7917c8c0c59890ecfd93R93-R113))
  - Use the new `mergeBuildConfig` function to combine the user config and the preset config before running the `beforeBuild` hooks ([link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-20c58c09f062ae8a5282b8d8d25fb7ac467d0ca360ec4f5e079369e0e71051d0L18-R32), [link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-8aa7727ba828087c3fa3ee640d59bd8addf83d27904d7917c8c0c59890ecfd93R93-R113))
  - Pass the merged config as an argument to the `normalizeBuildConfig` function after the hooks, and validate and transform it into the final config ([link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-20c58c09f062ae8a5282b8d8d25fb7ac467d0ca360ec4f5e079369e0e71051d0R38-R49), [link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-8aa7727ba828087c3fa3ee640d59bd8addf83d27904d7917c8c0c59890ecfd93L70-R73))
  - Change the type of the `config` property in the `beforeBuild` hook context to match the merged config structure ([link](https://github.com/web-infra-dev/modern.js/pull/4972/files?diff=unified&w=0#diff-0ab59294567ae566d4262e77b2188d9d0debbede6eda73d741c022340e194e0bL13-R19))

```ts
import { moduleTools, defineConfig } from '@modern-js/module-tools';

const CWD = process.cwd();
const defaultConfig = [
  {
    sourceMap: 'external',
    target: 'es6',
    buildType: 'bundleless',
    format: 'cjs',
    outDir: './lib',
    copy: {
      patterns: [{ from: './src/style', to: './style', context: CWD }],
    },
  },
  {
    sourceMap: 'external',
    target: 'es6',
    buildType: 'bundleless',
    format: 'esm',
    outDir: './es',
    copy: {
      patterns: [{ from: './src/style', to: './style', context: CWD }],
    },
  },
];

const customPlugins: any = {
  setup() {
    return {
      beforeBuild({ config, cliOptions }) {
        console.log('beforeBuild', config, cliOptions);
        config.length = [];
        config.push(...defaultConfig);
      },
    };
  },
};

export default defineConfig({
  plugins: [moduleTools(), customPlugins],
  buildPreset: 'npm-library',
});
```
Hi.
I want to define a plugin that will clear all original config and insert some custom config.
But it dosen't work.
<img width="702" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/51100990/f6fe3032-03f3-45ec-8e1d-84a1d3058c8f">
I look up the code and find the reason is the config only normalize before the beforeBuild hook.
It caused me to not be able to insert some custom config.
So I want to change some code that make normalize config after the beforeBuild hook.


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
