### PR TITLE
fix: when splitRouteChunks is false, dont use loadable to load compon…

### DIFF
--- a/.changeset/strange-fishes-repeat.md
+++ b/.changeset/strange-fishes-repeat.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: when splitRouteChunks is false, dont use loadable to load components
+fix: 当 splitRouteChunks 为 false，不使用 loadable 加载组件

--- a/packages/document/main-doc/docs/en/guides/basic-features/data/data-fetch.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/data/data-fetch.mdx
@@ -306,6 +306,10 @@ If you define the [`shouldRevalidate`](#/shouldrevalidate) function on the route
 
 ### `shouldRevalidate`
 
+:::warning
+Currently `shouldRevalidate` works under csr and streaming ssr.
+:::
+
 In each routing component (`layout.tsx`, `page.tsx`, `$.tsx`), we can export a `shouldRevalidate` function, which is triggered each time a route changes in the project. This function controls which routes' data are reloaded, and when it returns true, the data for the corresponding route is reloaded. data of the corresponding route will be reloaded.
 
 ```ts title="routes/user/layout.tsx"

--- a/packages/document/main-doc/docs/zh/guides/basic-features/data/data-fetch.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/data/data-fetch.mdx
@@ -299,6 +299,10 @@ defer 的具体用法请查看 [defer](https://reactrouter.com/en/main/guides/de
 
 ### `shouldRevalidate`
 
+:::warning
+目前 `shouldRevalidate` 会在 csr 和 streaming ssr 下生效。
+:::
+
 在每个路由组件(`layout.tsx`，`page.tsx`, `$.tsx`)中，我们可以导出一个 `shouldRevalidate` 函数，在每次项目中的路由变化时，这个函数会触发，该函数可以控制要重新加载哪些路由中的数据，当这个函数返回 true， 对应路由的数据就会重新加载。
 
 ```ts title="routes/user/layout.tsx"

--- a/packages/solutions/app-tools/src/analyze/templates.ts
+++ b/packages/solutions/app-tools/src/analyze/templates.ts
@@ -353,13 +353,12 @@ export const fileSystemRoutes = async ({
             lazyImport = `() => import(/* webpackChunkName: "${route.id}" */  '${route._component}').then(routeModule => handleRouteModule(routeModule, "${route.id}")).catch(handleRouteModuleError) `;
             component = `lazy(${lazyImport})`;
           }
+        } else if (ssrMode === 'string') {
+          components.push(route._component);
+          component = `component_${components.length - 1}`;
         } else {
           lazyImport = `() => import(/* webpackMode: "eager" */  '${route._component}').then(routeModule => handleRouteModule(routeModule, "${route.id}")).catch(handleRouteModuleError) `;
-          if (ssrMode === 'string') {
-            component = `loadable(${lazyImport})`;
-          } else {
-            component = `lazy(${lazyImport})`;
-          }
+          component = `lazy(${lazyImport})`;
         }
       }
     } else if (route._component) {


### PR DESCRIPTION
…ents

## Summary

1. When server-side rendering, loadable will query chunk information through loadable-stats. When splitRouteChunks is false, the corresponding chunk information cannot be found.

2. When using loadable to load components, on the client side, loadable does not load through dynamic import, so it cannot inject modules into `window_routeModules`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
