### PR TITLE
fix(plugin-swc): should not override extensions when using function config

### DIFF
--- a/.changeset/metal-adults-begin.md
+++ b/.changeset/metal-adults-begin.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-swc': patch
+---
+
+fix(plugin-swc): should not override extensions when using function config
+fix(plugin-swc): 使用函数配置时不应该覆盖 extensions

--- a/packages/cli/plugin-swc/src/index.ts
+++ b/packages/cli/plugin-swc/src/index.ts
@@ -45,10 +45,8 @@ export function applyBuilderSwcConfig(
   if (isSSR) {
     // eslint-disable-next-line no-param-reassign
     swc = applyConfig(swc, config => {
-      config.extensions = {
-        ...(config.extensions || {}),
-        loadableComponents: true,
-      };
+      config.extensions ??= {};
+      config.extensions.loadableComponents = true;
     });
   }
 
@@ -72,12 +70,10 @@ const PLUGIN_NAME = '@modern-js/plugin-swc';
 
 export const swcPlugin = factory(PLUGIN_NAME, swcOptions => {
   return applyConfig(swcOptions, swcOptions => {
-    swcOptions.extensions = {
-      ...(swcOptions.extensions || {}),
-      ssrLoaderId: {
-        runtimePackageName: '@modern-js/runtime',
-        functionUseLoaderName: 'useLoader',
-      },
+    swcOptions.extensions ??= {};
+    swcOptions.extensions.ssrLoaderId = {
+      runtimePackageName: '@modern-js/runtime',
+      functionUseLoaderName: 'useLoader',
     };
   });
 });
@@ -91,7 +87,7 @@ function applyConfig(
       handler(config);
 
       // in the last invoke user config
-      return rawConfig(config, utils);
+      return rawConfig(config, utils) || config;
     };
   } else {
     handler(rawConfig);

--- a/packages/cli/plugin-swc/tests/index.test.ts
+++ b/packages/cli/plugin-swc/tests/index.test.ts
@@ -49,4 +49,28 @@ describe('plugin config', () => {
 
     expect(count).toBe(2);
   });
+
+  it('should not override user extensions config', () => {
+    const config = applyBuilderSwcConfig(
+      config => {
+        config.extensions ??= {};
+        config.extensions.emotion = true;
+      },
+      undefined,
+      true,
+    ) as FnPluginSwcOptions;
+
+    const finalConfig = config(
+      {
+        extensions: {
+          styledComponents: true,
+        },
+      },
+      null as any,
+    )!;
+
+    expect(finalConfig.extensions).toBeDefined();
+    expect(finalConfig.extensions!.emotion).toBeDefined();
+    expect(finalConfig.extensions!.styledComponents).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

fix function config overrides user extension config
fix function config return undefined causes final config to be undefined

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
