### PR TITLE
fix(hmr-client): reload when the updated modules are empty

### DIFF
--- a/.changeset/violet-eels-pull.md
+++ b/.changeset/violet-eels-pull.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server': patch
+---
+
+fix(hmr-client): reload when the updated modules are empty
+fix(hmr-client): updated modules 为空时刷新页面

--- a/packages/server/server/src/dev-tools/dev-middleware/hmr-client/index.ts
+++ b/packages/server/server/src/dev-tools/dev-middleware/hmr-client/index.ts
@@ -190,7 +190,8 @@ function tryApplyUpdates() {
   }
 
   function handleApplyUpdates(err: any, updatedModules: any) {
-    const wantsForcedReload = err || !updatedModules || hadRuntimeError;
+    const wantsForcedReload =
+      err || !updatedModules || updatedModules.length === 0 || hadRuntimeError;
     if (wantsForcedReload) {
       window.location.reload();
       return;


### PR DESCRIPTION
## Summary

https://github.com/webpack/webpack/blob/2e5fc25fa791e5cd2d51c3b98993666f54800c52/test/hotPlayground/index.js#L21-L22

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
