### PR TITLE
fix: adapte webpack-dev-middleware disable write-to-disk

### DIFF
--- a/.changeset/funny-flowers-hunt.md
+++ b/.changeset/funny-flowers-hunt.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime-utils': patch
+'@modern-js/server': patch
+---
+
+fix: adapte webpack-dev-middleware disable write-to-disk
+fix: 适配 webpack-dev-middleware 禁止写入磁盘

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -166,6 +166,8 @@ export class ModernDevServer extends ModernServer {
 
     this.closeCb.push(close);
 
+    // use webpack Fs to init FileReader
+    this.initFileReader();
     await super.onInit(runner, app);
 
     // watch mock/ server/ api/ dir file change
@@ -173,6 +175,33 @@ export class ModernDevServer extends ModernServer {
       this.startWatcher();
       app.on('close', async () => {
         await this.watcher?.close();
+      });
+    }
+  }
+
+  private initFileReader() {
+    let isInit = false;
+
+    if (this.dev?.devMiddleware?.writeToDisk === false) {
+      this.addHandler((ctx, next) => {
+        if (isInit) {
+          return next();
+        }
+        isInit = true;
+
+        if (!ctx.res.locals?.webpack) {
+          fileReader.reset();
+          return next();
+        }
+
+        const { devMiddleware: webpackDevMid } = ctx.res.locals.webpack;
+        const { outputFileSystem } = webpackDevMid;
+        if (outputFileSystem) {
+          fileReader.reset(outputFileSystem);
+        } else {
+          fileReader.reset();
+        }
+        return next();
       });
     }
   }


### PR DESCRIPTION
## Summary

webpack would write output to memory.

adapte webpack-dev-middleware.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
