### PR TITLE
feat(plugin-vue): set default vue hydration mismatch flag

### DIFF
--- a/.changeset/fluffy-games-trade.md
+++ b/.changeset/fluffy-games-trade.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-plugin-vue': patch
+---
+
+feat: set default vue hydration mismatch flag
+feat: 设置默认 vue hydration mismatch flag

--- a/packages/builder/plugin-vue/src/index.ts
+++ b/packages/builder/plugin-vue/src/index.ts
@@ -35,6 +35,7 @@ export function builderPluginVue(
               // https://link.vuejs.org/feature-flags
               __VUE_OPTIONS_API__: true,
               __VUE_PROD_DEVTOOLS__: false,
+              __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
             },
           },
           tools: {

--- a/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/builder/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -529,6 +529,7 @@ exports[`plugins/vue > should define feature flags correctly 1`] = `
       "definitions": {
         "__VUE_OPTIONS_API__": true,
         "__VUE_PROD_DEVTOOLS__": false,
+        "__VUE_PROD_HYDRATION_MISMATCH_DETAILS__": false,
         "process.env.ASSET_PREFIX": "\\"\\"",
         "process.env.NODE_ENV": "\\"test\\"",
       },


### PR DESCRIPTION
## Summary

The flag was added in the recent [Vue 3.4 release](https://github.com/vuejs/core/blob/main/CHANGELOG.md#340-slam-dunk-2023-12-29).

## Related Links

https://vuejs.org/api/compile-time-flags.html#VUE_PROD_HYDRATATION_MISMATCH_DETAILS

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
