### PR TITLE
fix(builder): should generate manifest correctly when enable SSR

### DIFF
--- a/.changeset/eighty-beans-serve.md
+++ b/.changeset/eighty-beans-serve.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/builder-rspack-provider': patch
+---
+
+fix(builder): should generate manifest correctly when enable SSR

--- a/packages/builder/builder-rspack-provider/src/plugins/manifest.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/manifest.ts
@@ -5,7 +5,7 @@ export const builderPluginManifest = (): BuilderPlugin => ({
   name: 'builder-plugin-manifest',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
       const config = api.getNormalizedConfig();
 
       if (!config.output.enableAssetManifest) {
@@ -17,7 +17,10 @@ export const builderPluginManifest = (): BuilderPlugin => ({
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(WebpackManifestPlugin, [
         {
-          fileName: 'asset-manifest.json',
+          fileName:
+            target === 'web'
+              ? 'asset-manifest.json'
+              : `asset-manifest-${target}.json`,
           publicPath,
           generate: generateManifest,
         },

--- a/packages/builder/builder-webpack-provider/src/plugins/manifest.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/manifest.ts
@@ -5,7 +5,7 @@ export const builderPluginManifest = (): BuilderPlugin => ({
   name: 'builder-plugin-manifest',
 
   setup(api) {
-    api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {
+    api.modifyWebpackChain(async (chain, { CHAIN_ID, target }) => {
       const config = api.getNormalizedConfig();
 
       if (!config.output.enableAssetManifest) {
@@ -19,7 +19,10 @@ export const builderPluginManifest = (): BuilderPlugin => ({
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(WebpackManifestPlugin, [
         {
-          fileName: 'asset-manifest.json',
+          fileName:
+            target === 'web'
+              ? 'asset-manifest.json'
+              : `asset-manifest-${target}.json`,
           publicPath,
           generate: generateManifest,
         },

--- a/packages/document/builder-doc/docs/en/config/output/enableAssetManifest.md
+++ b/packages/document/builder-doc/docs/en/config/output/enableAssetManifest.md
@@ -27,3 +27,8 @@ After compiler, there will be a `dist/manifest.json` file:
   "entrypoints": ["static/css/main.45b01211.css", "static/js/main.52fd298f.js"]
 }
 ```
+
+If the current project has multiple types of build artifacts, such as including SSR build artifacts, multiple manifest.json files will be generated.
+
+- web artifact: `asset-manifest.json`
+- node artifact: `asset-manifest-node.json`

--- a/packages/document/builder-doc/docs/zh/config/output/enableAssetManifest.md
+++ b/packages/document/builder-doc/docs/zh/config/output/enableAssetManifest.md
@@ -15,7 +15,7 @@ export default {
 };
 ```
 
-开启后，当编译完成时，会自动生成 `dist/manifest.json` 文件：
+开启后，当编译完成时，会自动生成 `dist/asset-manifest.json` 文件：
 
 ```json
 {
@@ -27,3 +27,8 @@ export default {
   "entrypoints": ["static/css/main.45b01211.css", "static/js/main.52fd298f.js"]
 }
 ```
+
+如果当前项目有多种类型构建产物，比如包含了 SSR 构建产物，那么会生成多份 manifest.json 文件。
+
+- web 产物：`asset-manifest.json`
+- node 产物：`asset-manifest-node.json`


### PR DESCRIPTION
## Summary

Should generate manifest correctly when enable SSR.

If the current project has multiple types of build artifacts, such as including SSR build artifacts, multiple manifest.json files will be generated.

- web artifact: `asset-manifest.json`
- node artifact: `asset-manifest-node.json`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
