### PR TITLE
fix: 0.4 type

### DIFF
--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -106,7 +106,7 @@ export class RouterPlugin {
     }
 
     const { webpack } = compiler;
-    const isRspack = webpack.rspackVersion;
+    const isRspack = 'rspackVersion' in webpack;
     const { Compilation, sources } = webpack;
     const { RawSource } = sources;
 


### PR DESCRIPTION
## Summary

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 816fd94</samp>

Fix TypeScript errors caused by `@types/webpack` update. Use `in` operator to check for `rspackVersion` property in `RouterPlugin.ts`.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 816fd94</samp>

* Fix TypeScript errors caused by updating `@types/webpack` dependency ([link](https://github.com/web-infra-dev/modern.js/pull/4980/files?diff=unified&w=0#diff-165d76812954ccffc54289dc0ea209e601e11189d83ad739ef79ac1d78ca3ae3L109-R109),                             F0L

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
