### PR TITLE
feat(module-tools): support svgr with url-loader

### DIFF
--- a/.changeset/three-windows-move.md
+++ b/.changeset/three-windows-move.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+feat(module-tools): support svgr with url-loader
+feat(module-tools): 支持 svgr 与 url-loader 一起使用

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -161,7 +161,7 @@ Set unmatched svg files
 
 ## asset.svgr.exportType
 
-use named exoprt in case
+Used to configure the SVG export type when using SVGR.
 
 - **Type**: `'named' | 'default'`
 - **Default**: `default`

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -132,13 +132,6 @@ import Logo from './logo.svg';
 export default () => <Logo />;
 ```
 
-:::warning
-The following usage is not currently supported:
-
-```js title="index.ts"
-import { ReactComponent } from './logo.svg';
-```
-
 :::
 
 When enabled, the type of svg used can be modified by adding a type definition to the `modern-app-env.d.ts` file:
@@ -165,6 +158,21 @@ Set unmatched svg files
 
 - **Type**: `string | RegExp | (string | RegExp)[]`
 - **Default**: `undefined`
+
+## asset.svgr.exportType
+
+use named exoprt in case
+
+- **Type**: `'named' | 'default'`
+- **Default**: `default`
+
+when it is 'named', use the following syntax:
+
+```js title="index.ts"
+import { ReactComponent } from './logo.svg';
+```
+
+The named export defaults to `ReactComponent`, and can be customized with the `asset.svgr.namedExport`.
 
 ## autoExtension
 
@@ -1335,10 +1343,7 @@ Used to modify the configuration of [Tailwind CSS](https://tailwindcss.com/docs/
 
 ```js title="modern.config.ts"
 const tailwind = {
-  content: [
-    './src/**/*.{js,jsx,ts,tsx}',
-    './config/html/**/*.{html,ejs,hbs}',
-  ],
+  content: ['./src/**/*.{js,jsx,ts,tsx}', './config/html/**/*.{html,ejs,hbs}'],
 };
 ```
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -159,18 +159,12 @@ declare module '*.svg' {
 
 ## asset.svgr.exportType
 
-使用 svgr 的导出形式
+用于配置使用 SVGR 时 SVG 的导出形式。
 
 - 类型： `'named' | 'default'`
 - 默认值： `default`
 
-当此设置为 'named' 时，使用以下语法导入组件：
-
-```js title="index.ts"
-import { ReactComponent } from './logo.svg';
-```
-
-named export 默认导出为 `ReactComponent`，这可以通过 `asset.svgr.namedExport` 自定义
+当此选项设置为 'named' 时，你可以使用以下语法导入组件：
 
 ## autoExtension
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -166,6 +166,12 @@ declare module '*.svg' {
 
 当此选项设置为 'named' 时，你可以使用以下语法导入组件：
 
+```js title="index.ts"
+import { ReactComponent } from './logo.svg';
+```
+
+命名导出默认为 `ReactComponent`，并可以通过 `asset.svgr.namedExport` 进行自定义。
+
 ## autoExtension
 
 根据 [format](#format) 和 [type](https://nodejs.org/api/packages.html#type) 自动添加产物里 js 文件和类型描述文件的后缀。

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -132,16 +132,6 @@ import Logo from './logo.svg';
 export default () => <Logo />;
 ```
 
-:::warning
-
-目前不支持下面的用法：
-
-```js title="index.ts"
-import { ReactComponent } from './logo.svg';
-```
-
-:::
-
 当开启功能后，可以通过在 `modern-app-env.d.ts` 文件中增加类型定义，修改使用 SVG 的类型：
 
 ```ts title="modern-app-env.d.ts"
@@ -166,6 +156,21 @@ declare module '*.svg' {
 
 - 类型： `string | RegExp | (string | RegExp)[]`
 - 默认值： `undefined`
+
+## asset.svgr.exportType
+
+使用 svgr 的导出形式
+
+- 类型： `'named' | 'default'`
+- 默认值： `default`
+
+当此设置为 'named' 时，使用以下语法导入组件：
+
+```js title="index.ts"
+import { ReactComponent } from './logo.svg';
+```
+
+named export 默认导出为 `ReactComponent`，这可以通过 `asset.svgr.namedExport` 自定义
 
 ## autoExtension
 
@@ -1336,10 +1341,7 @@ export default defineConfig({
 
 ```js title="modern.config.ts"
 const tailwind = {
-  content: [
-    './src/**/*.{js,jsx,ts,tsx}',
-    './config/html/**/*.{html,ejs,hbs}',
-  ],
+  content: ['./src/**/*.{js,jsx,ts,tsx}', './config/html/**/*.{html,ejs,hbs}'],
 };
 ```
 

--- a/packages/solutions/module-tools/src/builder/feature/asset.ts
+++ b/packages/solutions/module-tools/src/builder/feature/asset.ts
@@ -5,7 +5,7 @@ import { createFilter } from '@rollup/pluginutils';
 import { transform } from '@svgr/core';
 import svgo from '@svgr/plugin-svgo';
 import jsx from '@svgr/plugin-jsx';
-import { ICompiler, LoadResult, SvgrOptions } from '../../types';
+import { ICompiler } from '../../types';
 import { assetExt } from '../../constants/file';
 import { normalizeSlashes, getHash } from '../../utils';
 
@@ -17,12 +17,7 @@ export const asset = {
   apply(compiler: ICompiler) {
     compiler.hooks.load.tapPromise({ name }, async args => {
       if (assetExt.find(ext => ext === extname(args.path))) {
-        const { buildType, outDir, sourceDir, asset } = compiler.config;
-
-        const svgrResult = await loadSvgr(args.path, asset.svgr);
-        if (svgrResult) {
-          return svgrResult;
-        }
+        const { buildType, outDir, sourceDir } = compiler.config;
 
         const rebaseFrom =
           buildType === 'bundle'
@@ -79,7 +74,7 @@ export async function getAssetContents(
 ) {
   const fileContent = await fs.promises.readFile(assetPath);
   const { buildType, format, outDir } = this.config;
-  const { limit, path, publicPath } = this.config.asset;
+  const { limit, path, publicPath, svgr } = this.config.asset;
   const hash = getHash(fileContent, null).slice(0, 8);
 
   const outputFileName = basename(assetPath).split('.').join(`.${hash}.`);
@@ -92,11 +87,33 @@ export async function getAssetContents(
     typeof publicPath === 'function' ? publicPath(assetPath) : publicPath
   }${path}/${outputFileName}`;
 
+  // default url-loader
   let emitAsset = true;
   let contents: string | Buffer = normalizedPublicPath;
   let loader: Loader = 'text';
-  if (buildType === 'bundle') {
-    // inline base64
+
+  const config = typeof svgr === 'boolean' ? {} : svgr;
+  const filter = createFilter(config.include || SVG_REGEXP, config.exclude);
+  if (svgr && filter(assetPath)) {
+    // svgr jsx-loader
+
+    // HACK: only support publich path, the same as url-loader of webpack and rollup,
+    // in fact, url-loader is not applicable to library scenario except for umd.
+    const previousExport =
+      config.exportType === 'named'
+        ? `export default "${normalizedPublicPath}"`
+        : null;
+    contents = await transform(fileContent.toString(), config, {
+      filePath: assetPath,
+      caller: {
+        name: 'svgr',
+        defaultPlugins: [svgo, jsx],
+        previousExport,
+      },
+    });
+    loader = 'jsx';
+  } else if (buildType === 'bundle') {
+    // inline base64 text-loader
     if (fileContent.length <= limit) {
       const mimetype = (
         await import('@modern-js/utils/mime-types')
@@ -110,12 +127,16 @@ export async function getAssetContents(
       loader = 'text';
       emitAsset = false;
     } else if ((format === 'esm' || format === 'cjs') && !publicPath) {
+      // copy-loader
+      // in the library scenario, the copy loader takes precedence over the url loader,
+      // so we use relative path.
       contents = calledOnLoad ? fileContent : normalizedRelativePath;
       loader = calledOnLoad ? 'copy' : 'text';
       emitAsset = !calledOnLoad;
     }
   } else {
-    // bundleless
+    // bundleless, it will be called in redirect plugin,
+    // so we use relative path.
     contents = normalizedRelativePath;
   }
   if (emitAsset) {
@@ -128,35 +149,6 @@ export async function getAssetContents(
   }
   return {
     contents,
-    loader,
-  };
-}
-
-export async function loadSvgr(
-  path: string,
-  options: boolean | SvgrOptions,
-): Promise<LoadResult | undefined> {
-  if (!options) {
-    return;
-  }
-
-  const config = typeof options === 'boolean' ? {} : options;
-
-  const filter = createFilter(config.include || SVG_REGEXP, config.exclude);
-  if (!filter(path)) {
-    return;
-  }
-  const loader = 'jsx';
-  const text = fs.readFileSync(path, 'utf8');
-  const jsCode = await transform(text, config, {
-    filePath: path,
-    caller: {
-      name: 'svgr',
-      defaultPlugins: [svgo, jsx],
-    },
-  });
-  return {
-    contents: jsCode,
     loader,
   };
 }

--- a/packages/solutions/module-tools/src/builder/feature/asset.ts
+++ b/packages/solutions/module-tools/src/builder/feature/asset.ts
@@ -97,7 +97,7 @@ export async function getAssetContents(
   if (svgr && filter(assetPath)) {
     // svgr jsx-loader
 
-    // HACK: only support publich path, the same as url-loader of webpack and rollup,
+    // HACK: only support public path, the same as url-loader of webpack and rollup,
     // in fact, url-loader is not applicable to library scenario except for umd.
     const previousExport =
       config.exportType === 'named'

--- a/packages/solutions/module-tools/src/builder/feature/asset.ts
+++ b/packages/solutions/module-tools/src/builder/feature/asset.ts
@@ -112,6 +112,8 @@ export async function getAssetContents(
       },
     });
     loader = 'jsx';
+    // if use url-loader, should copy asset by user, not emit in dist, or copy public dir like webpack.
+    emitAsset = false;
   } else if (buildType === 'bundle') {
     // inline base64 text-loader
     if (fileContent.length <= limit) {

--- a/packages/solutions/module-tools/src/builder/feature/redirect.ts
+++ b/packages/solutions/module-tools/src/builder/feature/redirect.ts
@@ -29,7 +29,7 @@ import {
   getDefaultOutExtension,
   isTsExt,
 } from '../../utils';
-import { getAssetContents, loadSvgr } from './asset';
+import { getAssetContents } from './asset';
 import { isCssModule } from './style/postcssTransformer';
 
 type MatchModule = {
@@ -59,7 +59,7 @@ async function redirectImport(
       let { name } = module;
       const ext = extname(name);
 
-      const { redirect, asset } = compiler.config;
+      const { redirect } = compiler.config;
       const { alias, style } = redirect;
 
       if (alias) {
@@ -155,16 +155,15 @@ async function redirectImport(
         if (assetExt.filter(ext => name.endsWith(ext)).length) {
           // asset
           const absPath = resolve(dirname(filePath), name);
-          const svgrResult = await loadSvgr(absPath, asset.svgr);
-          if (svgrResult) {
+          const { contents: relativeImportPath, loader } =
+            await getAssetContents.apply(compiler, [absPath, outputDir]);
+          if (loader === 'jsx') {
             // svgr
             const ext = extname(name);
             const outputName = `${name.slice(0, -ext.length)}.js`;
             str.overwrite(start, end, outputName);
           } else {
             // other assets
-            const { contents: relativeImportPath } =
-              await getAssetContents.apply(compiler, [absPath, outputDir]);
             str.overwrite(start, end, `${relativeImportPath}`);
           }
         }

--- a/tests/integration/module/fixtures/build/asset/svgr/bundle.config.ts
+++ b/tests/integration/module/fixtures/build/asset/svgr/bundle.config.ts
@@ -1,14 +1,29 @@
 import { defineConfig } from '@modern-js/module-tools/defineConfig';
 
 export default defineConfig({
-  buildConfig: {
-    target: 'es2021',
-    buildType: 'bundle',
-    outDir: './dist/bundle',
-    externals: [/^react\/?/],
-    format: 'esm',
-    asset: {
-      svgr: true,
+  buildConfig: [
+    {
+      target: 'es2021',
+      buildType: 'bundle',
+      outDir: './dist/bundle',
+      externals: [/^react\/?/],
+      format: 'esm',
+      asset: {
+        svgr: true,
+      },
     },
-  },
+    {
+      input: ['src/namedExport.js'],
+      target: 'es2021',
+      buildType: 'bundle',
+      outDir: './dist/namedExport',
+      externals: [/^react\/?/],
+      format: 'esm',
+      asset: {
+        svgr: {
+          exportType: 'named',
+        },
+      },
+    },
+  ],
 });

--- a/tests/integration/module/fixtures/build/asset/svgr/bundleless.config.ts
+++ b/tests/integration/module/fixtures/build/asset/svgr/bundleless.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@modern-js/module-tools/defineConfig';
 
 export default defineConfig({
   buildConfig: {
+    input: ['src/index.js', 'src/logo.svg'],
     target: 'es2021',
     buildType: 'bundleless',
     outDir: './dist/bundleless',

--- a/tests/integration/module/fixtures/build/asset/svgr/src/namedExport.js
+++ b/tests/integration/module/fixtures/build/asset/svgr/src/namedExport.js
@@ -1,0 +1,3 @@
+import logo, { ReactComponent } from './logo.svg';
+
+console.log(ReactComponent, logo);


### PR DESCRIPTION
## Summary
Move loadSvgr to getAssetContents, and support svgr with url-loader

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
