### PR TITLE
fix: add missing babel types

### DIFF
--- a/.changeset/weak-beds-wash.md
+++ b/.changeset/weak-beds-wash.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/types': patch
+---
+
+fix: add missing babel types
+fix: 添加缺失 babel 类型

--- a/packages/toolkit/types/common/babel.d.ts
+++ b/packages/toolkit/types/common/babel.d.ts
@@ -1,3 +1,8 @@
+import {
+  TransformOptions as BabelTransformOptions,
+  PluginItem as BabelPlugin,
+} from '@babel/core';
+
 export type {
   TransformOptions as BabelTransformOptions,
   PluginItem as BabelPlugin,


### PR DESCRIPTION
## Summary

the type `BabelPlugin` is not defined, resulting in the tools.babel `addPlugins`/`addPresets` parameters actually being of `any`.

https://github.com/modern-js-dev/modern.js/blob/a8db932a4f006f4c6f256dd93b1bd989724306a7/packages/toolkit/types/common/babel.d.ts#L59-L60

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
