### PR TITLE
fix(module-tools): upgrade remapping version to 2.2.1

### DIFF
--- a/.changeset/tall-pugs-mix.md
+++ b/.changeset/tall-pugs-mix.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+chore(module-tools): upgrade remapping version to 2.2.1
+chore(module-tools): 更新 remapping 版本至 2.2.1

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -55,7 +55,7 @@
     "test:watch": "vitest dev"
   },
   "dependencies": {
-    "@ampproject/remapping": "1.0.2",
+    "@ampproject/remapping": "^2.2.1",
     "@ast-grep/napi": "0.12.0",
     "@modern-js/core": "workspace:*",
     "@modern-js/new-action": "workspace:*",

--- a/packages/solutions/module-tools/src/utils/map.ts
+++ b/packages/solutions/module-tools/src/utils/map.ts
@@ -1,6 +1,6 @@
 import convertSourceMap from 'convert-source-map';
 import ampremapping from '@ampproject/remapping';
-import { RawSourceMap } from '@ampproject/remapping/dist/types/types';
+import type { RawSourceMap } from '@ampproject/remapping';
 import type { SourceMap } from '../types';
 
 interface Options {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4624,8 +4624,8 @@ importers:
   packages/solutions/module-tools:
     dependencies:
       '@ampproject/remapping':
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: ^2.2.1
+        version: 2.2.1
       '@ast-grep/napi':
         specifier: 0.12.0
         version: 0.12.0
@@ -8392,14 +8392,6 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  /@ampproject/remapping@1.0.2:
-    resolution: {integrity: sha512-SncaVxs+E3EdoA9xJgHfWPxZfowAgeIsd71VpqCKP6KNKm6s7zSqqvUc70UpKUFsrV3dAmy6qxHoIj5NG+3DiA==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/resolve-uri': 1.0.0
-      sourcemap-codec: 1.4.8
-    dev: false
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -12611,11 +12603,6 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.19
-
-  /@jridgewell/resolve-uri@1.0.0:
-    resolution: {integrity: sha512-9oLAnygRMi8Q5QkYEU4XWK04B+nuoXoxjRvRxgjuChkLZFBja0YPSgdZ7dZtwhncLBcQe/I/E+fLuk5qxcYVJA==}
-    engines: {node: '>=6.0.0'}
-    dev: false
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -31648,6 +31635,7 @@ packages:
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
+    dev: true
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}

--- a/tests/integration/module/fixtures/build/dts/tsconfig.json
+++ b/tests/integration/module/fixtures/build/dts/tsconfig.json
@@ -3,17 +3,14 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@src/*": [
-        "./src/*"
-      ]
+      "@src/*": ["./src/*"]
     },
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
     "outDir": "dist/bundleless/types"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "../dts-composite"

--- a/tests/integration/module/fixtures/build/sourceMap/__snapshots__/sourceMap.test.ts.snap
+++ b/tests/integration/module/fixtures/build/sourceMap/__snapshots__/sourceMap.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`sourcemap usage sourcemap is external 1`] = `
 {
-  "mappings": ";;;;;;;;;;;;;;;;;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;ACAO,IAAM,YAAY,CAAC,QAAQ,QAAQ,GAAG,MAAM,IAAI,GAAG;;;ADEnD,IAAM,QAAQ,SAAO,UAAU,UAAU,GAAG;",
+  "mappings": ";;;;;;;;;;;;;;;;;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;ACAO,IAAM,YAAY,CAAC,QAAQ,QAAQ,GAAG,MAAM,IAAI,GAAG;;;ADEnD,IAAM,QAAQ,SAAO,UAAU,UAAU,GAAG",
   "names": [],
   "sources": [
     "../../src/index.js",
@@ -22,7 +22,7 @@ export const debug = str => addPrefix('DEBUG:', str);
 
 exports[`sourcemap usage sourcemap is true 1`] = `
 {
-  "mappings": ";;;;;;;;;;;;;;;;;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;ACAO,IAAM,YAAY,CAAC,QAAQ,QAAQ,GAAG,MAAM,IAAI,GAAG;;;ADEnD,IAAM,QAAQ,SAAO,UAAU,UAAU,GAAG;",
+  "mappings": ";;;;;;;;;;;;;;;;;;;AAAA;AAAA;AAAA;AAAA;AAAA;;;ACAO,IAAM,YAAY,CAAC,QAAQ,QAAQ,GAAG,MAAM,IAAI,GAAG;;;ADEnD,IAAM,QAAQ,SAAO,UAAU,UAAU,GAAG",
   "names": [],
   "sources": [
     "../../src/index.js",
@@ -42,7 +42,7 @@ export const debug = str => addPrefix('DEBUG:', str);
 
 exports[`sourcemap usage sourcemap with swc 1`] = `
 {
-  "mappings": ";;;;;;;;;;;;;;;;;;;AAAA;;;;;;;ACAO,IAAMA,YAAY,CAACC,QAAQC,QAAQ,GAAGD,UAAUC;;;ADEhD,IAAMC,QAAQD,SAAOF,UAAU,UAAUE;",
+  "mappings": ";;;;;;;;;;;;;;;;;;;AAAA;;;;;;;ACAO,IAAMA,YAAY,CAACC,QAAQC,QAAQ,GAAGD,UAAUC;;;ADEhD,IAAMC,QAAQD,SAAOF,UAAU,UAAUE",
   "names": [
     "addPrefix",
     "prefix",


### PR DESCRIPTION
## Summary
![image](https://github.com/web-infra-dev/modern.js/assets/50694858/7f409875-2b76-4d51-8986-2b606246ae85)
Upgrade '@ampproject/remapping' to avoid this warn. 

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
