### PR TITLE
fix(builder): export type of rspack config and add globalObject type

### DIFF
--- a/.changeset/lemon-clocks-look.md
+++ b/.changeset/lemon-clocks-look.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(builder): export type of rspack config and add globalObject type for rspack output
+fix(builder): 导出一些 rspack config 类型同时给 rspack output 添加 globalObject 类型

--- a/packages/builder/builder-rspack-provider/src/index.ts
+++ b/packages/builder/builder-rspack-provider/src/index.ts
@@ -6,6 +6,12 @@ export type {
   // Config Types
   BuilderConfig,
   NormalizedConfig,
+  DevConfig,
+  OutputConfig,
+  ToolsConfig,
+  SourceConfig,
+  SecurityConfig,
+  PerformanceConfig,
 
   // Hook Callback Types
   ModifyRspackConfigFn,

--- a/packages/builder/builder-shared/src/types/bundlerConfig.ts
+++ b/packages/builder/builder-shared/src/types/bundlerConfig.ts
@@ -50,6 +50,7 @@ type RspackOutput = {
   assetModuleFilename?: string;
   filename?: string;
   chunkFilename?: string;
+  globalObject?: string;
   uniqueName?: string;
   hashFunction?: string;
   cssFilename?: string;


### PR DESCRIPTION
…for rspack output

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
