### PR TITLE
fix(prod-server): ssr cache cant work in serve command

### DIFF
--- a/.changeset/early-doors-join.md
+++ b/.changeset/early-doors-join.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix(prod-server): ssr cache can't work in `serve` command
+fix(prod-server): ssr 缓存不能在 `serve` 指令中正常工作

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -3,6 +3,7 @@ import { IncomingMessage, ServerResponse, Server, createServer } from 'http';
 import path from 'path';
 import {
   fs,
+  isProd,
   isPromise,
   isWebOnly,
   mime,
@@ -165,7 +166,7 @@ export class ModernServer implements ModernServerInterface {
     this.warmupSSRBundle();
 
     // warmup cacheMod
-    cacheMod.loadServerCacheMod(this.pwd);
+    cacheMod.loadServerCacheMod(isProd() ? distDir : this.pwd);
 
     await this.prepareFrameHandler();
     await this.prepareLoaderHandler(usageRoutes, distDir);


### PR DESCRIPTION
## Summary

**How to repeat?**
```shell
npm run build 

npm run serve
```

When run build, the server/cache.ts would compiler to dist/server/cache.js.
So the load path must be distDir in production.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
