### PR TITLE
fix(module-tools): use tsc --clean to clear the tsbuildinfo and d.ts

### DIFF
--- a/.changeset/wet-beds-eat.md
+++ b/.changeset/wet-beds-eat.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): use tsc --clean to clear the tsbuildinfo and d.ts files
+fix(module-tools): 使用 "tsc --clean" 来清理生成的 tsbuildinfo 和类型描述文件

--- a/packages/solutions/module-tools/src/builder/clear.ts
+++ b/packages/solutions/module-tools/src/builder/clear.ts
@@ -1,6 +1,7 @@
-import { fs, logger, chalk } from '@modern-js/utils';
+import { fs, logger, chalk, execa } from '@modern-js/utils';
 import type { BaseBuildConfig } from '../types';
 import { i18n, localeKeys } from '../locale';
+import { getTscBinPath } from '../utils';
 
 export const clearBuildConfigPaths = async (
   configs: BaseBuildConfig[],
@@ -11,6 +12,20 @@ export const clearBuildConfigPaths = async (
       logger.warn(chalk.bgYellowBright(i18n.t(localeKeys.warns.clearRootPath)));
     } else {
       await fs.remove(config.outDir);
+    }
+
+    // tsc --build --clean
+    if (config.buildType === 'bundleless' && config.dts) {
+      const tscBinFile = await getTscBinPath(projectAbsRootPath);
+      const childProgress = execa(tscBinFile, ['--build', '--clean'], {
+        stdio: 'pipe',
+        cwd: projectAbsRootPath,
+      });
+      try {
+        await childProgress;
+      } catch (e) {
+        logger.error(e);
+      }
     }
   }
 };


### PR DESCRIPTION


## Summary
When we use references, we will add '--build' option, this will generate tsbuildinfo which need to be cleared.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
