### PR TITLE
fix(rspack-provider): react refresh not work in Micro front-end projects

### DIFF
--- a/.changeset/afraid-trains-leave.md
+++ b/.changeset/afraid-trains-leave.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/builder-rspack-provider': patch
+'@modern-js/builder-shared': patch
+---
+
+fix(rspack-provider): react refresh not work in Micro front-end projects
+
+fix(rspack-provider): 修复 react refresh 在微前端场景下不生效的问题

--- a/packages/builder/builder-rspack-provider/src/plugins/react.ts
+++ b/packages/builder/builder-rspack-provider/src/plugins/react.ts
@@ -1,5 +1,29 @@
-import type { BuilderPlugin } from '../types';
-import { setConfig, isUsingHMR } from '@modern-js/builder-shared';
+import type { BuilderPlugin, Rspack } from '../types';
+import {
+  setConfig,
+  isUsingHMR,
+  isClientCompiler,
+  isProd,
+} from '@modern-js/builder-shared';
+
+// Not needed in Rsbuild
+const setupCompiler = (compiler: Rspack.Compiler) => {
+  if (!isClientCompiler(compiler)) {
+    return;
+  }
+
+  // fix react refresh not work in Micro front-end projects when use legacy transformByDefault
+  // https://github.com/web-infra-dev/rspack/pull/4628/files#diff-81b3afbbf84bc30f7332fb7bd43d52a4544ae16190d41b4b0fe8e8d4c9ca89e0R59
+  const definedModules = {
+    // For Mutiple Instance Mode
+    __react_refresh_library__: JSON.stringify(
+      compiler.webpack.Template.toIdentifier(
+        compiler.options.output.uniqueName || compiler.options.output.library,
+      ),
+    ),
+  };
+  new compiler.webpack.DefinePlugin(definedModules).apply(compiler);
+};
 
 export const builderPluginReact = (): BuilderPlugin => ({
   name: 'builder-plugin-react',
@@ -33,6 +57,20 @@ export const builderPluginReact = (): BuilderPlugin => ({
             ],
           },
         ]);
+      }
+    });
+
+    api.onAfterCreateCompiler(({ compiler: multiCompiler }) => {
+      if (isProd()) {
+        return;
+      }
+
+      if ((multiCompiler as Rspack.MultiCompiler).compilers) {
+        (multiCompiler as Rspack.MultiCompiler).compilers.forEach(
+          setupCompiler,
+        );
+      } else {
+        setupCompiler(multiCompiler as Rspack.Compiler);
       }
     });
   },

--- a/packages/builder/builder-shared/src/utils.ts
+++ b/packages/builder/builder-shared/src/utils.ts
@@ -5,6 +5,8 @@ import type {
 } from './types';
 import { join } from 'path';
 
+export const isProd = (): boolean => process.env.NODE_ENV === 'production';
+
 export const createVirtualModule = (content: string) =>
   `data:text/javascript,${content}`;
 


### PR DESCRIPTION
## Summary

It's fixed in rspack, but only works in builtin:swc-loader, not support in modern.js (legacy transformByDefault) 😭 
https://github.com/web-infra-dev/rspack/pull/4628

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
