### PR TITLE
chore(rspack-provider): return compiler instead of multiCompiler

### DIFF
--- a/.changeset/quiet-coins-collect.md
+++ b/.changeset/quiet-coins-collect.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+chore(rspack-provider): return compiler instead of multiCompiler when targets length is 1
+
+chore(rspack-provider): 返回 compiler 而非 multiCompiler 当 targets 长度为 1 时


### PR DESCRIPTION

## Summary

create Compiler instead of MultiCompiler when target length is 1:

<img width="1400" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/f373bdfd-6db0-4fa2-82a4-a95d2ef6eefb">


<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f1a8e96</samp>

This pull request enhances the `createCompiler` function in the `@modern-js/builder-rspack-provider` package by adding types, simplifying logic, and fixing a bug. It also updates the changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f1a8e96</samp>

*  Add changeset file for patch update of `@modern-js/builder-rspack-provider` package ([link](https://github.com/web-infra-dev/modern.js/pull/4973/files?diff=unified&w=0#diff-e3d8d2c004858d8d30100e392ee177a2ae6bab1cc695ba7cd97ad4e43b10d43bR1-R7))
*  Import `Stats` and `MultiStats` types from `@rspack/core` package and use them to annotate `stats` parameter of `done` hook in `createCompiler` function ([link](https://github.com/web-infra-dev/modern.js/pull/4973/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3R9))
*  Simplify `createCompiler` function to return a single `compiler` instance instead of a `multiCompiler` instance when there is only one target in `rspackConfigs` array ([link](https://github.com/web-infra-dev/modern.js/pull/4973/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L25-R33))
*  Refactor and fix logic for printing compilation time for each target in `createCompiler` function by extracting a helper function `printTime` and handling the case where `stats` object does not have a `children` property ([link](https://github.com/web-infra-dev/modern.js/pull/4973/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L35-R57))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
