### PR TITLE
WIP: explicitly declare Node version of babel target

### DIFF
--- a/.changeset/young-vans-carry.md
+++ b/.changeset/young-vans-carry.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/builder-webpack-provider': patch
+'@modern-js/uni-builder': patch
+'@modern-js/server-utils': patch
+---
+
+chore: explicitly declare Node version of babel target
+
+chore: 显式声明 babel 的目标 Node 版本

--- a/packages/builder/builder-webpack-provider/src/plugins/babel.ts
+++ b/packages/builder/builder-webpack-provider/src/plugins/babel.ts
@@ -88,6 +88,9 @@ export const builderPluginBabel = (): BuilderPlugin => ({
           const baseBabelConfig =
             isServer || isServiceWorker
               ? getBabelConfigForNode({
+                  presetEnv: {
+                    targets: ['node >= 14'],
+                  },
                   pluginDecorators: decoratorConfig,
                 })
               : getBabelConfigForWeb({

--- a/packages/builder/uni-builder/src/webpack/plugins/babel.ts
+++ b/packages/builder/uni-builder/src/webpack/plugins/babel.ts
@@ -65,6 +65,9 @@ export const pluginBabel = (options?: PluginBabelOptions): RsbuildPlugin => ({
           const baseBabelConfig =
             isServer || isServiceWorker
               ? getBabelConfigForNode({
+                  presetEnv: {
+                    targets: ['node >= 14'],
+                  },
                   pluginDecorators: decoratorConfig,
                 })
               : getBabelConfigForWeb({

--- a/packages/server/utils/src/compilers/babel/preset/index.ts
+++ b/packages/server/utils/src/compilers/babel/preset/index.ts
@@ -7,6 +7,7 @@ export const getBabelConfig = (libPresetOption: ILibPresetOption) => {
     presetEnv: {
       loose: true,
       modules: 'commonjs',
+      targets: ['node >= 14'],
     },
     pluginDecorators: {
       version: 'legacy',


### PR DESCRIPTION
## Summary

Explicitly declare Node version of babel target, as Rsbuild will change the default target Node version in v0.3.0.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/1181
- https://github.com/web-infra-dev/rsbuild/discussions/1101

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
