### PR TITLE
fix(module-tools): add -b param to tsc when user add references

### DIFF
--- a/.changeset/proud-gifts-love.md
+++ b/.changeset/proud-gifts-love.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): add -b param to tsc when user add references to avoid error ts6305
+fix(module-tools): 用户使用 references 时给 tsc 添加 -b 参数来避免 TS6305 错误

--- a/packages/solutions/module-tools/src/builder/dts/tsc.ts
+++ b/packages/solutions/module-tools/src/builder/dts/tsc.ts
@@ -65,11 +65,21 @@ const runTscBin = async (
 ) => {
   const { appDirectory, watch = false, abortOnError = true } = config;
 
-  const { tempTsconfigPath } = info;
+  const { tempTsconfigPath, userTsconfig } = info;
 
   const tscBinFile = await getTscBinPath(appDirectory);
 
-  const watchParams = watch ? ['-w'] : [];
+  const params: string[] = [];
+
+  if (watch) {
+    params.push('-w');
+  }
+
+  // avoid error TS6305
+  if (userTsconfig.references) {
+    params.push('-b');
+  }
+
   const childProgress = execa(
     tscBinFile,
     [
@@ -79,7 +89,7 @@ const runTscBin = async (
       '--pretty',
       // https://github.com/microsoft/TypeScript/issues/21824
       '--preserveWatchOutput',
-      ...watchParams,
+      ...params,
     ],
     {
       stdio: 'pipe',


### PR DESCRIPTION
## Summary
Add buildOptions, '-b' means that Build one or more projects and their dependencies, if out of date.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
