### PR TITLE
chore: remove Rsbuild unsupported CHAIN_ID

### DIFF
--- a/.changeset/wise-pants-sparkle.md
+++ b/.changeset/wise-pants-sparkle.md
@@ -7,6 +7,6 @@
 '@modern-js/plugin-bff': patch
 ---
 
-chore: remove Rsbuild unsupport CHAIN_ID
+chore: remove Rsbuild unsupported CHAIN_ID
 
 chore: 移除在 Rsbuild 中不支持的 CHAIN_ID

--- a/.changeset/wise-pants-sparkle.md
+++ b/.changeset/wise-pants-sparkle.md
@@ -1,0 +1,12 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/builder-doc': patch
+'@modern-js/app-tools': patch
+'@modern-js/builder-plugin-swc': patch
+'@modern-js/storybook-builder': patch
+'@modern-js/plugin-bff': patch
+---
+
+chore: remove Rsbuild unsupport CHAIN_ID
+
+chore: 移除在 Rsbuild 中不支持的 CHAIN_ID

--- a/packages/builder/plugin-swc/src/plugin.ts
+++ b/packages/builder/plugin-swc/src/plugin.ts
@@ -92,7 +92,7 @@ export const builderPluginSwc = (
         const { CheckPolyfillPlugin } = await import('./checkPolyfillPlugin');
 
         chain
-          .plugin(CHAIN_ID.PLUGIN.SWC_POLYFILL_CHECKER)
+          .plugin('swc-polyfill-checker-plugin')
           .use(new CheckPolyfillPlugin(mainConfig));
       }
 

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -50,7 +50,7 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
               const name = isServer ? 'server' : 'client';
               chain.module.rule(CHAIN_ID.RULE.JS).exclude.add(apiRegexp);
               chain.module
-                .rule(CHAIN_ID.RULE.JS_BFF_API)
+                .rule('js-bff-api')
                 .test(apiRegexp)
                 .use('custom-loader')
                 .loader(require.resolve('./loader').replace(/\\/g, '/'))

--- a/packages/document/builder-doc/docs/en/config/tools/bundlerChain.mdx
+++ b/packages/document/builder-doc/docs/en/config/tools/bundlerChain.mdx
@@ -183,7 +183,6 @@ For example, the `RULE.STYLUS` rule exists only when the Stylus plugin is regist
 | `PLUGIN.APP_ICON`           | correspond to `AppIconPlugin`                                                                           |
 | `PLUGIN.INLINE_HTML`        | correspond to `InlineChunkHtmlPlugin`                                                                   |
 | `PLUGIN.BUNDLE_ANALYZER`    | correspond to `WebpackBundleAnalyzer`                                                                   |
-| `PLUGIN.BOTTOM_TEMPLATE`    | correspond to `BottomTemplatePlugin`                                                                    |
 | `PLUGIN.VUE_LOADER_PLUGIN`  | correspond to `VueLoaderPlugin`                                                                         |
 | `PLUGIN.AUTO_SET_ROOT_SIZE` | correspond to automatically set root font size plugin in Builder                                        |
 

--- a/packages/document/builder-doc/docs/en/config/tools/rspack.md
+++ b/packages/document/builder-doc/docs/en/config/tools/rspack.md
@@ -279,9 +279,6 @@ Get the path to the builder built-in dependencies, such as:
 - sass-loader
 - less
 - less-loader
-- babel-loader
-- url-loader
-- file-loader
 - ...
 
 This method is usually used when you need to reuse the same dependency with the builder.

--- a/packages/document/builder-doc/docs/en/config/tools/webpackChain.md
+++ b/packages/document/builder-doc/docs/en/config/tools/webpackChain.md
@@ -143,9 +143,6 @@ Get the path to the builder built-in dependencies, such as:
 - less
 - less-loader
 - css-loader
-- babel-loader
-- url-loader
-- file-loader
 - ...
 
 This method is usually used when you need to reuse the same dependency with the builder.
@@ -223,7 +220,6 @@ For example, the `RULE.STYLUS` rule exists only when the Stylus plugin is regist
 | `USE.TOML`                        | correspond to `toml-loader`                    |
 | `USE.YAML`                        | correspond to `yaml-loader`                    |
 | `USE.NODE`                        | correspond to `node-loader`                    |
-| `USE.FILE`                        | correspond to `file-loader`                    |
 | `USE.URL`                         | correspond to `url-loader`                     |
 | `USE.SVGR`                        | correspond to `@svgr/webpack`                  |
 | `USE.BABEL`                       | correspond to `babel-loader`                   |
@@ -247,12 +243,10 @@ For example, the `RULE.STYLUS` rule exists only when the Stylus plugin is regist
 | `PLUGIN.BANNER`                | correspond to `BannerPlugin`                                                                                   |
 | `PLUGIN.PROGRESS`              | correspond to `Webpackbar`                                                                                     |
 | `PLUGIN.APP_ICON`              | correspond to `AppIconPlugin`                                                                                  |
-| `PLUGIN.LOADABLE`              | correspond to `LoadableWebpackPlugin`                                                                          |
 | `PLUGIN.MANIFEST`              | correspond to `WebpackManifestPlugin`                                                                          |
 | `PLUGIN.TS_CHECKER`            | correspond to `ForkTsCheckerWebpackPlugin`                                                                     |
 | `PLUGIN.INLINE_HTML`           | correspond to `InlineChunkHtmlPlugin`                                                                          |
 | `PLUGIN.BUNDLE_ANALYZER`       | correspond to `WebpackBundleAnalyzer`                                                                          |
-| `PLUGIN.BOTTOM_TEMPLATE`       | correspond to `BottomTemplatePlugin`                                                                           |
 | `PLUGIN.MINI_CSS_EXTRACT`      | correspond to `MiniCssExtractPlugin`                                                                           |
 | `PLUGIN.VUE_LOADER_PLUGIN`     | correspond to `VueLoaderPlugin`                                                                                |
 | `PLUGIN.REACT_FAST_REFRESH`    | correspond to `ReactFastRefreshPlugin`                                                                         |

--- a/packages/document/builder-doc/docs/zh/config/tools/bundlerChain.mdx
+++ b/packages/document/builder-doc/docs/zh/config/tools/bundlerChain.mdx
@@ -186,7 +186,6 @@ Builder 中预先定义了一些常用的 Chain ID，你可以通过这些 ID �
 | `PLUGIN.APP_ICON`           | 对应 `AppIconPlugin`                                                        |
 | `PLUGIN.INLINE_HTML`        | 对应 `InlineChunkHtmlPlugin`                                                |
 | `PLUGIN.BUNDLE_ANALYZER`    | 对应 `WebpackBundleAnalyzer`                                                |
-| `PLUGIN.BOTTOM_TEMPLATE`    | 对应 `BottomTemplatePlugin`                                                 |
 | `PLUGIN.ASSETS_RETRY`       | 对应 Builder 中的 webpack 静态资源重试插件 `WebpackAssetsRetryPlugin`       |
 | `PLUGIN.VUE_LOADER_PLUGIN`  | 对应 `VueLoaderPlugin`                                                      |
 | `PLUGIN.AUTO_SET_ROOT_SIZE` | 对应 Builder 中的自动设置根字体大小插件 `AutoSetRootSizePlugin`             |

--- a/packages/document/builder-doc/docs/zh/config/tools/rspack.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/rspack.md
@@ -279,9 +279,6 @@ export default {
 - sass-loader
 - less
 - less-loader
-- babel-loader
-- url-loader
-- file-loader
 - ...
 
 该方法通常在需要与 builder 复用同一份依赖时会被用到。

--- a/packages/document/builder-doc/docs/zh/config/tools/webpackChain.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/webpackChain.md
@@ -146,9 +146,6 @@ export default {
 - less
 - less-loader
 - css-loader
-- babel-loader
-- url-loader
-- file-loader
 - ...
 
 该方法通常在需要与 builder 复用同一份依赖时会被用到。
@@ -226,7 +223,6 @@ Builder 中预先定义了一些常用的 Chain ID，你可以通过这些 ID �
 | `USE.TOML`                        | 对应 `toml-loader`                    |
 | `USE.YAML`                        | 对应 `yaml-loader`                    |
 | `USE.NODE`                        | 对应 `node-loader`                    |
-| `USE.FILE`                        | 对应 `file-loader`                    |
 | `USE.URL`                         | 对应 `url-loader`                     |
 | `USE.SVGR`                        | 对应 `@svgr/webpack`                  |
 | `USE.BABEL`                       | 对应 `babel-loader`                   |
@@ -250,12 +246,10 @@ Builder 中预先定义了一些常用的 Chain ID，你可以通过这些 ID �
 | `PLUGIN.BANNER`                | 对应 `BannerPlugin`                                                                |
 | `PLUGIN.PROGRESS`              | 对应 `Webpackbar`                                                                  |
 | `PLUGIN.APP_ICON`              | 对应 `AppIconPlugin`                                                               |
-| `PLUGIN.LOADABLE`              | 对应 `LoadableWebpackPlugin`                                                       |
 | `PLUGIN.MANIFEST`              | 对应 `WebpackManifestPlugin`                                                       |
 | `PLUGIN.TS_CHECKER`            | 对应 `ForkTsCheckerWebpackPlugin`                                                  |
 | `PLUGIN.INLINE_HTML`           | 对应 `InlineChunkHtmlPlugin`                                                       |
 | `PLUGIN.BUNDLE_ANALYZER`       | 对应 `WebpackBundleAnalyzer`                                                       |
-| `PLUGIN.BOTTOM_TEMPLATE`       | 对应 `BottomTemplatePlugin`                                                        |
 | `PLUGIN.MINI_CSS_EXTRACT`      | 对应 `MiniCssExtractPlugin`                                                        |
 | `PLUGIN.VUE_LOADER_PLUGIN`     | 对应 `VueLoaderPlugin`                                                             |
 | `PLUGIN.REACT_FAST_REFRESH`    | 对应 `ReactFastRefreshPlugin`                                                      |

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -119,7 +119,7 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
             },
           },
           tools: {
-            bundlerChain(chain, { isServer, isServiceWorker, CHAIN_ID }) {
+            bundlerChain(chain, { isServer, isServiceWorker }) {
               const userConfig = api.useResolvedConfigContext();
 
               if (
@@ -131,7 +131,7 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
                 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
                 const LoadableBundlerPlugin = require('./loadable-bundler-plugin.js');
                 chain
-                  .plugin(CHAIN_ID.PLUGIN.LOADABLE)
+                  .plugin('loadable')
                   .use(LoadableBundlerPlugin, [
                     { filename: LOADABLE_STATS_FILE },
                   ]);

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterHtml.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterHtml.ts
@@ -107,6 +107,6 @@ function applyBottomHtmlPlugin<B extends Bundler>({
     ]);
   }
   chain
-    .plugin(CHAIN_ID.PLUGIN.BOTTOM_TEMPLATE)
+    .plugin('bottom-template')
     .use(BottomTemplatePlugin, [HtmlBundlerPlugin]);
 }

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -44,12 +44,7 @@ export const builderPluginAdapterSSR = <B extends Bundler>(
         const builderConfig = api.getNormalizedConfig();
         const { normalizedConfig } = options;
 
-        applyRouterPlugin(
-          chain,
-          CHAIN_ID.PLUGIN.ROUTER_MANIFEST,
-          options,
-          HtmlBundlerPlugin,
-        );
+        applyRouterPlugin(chain, 'route-plugin', options, HtmlBundlerPlugin);
         if (isSSR(normalizedConfig)) {
           await applySSRLoaderEntry(chain, options, isServer);
           applySSRDataLoader(chain, options);

--- a/packages/storybook/builder/src/docgen/index.ts
+++ b/packages/storybook/builder/src/docgen/index.ts
@@ -40,7 +40,7 @@ export async function applyDocgenWebpack(
 
     chain.module
       .rule(CHAIN_ID.RULE.JS)
-      .use(CHAIN_ID.USE.REACT_DOCGEN)
+      .use('react-docgen')
       .loader(loader)
       .options({
         resolveOptions,
@@ -53,7 +53,7 @@ export async function applyDocgenWebpack(
     const tsRuls = chain.module.rule(CHAIN_ID.RULE.TS);
     if (tsRuls.uses.values().length !== 0) {
       tsRuls
-        .use(CHAIN_ID.USE.REACT_DOCGEN)
+        .use('react-docgen')
         .loader(loader)
         .options({
           resolveOptions,

--- a/packages/toolkit/utils/src/cli/constants/chainId.ts
+++ b/packages/toolkit/utils/src/cli/constants/chainId.ts
@@ -1,3 +1,6 @@
+/**
+ * Don't add anything. will be removed on next version
+ */
 export const CHAIN_ID = {
   /** Predefined rules */
   RULE: {


### PR DESCRIPTION
## Summary

builder CHAIN_ID will be replaced by Rsbuild CHAIN_ID, and some CHAIN_ID not support in rsbuild.

https://github.com/web-infra-dev/rsbuild/blob/main/packages/shared/src/chain.ts#L62

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
