### PR TITLE
docs: deprecate addIncludes/addExcludes utils

### DIFF
--- a/packages/document/builder-doc/docs/en/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/en/config/tools/babel.md
@@ -12,7 +12,6 @@ Please note the limitations of `tools.babel` in the following usage scenarios:
 
 ### Function Type
 
-
 When `tools.babel` is of type `Function`, the default Babel configuration will be passed as the first parameter. You can directly modify the configuration object or return an object as the final `babel-loader` configuration.
 
 ```js
@@ -144,50 +143,6 @@ export default {
 };
 ```
 
-#### addIncludes
-
-- **Type:** `(includes: string | RegExp | (string | RegExp)[]) => void`
-
-By default, Babel will only compile the application code in the src directory. With `addIncludes` you can specify that Babel compile some files in node_modules. For example:
-
-```js
-export default {
-  tools: {
-    babel(config, { addIncludes }) {
-      addIncludes(/\/node_modules\/query-string\//);
-    },
-  },
-};
-```
-
-:::tip
-The usage of the `addIncludes` function is identical to the `source.include` configuration option. We recommend using `source.include` instead of `addIncludes` because `source.include` has a wider range of use cases. For example, when migrating from Babel to SWC compilation, `source.include` can still work, while the `addIncludes` function will not be effective.
-
-Please refer to the [source.include documentation](https://modernjs.dev/builder/en/api/config-source.html#sourceinclude) for more detailed usage.
-:::
-
-#### addExcludes
-
-- **Type:** `(excludes: string | RegExp | (string | RegExp)[]) => void`
-
-Contrary to `addIncludes`, specifies that certain files are excluded from Babel's compilation.
-
-For example, without compiling files in the `src/example` directory:
-
-```js
-export default {
-  tools: {
-    babel(config, { addExcludes }) {
-      addExcludes('src/example');
-    },
-  },
-};
-```
-
-:::tip
-The usage of the `addExcludes` function is basically the same as the `source.exclude` config, please see the [source.exclude documentation](https://modernjs.dev/builder/api/config-source.html#sourceexclude) for a more detailed usage. You can also use `source.exclude` directly instead of the `addExcludes` function.
-:::
-
 #### modifyPresetEnvOptions
 
 - **Type:** `(options: PresetEnvOptions) => void`
@@ -225,6 +180,14 @@ export default {
   },
 };
 ```
+
+#### addIncludes
+
+Deprecated, please use [source.include](https://modernjs.dev/en/configure/app/source/include.html) instead, both have the same functionality.
+
+#### addExcludes
+
+Deprecated, please use [source.exclude](https://modernjs.dev/en/configure/app/source/exclude.html) instead, both have the same functionality.
 
 ### Debugging Babel Configuration
 

--- a/packages/document/builder-doc/docs/en/config/tools/tsLoader.md
+++ b/packages/document/builder-doc/docs/en/config/tools/tsLoader.md
@@ -49,38 +49,10 @@ export default {
 
 ### Util Functions
 
-When the value of `tools.tsLoader` is a Function, the utils functions available for the second parameter are as follows:
-
 #### addIncludes
 
-- **Type:** `(includes: string | RegExp | Array<string | RegExp>) => void`
-
-By default, only the application code in the src directory will be compiled. Use `addIncludes` to specify ts-loader to compile some files under `node_modules`. For example:
-
-```ts
-export default {
-  tools: {
-    tsLoader: (config, { addIncludes }) => {
-      addIncludes([/node_modules\/react/]);
-    },
-  },
-};
-```
+Deprecated, please use [source.include](https://modernjs.dev/en/configure/app/source/include.html) instead, both have the same functionality.
 
 #### addExcludes
 
-- **Type:** `(excludes: string | RegExp | Array<string | RegExp>) => void`
-
-Contrary to `addIncludes`, specify `ts-loader` to exclude certain files when compiling.
-
-For example, without compiling files in the `src/example` directory:
-
-```ts
-export default {
-  tools: {
-    tsLoader: (config, { addExcludes }) => {
-      addExcludes([/src\/example\//]);
-    },
-  },
-};
-```
+Deprecated, please use [source.exclude](https://modernjs.dev/en/configure/app/source/exclude.html) instead, both have the same functionality.

--- a/packages/document/builder-doc/docs/zh/config/tools/babel.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/babel.md
@@ -142,51 +142,6 @@ export default {
 };
 ```
 
-#### addIncludes
-
-- **类型：** `(includes: string | RegExp | (string | RegExp)[]) => void`
-
-默认情况下 Babel 只会编译 src 目录下的业务代码，使用 `addIncludes` 你可以指定 Babel 编译 node_modules 下的一些文件。比如编译 `query-string` 依赖：
-
-```js
-export default {
-  tools: {
-    babel(config, { addIncludes }) {
-      addIncludes(/\/node_modules\/query-string\//);
-    },
-  },
-};
-```
-
-:::tip
-`addIncludes` 函数的用法与 `source.include` 配置项完全一致，我们建议直接使用 `source.include` 来代替它，因为 `source.include` 的使用场景更广。比如，当你从 Babel 迁移切换到 SWC 编译时，`source.include` 仍然可以生效，而 `addIncludes` 函数则无法生效。
-
-请查看 [「source.include 文档」](https://modernjs.dev/builder/api/config-source.html#sourceinclude) 来查看更详细的用法说明。
-
-:::
-
-#### addExcludes
-
-- **类型：** `(excludes: string | RegExp | (string | RegExp)[]) => void`
-
-`addExcludes` 和 `addIncludes` 的用处相反，指定 Babel 编译时排除某些文件。
-
-比如不编译 `src/example` 目录下的文件:
-
-```js
-export default {
-  tools: {
-    babel(config, { addExcludes }) {
-      addExcludes('src/example');
-    },
-  },
-};
-```
-
-:::tip
-`addExcludes` 函数的用法与 `source.exclude` 配置项基本一致，请查看 [source.exclude 文档](https://modernjs.dev/builder/api/config-source.html#sourceexclude) 来查看更详细的用法说明。也可以直接使用 `source.exclude` 来代替 `addExcludes` 函数。
-:::
-
 #### modifyPresetEnvOptions
 
 - **类型：** `(options: PresetEnvOptions) => void`
@@ -224,6 +179,14 @@ export default {
   },
 };
 ```
+
+#### addIncludes
+
+已废弃，请使用 [source.include](https://modernjs.dev/configure/app/source/include.html) 代替，两者功能完全一致。
+
+#### addExcludes
+
+已废弃，请使用 [source.exclude](https://modernjs.dev/configure/app/source/exclude.html) 代替，两者功能完全一致。
 
 ### 调试 Babel 配置
 

--- a/packages/document/builder-doc/docs/zh/config/tools/tsLoader.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/tsLoader.md
@@ -49,38 +49,10 @@ export default {
 
 ### 工具函数
 
-`tools.tsLoader` 的值为 Function 类型时，第二个参数可用的工具函数如下：
-
 #### addIncludes
 
-- **类型：** `(includes: string | RegExp | Array<string | RegExp>) => void`
-
-默认情况下只会编译 src 目录下的业务代码，使用 addIncludes 可以指定 ts-loader 编译 `node_modules` 下的一些文件。比如:
-
-```ts
-export default {
-  tools: {
-    tsLoader: (config, { addIncludes }) => {
-      addIncludes([/node_modules\/react/]);
-    },
-  },
-};
-```
+已废弃，请使用 [source.include](https://modernjs.dev/configure/app/source/include.html) 代替，两者功能完全一致。
 
 #### addExcludes
 
-- **类型：** `(excludes: string | RegExp | Array<string | RegExp>) => void`
-
-和 `addIncludes` 相反，指定 `ts-loader` 编译时排除某些文件。
-
-例如不编译 src/example 目录下的文件：
-
-```ts
-export default {
-  tools: {
-    tsLoader: (config, { addExcludes }) => {
-      addExcludes([/src\/example\//]);
-    },
-  },
-};
-```
+已废弃，请使用 [source.exclude](https://modernjs.dev/configure/app/source/exclude.html) 代替，两者功能完全一致。

--- a/packages/document/main-doc/docs/en/guides/troubleshooting/builder.mdx
+++ b/packages/document/main-doc/docs/en/guides/troubleshooting/builder.mdx
@@ -209,7 +209,7 @@ Solution:
 
 If the compilation is succeed, but the `exports is not defined` error appears after opening the page, it is usually because a CommonJS module is compiled by Babel.
 
-Under normal circumstances, Modern.js will not use Babel to compile CommonJS modules. If the [source.include](/en/configure/app/source/include.html) configuration option is used in the project, or the [tools.babel](/configure/app/tools/babel.html) `addIncludes` method, some CommonJS modules may be added to the Babel compilation.
+Under normal circumstances, Modern.js will not use Babel to compile CommonJS modules. If the [source.include](/en/configure/app/source/include.html) configuration option is used in the project, some CommonJS modules may be added to the Babel compilation.
 
 There are two workarounds for this problem:
 

--- a/packages/document/main-doc/docs/zh/guides/troubleshooting/builder.mdx
+++ b/packages/document/main-doc/docs/zh/guides/troubleshooting/builder.mdx
@@ -209,7 +209,7 @@ npm ls postcss
 
 如果编译正常，但是打开页面后出现 `exports is not defined` 报错，通常是因为在项目中使用 Babel 编译了一个 CommonJS 模块，导致 Babel 出现异常。
 
-在正常情况下，Modern.js 是不会使用 Babel 来编译 CommonJS 模块的。如果项目中使用了 [source.include](/configure/app/source/include.html) 配置项，或使用了 [tools.babel](/configure/app/tools/babel.html) 的 `addIncludes` 方法，则可能会把一些 CommonJS 模块加入到 Babel 编译中。
+在正常情况下，Modern.js 是不会使用 Babel 来编译 CommonJS 模块的。如果项目中使用了 [source.include](/configure/app/source/include.html) 配置项，则可能会把一些 CommonJS 模块加入到 Babel 编译中。
 
 该问题有两种解决方法：
 


### PR DESCRIPTION
## Summary

Deprecate addIncludes/addExcludes utils, as the function is the same as `source.include` and `source.exclude` (Users can still use these utils util next major version).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
