### PR TITLE
fix(builder): printFileSize throw err when set output.filename query

### DIFF
--- a/.changeset/warm-cups-cross.md
+++ b/.changeset/warm-cups-cross.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder': patch
+---
+
+fix(builder): printFileSize throw err when set output.filename query
+fix(builder): printFileSize 报错当用户设置了 filename query 参数

--- a/packages/builder/builder/src/plugins/fileSize.ts
+++ b/packages/builder/builder/src/plugins/fileSize.ts
@@ -50,14 +50,15 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
   );
 
   const formatAsset = (asset: StatsAsset) => {
-    const contents = fs.readFileSync(path.join(distPath, asset.name));
+    const fileName = asset.name.split('?')[0];
+    const contents = fs.readFileSync(path.join(distPath, fileName));
     const size = contents.length;
     const gzippedSize = gzipSize.sync(contents);
 
     return {
       size,
-      folder: path.join(path.basename(distPath), path.dirname(asset.name)),
-      name: path.basename(asset.name),
+      folder: path.join(path.basename(distPath), path.dirname(fileName)),
+      name: path.basename(fileName),
       gzippedSize,
       sizeLabel: filesize(size, { round: 1 }),
       gzipSizeLabel: getAssetColor(gzippedSize)(


### PR DESCRIPTION
## Summary

当用户给 filename 给配置 query 的时候:

```ts
output: {
    filename: {
      js: `[name].[contenthash:8].js?version=1.0`,
    },
  },
```

这里 `asset.name` 会拿到带 query 的 name 值，但实际输出文件是不带 query 的。

BTW: webpack 本身支持 query 参数的:

https://webpack.js.org/configuration/output/#outputfilename

![image](https://github.com/web-infra-dev/modern.js/assets/32598811/881a9b11-6fc7-4bb0-bd1b-0195cbc3d72b)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
