### PR TITLE
chore: bump rsbuild to 0.2.3

### DIFF
--- a/.changeset/early-chairs-obey.md
+++ b/.changeset/early-chairs-obey.md
@@ -7,6 +7,6 @@
 '@modern-js/server-utils': patch
 ---
 
-chore: bump rsbuild to 0.2.2
+chore: bump rsbuild to 0.2.3
 
-chore: 升级 rsbuild 到 0.2.2
+chore: 升级 rsbuild 到 0.2.3

--- a/.changeset/early-chairs-obey.md
+++ b/.changeset/early-chairs-obey.md
@@ -1,0 +1,12 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js-app/eslint-config': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/builder': patch
+'@modern-js/devtools-client': patch
+'@modern-js/server-utils': patch
+---
+
+chore: bump rsbuild to 0.2.2
+
+chore: 升级 rsbuild 到 0.2.2

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -96,7 +96,7 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
-    "@rsbuild/babel-preset": "0.2.2",
+    "@rsbuild/babel-preset": "0.2.3",
     "@swc/helpers": "0.5.3",
     "babel-plugin-import": "1.13.5",
     "babel-plugin-styled-components": "1.13.3",

--- a/packages/builder/builder-webpack-provider/package.json
+++ b/packages/builder/builder-webpack-provider/package.json
@@ -96,7 +96,7 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
-    "@rsbuild/babel-preset": "0.0.7",
+    "@rsbuild/babel-preset": "0.2.2",
     "@swc/helpers": "0.5.3",
     "babel-plugin-import": "1.13.5",
     "babel-plugin-styled-components": "1.13.3",

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@rsbuild/monorepo-utils": "0.0.7",
+    "@rsbuild/monorepo-utils": "0.2.2",
     "@svgr/webpack": "8.0.1",
     "@swc/helpers": "0.5.3",
     "deepmerge": "^4.3.1",

--- a/packages/builder/builder/package.json
+++ b/packages/builder/builder/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@modern-js/builder-shared": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@rsbuild/monorepo-utils": "0.2.2",
+    "@rsbuild/monorepo-utils": "0.2.3",
     "@svgr/webpack": "8.0.1",
     "@swc/helpers": "0.5.3",
     "deepmerge": "^4.3.1",

--- a/packages/devtools/client/package.json
+++ b/packages/devtools/client/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/themes": "^2.0.0",
-    "@rsbuild/core": "^0.1.0",
+    "@rsbuild/core": "0.2.2",
     "@types/jest": "^29",
     "@types/lodash": "^4.14.202",
     "@types/node": "~16.11.7",

--- a/packages/devtools/client/package.json
+++ b/packages/devtools/client/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/themes": "^2.0.0",
-    "@rsbuild/core": "0.2.2",
+    "@rsbuild/core": "0.2.3",
     "@types/jest": "^29",
     "@types/lodash": "^4.14.202",
     "@types/node": "~16.11.7",

--- a/packages/devtools/client/plugins/ServiceWorkerCompilerPlugin.ts
+++ b/packages/devtools/client/plugins/ServiceWorkerCompilerPlugin.ts
@@ -12,14 +12,17 @@ export class ServiceWorkerCompilerPlugin {
 
       const builder = await createRsbuild({
         cwd,
-        target: 'service-worker',
         rsbuildConfig: {
           source: {
             entry: { 'sw-proxy': path.resolve(cwd, './src/service.worker.ts') },
             define: { 'process.env.VERSION': JSON.stringify(version) },
           },
           output: {
-            disableSourceMap: true,
+            targets: ['service-worker'],
+            sourceMap: {
+              js: false,
+              css: false,
+            },
             distPath: {
               root: './dist',
               worker: './public',

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/eslint-plugin": "^7.22.10",
-    "@rsbuild/babel-preset": "0.2.2",
+    "@rsbuild/babel-preset": "0.2.3",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.28.0",

--- a/packages/review/eslint-config-app/package.json
+++ b/packages/review/eslint-config-app/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/eslint-plugin": "^7.22.10",
-    "@rsbuild/babel-preset": "0.0.7",
+    "@rsbuild/babel-preset": "0.2.2",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "eslint": "^8.28.0",

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -128,7 +128,7 @@
     "@modern-js/plugin": "workspace:*",
     "@modern-js/prod-server": "workspace:*",
     "@modern-js/types": "workspace:*",
-    "@rsbuild/babel-preset": "0.2.2",
+    "@rsbuild/babel-preset": "0.2.3",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^13.4.0",
     "@types/testing-library__jest-dom": "^5.14.3",

--- a/packages/runtime/plugin-testing/package.json
+++ b/packages/runtime/plugin-testing/package.json
@@ -128,7 +128,7 @@
     "@modern-js/plugin": "workspace:*",
     "@modern-js/prod-server": "workspace:*",
     "@modern-js/types": "workspace:*",
-    "@rsbuild/babel-preset": "0.0.7",
+    "@rsbuild/babel-preset": "0.2.2",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^13.4.0",
     "@types/testing-library__jest-dom": "^5.14.3",

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -46,7 +46,7 @@
     "@modern-js/babel-compiler": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@modern-js/babel-plugin-module-resolver": "workspace:*",
-    "@rsbuild/babel-preset": "0.0.7",
+    "@rsbuild/babel-preset": "0.2.2",
     "@swc/helpers": "0.5.3",
     "babel-plugin-transform-typescript-metadata": "^0.3.2"
   },

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -46,7 +46,7 @@
     "@modern-js/babel-compiler": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@modern-js/babel-plugin-module-resolver": "workspace:*",
-    "@rsbuild/babel-preset": "0.2.2",
+    "@rsbuild/babel-preset": "0.2.3",
     "@swc/helpers": "0.5.3",
     "babel-plugin-transform-typescript-metadata": "^0.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: workspace:*
         version: link:../../toolkit/utils
       '@rsbuild/monorepo-utils':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       '@svgr/webpack':
         specifier: 8.0.1
         version: 8.0.1
@@ -356,8 +356,8 @@ importers:
         specifier: 0.5.10
         version: 0.5.10(react-refresh@0.14.0)(webpack@5.88.1)
       '@rsbuild/babel-preset':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -1335,8 +1335,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@rsbuild/core':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       '@types/jest':
         specifier: ^29
         version: 29.2.6
@@ -3238,8 +3238,8 @@ importers:
         specifier: ^7.22.10
         version: 7.22.10(@babel/eslint-parser@7.22.15)(eslint@8.28.0)
       '@rsbuild/babel-preset':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.0
         version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.28.0)(typescript@5.0.4)
@@ -3646,8 +3646,8 @@ importers:
         specifier: workspace:*
         version: link:../../toolkit/utils
       '@rsbuild/babel-preset':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -4478,8 +4478,8 @@ importers:
         specifier: workspace:*
         version: link:../../toolkit/utils
       '@rsbuild/babel-preset':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -15164,8 +15164,8 @@ packages:
       rollup: 3.23.0
     dev: true
 
-  /@rsbuild/babel-preset@0.2.2:
-    resolution: {integrity: sha512-hnfLcVnzfPmJk0IsXW0mcSO1zo6Gj44/vkcn1+o+Dn5Z3oXbVogf3gp5UJRRJUQjt/OM5Keeyj/Job0L3xoEKQ==}
+  /@rsbuild/babel-preset@0.2.3:
+    resolution: {integrity: sha512-wvCNqVIlujqC/x8r+QSxnw3Yugmtr3+L2wfNFXPgHjqWcnOdPX6Csw5crzrYRi+Yh3axX7iUbIztqizjFOCCoA==}
     dependencies:
       '@babel/core': 7.23.2
       '@babel/plugin-proposal-decorators': 7.23.6(@babel/core@7.23.2)
@@ -15177,8 +15177,8 @@ packages:
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.2)
       '@babel/runtime': 7.23.2
       '@babel/types': 7.23.0
-      '@rsbuild/plugin-babel': 0.2.2
-      '@rsbuild/shared': 0.2.2
+      '@rsbuild/plugin-babel': 0.2.3
+      '@rsbuild/shared': 0.2.3
       '@types/babel__core': 7.20.3
       babel-plugin-dynamic-import-node: 2.3.3
       core-js: 3.32.2
@@ -15198,22 +15198,22 @@ packages:
       postcss: 8.4.31
     dev: true
 
-  /@rsbuild/core@0.2.2:
-    resolution: {integrity: sha512-ioD1SVb5DJacIgH2riodxf6SbRBKPLZ+7Kf/M0tlH9Yc+i1/6ULPiLZ4OxBBUNHWKg1F8mt2VhOPTVlOlGab/A==}
+  /@rsbuild/core@0.2.3:
+    resolution: {integrity: sha512-9Az7XCBu/f0FKpFuyr4Zu1OXIaV2w+sWUfXZRc7FWFhPIAbZBfuMCP+sOMSGtonnJSVR4ABdB956NOnU4kKkKw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      '@rsbuild/shared': 0.2.2
-      '@rspack/core': 0.4.2
+      '@rsbuild/shared': 0.2.3
+      '@rspack/core': 0.4.3
       core-js: 3.32.2
       html-webpack-plugin: /html-rspack-plugin@5.5.7
       postcss: 8.4.31
     dev: true
 
-  /@rsbuild/monorepo-utils@0.2.2:
-    resolution: {integrity: sha512-0/fUpKGFvdJ/6trwNwvtH/XVrclWDlOiVPjFUVN8aNbDVJE3/T3m1FhI4zxxvxLNHiMqK17T/Mc2emYH+OZ9cQ==}
+  /@rsbuild/monorepo-utils@0.2.3:
+    resolution: {integrity: sha512-oo6wKhbSBLowrlnmEEGdTG907n28KW7miAhA2M4LjsTgXrzNNrIvzxJb7AJ+wErSFxxr0jVUDWoUf7/pj2kbaA==}
     dependencies:
-      '@rsbuild/shared': 0.2.2
+      '@rsbuild/shared': 0.2.3
       '@types/js-yaml': 4.0.6
       fast-glob: 3.3.1
       js-yaml: 4.1.0
@@ -15221,12 +15221,12 @@ packages:
       p-map: 4.0.0
     dev: false
 
-  /@rsbuild/plugin-babel@0.2.2:
-    resolution: {integrity: sha512-g7UzCm9QBD8fINO6xTbF4A1MMfVCemvFICaCmvFhOXnUAImmi3J+ByymrAoB1ynWQa++vgvqb0oaDnqvn3Gr+w==}
+  /@rsbuild/plugin-babel@0.2.3:
+    resolution: {integrity: sha512-Lda/fSvgruDRU4/MLzKLpPRRM8N021BO2iwkEKcYVFifdyRhxeB9JPmwXU8wVeDKgdcdv0BlXBpnVddXHrfXCA==}
     dependencies:
       '@babel/core': 7.23.2
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.2)
-      '@rsbuild/shared': 0.2.2
+      '@rsbuild/shared': 0.2.3
       '@types/babel__core': 7.20.3
       upath: 2.0.1
     transitivePeerDependencies:
@@ -15264,10 +15264,10 @@ packages:
       postcss: 8.4.31
     dev: true
 
-  /@rsbuild/shared@0.2.2:
-    resolution: {integrity: sha512-Vom6tkImWSVdycXOaju6niU8Hh2/QwJTYutzLv7cIXFaWnmia1kZ3FRJ1EEmVhTTv5M4f/R0Pf67b8ek60ylNg==}
+  /@rsbuild/shared@0.2.3:
+    resolution: {integrity: sha512-8ND3ETIr2pWnrVNLita2qEI0x3YKNhcPfiNdxWVdZoYaMCrbTJKLbxsMqOCsVk+TVBEnZ0QeIjU7o1ylTzhN7Q==}
     dependencies:
-      '@rspack/core': 0.4.2
+      '@rspack/core': 0.4.3
       caniuse-lite: 1.0.30001566
       lodash: 4.17.21
       postcss: 8.4.31
@@ -15280,19 +15280,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-darwin-arm64@0.4.2:
-    resolution: {integrity: sha512-DLchrjW1tTTFjtysgqKo6O+RBr4nq7wT4C+wHYqMqByPfQ6m0WtuSORFRDBHBEWt5RQvcjt+mSDO76imiBzSyg==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-darwin-arm64@0.4.3:
     resolution: {integrity: sha512-H/MW5oWawFY45OM+ePRELBueDlAusAMTaztn54AB1CRXyhLteyeX9luQv6+Fe1TDHeDfv27NL+eNTfO0+YJeZg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-darwin-x64@0.4.1:
@@ -15303,19 +15295,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-darwin-x64@0.4.2:
-    resolution: {integrity: sha512-NpGwHYcHxMwkdnn+g3LKCIcbogYrxvI3lHZZuZdbBf9tIOzYBgSq6RRmfIHIl/WQ9UVcnwjpb1zxUganmwhi7Q==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-darwin-x64@0.4.3:
     resolution: {integrity: sha512-m/XiTWbsrJ45sFTD+I3P9V7OT9sNx4+RW6PbS28n9yvPflrx5TX6r9WjFnFD6RJcPnt81hvO6oOE3LDO5LPvAw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-arm64-gnu@0.4.1:
@@ -15326,19 +15310,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-linux-arm64-gnu@0.4.2:
-    resolution: {integrity: sha512-m8kaD2EfdNHoHWZrnhYRvq/AP2K9ztrfeYLUC9qF8lDJW0cnI/easUigr0sfoPqml7iVVwsepKOQmjsDMvKT3A==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-linux-arm64-gnu@0.4.3:
     resolution: {integrity: sha512-t7wbd5NbZ5H3LeiUGZey0CKJdJWluu/iqdecnoPDEbXRdF7caev9OAJuQ9fKEsK4uQHQLvQ0/pjFDyDbJbPG5w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-arm64-musl@0.4.1:
@@ -15349,19 +15325,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-linux-arm64-musl@0.4.2:
-    resolution: {integrity: sha512-k5JhGPYjeZYDV819eNVrA1ajr/q+dBOb1mAwzuzgDJn38sMPLjj589XjlopuzY+JrpsQtP0p2iC/Yi+HPyYRmw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-linux-arm64-musl@0.4.3:
     resolution: {integrity: sha512-VlqXmsgft9LeYxWm8bZB16f/SZE7xLaHgDwFR6KCFLhubPRnF7gvxLf/y8FAtZzV+9XDi7mhfLWHMyJJDqwFBQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-x64-gnu@0.4.1:
@@ -15372,19 +15340,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-linux-x64-gnu@0.4.2:
-    resolution: {integrity: sha512-Su5AgvdSg4QNHeem3mFNY9VlaRKyK+sHjK+/RefP/l3sCRKUcGDLXcf8wUBy8//Mt/yJ88Z6jzB38vpFlnwsCA==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-linux-x64-gnu@0.4.3:
     resolution: {integrity: sha512-7eGymsvYsHz/P1mvUo1O+UJqrFzlMXY41599UWRiX4M3tX/pvDtLvxxjZ3JHVvNzEaBCiQ5xyRzqhhRDzcj4ww==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-x64-musl@0.4.1:
@@ -15395,19 +15355,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-linux-x64-musl@0.4.2:
-    resolution: {integrity: sha512-1xEBR719aSxpgARpnhSOpyFYOEqLCdfdz+KaeMt5NCl4FJ0p/Ob6h27GRcWdK91MQgCV2/4az6THiN5YKGTM7A==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-linux-x64-musl@0.4.3:
     resolution: {integrity: sha512-16PptmbtvpGHtEfbLoQjWjhBXOykdQRHXxn3RUTpkEXFbmhLnvnXbfmfSRoBuVNR+j0BqCrGiwweO43VBceJPg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-win32-arm64-msvc@0.4.1:
@@ -15418,19 +15370,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-win32-arm64-msvc@0.4.2:
-    resolution: {integrity: sha512-7iKlOtp2AQjPEA81tSxf9rKu1gE7b+rkMiJnnlzqfDjUvUk4zD71F6BdY9jXXiPjCTUfL5Oym8f1OMkjZsrjDA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-win32-arm64-msvc@0.4.3:
     resolution: {integrity: sha512-q9Vsn9Glj6m24UQfXpxcirk5S8r1RmAShXxjF+yRrKqpOtq1IodLWWRZ85kQfJyfk9deAfVkpiqHdsoK54uqQQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-win32-ia32-msvc@0.4.1:
@@ -15441,19 +15385,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-win32-ia32-msvc@0.4.2:
-    resolution: {integrity: sha512-XXy3/I/TqpLTrHPqrfWkqzZC53gGqJ6BHuPkCRJQFVgJI9zdBADqumj7A2s7VuH411zZQrCQVa/YBWxXWlScxA==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-win32-ia32-msvc@0.4.3:
     resolution: {integrity: sha512-jY6RiFwKQQjX3QR28K7boydBIhWKgAcGlDR+p4KnDSciF0H19ImT9QAf31Wcj2+XjN0wRev58cHRI2tgRw2+cw==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-win32-x64-msvc@0.4.1:
@@ -15464,19 +15400,11 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-win32-x64-msvc@0.4.2:
-    resolution: {integrity: sha512-OIMbPhhlGxwr6j4hQ7zeQAGMu217ZeV+/2PY+yQddgHUv/eFwH9MFhBZQc+k5Ad8+hurdyrLwOHGqjvo00ri/Q==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-win32-x64-msvc@0.4.3:
     resolution: {integrity: sha512-tZySo3ZZptxjuR0DDYQWQATUf5ApdDH7lQBezum/q5kzKVFFHN963JnInPHEO1wUtNXaTWXcx31habZTBrse/A==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding@0.4.1:
@@ -15493,19 +15421,6 @@ packages:
       '@rspack/binding-win32-x64-msvc': 0.4.1
     dev: true
 
-  /@rspack/binding@0.4.2:
-    resolution: {integrity: sha512-2Rb4cmDxHOqAoExiB7RZGyMUp17kDUkcHoPIi3W803mclqwHU9XpLdIMggy0J2Ig2Kp8TCF0tpoUSu2UhgXQgA==}
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.4.2
-      '@rspack/binding-darwin-x64': 0.4.2
-      '@rspack/binding-linux-arm64-gnu': 0.4.2
-      '@rspack/binding-linux-arm64-musl': 0.4.2
-      '@rspack/binding-linux-x64-gnu': 0.4.2
-      '@rspack/binding-linux-x64-musl': 0.4.2
-      '@rspack/binding-win32-arm64-msvc': 0.4.2
-      '@rspack/binding-win32-ia32-msvc': 0.4.2
-      '@rspack/binding-win32-x64-msvc': 0.4.2
-
   /@rspack/binding@0.4.3:
     resolution: {integrity: sha512-cw7Sca7YL9FeSTWdYahxr6HgWXnboOgPiM5SJai2Nfj6c/PWJV+ntBZbIW0LRY1fFDL7dYz3GUCXj4Dv3QYc8A==}
     optionalDependencies:
@@ -15518,7 +15433,6 @@ packages:
       '@rspack/binding-win32-arm64-msvc': 0.4.3
       '@rspack/binding-win32-ia32-msvc': 0.4.3
       '@rspack/binding-win32-x64-msvc': 0.4.3
-    dev: false
 
   /@rspack/core@0.4.1:
     resolution: {integrity: sha512-g502i0fHMj0lCr1Y/Bh5iwsEGB1BTiN+H06Oc39qEgs4bwQqnkGg/iQSBoR7q1886lAK8yIIDQeyCxF/6qI7EA==}
@@ -15542,27 +15456,6 @@ packages:
       zod-validation-error: 1.3.1(zod@3.22.3)
     dev: true
 
-  /@rspack/core@0.4.2:
-    resolution: {integrity: sha512-D5gKawtOMnzp0JIk62t09WrgqU1TR1X44km8mWZqGs5EunQVCvE5wW785cGOXgfuV8yxFXUKEqdHPg5Cp9fvEg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@rspack/binding': 0.4.2
-      '@swc/helpers': 0.5.1
-      browserslist: 4.22.2
-      compare-versions: 6.0.0-rc.1
-      enhanced-resolve: 5.12.0
-      fast-querystring: 1.1.2
-      graceful-fs: 4.2.10
-      json-parse-even-better-errors: 3.0.0
-      neo-async: 2.6.2
-      react-refresh: 0.14.0
-      tapable: 2.2.1
-      terminal-link: 2.1.1
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-      zod: 3.22.3
-      zod-validation-error: 1.3.1(zod@3.22.3)
-
   /@rspack/core@0.4.3:
     resolution: {integrity: sha512-YKzOOt6v6vZZH15+HdwWbd7DdXdXIJLlYQdQ6jgrAK7/X+5qg99MUgsfra3k+MXXX0vWROOy8mM6/dBaaDb7tg==}
     engines: {node: '>=16.0.0'}
@@ -15583,7 +15476,6 @@ packages:
       webpack-sources: 3.2.3
       zod: 3.22.3
       zod-validation-error: 1.3.1(zod@3.22.3)
-    dev: false
 
   /@rspack/plugin-html@0.4.3(@rspack/core@0.4.3):
     resolution: {integrity: sha512-mwnWJ2mKzGFg2XkgPbZaezj44YHaAaJgEJaZHNOTWtq5GxgRD+AmlLStYuQVjDST8NsuVy15yP+uIlJ3Ik5wJg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: workspace:*
         version: link:../../toolkit/utils
       '@rsbuild/monorepo-utils':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: 0.2.2
+        version: 0.2.2
       '@svgr/webpack':
         specifier: 8.0.1
         version: 8.0.1
@@ -356,8 +356,8 @@ importers:
         specifier: 0.5.10
         version: 0.5.10(react-refresh@0.14.0)(webpack@5.88.1)
       '@rsbuild/babel-preset':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: 0.2.2
+        version: 0.2.2
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -1335,8 +1335,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@rsbuild/core':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: 0.2.2
+        version: 0.2.2
       '@types/jest':
         specifier: ^29
         version: 29.2.6
@@ -3238,8 +3238,8 @@ importers:
         specifier: ^7.22.10
         version: 7.22.10(@babel/eslint-parser@7.22.15)(eslint@8.28.0)
       '@rsbuild/babel-preset':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: 0.2.2
+        version: 0.2.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.0
         version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.28.0)(typescript@5.0.4)
@@ -3646,8 +3646,8 @@ importers:
         specifier: workspace:*
         version: link:../../toolkit/utils
       '@rsbuild/babel-preset':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: 0.2.2
+        version: 0.2.2
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -4478,8 +4478,8 @@ importers:
         specifier: workspace:*
         version: link:../../toolkit/utils
       '@rsbuild/babel-preset':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: 0.2.2
+        version: 0.2.2
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -8730,6 +8730,24 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
+  /@babel/helper-create-class-features-plugin@7.23.6(@babel/core@7.23.2):
+    resolution: {integrity: sha512-cBXU1vZni/CpGF29iTu4YRbOZt3Wat6zCoMDxRF1MayiEc4URxOj31tT65HUM0CRpMowA3HCJaAOVOUnMf96cw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+    dev: false
+
   /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
     engines: {node: '>=6.9.0'}
@@ -8808,6 +8826,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.0
+
+  /@babel/helper-member-expression-to-functions@7.23.0:
+    resolution: {integrity: sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: false
 
   /@babel/helper-module-imports@7.22.15:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
@@ -9048,6 +9073,21 @@ packages:
       '@babel/plugin-syntax-decorators': 7.22.10(@babel/core@7.23.2)
     dev: false
 
+  /@babel/plugin-proposal-decorators@7.23.6(@babel/core@7.23.2):
+    resolution: {integrity: sha512-D7Ccq9LfkBFnow3azZGJvZYgcfeqAw3I1e5LoTpj6UKIFQilh8yqXsIGcRIqbBdsPWIz+Ze7ZZfggSj62Qp+Fg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.23.6(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.23.2)
+    dev: false
+
   /@babel/plugin-proposal-export-default-from@7.22.17(@babel/core@7.23.2):
     resolution: {integrity: sha512-cop/3quQBVvdz6X5SJC6AhUv3C9DrVTM06LUEXimEdWAhCSyOJIr9NiZDU9leHZ0/aiG0Sh7Zmvaku5TWYNgbA==}
     engines: {node: '>=6.9.0'}
@@ -9136,6 +9176,16 @@ packages:
 
   /@babel/plugin-syntax-decorators@7.22.10(@babel/core@7.23.2):
     resolution: {integrity: sha512-z1KTVemBjnz+kSEilAsI4lbkPOl5TvJH7YDSY1CTIzvLWJ+KHXp+mRe8VPmfnyvqOPqar1V2gid2PleKzRUstQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: false
+
+  /@babel/plugin-syntax-decorators@7.23.3(@babel/core@7.23.2):
+    resolution: {integrity: sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -10263,8 +10313,8 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-runtime@7.22.15(@babel/core@7.23.2):
-    resolution: {integrity: sha512-tEVLhk8NRZSmwQ0DJtxxhTrCht1HVo8VaMzYT4w6lwyKBuHsgoioAUA7/6eT2fRfc5/23fuGdlwIxXhRVgWr4g==}
+  /@babel/plugin-transform-runtime@7.23.6(@babel/core@7.23.2):
+    resolution: {integrity: sha512-kF1Zg62aPseQ11orDhFRw+aPG/eynNQtI+TyY+m33qJa2cJ5EEvza2P2BNTIA9E5MyqFABHEyY6CPHwgdy9aNg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -10272,9 +10322,9 @@ packages:
       '@babel/core': 7.23.2
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.23.2)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.23.2)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.23.2)
+      babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.23.2)
+      babel-plugin-polyfill-corejs3: 0.8.6(@babel/core@7.23.2)
+      babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.23.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -10650,6 +10700,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/preset-env@7.23.5(@babel/core@7.23.2):
     resolution: {integrity: sha512-0d/uxVD6tFGWXGDSfyMD1p2otoaKmu6+GD+NfAx0tMaH+dxORnp7T9TaVQ6mKyya7iBtCIVxHjWT7MuzzM9z+A==}
@@ -10736,7 +10787,7 @@ packages:
       babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.23.2)
       babel-plugin-polyfill-corejs3: 0.8.6(@babel/core@7.23.2)
       babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.23.2)
-      core-js-compat: 3.32.1
+      core-js-compat: 3.34.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -10799,9 +10850,9 @@ packages:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.15
+      '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
-      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.2)
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.23.2)
     dev: false
 
@@ -15113,43 +15164,27 @@ packages:
       rollup: 3.23.0
     dev: true
 
-  /@rsbuild/babel-preset@0.0.7:
-    resolution: {integrity: sha512-U8XzLq+FBAryfBiDzTGrWrZyEcqwVnpg5q/Af1jYBBI7o6/xaBHJcgvCmvyk1JvbciQCUGrwWthWau5qc1CJPA==}
+  /@rsbuild/babel-preset@0.2.2:
+    resolution: {integrity: sha512-hnfLcVnzfPmJk0IsXW0mcSO1zo6Gj44/vkcn1+o+Dn5Z3oXbVogf3gp5UJRRJUQjt/OM5Keeyj/Job0L3xoEKQ==}
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/plugin-proposal-decorators': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-proposal-decorators': 7.23.6(@babel/core@7.23.2)
       '@babel/plugin-proposal-export-default-from': 7.22.17(@babel/core@7.23.2)
       '@babel/plugin-proposal-partial-application': 7.22.5(@babel/core@7.23.2)
       '@babel/plugin-proposal-pipeline-operator': 7.22.15(@babel/core@7.23.2)
-      '@babel/plugin-transform-runtime': 7.22.15(@babel/core@7.23.2)
-      '@babel/preset-env': 7.22.20(@babel/core@7.23.2)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.2)
+      '@babel/plugin-transform-runtime': 7.23.6(@babel/core@7.23.2)
+      '@babel/preset-env': 7.23.5(@babel/core@7.23.2)
+      '@babel/preset-typescript': 7.23.2(@babel/core@7.23.2)
       '@babel/runtime': 7.23.2
       '@babel/types': 7.23.0
-      '@rsbuild/shared': 0.0.7
+      '@rsbuild/plugin-babel': 0.2.2
+      '@rsbuild/shared': 0.2.2
       '@types/babel__core': 7.20.3
       babel-plugin-dynamic-import-node: 2.3.3
       core-js: 3.32.2
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /@rsbuild/core@0.1.0:
-    resolution: {integrity: sha512-fOx8iGwymNRdWoEnaUZ2mMdPRQlfMh8Z4wR1gCaspGH+WHbfNGv/HWTkahsrOgR12TOMog/0oSCr0knZtD88Ig==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      '@rsbuild/shared': 0.1.0
-      '@rspack/core': 0.4.0
-      core-js: 3.32.2
-      html-webpack-plugin: /html-rspack-plugin@5.5.7
-      postcss: 8.4.31
-      semver: 7.5.4
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
 
   /@rsbuild/core@0.1.9:
     resolution: {integrity: sha512-UsMUeBQqIOulHyLCaVQew0WtHSL+/S5zSMU9+Iby/t5szEsWytRDjwekcZDxKhhut21Kyktr5d1RofTvY19ttg==}
@@ -15163,15 +15198,39 @@ packages:
       postcss: 8.4.31
     dev: true
 
-  /@rsbuild/monorepo-utils@0.0.7:
-    resolution: {integrity: sha512-Sm/QdCm3QfvzylyxKBy+u7N6OWpuhtEFJRy9btXkiI6W/jSRAzfLpT4akrtx+o3cGP98jeR2frwxwHUbHIe8NQ==}
+  /@rsbuild/core@0.2.2:
+    resolution: {integrity: sha512-ioD1SVb5DJacIgH2riodxf6SbRBKPLZ+7Kf/M0tlH9Yc+i1/6ULPiLZ4OxBBUNHWKg1F8mt2VhOPTVlOlGab/A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
     dependencies:
-      '@rsbuild/shared': 0.0.7
+      '@rsbuild/shared': 0.2.2
+      '@rspack/core': 0.4.2
+      core-js: 3.32.2
+      html-webpack-plugin: /html-rspack-plugin@5.5.7
+      postcss: 8.4.31
+    dev: true
+
+  /@rsbuild/monorepo-utils@0.2.2:
+    resolution: {integrity: sha512-0/fUpKGFvdJ/6trwNwvtH/XVrclWDlOiVPjFUVN8aNbDVJE3/T3m1FhI4zxxvxLNHiMqK17T/Mc2emYH+OZ9cQ==}
+    dependencies:
+      '@rsbuild/shared': 0.2.2
       '@types/js-yaml': 4.0.6
       fast-glob: 3.3.1
       js-yaml: 4.1.0
       json5: 2.2.3
       p-map: 4.0.0
+    dev: false
+
+  /@rsbuild/plugin-babel@0.2.2:
+    resolution: {integrity: sha512-g7UzCm9QBD8fINO6xTbF4A1MMfVCemvFICaCmvFhOXnUAImmi3J+ByymrAoB1ynWQa++vgvqb0oaDnqvn3Gr+w==}
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/preset-typescript': 7.23.2(@babel/core@7.23.2)
+      '@rsbuild/shared': 0.2.2
+      '@types/babel__core': 7.20.3
+      upath: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@rsbuild/plugin-react@0.1.9:
@@ -15195,25 +15254,6 @@ packages:
       - webpack
     dev: true
 
-  /@rsbuild/shared@0.0.7:
-    resolution: {integrity: sha512-r5vmIpYPM2FCcxXvjskQ7JIIRA+jY0cUplyW3/R/eL/6p/3NIKhFQEc/UBgx8FmZxNd1eRb1/Xh325vgaLHDvA==}
-    dependencies:
-      '@types/fs-extra': 11.0.2
-      chalk: 4.1.2
-      deepmerge: 4.3.1
-      fs-extra: 11.1.1
-    dev: false
-
-  /@rsbuild/shared@0.1.0:
-    resolution: {integrity: sha512-1jzMYMfh7iEIF8BC+bWXNihNWV07oCDvzR5jv1YOkdJ+SSD5S/oYoTmdttBjTkeMLRT6OTJAOshISTNOH5rc6g==}
-    dependencies:
-      '@rspack/core': 0.4.0
-      caniuse-lite: 1.0.30001559
-      line-diff: 2.1.1
-      lodash: 4.17.21
-      postcss: 8.4.31
-    dev: true
-
   /@rsbuild/shared@0.1.9:
     resolution: {integrity: sha512-u2RAfuNRMIt+7KnCgikjIzl64nS3Ce3HI1EB3ALPkPdtV8ZvORID8RqdYzIJSfv4/cHD8rGeR6oXIFsAOc84OA==}
     dependencies:
@@ -15224,13 +15264,13 @@ packages:
       postcss: 8.4.31
     dev: true
 
-  /@rspack/binding-darwin-arm64@0.4.0:
-    resolution: {integrity: sha512-iQ6ERHXzY58zgHIZZAC7L7hrosO7BZXH3RpOTTibiZdTVex4Bq10CVmy6q6m88iQuqAQS2BHOXzAYLJtZlZRRw==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
+  /@rsbuild/shared@0.2.2:
+    resolution: {integrity: sha512-Vom6tkImWSVdycXOaju6niU8Hh2/QwJTYutzLv7cIXFaWnmia1kZ3FRJ1EEmVhTTv5M4f/R0Pf67b8ek60ylNg==}
+    dependencies:
+      '@rspack/core': 0.4.2
+      caniuse-lite: 1.0.30001566
+      lodash: 4.17.21
+      postcss: 8.4.31
 
   /@rspack/binding-darwin-arm64@0.4.1:
     resolution: {integrity: sha512-oGosukPLEycihtFq+sfx4NOCYJW6+LBbdwlj9hNW8s7mqSshkKBTEkzGgEA+tsyQODOD13Qvg9R4dhUkXnMFJg==}
@@ -15238,6 +15278,13 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-darwin-arm64@0.4.2:
+    resolution: {integrity: sha512-DLchrjW1tTTFjtysgqKo6O+RBr4nq7wT4C+wHYqMqByPfQ6m0WtuSORFRDBHBEWt5RQvcjt+mSDO76imiBzSyg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-darwin-arm64@0.4.3:
@@ -15248,20 +15295,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-darwin-x64@0.4.0:
-    resolution: {integrity: sha512-LRCiMPCbAIwwo0euqao7+8peUXj+qPDSi0nSK2y6wjaXfUVi8FwpWQ+O+B3RH3rpyFBU63IqatC8razalt8JgQ==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-darwin-x64@0.4.1:
     resolution: {integrity: sha512-k7PbuNXxeqTL+5JONH+5PWk0iwiztT3zXej12qgy2joddWXpxkZJPjTxy8sNFV2tMQ7T0UqbWZaB3ZUFvPu5IA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-darwin-x64@0.4.2:
+    resolution: {integrity: sha512-NpGwHYcHxMwkdnn+g3LKCIcbogYrxvI3lHZZuZdbBf9tIOzYBgSq6RRmfIHIl/WQ9UVcnwjpb1zxUganmwhi7Q==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-darwin-x64@0.4.3:
@@ -15272,20 +15318,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-linux-arm64-gnu@0.4.0:
-    resolution: {integrity: sha512-trfEUQ7awu6dLWUlIXmSJmwW48lSxEl7kW4FUas/UMNH3/B/wim8TPx6ZuDrCzVhYk5HP7ccjbQg7mnbJ+E48w==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-linux-arm64-gnu@0.4.1:
     resolution: {integrity: sha512-dunS6sTH14cbDIbt4gs7Bd/tHLS/D87dhgEu9GUH+oVR8niSzXKyhJayOOefxr7L1/tSUtEVGJAbYFXgz5LvNg==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-linux-arm64-gnu@0.4.2:
+    resolution: {integrity: sha512-m8kaD2EfdNHoHWZrnhYRvq/AP2K9ztrfeYLUC9qF8lDJW0cnI/easUigr0sfoPqml7iVVwsepKOQmjsDMvKT3A==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-linux-arm64-gnu@0.4.3:
@@ -15296,20 +15341,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-linux-arm64-musl@0.4.0:
-    resolution: {integrity: sha512-ubIcXmRopSJ6n+F/cRXDfGSgK847OX0CPeSSL4tiJ4dah5lz8iISZ9GLrNHJQ+SvphOH8F9lDpp8h2iwVt0Pbw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-linux-arm64-musl@0.4.1:
     resolution: {integrity: sha512-d/iUGx/uLy6eJ5OpFWH+ALcdgMiTgktq0UNbPN69lKkDctvfGCyi5tPHwbIh1g6WrpbROq7EPldNAxYAIAH8aw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-linux-arm64-musl@0.4.2:
+    resolution: {integrity: sha512-k5JhGPYjeZYDV819eNVrA1ajr/q+dBOb1mAwzuzgDJn38sMPLjj589XjlopuzY+JrpsQtP0p2iC/Yi+HPyYRmw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-linux-arm64-musl@0.4.3:
@@ -15320,20 +15364,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-linux-x64-gnu@0.4.0:
-    resolution: {integrity: sha512-Q3mqjgV2k68F8VuzZwaqhHggBhcSlD0N+vvtFP8BxXIX4Pdkmk2shwwVjniZmY+oKB16dbSmXxShdMlCE3CCng==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-linux-x64-gnu@0.4.1:
     resolution: {integrity: sha512-bDLwt2D5dSQlJPfbzdtANvaZfaQrRAU/g6wmFF12RX2rZjPTipihMi5gywdGaDzAfCryRy8JE2CLqECI5sxKNw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-linux-x64-gnu@0.4.2:
+    resolution: {integrity: sha512-Su5AgvdSg4QNHeem3mFNY9VlaRKyK+sHjK+/RefP/l3sCRKUcGDLXcf8wUBy8//Mt/yJ88Z6jzB38vpFlnwsCA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-linux-x64-gnu@0.4.3:
@@ -15344,20 +15387,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-linux-x64-musl@0.4.0:
-    resolution: {integrity: sha512-5l6Q00yZDIeT8T1ruxEfF1Wj3m3SqnSHrPFiUqYydmgmNll1iCCRC2AmGVsmAACDQ7rg9z8BhhHtKukNBvmwTQ==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-linux-x64-musl@0.4.1:
     resolution: {integrity: sha512-lROn0GNzSjVBjILfeaoy5fLhVvjaY6bHGXit6EecDsd3BsruvlOVMaru+gU5otZO/o4ndTqFcA6xwCmXNn6Atg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-linux-x64-musl@0.4.2:
+    resolution: {integrity: sha512-1xEBR719aSxpgARpnhSOpyFYOEqLCdfdz+KaeMt5NCl4FJ0p/Ob6h27GRcWdK91MQgCV2/4az6THiN5YKGTM7A==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-linux-x64-musl@0.4.3:
@@ -15368,20 +15410,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-win32-arm64-msvc@0.4.0:
-    resolution: {integrity: sha512-k96/PSkVT/VEvqHygenzgr8Z7n4SuCSKONVFB5zazWDPaJwCqaqANQuvX0PbuazVy6PbiLE/YI0+4TDjL7dHCw==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-win32-arm64-msvc@0.4.1:
     resolution: {integrity: sha512-PKIQDu4vRADPqQtnkiJwqDmgT5kuRj8oJgx6tb6D8kR+SFq2Y26zadNPu/LulfUTgQmxJSyQEvz4su3Gp1tAsQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-win32-arm64-msvc@0.4.2:
+    resolution: {integrity: sha512-7iKlOtp2AQjPEA81tSxf9rKu1gE7b+rkMiJnnlzqfDjUvUk4zD71F6BdY9jXXiPjCTUfL5Oym8f1OMkjZsrjDA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-win32-arm64-msvc@0.4.3:
@@ -15392,20 +15433,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-win32-ia32-msvc@0.4.0:
-    resolution: {integrity: sha512-DmC7MumePZuss1AigT4FaIbFPZFtZXdcWBhD7dF88CvsvQRVtOcMujtByWkkNJ6ZDp+IUHyXOtPQWr1iRjDOCQ==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-win32-ia32-msvc@0.4.1:
     resolution: {integrity: sha512-RqcW+kedZoNlWXUdZiyuxHEQKerDx6zGjoCg5GSMZpCxFZsNMwq65Ok5WCH8WI+hzFXzphq06FgjpB5Y8K3zsQ==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-win32-ia32-msvc@0.4.2:
+    resolution: {integrity: sha512-XXy3/I/TqpLTrHPqrfWkqzZC53gGqJ6BHuPkCRJQFVgJI9zdBADqumj7A2s7VuH411zZQrCQVa/YBWxXWlScxA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-win32-ia32-msvc@0.4.3:
@@ -15416,20 +15456,19 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-win32-x64-msvc@0.4.0:
-    resolution: {integrity: sha512-F3pAxz1GakFkyq8S+iPTqVkvIFnHG9te36wLW+tIzY4oC0vNPsEVunBp6NrYHzTaOf3aBZ+bvsLZyfvg+pKxqA==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-win32-x64-msvc@0.4.1:
     resolution: {integrity: sha512-eNvamV92pt0lP9o43HdtpiD7Oo7lHeQqwNnaKAetN4BHVSPLtOjkHFS/aM1SKMtxCayEdzXYU7UZGPQvmdcXqQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@rspack/binding-win32-x64-msvc@0.4.2:
+    resolution: {integrity: sha512-OIMbPhhlGxwr6j4hQ7zeQAGMu217ZeV+/2PY+yQddgHUv/eFwH9MFhBZQc+k5Ad8+hurdyrLwOHGqjvo00ri/Q==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-win32-x64-msvc@0.4.3:
@@ -15439,20 +15478,6 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
-
-  /@rspack/binding@0.4.0:
-    resolution: {integrity: sha512-SpjaySPGmyRnRHrQItl9W9NGE2WoHsUPnererZaLK+pfVgO92q9uoEoKl3EBNNI9uttG132SCz4cx1zXwN394w==}
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.4.0
-      '@rspack/binding-darwin-x64': 0.4.0
-      '@rspack/binding-linux-arm64-gnu': 0.4.0
-      '@rspack/binding-linux-arm64-musl': 0.4.0
-      '@rspack/binding-linux-x64-gnu': 0.4.0
-      '@rspack/binding-linux-x64-musl': 0.4.0
-      '@rspack/binding-win32-arm64-msvc': 0.4.0
-      '@rspack/binding-win32-ia32-msvc': 0.4.0
-      '@rspack/binding-win32-x64-msvc': 0.4.0
-    dev: true
 
   /@rspack/binding@0.4.1:
     resolution: {integrity: sha512-tPETZWbP9VYzmdCIKmaxWWx0z2c//acd5eV2kgKOSWt29MH2wo+EFySfvWKWVCTwjBkuVrqaULUxcIJB3vUCTg==}
@@ -15468,6 +15493,19 @@ packages:
       '@rspack/binding-win32-x64-msvc': 0.4.1
     dev: true
 
+  /@rspack/binding@0.4.2:
+    resolution: {integrity: sha512-2Rb4cmDxHOqAoExiB7RZGyMUp17kDUkcHoPIi3W803mclqwHU9XpLdIMggy0J2Ig2Kp8TCF0tpoUSu2UhgXQgA==}
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 0.4.2
+      '@rspack/binding-darwin-x64': 0.4.2
+      '@rspack/binding-linux-arm64-gnu': 0.4.2
+      '@rspack/binding-linux-arm64-musl': 0.4.2
+      '@rspack/binding-linux-x64-gnu': 0.4.2
+      '@rspack/binding-linux-x64-musl': 0.4.2
+      '@rspack/binding-win32-arm64-msvc': 0.4.2
+      '@rspack/binding-win32-ia32-msvc': 0.4.2
+      '@rspack/binding-win32-x64-msvc': 0.4.2
+
   /@rspack/binding@0.4.3:
     resolution: {integrity: sha512-cw7Sca7YL9FeSTWdYahxr6HgWXnboOgPiM5SJai2Nfj6c/PWJV+ntBZbIW0LRY1fFDL7dYz3GUCXj4Dv3QYc8A==}
     optionalDependencies:
@@ -15481,28 +15519,6 @@ packages:
       '@rspack/binding-win32-ia32-msvc': 0.4.3
       '@rspack/binding-win32-x64-msvc': 0.4.3
     dev: false
-
-  /@rspack/core@0.4.0:
-    resolution: {integrity: sha512-GY8lsCGRzj1mj5q1Ss5kjazpSisT/HJdXpIU730pG4Os6mE2sGYVUJ0ncYRv/DEBcL1c2dVr5vtMKTHlNYRlfg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@rspack/binding': 0.4.0
-      '@swc/helpers': 0.5.1
-      browserslist: 4.22.1
-      compare-versions: 6.0.0-rc.1
-      enhanced-resolve: 5.12.0
-      fast-querystring: 1.1.2
-      graceful-fs: 4.2.10
-      json-parse-even-better-errors: 3.0.0
-      neo-async: 2.6.2
-      react-refresh: 0.14.0
-      tapable: 2.2.1
-      terminal-link: 2.1.1
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-      zod: 3.22.3
-      zod-validation-error: 1.2.0(zod@3.22.3)
-    dev: true
 
   /@rspack/core@0.4.1:
     resolution: {integrity: sha512-g502i0fHMj0lCr1Y/Bh5iwsEGB1BTiN+H06Oc39qEgs4bwQqnkGg/iQSBoR7q1886lAK8yIIDQeyCxF/6qI7EA==}
@@ -15525,6 +15541,27 @@ packages:
       zod: 3.22.3
       zod-validation-error: 1.3.1(zod@3.22.3)
     dev: true
+
+  /@rspack/core@0.4.2:
+    resolution: {integrity: sha512-D5gKawtOMnzp0JIk62t09WrgqU1TR1X44km8mWZqGs5EunQVCvE5wW785cGOXgfuV8yxFXUKEqdHPg5Cp9fvEg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@rspack/binding': 0.4.2
+      '@swc/helpers': 0.5.1
+      browserslist: 4.22.2
+      compare-versions: 6.0.0-rc.1
+      enhanced-resolve: 5.12.0
+      fast-querystring: 1.1.2
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 3.0.0
+      neo-async: 2.6.2
+      react-refresh: 0.14.0
+      tapable: 2.2.1
+      terminal-link: 2.1.1
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+      zod: 3.22.3
+      zod-validation-error: 1.3.1(zod@3.22.3)
 
   /@rspack/core@0.4.3:
     resolution: {integrity: sha512-YKzOOt6v6vZZH15+HdwWbd7DdXdXIJLlYQdQ6jgrAK7/X+5qg99MUgsfra3k+MXXX0vWROOy8mM6/dBaaDb7tg==}
@@ -17102,13 +17139,6 @@ packages:
     resolution: {integrity: sha512-eGPzuyc6wZM3sSHJdF7NM2jW6B/xsB014Rqg/iDa6xY02mlfy1w/TE2sYhR8vbHxkzJOXiGo6NuIk3xk35vsgQ==}
     dev: true
 
-  /@types/fs-extra@11.0.2:
-    resolution: {integrity: sha512-c0hrgAOVYr21EX8J0jBMXGLMgJqVf/v6yxi0dLaJboW9aQPh16Id+z6w2Tx1hm+piJOLv8xPfVKZCLfjPw/IMQ==}
-    dependencies:
-      '@types/jsonfile': 6.1.2
-      '@types/node': 18.11.17
-    dev: false
-
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
@@ -17240,12 +17270,6 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  /@types/jsonfile@6.1.2:
-    resolution: {integrity: sha512-8t92P+oeW4d/CRQfJaSqEwXujrhH4OEeHRjGU3v1Q8mUS8GPF3yiX26sw4svv6faL2HfBtGTe2xWIoVgN3dy9w==}
-    dependencies:
-      '@types/node': 18.11.17
-    dev: false
 
   /@types/keygrip@1.0.2:
     resolution: {integrity: sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==}
@@ -19449,6 +19473,7 @@ packages:
       electron-to-chromium: 1.4.572
       node-releases: 2.0.13
       update-browserslist-db: 1.0.13(browserslist@4.22.1)
+    dev: false
 
   /browserslist@4.22.2:
     resolution: {integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==}
@@ -33486,6 +33511,7 @@ packages:
       browserslist: 4.22.1
       escalade: 3.1.1
       picocolors: 1.0.0
+    dev: false
 
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
@@ -34923,6 +34949,7 @@ packages:
       zod: ^3.18.0
     dependencies:
       zod: 3.22.3
+    dev: false
 
   /zod-validation-error@1.3.1(zod@3.22.3):
     resolution: {integrity: sha512-cNEXpla+tREtNdAnNKY4xKY1SGOn2yzyuZMu4O0RQylX9apRpUjNcPkEc3uHIAr5Ct7LenjZt6RzjEH6+JsqVQ==}


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/rsbuild/releases/tag/v0.2.3

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
