### PR TITLE
fix(builder): plugin-image-compress can not work with filename query

### DIFF
--- a/.changeset/blue-jars-raise.md
+++ b/.changeset/blue-jars-raise.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-plugin-image-compress': patch
+---
+
+fix(builder): plugin-image-compress can not work with filename query
+fix(builder): plugin-image-compress 在 filename 包含 query 时不生效

--- a/packages/builder/plugin-image-compress/src/minimizer.ts
+++ b/packages/builder/plugin-image-compress/src/minimizer.ts
@@ -49,10 +49,11 @@ export class ModernJsImageMinimizerPlugin {
 
     const handleAsset = async (name: string) => {
       const info = compilation.getAsset(name)?.info;
+      const fileName = name.split('?')[0];
 
       // 1. Skip double minimize assets from child compilation
       // 2. Test file by options (e.g. test, include, exclude)
-      if (info?.minimized || !matchObject(opts, name)) {
+      if (info?.minimized || !matchObject(opts, fileName)) {
         return;
       }
 


### PR DESCRIPTION
## Summary

The same situation as pr: https://github.com/web-infra-dev/modern.js/pull/4988

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
