### PR TITLE
chore(workflow): remove copilot from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,5 @@
 ## Summary
 
-<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
-<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->
-
-copilot:summary
-
-## Details
-
-<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
-<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->
-
-copilot:walkthrough
 
 ## Related Issue
 


### PR DESCRIPTION
## Summary

Remove copilot from PR template, it has been deprecated.

## Related Issue

https://githubnext.com/copilot-for-prs-sunset

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
