### PR TITLE
chore(server): remove useless server plugin hooks

### DIFF
--- a/.changeset/weak-pumas-guess.md
+++ b/.changeset/weak-pumas-guess.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/server': patch
+'@modern-js/server-core': patch
+---
+
+chore(server): remove useless server plugin hooks (beforeDevServer & afterDevServer)
+
+chore(server): 移除无用的 server 插件钩子 (beforeDevServer 和 afterDevServer)

--- a/packages/server/core/src/plugin.ts
+++ b/packages/server/core/src/plugin.ts
@@ -91,11 +91,7 @@ const beforeServerInit = createAsyncWaterfall<ServerInitHookContext>();
 
 const afterServerInit = createAsyncWaterfall<ServerInitHookContext>();
 
-const beforeDevServer = createParallelWorkflow<ServerOptions, any>();
-
 const setupCompiler = createParallelWorkflow<Record<string, unknown>, any[]>();
-
-const afterDevServer = createParallelWorkflow<ServerOptions, any>();
 
 // TODO FIXME
 export type Route = Record<string, unknown>;
@@ -198,9 +194,7 @@ const serverHooks = {
   onApiChange,
   beforeServerInit,
   afterServerInit,
-  beforeDevServer,
   setupCompiler,
-  afterDevServer,
   beforeRouteSet,
   afterRouteSet,
   beforeProdServer,

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -117,13 +117,13 @@ export class ModernDevServer extends ModernServer {
     const { befores, afters } = this.applySetupMiddlewares();
 
     // before dev handler
-    const beforeHandlers = await this.setupBeforeDevMiddleware();
+    const beforeHandlers = this.dev.before || [];
     this.addMiddlewareHandler([...beforeHandlers, ...befores]);
 
     await this.applyDefaultMiddlewares(app);
 
     // after dev handler
-    const afterHandlers = await this.setupAfterDevMiddleware();
+    const afterHandlers = this.dev.after || [];
 
     this.addMiddlewareHandler([...afters, ...afterHandlers]);
 
@@ -380,24 +380,6 @@ export class ModernDevServer extends ModernServer {
     return async (context: ModernServerContext, next: NextFunction) => {
       return next();
     };
-  }
-
-  private async setupBeforeDevMiddleware() {
-    const { runner, conf, dev } = this;
-
-    const setupMids = dev.before || [];
-    const pluginMids = await runner.beforeDevServer(conf);
-
-    return [...setupMids, ...pluginMids].flat();
-  }
-
-  private async setupAfterDevMiddleware() {
-    const { runner, conf, dev } = this;
-
-    const setupMids = dev.after || [];
-    const pluginMids = await runner.afterDevServer(conf);
-
-    return [...pluginMids, ...setupMids].flat();
   }
 
   private cleanSSRCache() {


### PR DESCRIPTION
## Summary

these two hooks are not used. so we can remove them, and developer won't need to use them later.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
