### PR TITLE
fix(module-tools): clear .tsbuildinfo before build instead of tsc --clean

### DIFF
--- a/.changeset/silly-timers-knock.md
+++ b/.changeset/silly-timers-knock.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): clear .tsbuildinfo before build instead of tsc --clean
+fix(module-tools): 构建前清除 .tsbuildinfo 文件而不是调用 tsc --clean

--- a/packages/solutions/module-tools/src/types/dts.ts
+++ b/packages/solutions/module-tools/src/types/dts.ts
@@ -53,6 +53,9 @@ export interface ITsconfig {
         paths?: Record<string, string[]>;
         target?: TsTarget;
         useDefineForClassFields?: boolean;
+        composite?: boolean;
+        incremental?: boolean;
+        tsBuildInfoFile?: string;
       }
     | undefined;
   include?: string[];


### PR DESCRIPTION
## Summary
In #5064 , we execa `tsc --build --clean`, the reason is that when we clean the output, we doesn't clean the .tsbuildinfo which generated by incremental build. 
But `tsc --build --clean` will bring two problems: 
- first, tsc --clean will remove the outputs by esbuild, tsc --clean only respect the project tsconfig.json, so this need that we should set `emitDeclarationOnly` in our tsconfig.
- second, we don't respect the incremental build. we delete the outputs for all projects.

Now we will respect the incremental, in the root project, we will clear the .tsbuildinfo, unless you close the clean func.
For the dependencies, we do nothing.

## Related Links

#5064 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
