### PR TITLE
fix: default appicon should after user set

### DIFF
--- a/packages/solutions/app-tools/src/config/initialize/inits.ts
+++ b/packages/solutions/app-tools/src/config/initialize/inits.ts
@@ -16,8 +16,9 @@ export function initHtmlConfig(
     config: AppNormalizedConfig<'shared'>,
     appContext: IAppContext,
   ) {
+    const { appIcon } = config.html;
     const { configDir } = config.source;
-    const appIcon = findExists(
+    const defaultAppIcon = findExists(
       ICON_EXTENSIONS.map(ext =>
         path.resolve(
           appContext.appDirectory,
@@ -26,7 +27,7 @@ export function initHtmlConfig(
         ),
       ),
     );
-    return typeof appIcon === 'string' ? appIcon : undefined;
+    return appIcon || defaultAppIcon || undefined;
   }
   function createBuilderFavicon(
     config: AppNormalizedConfig<'shared'>,


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
