### PR TITLE
fix(rspack-provider): rspack pretty time

### DIFF
--- a/.changeset/quiet-coins-collect.md
+++ b/.changeset/quiet-coins-collect.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+---
+
+chore(rspack-provider): return compiler instead of multiCompiler when targets length is 1
+
+chore(rspack-provider): 返回 compiler 而非 multiCompiler 当 targets 长度为 1 时

--- a/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
+++ b/packages/builder/builder-rspack-provider/src/core/createCompiler.ts
@@ -38,7 +38,7 @@ export async function createCompiler({
 
     const printTime = (c: typeof obj, index: number) => {
       if (c.time) {
-        const time = prettyTime(c.time / 1000);
+        const time = prettyTime([0, c.time * 10 ** 6]);
         const target = Array.isArray(context.target)
           ? context.target[index]
           : context.target;


### PR DESCRIPTION
## Summary

Related PR: https://github.com/web-infra-dev/modern.js/pull/4973/files

fix pretty time params
![image](https://github.com/web-infra-dev/modern.js/assets/22373761/825d16c2-abb5-4fb3-b347-dace2c9c7851)

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2343bf8</samp>

This pull request enhances the `rspack` compiler integration and fixes a bug in the `@modern-js/builder-rspack-provider` package. It also adds a changeset file for the patch update and a Chinese translation.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2343bf8</samp>

*  Add changeset file for patch update of `@modern-js/builder-rspack-provider` package ([link](https://github.com/web-infra-dev/modern.js/pull/4976/files?diff=unified&w=0#diff-e3d8d2c004858d8d30100e392ee177a2ae6bab1cc695ba7cd97ad4e43b10d43bR1-R7))
*  Modify `createCompiler` function in `createCompiler.ts` to return single compiler or multi-compiler based on targets length ([link](https://github.com/web-infra-dev/modern.js/pull/4976/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L25-R33))
*  Import `Stats` and `MultiStats` types from `@rspack/core` and annotate `stats` parameter of `done` hook in `createCompiler` function ([link](https://github.com/web-infra-dev/modern.js/pull/4976/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3R9))
*  Refactor `createCompiler` function to extract `printTime` helper function and handle single or multi stats object ([link](https://github.com/web-infra-dev/modern.js/pull/4976/files?diff=unified&w=0#diff-c01cf21ca287cb9e14f1a082ca9968f47802c413eb386229cece3de3b3597dd3L35-R57))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
