### PR TITLE
feat(plugin-testing): support -u option to update snapshot

### DIFF
--- a/.changeset/twenty-ways-tickle.md
+++ b/.changeset/twenty-ways-tickle.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-testing': patch
+---
+
+feat(plugin-testing): support -u option to update snapshot
+
+feat(plugin-testing): 支持 -u 选项来更新快照

--- a/packages/document/main-doc/docs/en/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/commands.mdx
@@ -276,7 +276,9 @@ Normally, only the part of the code modified by this commit needs to be checked 
 Usage: modern test [options]
 
 Options:
-  -h, --help  show command help
+  -u --updateSnapshot  use this flag to re-record snapshots.
+  --watch              watch files for changes and rerun tests related to changed files.
+  -h, --help           show command help
 ```
 
 :::tip

--- a/packages/document/main-doc/docs/zh/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/commands.mdx
@@ -278,7 +278,9 @@ Options:
 Usage: modern test [options]
 
 Options:
-  -h, --help  显示命令帮助
+  -u --updateSnapshot  使用此选项来更新快照
+  --watch              监视文件的变更并重新运行相关的测试
+  -h, --help           显示命令帮助
 ```
 
 :::tip

--- a/packages/runtime/plugin-testing/src/base/runJest.ts
+++ b/packages/runtime/plugin-testing/src/base/runJest.ts
@@ -41,6 +41,12 @@ const buildArgv = async (
     result.config = JSON.stringify(config);
   }
 
+  // `-u` is the shorthand of `--updateSnapshot`
+  if (result.u === true) {
+    result.updateSnapshot = true;
+    delete result.u;
+  }
+
   return result;
 };
 

--- a/packages/runtime/plugin-testing/src/cli/index.ts
+++ b/packages/runtime/plugin-testing/src/cli/index.ts
@@ -69,6 +69,14 @@ export const testingPlugin = (): CliPlugin<{
         commands: ({ program }: any) => {
           program
             .command('test')
+            .option(
+              '-u --updateSnapshot',
+              'use this flag to re-record snapshots',
+            )
+            .option(
+              '--watch',
+              'watch files for changes and rerun tests related to changed files',
+            )
             .allowUnknownOption()
             .usage('<regexForTestFiles> --[options]')
             .action(async () => {


### PR DESCRIPTION
## Summary

Support -u option to update snapshot.

```bash
modern test -u

// same as 
modern test --updateSnapshot
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
