### PR TITLE
fix(uni-builder): fix some cases and update e2e test cases

### DIFF
--- a/packages/builder/uni-builder/src/index.ts
+++ b/packages/builder/uni-builder/src/index.ts
@@ -2,6 +2,8 @@ import { createRspackBuilder } from './rspack';
 import { createWebpackBuilder } from './webpack';
 import type { CreateUniBuilderOptions } from './types';
 
+export type { BuilderConfig } from './types';
+
 export async function createUniBuilder(options: CreateUniBuilderOptions) {
   return options.bundlerType === 'rspack'
     ? createRspackBuilder(options)

--- a/packages/builder/uni-builder/src/index.ts
+++ b/packages/builder/uni-builder/src/index.ts
@@ -2,10 +2,13 @@ import { createRspackBuilder } from './rspack';
 import { createWebpackBuilder } from './webpack';
 import type { CreateUniBuilderOptions } from './types';
 
-export type { BuilderConfig } from './types';
-
 export async function createUniBuilder(options: CreateUniBuilderOptions) {
   return options.bundlerType === 'rspack'
     ? createRspackBuilder(options)
     : createWebpackBuilder(options);
 }
+
+export type { BundlerChain } from '@rsbuild/shared';
+export type { BuilderConfig } from './types';
+
+export { RUNTIME_CHUNK_NAME } from './shared/constants';

--- a/packages/builder/uni-builder/src/rspack/defaults.ts
+++ b/packages/builder/uni-builder/src/rspack/defaults.ts
@@ -7,8 +7,8 @@ import {
   getDefaultSecurityConfig,
   getDefaultPerformanceConfig,
   getDefaultExperimentsConfig,
-  mergeUniBuilderConfig,
 } from '../shared/defaults';
+import { mergeRsbuildConfig } from '@rsbuild/core';
 import type { UniBuilderRspackConfig } from '../types';
 
 export const createDefaultConfig = (): UniBuilderRspackConfig => ({
@@ -23,4 +23,4 @@ export const createDefaultConfig = (): UniBuilderRspackConfig => ({
 });
 
 export const withDefaultConfig = (config: UniBuilderRspackConfig) =>
-  mergeUniBuilderConfig<UniBuilderRspackConfig>(createDefaultConfig(), config);
+  mergeRsbuildConfig<UniBuilderRspackConfig>(createDefaultConfig(), config);

--- a/packages/builder/uni-builder/src/rspack/defaults.ts
+++ b/packages/builder/uni-builder/src/rspack/defaults.ts
@@ -7,8 +7,8 @@ import {
   getDefaultSecurityConfig,
   getDefaultPerformanceConfig,
   getDefaultExperimentsConfig,
+  mergeUniBuilderConfig,
 } from '../shared/defaults';
-import { mergeRsbuildConfig } from '@rsbuild/core';
 import type { UniBuilderRspackConfig } from '../types';
 
 export const createDefaultConfig = (): UniBuilderRspackConfig => ({
@@ -23,4 +23,4 @@ export const createDefaultConfig = (): UniBuilderRspackConfig => ({
 });
 
 export const withDefaultConfig = (config: UniBuilderRspackConfig) =>
-  mergeRsbuildConfig<UniBuilderRspackConfig>(createDefaultConfig(), config);
+  mergeUniBuilderConfig<UniBuilderRspackConfig>(createDefaultConfig(), config);

--- a/packages/builder/uni-builder/src/rspack/index.ts
+++ b/packages/builder/uni-builder/src/rspack/index.ts
@@ -8,6 +8,7 @@ import type { RsbuildProvider } from '@rsbuild/shared';
 import type {
   UniBuilderRspackConfig,
   CreateRspackBuilderOptions,
+  CreateBuilderCommonOptions,
 } from '../types';
 import { parseCommonConfig } from '../shared/parseCommonConfig';
 import { pluginStyledComponents } from '@rsbuild/plugin-styled-components';
@@ -15,16 +16,14 @@ import { withDefaultConfig } from './defaults';
 
 export async function parseConfig(
   uniBuilderConfig: UniBuilderRspackConfig,
-  cwd: string,
-  frameworkConfigPath?: string,
+  options: CreateBuilderCommonOptions,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 }> {
   const { rsbuildConfig, rsbuildPlugins } = await parseCommonConfig<'rspack'>(
     uniBuilderConfig,
-    cwd,
-    frameworkConfigPath,
+    options,
   );
 
   if (uniBuilderConfig.output?.enableAssetManifest) {
@@ -54,12 +53,14 @@ export async function parseConfig(
 export async function createRspackBuilder(
   options: CreateRspackBuilderOptions,
 ): Promise<RsbuildInstance<RsbuildProvider>> {
-  const { cwd = process.cwd() } = options;
+  const { cwd = process.cwd(), config, ...rest } = options;
 
   const { rsbuildConfig, rsbuildPlugins } = await parseConfig(
     withDefaultConfig(options.config),
-    cwd,
-    options.frameworkConfigPath,
+    {
+      ...rest,
+      cwd,
+    },
   );
   const rsbuild = await createRsbuild({
     cwd,

--- a/packages/builder/uni-builder/src/shared/constants.ts
+++ b/packages/builder/uni-builder/src/shared/constants.ts
@@ -1,1 +1,1 @@
-export const RUNTIME_CHUNK_NAME = 'bundler-runtime';
+export const RUNTIME_CHUNK_NAME = 'builder-runtime';

--- a/packages/builder/uni-builder/src/shared/defaults.ts
+++ b/packages/builder/uni-builder/src/shared/defaults.ts
@@ -32,6 +32,7 @@ export const getDefaultHtmlConfig = (): UniBuilderRspackConfig['html'] => ({
   crossorigin: rsbuildDefaultHtmlConfig.crossorigin,
   scriptLoading: rsbuildDefaultHtmlConfig.scriptLoading,
   disableHtmlFolder: false,
+  title: '',
 });
 
 export const getDefaultSecurityConfig = () => ({

--- a/packages/builder/uni-builder/src/shared/defaults.ts
+++ b/packages/builder/uni-builder/src/shared/defaults.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { UniBuilderRspackConfig } from '../types';
 import {
   getDefaultOutputConfig as getRsbuildDefaultOutputConfig,
@@ -9,10 +7,6 @@ import {
   getDefaultSecurityConfig as getRsbuildDefaultSecurityConfig,
   getDefaultDevConfig as getRsbuildDefaultDevConfig,
   getDefaultServerConfig as getRsbuildDefaultServerConfig,
-  castArray,
-  isFunction,
-  isUndefined,
-  isOverriddenConfigKey as isRsbuildOverriddenConfigKey,
 } from '@rsbuild/shared';
 
 const rsbuildDefaultServerConfig = getRsbuildDefaultServerConfig();
@@ -75,40 +69,7 @@ export const getDefaultOutputConfig = (): UniBuilderRspackConfig['output'] => ({
   enableAssetFallback: false,
   enableAssetManifest: false,
   enableLatestDecorators: false,
-  enableInlineScripts: false,
-  enableInlineStyles: false,
   cssModules: {
     exportLocalsConvention: 'camelCase',
   },
 });
-
-const isOverriddenConfigKey = (key: string) =>
-  ['enableInlineScripts', 'enableInlineStyles'].includes(key);
-
-export const mergeUniBuilderConfig = <T>(...configs: T[]): T =>
-  _.mergeWith(
-    {},
-    ...configs,
-    (target: unknown, source: unknown, key: string) => {
-      const pair = [target, source];
-      if (pair.some(isUndefined)) {
-        // fallback to lodash default merge behavior
-        return undefined;
-      }
-
-      // Some keys should use source to override target
-      if (isRsbuildOverriddenConfigKey(key) || isOverriddenConfigKey(key)) {
-        return source ?? target;
-      }
-
-      if (pair.some(Array.isArray)) {
-        return [...castArray(target), ...castArray(source)];
-      }
-      // convert function to chained function
-      if (pair.some(isFunction)) {
-        return [target, source];
-      }
-      // fallback to lodash default merge behavior
-      return undefined;
-    },
-  );

--- a/packages/builder/uni-builder/src/shared/defaults.ts
+++ b/packages/builder/uni-builder/src/shared/defaults.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import { UniBuilderRspackConfig } from '../types';
 import {
   getDefaultOutputConfig as getRsbuildDefaultOutputConfig,
@@ -7,6 +9,10 @@ import {
   getDefaultSecurityConfig as getRsbuildDefaultSecurityConfig,
   getDefaultDevConfig as getRsbuildDefaultDevConfig,
   getDefaultServerConfig as getRsbuildDefaultServerConfig,
+  castArray,
+  isFunction,
+  isUndefined,
+  isOverriddenConfigKey as isRsbuildOverriddenConfigKey,
 } from '@rsbuild/shared';
 
 const rsbuildDefaultServerConfig = getRsbuildDefaultServerConfig();
@@ -75,3 +81,34 @@ export const getDefaultOutputConfig = (): UniBuilderRspackConfig['output'] => ({
     exportLocalsConvention: 'camelCase',
   },
 });
+
+const isOverriddenConfigKey = (key: string) =>
+  ['enableInlineScripts', 'enableInlineStyles'].includes(key);
+
+export const mergeUniBuilderConfig = <T>(...configs: T[]): T =>
+  _.mergeWith(
+    {},
+    ...configs,
+    (target: unknown, source: unknown, key: string) => {
+      const pair = [target, source];
+      if (pair.some(isUndefined)) {
+        // fallback to lodash default merge behavior
+        return undefined;
+      }
+
+      // Some keys should use source to override target
+      if (isRsbuildOverriddenConfigKey(key) || isOverriddenConfigKey(key)) {
+        return source ?? target;
+      }
+
+      if (pair.some(Array.isArray)) {
+        return [...castArray(target), ...castArray(source)];
+      }
+      // convert function to chained function
+      if (pair.some(isFunction)) {
+        return [target, source];
+      }
+      // fallback to lodash default merge behavior
+      return undefined;
+    },
+  );

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+/* eslint-disable complexity */
 import {
   deepmerge,
   NODE_MODULES_REGEX,
@@ -344,9 +346,9 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
     );
   }
 
-  if (!uniBuilderConfig.output?.disableInlineRuntimeChunk) {
-    rsbuildPlugins.push(pluginRuntimeChunk());
-  }
+  rsbuildPlugins.push(
+    pluginRuntimeChunk(uniBuilderConfig.output?.disableInlineRuntimeChunk),
+  );
 
   if (uniBuilderConfig.experiments?.sourceBuild) {
     const { pluginSourceBuild } = await import('@rsbuild/plugin-source-build');

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -19,6 +19,7 @@ import type {
   UniBuilderRspackConfig,
   UniBuilderWebpackConfig,
   DevServerHttpsOptions,
+  CreateBuilderCommonOptions,
 } from '../types';
 import { pluginRem } from '@rsbuild/plugin-rem';
 import { pluginPug } from '@rsbuild/plugin-pug';
@@ -132,12 +133,12 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   uniBuilderConfig: B extends 'rspack'
     ? UniBuilderRspackConfig
     : UniBuilderWebpackConfig,
-  cwd: string,
-  frameworkConfigPath?: string,
+  options: CreateBuilderCommonOptions,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 }> {
+  const { cwd, frameworkConfigPath, entry } = options;
   const rsbuildConfig = deepmerge({}, uniBuilderConfig);
   const { dev = {}, html = {}, output = {}, tools = {} } = rsbuildConfig;
 
@@ -175,7 +176,7 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   for (const target of targets) {
     // Incompatible with the scenario where target contains both 'web' and 'modern-web'
     overrideBrowserslist[target] = await getBrowserslistWithDefault(
-      cwd,
+      cwd!,
       uniBuilderConfig,
       target,
     );
@@ -193,37 +194,39 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   extraConfig.html.outputStructure = html.disableHtmlFolder ? 'flat' : 'nested';
   delete html.disableHtmlFolder;
 
-  if (html.metaByEntries) {
-    extraConfig.html.meta = ({ entryName }) => html.metaByEntries![entryName];
+  if (uniBuilderConfig.html?.metaByEntries) {
+    extraConfig.html.meta = ({ entryName }) =>
+      uniBuilderConfig.html!.metaByEntries![entryName];
     delete html.metaByEntries;
   }
 
-  if (html.titleByEntries) {
-    extraConfig.html.title = ({ entryName }) => html.titleByEntries![entryName];
+  if (uniBuilderConfig.html?.titleByEntries) {
+    extraConfig.html.title = ({ entryName }) =>
+      uniBuilderConfig.html!.titleByEntries![entryName];
     delete html.titleByEntries;
   }
 
-  if (html.faviconByEntries) {
+  if (uniBuilderConfig.html?.faviconByEntries) {
     extraConfig.html.favicon = ({ entryName }) =>
-      html.faviconByEntries![entryName];
+      uniBuilderConfig.html!.faviconByEntries![entryName];
     delete html.faviconByEntries;
   }
 
-  if (html.injectByEntries) {
+  if (uniBuilderConfig.html?.injectByEntries) {
     extraConfig.html.inject = ({ entryName }) =>
-      html.injectByEntries![entryName];
+      uniBuilderConfig.html!.injectByEntries![entryName];
     delete html.injectByEntries;
   }
 
-  if (html.templateByEntries) {
+  if (uniBuilderConfig.html?.templateByEntries) {
     extraConfig.html.template = ({ entryName }) =>
-      html.templateByEntries![entryName];
+      uniBuilderConfig.html!.templateByEntries![entryName];
     delete html.templateByEntries;
   }
 
-  if (html.templateParametersByEntries) {
+  if (uniBuilderConfig.html?.templateParametersByEntries) {
     extraConfig.html.templateParameters = (_, { entryName }) =>
-      html.templateParametersByEntries![entryName];
+      uniBuilderConfig.html!.templateParametersByEntries![entryName];
     delete html.templateParametersByEntries;
   }
 
@@ -234,7 +237,10 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
     : {
         https:
           tools.devServer?.https || dev.https
-            ? await genHttpsOptions((tools.devServer?.https || dev.https)!, cwd)
+            ? await genHttpsOptions(
+                (tools.devServer?.https || dev.https)!,
+                cwd!,
+              )
             : undefined,
         port: dev.port,
         host: dev.host,
@@ -276,6 +282,8 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   rsbuildConfig.dev = removeUndefinedKey(dev);
   rsbuildConfig.html = html;
   rsbuildConfig.output = output;
+
+  rsbuildConfig.source.entry = entry;
 
   const rsbuildPlugins: RsbuildPlugin[] = [
     pluginSplitChunks(),
@@ -329,12 +337,6 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
     );
   }
 
-  if (uniBuilderConfig.output?.assetsRetry) {
-    rsbuildPlugins.push(
-      pluginAssetsRetry(uniBuilderConfig.output?.assetsRetry),
-    );
-  }
-
   const remOptions = uniBuilderConfig.output?.convertToRem;
   if (remOptions) {
     rsbuildPlugins.push(
@@ -364,6 +366,13 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
               pugOptions,
             },
       ),
+    );
+  }
+
+  // assetsRetry inject should be later
+  if (uniBuilderConfig.output?.assetsRetry) {
+    rsbuildPlugins.push(
+      pluginAssetsRetry(uniBuilderConfig.output?.assetsRetry),
     );
   }
 

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -285,7 +285,10 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   rsbuildConfig.html = html;
   rsbuildConfig.output = output;
 
-  rsbuildConfig.source.entry = entry;
+  if (entry) {
+    rsbuildConfig.source ??= {};
+    rsbuildConfig.source.entry = entry;
+  }
 
   const rsbuildPlugins: RsbuildPlugin[] = [
     pluginSplitChunks(),

--- a/packages/builder/uni-builder/src/shared/plugins/runtimeChunk.ts
+++ b/packages/builder/uni-builder/src/shared/plugins/runtimeChunk.ts
@@ -1,7 +1,9 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { RUNTIME_CHUNK_NAME } from '../constants';
 
-export const pluginRuntimeChunk = (): RsbuildPlugin => ({
+export const pluginRuntimeChunk = (
+  disableInlineRuntimeChunk?: boolean,
+): RsbuildPlugin => ({
   name: 'uni-builder:runtime-chunk',
 
   setup(api) {
@@ -23,6 +25,10 @@ export const pluginRuntimeChunk = (): RsbuildPlugin => ({
 
     api.modifyRsbuildConfig(config => {
       config.output ||= {};
+
+      if (disableInlineRuntimeChunk) {
+        return;
+      }
 
       // RegExp like /bundler-runtime([.].+)?\.js$/
       // matches bundler-runtime.js and bundler-runtime.123456.js

--- a/packages/builder/uni-builder/src/types.ts
+++ b/packages/builder/uni-builder/src/types.ts
@@ -9,6 +9,7 @@ import type {
   InlineChunkTest,
   DevConfig,
   RequestHandler,
+  RsbuildEntry,
 } from '@rsbuild/shared';
 import type { RsbuildConfig } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
@@ -23,21 +24,22 @@ import type { PluginCheckSyntaxOptions } from '@rsbuild/plugin-check-syntax';
 import type { PluginPugOptions } from '@rsbuild/plugin-pug';
 import type { PluginBabelOptions } from '@rsbuild/plugin-babel';
 
-export type CreateWebpackBuilderOptions = {
-  bundlerType: 'webpack';
-  config: UniBuilderWebpackConfig;
-  frameworkConfigPath?: string;
-  /** The root path of current project. */
-  cwd: string;
-};
-
-export type CreateRspackBuilderOptions = {
-  bundlerType: 'rspack';
-  config: UniBuilderRspackConfig;
+export type CreateBuilderCommonOptions = {
+  entry?: RsbuildEntry;
   frameworkConfigPath?: string;
   /** The root path of current project. */
   cwd?: string;
 };
+
+export type CreateWebpackBuilderOptions = {
+  bundlerType: 'webpack';
+  config: UniBuilderWebpackConfig;
+} & CreateBuilderCommonOptions;
+
+export type CreateRspackBuilderOptions = {
+  bundlerType: 'rspack';
+  config: UniBuilderRspackConfig;
+} & CreateBuilderCommonOptions;
 
 export type CreateUniBuilderOptions =
   | CreateWebpackBuilderOptions

--- a/packages/builder/uni-builder/src/webpack/defaults.ts
+++ b/packages/builder/uni-builder/src/webpack/defaults.ts
@@ -7,8 +7,8 @@ import {
   getDefaultSecurityConfig,
   getDefaultPerformanceConfig,
   getDefaultExperimentsConfig,
+  mergeUniBuilderConfig,
 } from '../shared/defaults';
-import { mergeRsbuildConfig } from '@rsbuild/core';
 import type { UniBuilderWebpackConfig } from '../types';
 
 export const createDefaultConfig = (): UniBuilderWebpackConfig => ({
@@ -35,4 +35,4 @@ export const createDefaultConfig = (): UniBuilderWebpackConfig => ({
 });
 
 export const withDefaultConfig = (config: UniBuilderWebpackConfig) =>
-  mergeRsbuildConfig<UniBuilderWebpackConfig>(createDefaultConfig(), config);
+  mergeUniBuilderConfig<UniBuilderWebpackConfig>(createDefaultConfig(), config);

--- a/packages/builder/uni-builder/src/webpack/defaults.ts
+++ b/packages/builder/uni-builder/src/webpack/defaults.ts
@@ -7,8 +7,8 @@ import {
   getDefaultSecurityConfig,
   getDefaultPerformanceConfig,
   getDefaultExperimentsConfig,
-  mergeUniBuilderConfig,
 } from '../shared/defaults';
+import { mergeRsbuildConfig } from '@rsbuild/core';
 import type { UniBuilderWebpackConfig } from '../types';
 
 export const createDefaultConfig = (): UniBuilderWebpackConfig => ({
@@ -35,4 +35,4 @@ export const createDefaultConfig = (): UniBuilderWebpackConfig => ({
 });
 
 export const withDefaultConfig = (config: UniBuilderWebpackConfig) =>
-  mergeUniBuilderConfig<UniBuilderWebpackConfig>(createDefaultConfig(), config);
+  mergeRsbuildConfig<UniBuilderWebpackConfig>(createDefaultConfig(), config);

--- a/packages/builder/uni-builder/src/webpack/index.ts
+++ b/packages/builder/uni-builder/src/webpack/index.ts
@@ -7,6 +7,7 @@ import {
 import type {
   UniBuilderWebpackConfig,
   CreateWebpackBuilderOptions,
+  CreateBuilderCommonOptions,
 } from '../types';
 import { parseCommonConfig } from '../shared/parseCommonConfig';
 import { pluginModuleScopes } from './plugins/moduleScopes';
@@ -17,16 +18,14 @@ import { withDefaultConfig } from './defaults';
 
 export async function parseConfig(
   uniBuilderConfig: UniBuilderWebpackConfig,
-  cwd: string,
-  frameworkConfigPath?: string,
+  options: CreateBuilderCommonOptions,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 }> {
   const { rsbuildConfig, rsbuildPlugins } = await parseCommonConfig<'webpack'>(
     uniBuilderConfig,
-    cwd,
-    frameworkConfigPath,
+    options,
   );
 
   rsbuildPlugins.push(
@@ -76,12 +75,14 @@ export async function parseConfig(
 export async function createWebpackBuilder(
   options: CreateWebpackBuilderOptions,
 ): Promise<RsbuildInstance> {
-  const { cwd = process.cwd() } = options;
+  const { cwd = process.cwd(), config, ...rest } = options;
 
   const { rsbuildConfig, rsbuildPlugins } = await parseConfig(
     withDefaultConfig(options.config),
-    cwd,
-    options.frameworkConfigPath,
+    {
+      ...rest,
+      cwd,
+    },
   );
 
   const { webpackProvider } = await import('@rsbuild/webpack');

--- a/packages/builder/uni-builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/default.test.ts.snap
@@ -731,7 +731,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
   "optimization": {
     "minimize": false,
     "runtimeChunk": {
-      "name": "bundler-runtime",
+      "name": "builder-runtime",
     },
     "splitChunks": {
       "cacheGroups": {
@@ -823,9 +823,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -1670,7 +1668,7 @@ exports[`uni-builder rspack > should generator rspack config correctly when prod
       },
     ],
     "runtimeChunk": {
-      "name": "bundler-runtime",
+      "name": "builder-runtime",
     },
     "splitChunks": {
       "cacheGroups": {
@@ -1780,9 +1778,7 @@ exports[`uni-builder rspack > should generator rspack config correctly when prod
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -1811,7 +1807,7 @@ exports[`uni-builder rspack > should generator rspack config correctly when prod
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
       "scriptTests": [
-        /bundler-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
+        /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
       ],
       "styleTests": [],
     },
@@ -2573,7 +2569,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
   "optimization": {
     "minimize": false,
     "runtimeChunk": {
-      "name": "bundler-runtime",
+      "name": "builder-runtime",
     },
     "splitChunks": {
       "cacheGroups": {
@@ -2681,9 +2677,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -3542,7 +3536,7 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
       },
     ],
     "runtimeChunk": {
-      "name": "bundler-runtime",
+      "name": "builder-runtime",
     },
     "splitChunks": {
       "cacheGroups": {
@@ -3665,9 +3659,7 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -3700,7 +3692,7 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
       "inlinedAssets": Set {},
       "name": "InlineChunkHtmlPlugin",
       "scriptTests": [
-        /bundler-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
+        /builder-runtime\\(\\[\\.\\]\\.\\+\\)\\?\\\\\\.js\\$/,
       ],
       "styleTests": [],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6076,6 +6076,9 @@ importers:
       '@modern-js/e2e':
         specifier: workspace:*
         version: link:../../../packages/toolkit/e2e
+      '@modern-js/uni-builder':
+        specifier: workspace:*
+        version: link:../../../packages/builder/uni-builder
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../../packages/toolkit/utils

--- a/tests/e2e/builder/cases/css/style-loader/index.test.ts
+++ b/tests/e2e/builder/cases/css/style-loader/index.test.ts
@@ -4,8 +4,8 @@ import { expect, test } from '@modern-js/e2e/playwright';
 
 const fixtures = __dirname;
 
-// TODO: fixed in next version
-test.skip('should inline style when disableCssExtract is false', async ({
+// TODO: apply cssnano in uni-builder
+test('should inline style when disableCssExtract is false', async ({
   page,
 }) => {
   const builder = await build({
@@ -13,6 +13,7 @@ test.skip('should inline style when disableCssExtract is false', async ({
     entry: {
       main: join(fixtures, 'src/index.ts'),
     },
+    useUniBuilder: false,
     runServer: true,
     builderConfig: {
       output: {

--- a/tests/e2e/builder/cases/css/style-loader/index.test.ts
+++ b/tests/e2e/builder/cases/css/style-loader/index.test.ts
@@ -4,7 +4,8 @@ import { expect, test } from '@modern-js/e2e/playwright';
 
 const fixtures = __dirname;
 
-test('should inline style when disableCssExtract is false', async ({
+// TODO: fixed in next version
+test.skip('should inline style when disableCssExtract is false', async ({
   page,
 }) => {
   const builder = await build({

--- a/tests/e2e/builder/cases/decorator/latest/index.test.ts
+++ b/tests/e2e/builder/cases/decorator/latest/index.test.ts
@@ -1,8 +1,9 @@
 import path from 'path';
-import { expect, test } from '@modern-js/e2e/playwright';
+import { expect } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
+import { webpackOnlyTest } from '@scripts/helper';
 
-test('decorator latest', async ({ page }) => {
+webpackOnlyTest('decorator latest', async ({ page }) => {
   const builder = await build({
     cwd: __dirname,
     entry: {

--- a/tests/e2e/builder/cases/html/inject-false/index.test.ts
+++ b/tests/e2e/builder/cases/html/inject-false/index.test.ts
@@ -6,6 +6,7 @@ test('builder injection script order should be as expected', async () => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
+    useUniBuilder: false,
     builderConfig: {
       html: {
         inject: false,

--- a/tests/e2e/builder/cases/html/inject-false/index.test.ts
+++ b/tests/e2e/builder/cases/html/inject-false/index.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
 
-test.only('builder injection script order should be as expected', async () => {
+test('builder injection script order should be as expected', async () => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
@@ -26,11 +26,6 @@ test.only('builder injection script order should be as expected', async () => {
 
   const html =
     files[Object.keys(files).find(file => file.endsWith('index.html'))!];
-
-  // only inject once
-  expect(
-    html.indexOf('/js/assets-retry') === html.lastIndexOf('/js/assets-retry'),
-  ).toBeTruthy();
 
   // assetsRetry => rem => normal resource => template custom resource
   expect(

--- a/tests/e2e/builder/cases/html/inject-false/index.test.ts
+++ b/tests/e2e/builder/cases/html/inject-false/index.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
 
-test('builder injection script order should be as expected', async () => {
+test.only('builder injection script order should be as expected', async () => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
@@ -27,10 +27,17 @@ test('builder injection script order should be as expected', async () => {
   const html =
     files[Object.keys(files).find(file => file.endsWith('index.html'))!];
 
+  // only inject once
+  expect(
+    html.indexOf('/js/assets-retry') === html.lastIndexOf('/js/assets-retry'),
+  ).toBeTruthy();
+
   // assetsRetry => rem => normal resource => template custom resource
   expect(
-    /(<script src="\/static\/js\/assets-retry).*(<script src="\/static\/js\/convert-rem).*(\/static\/js\/index).*(example.com\/assets\/a.js)/.test(
-      html,
-    ),
+    html.indexOf('/js/assets-retry') < html.indexOf('/js/convert-rem'),
   ).toBeTruthy();
+  expect(
+    html.indexOf('/js/convert-rem') < html.indexOf('/js/index'),
+  ).toBeTruthy();
+  expect(html.indexOf('/js/index') < html.indexOf('/assets/a.js')).toBeTruthy();
 });

--- a/tests/e2e/builder/cases/inline-chunk/index.test.ts
+++ b/tests/e2e/builder/cases/inline-chunk/index.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { webpackOnlyTest } from '@scripts/helper';
 import { build, getHrefByEntryName } from '@scripts/shared';
-import { BundlerChain, RUNTIME_CHUNK_NAME } from '@modern-js/builder-shared';
+import { BundlerChain, RUNTIME_CHUNK_NAME } from '@modern-js/uni-builder';
 
 // Rspack will not output builder runtime source map, but it not necessary
 // Identify whether the builder runtime chunk is included through some specific code snippets

--- a/tests/e2e/builder/cases/node-addons/index.test.ts
+++ b/tests/e2e/builder/cases/node-addons/index.test.ts
@@ -6,6 +6,7 @@ test('should compile Node addons correctly', async () => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
+    useUniBuilder: false,
     target: 'node',
   });
   const files = await builder.unwrapOutputJSON();

--- a/tests/e2e/builder/cases/output/externals/tests/index.test.ts
+++ b/tests/e2e/builder/cases/output/externals/tests/index.test.ts
@@ -44,6 +44,7 @@ test('should not external dependencies when target is web worker', async () => {
     cwd: fixtures,
     target: 'web-worker',
     entry: { index: resolve(fixtures, './src/index.js') },
+    useUniBuilder: false,
     builderConfig: {
       output: {
         externals: {

--- a/tests/e2e/builder/cases/output/rem/tests/index.test.ts
+++ b/tests/e2e/builder/cases/output/rem/tests/index.test.ts
@@ -30,6 +30,7 @@ test('rem enable', async ({ page }) => {
     entry: {
       main: join(fixtures, 'src/index.ts'),
     },
+    useUniBuilder: false,
     runServer: true,
     builderConfig: {
       output: {
@@ -62,6 +63,7 @@ test('should inline runtime code to html by default', async () => {
   const builder = await build({
     cwd: fixtures,
     entry: { index: join(fixtures, 'src/index.ts') },
+    useUniBuilder: false,
     builderConfig: {
       output: {
         convertToRem: {},

--- a/tests/e2e/builder/cases/output/rem/tests/index.test.ts
+++ b/tests/e2e/builder/cases/output/rem/tests/index.test.ts
@@ -79,6 +79,7 @@ test('should extract runtime code when inlineRuntime is false', async () => {
   const builder = await build({
     cwd: fixtures,
     entry: { index: join(fixtures, 'src/index.ts') },
+    useUniBuilder: false,
     builderConfig: {
       output: {
         convertToRem: {

--- a/tests/e2e/builder/cases/progress/index.test.ts
+++ b/tests/e2e/builder/cases/progress/index.test.ts
@@ -21,6 +21,7 @@ webpackOnlyTest('should emit progress log in non-TTY environment', async () => {
   await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
+    useUniBuilder: false,
     builderConfig: {
       dev: {
         progressBar: true,

--- a/tests/e2e/builder/cases/serve/index.test.ts
+++ b/tests/e2e/builder/cases/serve/index.test.ts
@@ -8,11 +8,13 @@ test('should serve dist files correctly', async ({ page }) => {
 
   const { instance } = await build({
     cwd,
+    useUniBuilder: false,
     entry: {
       main: join(cwd, 'src/index.js'),
     },
   });
 
+  // @ts-expect-error
   const { port, server } = await instance.serve();
 
   await page.goto(getHrefByEntryName('main', port));

--- a/tests/e2e/builder/cases/sri/index.test.ts
+++ b/tests/e2e/builder/cases/sri/index.test.ts
@@ -8,6 +8,7 @@ webpackOnlyTest('security.sri', async ({ page }) => {
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
     runServer: true,
+    useUniBuilder: false,
     builderConfig: {
       security: {
         sri: true,

--- a/tests/e2e/builder/cases/styled-component/index.test.ts
+++ b/tests/e2e/builder/cases/styled-component/index.test.ts
@@ -20,6 +20,7 @@ const commonConfig = {
 
 const noStyledConfig = {
   ...commonConfig,
+  useUniBuilder: false,
   builderConfig: {
     ...commonConfig.builderConfig,
     tools: {

--- a/tests/e2e/builder/cases/stylus-rem/index.test.ts
+++ b/tests/e2e/builder/cases/stylus-rem/index.test.ts
@@ -8,6 +8,7 @@ test('should compile stylus and rem correctly', async () => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },
+    useUniBuilder: false,
     plugins: [builderPluginStylus()],
     builderConfig: {
       output: {

--- a/tests/e2e/builder/cases/stylus/index.test.ts
+++ b/tests/e2e/builder/cases/stylus/index.test.ts
@@ -7,6 +7,7 @@ import { builderPluginStylus } from '@modern-js/builder-plugin-stylus';
 test('should compile stylus correctly', async () => {
   const builder = await build({
     cwd: __dirname,
+    useUniBuilder: false,
     entry: { index: path.resolve(__dirname, './src/index.js') },
     plugins: [builderPluginStylus()],
   });

--- a/tests/e2e/builder/cases/vue/index.test.ts
+++ b/tests/e2e/builder/cases/vue/index.test.ts
@@ -8,6 +8,7 @@ test('should build basic Vue sfc correctly', async ({ page }) => {
 
   const builder = await build({
     cwd: root,
+    useUniBuilder: false,
     entry: {
       main: join(root, 'src/index.js'),
     },
@@ -31,6 +32,7 @@ test('should build Vue sfc style correctly', async ({ page }) => {
 
   const builder = await build({
     cwd: root,
+    useUniBuilder: false,
     entry: {
       main: join(root, 'src/index.js'),
     },
@@ -54,6 +56,7 @@ test('should build basic Vue jsx correctly', async ({ page }) => {
 
   const builder = await build({
     cwd: root,
+    useUniBuilder: false,
     entry: {
       main: join(root, 'src/index.js'),
     },
@@ -77,6 +80,7 @@ test('should build Vue sfc with lang="ts" correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue()],
   });
@@ -97,6 +101,7 @@ test('should build Vue sfc with lang="jsx" correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue()],
   });
@@ -120,6 +125,7 @@ test('should build Vue sfc with lang="tsx" correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue()],
   });

--- a/tests/e2e/builder/cases/vue2/index.test.ts
+++ b/tests/e2e/builder/cases/vue2/index.test.ts
@@ -11,6 +11,7 @@ test('should build basic Vue sfc correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue2()],
   });
@@ -34,6 +35,7 @@ test('should build Vue sfc style correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue2()],
   });
@@ -57,6 +59,7 @@ test('should build basic Vue jsx correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue2()],
   });
@@ -77,6 +80,7 @@ test('should build Vue sfc with lang="ts" correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue2()],
   });
@@ -97,6 +101,7 @@ test('should build Vue sfc with lang="jsx" correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue2()],
   });
@@ -120,6 +125,7 @@ test('should build Vue sfc with lang="tsx" correctly', async ({ page }) => {
     entry: {
       main: join(root, 'src/index.js'),
     },
+    useUniBuilder: false,
     runServer: true,
     plugins: [builderPluginVue2()],
   });

--- a/tests/e2e/builder/cases/web-worker/index.test.ts
+++ b/tests/e2e/builder/cases/web-worker/index.test.ts
@@ -23,6 +23,7 @@ webpackOnlyTest(
   async () => {
     const builder = await build({
       cwd: __dirname,
+      useUniBuilder: false,
       entry: { index: path.resolve(__dirname, './src/index2.js') },
       target: 'web-worker',
     });

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -16,6 +16,7 @@
     "vue": "^3.3.4"
   },
   "devDependencies": {
+    "@modern-js/uni-builder": "workspace:*",
     "@modern-js/builder": "workspace:*",
     "@modern-js/builder-plugin-image-compress": "workspace:*",
     "@modern-js/builder-plugin-node-polyfill": "workspace:*",

--- a/tests/e2e/builder/scripts/shared.ts
+++ b/tests/e2e/builder/scripts/shared.ts
@@ -5,6 +5,7 @@ import fs from '@modern-js/utils/fs-extra';
 import type { CreateBuilderOptions } from '@modern-js/builder';
 import type { BuilderConfig } from '@modern-js/builder-webpack-provider';
 import type { BuilderConfig as RspackBuilderConfig } from '@modern-js/builder-rspack-provider';
+import type { BuilderConfig as UniBuilderConfig } from '@modern-js/uni-builder';
 import { StartDevServerOptions } from '@modern-js/builder-shared';
 
 export const getHrefByEntryName = (entryName: string, port: number) => {
@@ -42,6 +43,28 @@ async function getRspackBuilderProvider(builderConfig: RspackBuilderConfig) {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
+export const createUniBuilder = async (
+  builderOptions: CreateBuilderOptions,
+  builderConfig: UniBuilderConfig = {},
+) => {
+  const { createUniBuilder } = await import('@modern-js/uni-builder');
+
+  const builder =
+    process.env.PROVIDE_TYPE === 'rspack'
+      ? await createUniBuilder({
+          ...builderOptions,
+          bundlerType: 'rspack',
+          config: builderConfig,
+        })
+      : await createUniBuilder({
+          ...builderOptions,
+          bundlerType: 'webpack',
+          config: builderConfig as UniBuilderConfig<'webpack'>,
+        });
+
+  return builder;
+};
+
 export const createBuilder = async (
   builderOptions: CreateBuilderOptions,
   builderConfig: BuilderConfig | RspackBuilderConfig = {},
@@ -73,7 +96,9 @@ function getRandomPort(defaultPort = Math.ceil(Math.random() * 10000) + 10000) {
 }
 
 const updateConfigForTest = <BuilderType>(
-  config: BuilderType extends 'webpack' ? BuilderConfig : RspackBuilderConfig,
+  config: BuilderType extends 'webpack'
+    ? UniBuilderConfig<'webpack'>
+    : UniBuilderConfig<'rspack'>,
 ) => {
   // make devPort random to avoid port conflict
   config.dev = {
@@ -89,6 +114,8 @@ const updateConfigForTest = <BuilderType>(
       buildCache: false,
     };
   }
+
+  config.performance.printFileSize = false;
 
   // disable ts checker to make the tests faster
   if (config.output?.disableTsChecker !== false) {
@@ -119,6 +146,7 @@ export async function dev<BuilderType = 'webpack'>({
 }) {
   process.env.NODE_ENV = 'development';
 
+  // @ts-expect-error
   updateConfigForTest(builderConfig);
 
   const builder = await createBuilder(options, builderConfig);
@@ -137,17 +165,14 @@ export async function build<BuilderType = 'webpack'>({
   plugins?: any[];
   runServer?: boolean;
   builderConfig?: BuilderType extends 'webpack'
-    ? BuilderConfig
-    : RspackBuilderConfig;
+    ? UniBuilderConfig<'webpack'>
+    : UniBuilderConfig<'rspack'>;
 }) {
   process.env.NODE_ENV = 'production';
 
   updateConfigForTest(builderConfig);
 
-  // todo: support test swc (add swc plugin) use providerType 'webpack-swc'?
-  const builder = await createBuilder(options, builderConfig);
-
-  builder.removePlugins(['builder-plugin-file-size']);
+  const builder = await createUniBuilder(options, builderConfig);
 
   if (plugins) {
     builder.addPlugins(plugins);

--- a/tests/e2e/builder/scripts/shared.ts
+++ b/tests/e2e/builder/scripts/shared.ts
@@ -160,10 +160,13 @@ export async function build<BuilderType = 'webpack'>({
   plugins,
   runServer = false,
   builderConfig = {},
+  useUniBuilder = true,
   ...options
 }: CreateBuilderOptions & {
   plugins?: any[];
   runServer?: boolean;
+  /** TODO: should removed when all test cases migrate to uniBuilder */
+  useUniBuilder?: boolean;
   builderConfig?: BuilderType extends 'webpack'
     ? UniBuilderConfig<'webpack'>
     : UniBuilderConfig<'rspack'>;
@@ -172,7 +175,10 @@ export async function build<BuilderType = 'webpack'>({
 
   updateConfigForTest(builderConfig);
 
-  const builder = await createUniBuilder(options, builderConfig);
+  const builder = useUniBuilder
+    ? await createUniBuilder(options, builderConfig)
+    : // @ts-expect-error
+      await createBuilder(options, builderConfig);
 
   if (plugins) {
     builder.addPlugins(plugins);


### PR DESCRIPTION
## Summary

fix uni-builder error and migrate some e2e test cases from modern builder to uni-builder
- fix enableInlineScripts & enableInlineStyles merge error
- compat entry params
- update RUNTIME_CHUNK_NAME
- fix html.faviconByEntries / ... undefined
- runtimeChunk is not related disableInlineRuntimeChunk configuration

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
