### PR TITLE
chore: unify uni-builder config type

### DIFF
--- a/packages/builder/uni-builder/src/rspack/index.ts
+++ b/packages/builder/uni-builder/src/rspack/index.ts
@@ -6,21 +6,21 @@ import type {
 } from '@rsbuild/core';
 import type { RsbuildProvider, StartServerResult } from '@rsbuild/shared';
 import type {
-  UniBuilderRspackConfig,
-  CreateRspackBuilderOptions,
+  BuilderConfig,
+  CreateUniBuilderOptions,
   CreateBuilderCommonOptions,
 } from '../types';
 import { parseCommonConfig } from '../shared/parseCommonConfig';
 import type { StartDevServerOptions } from '../shared/devServer';
 
 export async function parseConfig(
-  uniBuilderConfig: UniBuilderRspackConfig,
+  uniBuilderConfig: BuilderConfig,
   options: CreateBuilderCommonOptions,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 }> {
-  const { rsbuildConfig, rsbuildPlugins } = await parseCommonConfig<'rspack'>(
+  const { rsbuildConfig, rsbuildPlugins } = await parseCommonConfig(
     uniBuilderConfig,
     options,
   );
@@ -69,7 +69,7 @@ type UniBuilderInstance = Omit<
 };
 
 export async function createRspackBuilder(
-  options: CreateRspackBuilderOptions,
+  options: CreateUniBuilderOptions,
 ): Promise<UniBuilderInstance> {
   const { cwd = process.cwd(), config, ...rest } = options;
 

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -14,11 +14,7 @@ import {
   type RsbuildPlugin,
   type RsbuildConfig,
 } from '@rsbuild/core';
-import type {
-  CreateBuilderCommonOptions,
-  UniBuilderRspackConfig,
-  UniBuilderWebpackConfig,
-} from '../types';
+import type { CreateBuilderCommonOptions, BuilderConfig } from '../types';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginGlobalVars } from './plugins/globalVars';
 import { pluginRuntimeChunk } from './plugins/runtimeChunk';
@@ -85,10 +81,8 @@ async function getBrowserslistWithDefault(
   return DEFAULT_BROWSERSLIST[target];
 }
 
-export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
-  uniBuilderConfig: B extends 'rspack'
-    ? UniBuilderRspackConfig
-    : UniBuilderWebpackConfig,
+export async function parseCommonConfig(
+  uniBuilderConfig: BuilderConfig,
   options: CreateBuilderCommonOptions,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
@@ -135,7 +129,7 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   for (const target of targets) {
     // Incompatible with the scenario where target contains both 'web' and 'modern-web'
     overrideBrowserslist[target] = await getBrowserslistWithDefault(
-      cwd!,
+      cwd,
       uniBuilderConfig,
       target,
     );

--- a/packages/builder/uni-builder/src/types.ts
+++ b/packages/builder/uni-builder/src/types.ts
@@ -29,22 +29,13 @@ export type CreateBuilderCommonOptions = {
   frameworkConfigPath?: string;
   target?: RsbuildTarget | RsbuildTarget[];
   /** The root path of current project. */
-  cwd?: string;
+  cwd: string;
 };
 
-export type CreateWebpackBuilderOptions = {
-  bundlerType: 'webpack';
-  config: UniBuilderWebpackConfig;
-} & CreateBuilderCommonOptions;
-
-export type CreateRspackBuilderOptions = {
-  bundlerType: 'rspack';
-  config: UniBuilderRspackConfig;
-} & CreateBuilderCommonOptions;
-
-export type CreateUniBuilderOptions =
-  | CreateWebpackBuilderOptions
-  | CreateRspackBuilderOptions;
+export type CreateUniBuilderOptions = {
+  bundlerType: 'rspack' | 'webpack';
+  config: BuilderConfig;
+} & Partial<CreateBuilderCommonOptions>;
 
 export type GlobalVars = Record<string, any>;
 
@@ -106,6 +97,13 @@ export type UniBuilderExtraConfig = {
      * Note that `Object.assign` is a shallow copy and will completely overwrite the built-in `presets` or `plugins` array, please use it with caution.
      */
     babel?: PluginBabelOptions['babelLoaderOptions'];
+    /**
+     * Modify the options of [ts-loader](https://github.com/TypeStrong/ts-loader).
+     * When `tools.tsLoader` is not undefined, Rsbuild will use ts-loader instead of babel-loader to compile TypeScript code.
+     *
+     * Tips: this configuration not yet support in rspack
+     */
+    tsLoader?: PluginTsLoaderOptions;
   };
   dev?: {
     /**
@@ -233,11 +231,22 @@ export type UniBuilderExtraConfig = {
   };
   security?: {
     /**
+     * Adding an integrity attribute (`integrity`) to sub-resources introduced by HTML allows the browser to
+     * verify the integrity of the introduced resource, thus preventing tampering with the downloaded resource.
+     *
+     * Tips: this configuration not yet support in rspack
+     */
+    sri?: SriOptions | boolean;
+    /**
      * Analyze the build artifacts to identify advanced syntax that is incompatible with the current browser scope.
      */
     checkSyntax?: boolean | PluginCheckSyntaxOptions;
   };
   experiments?: {
+    /**
+     * Tips: this configuration not yet support in rspack
+     */
+    lazyCompilation?: LazyCompilationOptions;
     /**
      * Enable the ability for source code building
      */
@@ -251,29 +260,4 @@ export type SriOptions = {
   hashLoading?: 'eager' | 'lazy';
 };
 
-export type UniBuilderWebpackConfig = RsbuildConfig &
-  UniBuilderExtraConfig & {
-    security?: {
-      /**
-       * Adding an integrity attribute (`integrity`) to sub-resources introduced by HTML allows the browser to
-       * verify the integrity of the introduced resource, thus preventing tampering with the downloaded resource.
-       */
-      sri?: SriOptions | boolean;
-    };
-    experiments?: {
-      lazyCompilation?: LazyCompilationOptions;
-    };
-    tools?: {
-      /**
-       * Modify the options of [ts-loader](https://github.com/TypeStrong/ts-loader).
-       * When `tools.tsLoader` is not undefined, Rsbuild will use ts-loader instead of babel-loader to compile TypeScript code.
-       */
-      tsLoader?: PluginTsLoaderOptions;
-    };
-  };
-
-export type UniBuilderRspackConfig = RsbuildConfig & UniBuilderExtraConfig;
-
-export type BuilderConfig<B = 'rspack'> = B extends 'rspack'
-  ? UniBuilderRspackConfig
-  : UniBuilderWebpackConfig;
+export type BuilderConfig = RsbuildConfig & UniBuilderExtraConfig;

--- a/packages/builder/uni-builder/src/types.ts
+++ b/packages/builder/uni-builder/src/types.ts
@@ -101,7 +101,7 @@ export type UniBuilderExtraConfig = {
      * Modify the options of [ts-loader](https://github.com/TypeStrong/ts-loader).
      * When `tools.tsLoader` is not undefined, Rsbuild will use ts-loader instead of babel-loader to compile TypeScript code.
      *
-     * Tips: this configuration not yet support in rspack
+     * Tips: this configuration is not yet supported in rspack
      */
     tsLoader?: PluginTsLoaderOptions;
   };
@@ -234,7 +234,7 @@ export type UniBuilderExtraConfig = {
      * Adding an integrity attribute (`integrity`) to sub-resources introduced by HTML allows the browser to
      * verify the integrity of the introduced resource, thus preventing tampering with the downloaded resource.
      *
-     * Tips: this configuration not yet support in rspack
+     * Tips: this configuration is not yet supported in rspack
      */
     sri?: SriOptions | boolean;
     /**
@@ -244,7 +244,7 @@ export type UniBuilderExtraConfig = {
   };
   experiments?: {
     /**
-     * Tips: this configuration not yet support in rspack
+     * Tips: this configuration is not yet supported in rspack
      */
     lazyCompilation?: LazyCompilationOptions;
     /**

--- a/packages/builder/uni-builder/src/webpack/index.ts
+++ b/packages/builder/uni-builder/src/webpack/index.ts
@@ -6,8 +6,8 @@ import {
 } from '@rsbuild/core';
 import type { StartServerResult } from '@rsbuild/shared';
 import type {
-  UniBuilderWebpackConfig,
-  CreateWebpackBuilderOptions,
+  BuilderConfig,
+  CreateUniBuilderOptions,
   CreateBuilderCommonOptions,
 } from '../types';
 import { parseCommonConfig } from '../shared/parseCommonConfig';
@@ -17,13 +17,13 @@ import { pluginReact } from './plugins/react';
 import type { StartDevServerOptions } from '../shared/devServer';
 
 export async function parseConfig(
-  uniBuilderConfig: UniBuilderWebpackConfig,
+  uniBuilderConfig: BuilderConfig,
   options: CreateBuilderCommonOptions,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 }> {
-  const { rsbuildConfig, rsbuildPlugins } = await parseCommonConfig<'webpack'>(
+  const { rsbuildConfig, rsbuildPlugins } = await parseCommonConfig(
     uniBuilderConfig,
     options,
   );
@@ -84,7 +84,7 @@ type UniBuilderWebpackInstance = Omit<RsbuildInstance, 'startDevServer'> & {
 };
 
 export async function createWebpackBuilder(
-  options: CreateWebpackBuilderOptions,
+  options: CreateUniBuilderOptions,
 ): Promise<UniBuilderWebpackInstance> {
   const { cwd = process.cwd(), config, ...rest } = options;
 

--- a/tests/e2e/builder/scripts/shared.ts
+++ b/tests/e2e/builder/scripts/shared.ts
@@ -56,18 +56,11 @@ export const createUniBuilder = async (
 ) => {
   const { createUniBuilder } = await import('@modern-js/uni-builder');
 
-  const builder =
-    process.env.PROVIDE_TYPE === 'rspack'
-      ? await createUniBuilder({
-          ...builderOptions,
-          bundlerType: 'rspack',
-          config: builderConfig,
-        })
-      : await createUniBuilder({
-          ...builderOptions,
-          bundlerType: 'webpack',
-          config: builderConfig as UniBuilderConfig<'webpack'>,
-        });
+  const builder = await createUniBuilder({
+    ...builderOptions,
+    bundlerType: process.env.PROVIDE_TYPE === 'rspack' ? 'rspack' : 'webpack',
+    config: builderConfig,
+  });
 
   return builder;
 };
@@ -102,11 +95,7 @@ function getRandomPort(defaultPort = Math.ceil(Math.random() * 10000) + 10000) {
   }
 }
 
-const updateConfigForTest = <BuilderType>(
-  config: BuilderType extends 'webpack'
-    ? UniBuilderConfig<'webpack'>
-    : UniBuilderConfig<'rspack'>,
-) => {
+const updateConfigForTest = (config: UniBuilderConfig) => {
   // make devPort random to avoid port conflict
   config.dev = {
     ...(config.dev || {}),
@@ -141,14 +130,12 @@ const updateConfigForTest = <BuilderType>(
   }
 };
 
-export async function dev<BuilderType = 'webpack'>({
+export async function dev({
   serverOptions,
   builderConfig = {},
   ...options
 }: CreateBuilderOptions & {
-  builderConfig?: BuilderType extends 'webpack'
-    ? UniBuilderConfig<'webpack'>
-    : UniBuilderConfig<'rspack'>;
+  builderConfig?: UniBuilderConfig;
   serverOptions?: StartDevServerOptions['serverOptions'];
 }) {
   process.env.NODE_ENV = 'development';
@@ -162,7 +149,7 @@ export async function dev<BuilderType = 'webpack'>({
   });
 }
 
-export async function build<BuilderType = 'webpack'>({
+export async function build({
   plugins,
   runServer = false,
   builderConfig = {},
@@ -173,9 +160,7 @@ export async function build<BuilderType = 'webpack'>({
   runServer?: boolean;
   /** TODO: should removed when all test cases migrate to uniBuilder */
   useUniBuilder?: boolean;
-  builderConfig?: BuilderType extends 'webpack'
-    ? UniBuilderConfig<'webpack'>
-    : UniBuilderConfig<'rspack'>;
+  builderConfig?: UniBuilderConfig;
 }) {
   process.env.NODE_ENV = 'production';
 


### PR DESCRIPTION
## Summary

unify and simplify uni-builder config type, because only three configurations not support in rspack mode.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
