### PR TITLE
fix(storybook): use default conditionNames

### DIFF
--- a/.changeset/moody-donkeys-film.md
+++ b/.changeset/moody-donkeys-film.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/storybook-builder': patch
+---
+
+fix(storybook): use default conditionNames
+fix(storybook): 使用默认的 conditionNames

--- a/packages/storybook/builder/src/plugin-storybook.ts
+++ b/packages/storybook/builder/src/plugin-storybook.ts
@@ -115,11 +115,6 @@ export const pluginStorybook: (
 
       const modifyConfig = async (config: WebpackConfig | RspackConfig) => {
         config.resolve ??= {};
-        config.resolve.conditionNames = [
-          'require',
-          'node',
-          ...(config.resolve.conditionNames || []),
-        ];
         config.resolve.fullySpecified = false;
         await applyMdxLoader(config, options);
         await applyCsfPlugin(config, options);


### PR DESCRIPTION
## Summary

use default conditionNames for storybook, align with @storybook/react-webpack5

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
