### PR TITLE
fix(builder): preload resource can't be used if crossOrigin attr not match

### DIFF
--- a/.changeset/lazy-days-smoke.md
+++ b/.changeset/lazy-days-smoke.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): add crossOrigin attr for preload resource when origin resource is crossOrigin
+
+fix(builder): preload 资源的 crossOrigin 属性与原资源的 crossOrigin 属性保持一致

--- a/packages/builder/builder-shared/src/plugins/HtmlCrossOriginPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlCrossOriginPlugin.ts
@@ -22,7 +22,13 @@ export class HtmlCrossOriginPlugin implements WebpackPluginInstance {
   }
 
   apply(compiler: Compiler): void {
-    if (!this.crossOrigin) {
+    if (
+      !this.crossOrigin ||
+      // align with webpack crossOriginLoading logic
+      // https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/lib/runtime/LoadScriptRuntimeModule.js#L104
+      (compiler.options.output.publicPath === '/' &&
+        this.crossOrigin !== ('use-credentials' as const))
+    ) {
       return;
     }
 

--- a/packages/builder/builder-shared/src/plugins/HtmlCrossOriginPlugin.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlCrossOriginPlugin.ts
@@ -25,7 +25,7 @@ export class HtmlCrossOriginPlugin implements WebpackPluginInstance {
     if (
       !this.crossOrigin ||
       // align with webpack crossOriginLoading logic
-      // https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/lib/runtime/LoadScriptRuntimeModule.js#L104
+      // https://github.com/web-infra-dev/rspack/blob/bc8e67b5419adda15c2b389517c9b37d02c8240f/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs#L39
       (compiler.options.output.publicPath === '/' &&
         this.crossOrigin !== ('use-credentials' as const))
     ) {

--- a/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
@@ -116,7 +116,7 @@ function generateLinks(
   const sortedFilteredFiles = filteredFiles.sort();
   const links: HtmlWebpackPlugin.HtmlTagObject[] = [];
   const publicPath = getPublicPathFromCompiler(compilation.compiler);
-  const { crossOriginLoading } = compilation.options.output;
+  const { crossOriginLoading } = compilation.compiler.options.output;
 
   for (const file of sortedFilteredFiles) {
     const href = withPublicPath(file, publicPath);

--- a/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
@@ -116,6 +116,7 @@ function generateLinks(
   const sortedFilteredFiles = filteredFiles.sort();
   const links: HtmlWebpackPlugin.HtmlTagObject[] = [];
   const publicPath = getPublicPathFromCompiler(compilation.compiler);
+  const { crossOriginLoading } = compilation.options.output;
 
   for (const file of sortedFilteredFiles) {
     const href = withPublicPath(file, publicPath);
@@ -137,6 +138,15 @@ function generateLinks(
       // fonts can't be used.
       if (attributes.as === 'font') {
         attributes.crossorigin = '';
+      }
+
+      if (attributes.as === 'script' || attributes.as === 'style') {
+        if (
+          crossOriginLoading &&
+          !(crossOriginLoading !== 'use-credentials' && publicPath === '/')
+        ) {
+          attributes.crossorigin = crossOriginLoading;
+        }
       }
     }
 

--- a/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
+++ b/packages/builder/builder-shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
@@ -145,7 +145,8 @@ function generateLinks(
           crossOriginLoading &&
           !(crossOriginLoading !== 'use-credentials' && publicPath === '/')
         ) {
-          attributes.crossorigin = crossOriginLoading;
+          attributes.crossorigin =
+            crossOriginLoading === 'anonymous' ? '' : crossOriginLoading;
         }
       }
     }

--- a/tests/e2e/builder/cases/html/cross-origin/index.test.ts
+++ b/tests/e2e/builder/cases/html/cross-origin/index.test.ts
@@ -1,0 +1,59 @@
+import path from 'path';
+import { expect, test } from '@playwright/test';
+import { build } from '@scripts/shared';
+
+test('should not apply crossOrigin by default', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
+      html: {
+        scriptLoading: 'blocking',
+      },
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find(file => file.endsWith('index.html'))!];
+
+  expect(html).not.toContain('crossorigin');
+});
+
+test('should not apply crossOrigin when same origin', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
+      html: {
+        scriptLoading: 'blocking',
+        crossorigin: 'anonymous',
+      },
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find(file => file.endsWith('index.html'))!];
+
+  expect(html).not.toContain('crossorigin');
+});
+
+test('should apply crossOrigin when crossorigin is "anonymous" and not same origin', async () => {
+  const builder = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index.js') },
+    builderConfig: {
+      html: {
+        scriptLoading: 'blocking',
+        crossorigin: 'anonymous',
+      },
+      output: {
+        assetPrefix: '//aaaa.com',
+      },
+    },
+  });
+  const files = await builder.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find(file => file.endsWith('index.html'))!];
+
+  expect(html).toContain('crossorigin="anonymous"></script>');
+});

--- a/tests/e2e/builder/cases/html/cross-origin/src/index.js
+++ b/tests/e2e/builder/cases/html/cross-origin/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');

--- a/tests/e2e/builder/cases/html/html.test.ts
+++ b/tests/e2e/builder/cases/html/html.test.ts
@@ -72,7 +72,6 @@ test.describe('html element set', () => {
             description: 'a description of the page',
           },
           inject: 'body',
-          crossorigin: 'anonymous',
           appIcon: './src/assets/icon.png',
           favicon: './src/assets/icon.png',
         },
@@ -135,14 +134,6 @@ test.describe('html element set', () => {
       /<meta name="description" content="a description of the page">/.test(
         mainContent,
       ),
-    ).toBeTruthy();
-  });
-
-  test('custom crossorigin', async () => {
-    const allScripts = /(<script [\s\S]*?>)/g.exec(mainContent);
-
-    expect(
-      allScripts?.every(data => data.includes('crossorigin="anonymous"')),
     ).toBeTruthy();
   });
 });

--- a/tests/e2e/builder/cases/performance/load-resource/index.test.ts
+++ b/tests/e2e/builder/cases/performance/load-resource/index.test.ts
@@ -193,3 +193,80 @@ test('should generate preload link when preload is defined', async () => {
     ),
   ).toBeTruthy();
 });
+
+test('should generate preload link with crossOrigin', async () => {
+  const builder = await build({
+    cwd: fixtures,
+    entry: {
+      main: join(fixtures, 'src/page1/index.ts'),
+    },
+    builderConfig: {
+      html: {
+        crossorigin: 'anonymous',
+      },
+      output: {
+        assetPrefix: '//aaa.com',
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
+
+  const files = await builder.unwrapOutputJSON();
+
+  const asyncFileName = Object.keys(files).find(file =>
+    file.includes('/static/js/async/'),
+  )!;
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // test.js、test.css、test.png
+  expect(content.match(/rel="preload"/g)?.length).toBe(3);
+
+  expect(
+    content.includes(
+      `<link href="//aaa.com${asyncFileName.slice(
+        asyncFileName.indexOf('/static/js/async/'),
+      )}" rel="preload" as="script" crossorigin="">`,
+    ),
+  ).toBeTruthy();
+});
+
+test('should generate preload link without crossOrigin when same origin', async () => {
+  const builder = await build({
+    cwd: fixtures,
+    entry: {
+      main: join(fixtures, 'src/page1/index.ts'),
+    },
+    builderConfig: {
+      html: {
+        crossorigin: 'anonymous',
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
+
+  const files = await builder.unwrapOutputJSON();
+
+  const asyncFileName = Object.keys(files).find(file =>
+    file.includes('/static/js/async/'),
+  )!;
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // test.js、test.css、test.png
+  expect(content.match(/rel="preload"/g)?.length).toBe(3);
+
+  expect(
+    content.includes(
+      `<link href="${asyncFileName.slice(
+        asyncFileName.indexOf('/static/js/async/'),
+      )}" rel="preload" as="script">`,
+    ),
+  ).toBeTruthy();
+});


### PR DESCRIPTION
## Summary

fix preload resource can't be used when crossOrigin attr does not match.
<img width="1553" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/00168084-42c7-4674-9879-5c7c101f5e38">

![20231127-160456](https://github.com/web-infra-dev/modern.js/assets/22373761/6113309e-cb55-4719-9550-2f865e7b0338)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
