### PR TITLE
docs: update builder glossary

### DIFF
--- a/packages/document/builder-doc/docs/en/shared/builder.md
+++ b/packages/document/builder-doc/docs/en/shared/builder.md
@@ -1,3 +1,3 @@
 Refers to the build layer of Modern.js. The goal of Builder is to provide Modern.js users with out-of-the-box build capabilities and support seamless switching between webpack and Rspack.
 
-Originally using `@modern-js/builder`, it has been upgraded to [Rsbuild](https://rsbuild.dev/).
+The previous version of Modern.js `MAJOR_VERSION.46.0` used `@modern-js/builder`, which was upgraded to [Rsbuild](https://rsbuild.dev/) starting from `MAJOR_VERSION.46.0`.

--- a/packages/document/builder-doc/docs/en/shared/builder.md
+++ b/packages/document/builder-doc/docs/en/shared/builder.md
@@ -1,9 +1,3 @@
-Refers to the build tool of Modern.js. The goal of Builder is to "reuse the best practices of build tools".
+Refers to the build layer of Modern.js. The goal of Builder is to provide Modern.js users with out-of-the-box build capabilities and support seamless switching between webpack and Rspack.
 
-Bundlers are low-level, when we build a project based on webpack, we need to fully understand the webpack config and many webpack plugins and loaders, then spend a lot of time to combine them.
-
-Builder is out-of-box. By using Builder, you can quickly gain the ability to build a web application.
-
-The layers within the Modern.js Builder are as follows:
-
-![](https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/builder-struct-10092.png)
+Originally using `@modern-js/builder`, it has been upgraded to [Rsbuild](https://rsbuild.dev/).

--- a/packages/document/builder-doc/docs/en/shared/rsbuild.md
+++ b/packages/document/builder-doc/docs/en/shared/rsbuild.md
@@ -1,0 +1,3 @@
+[Rsbuild](https://rsbuild.dev/) is an Rspack-based build tool for the web. The main goal of Rsbuild is to provide out-of-the-box build capabilities for Rspack users, allowing developers to start a web project with zero configuration.
+
+Rsbuild integrates high-performance Rust-based tools from the community, including Rspack and SWC, to provide first-class build speed and development experience.

--- a/packages/document/builder-doc/docs/zh/shared/builder.md
+++ b/packages/document/builder-doc/docs/zh/shared/builder.md
@@ -1,3 +1,3 @@
 Modern.js Builder 指的是 Modern.js 的构建层，它的目标是为 Modern.js 用户提供开箱即用的构建能力，并支持在 webpack 和 Rspack 间无缝切换。
 
-原本使用的是 `@modern-js/builder`, 目前已经升级为 [Rsbuild](https://rsbuild.dev/)。
+Modern.js `MAJOR_VERSION.46.0` 之前版本使用的是 `@modern-js/builder`, 从 `MAJOR_VERSION.46.0` 开始升级为 [Rsbuild](https://rsbuild.dev/)。

--- a/packages/document/builder-doc/docs/zh/shared/builder.md
+++ b/packages/document/builder-doc/docs/zh/shared/builder.md
@@ -1,9 +1,3 @@
-Modern.js Builder 指的是 Modern.js 的构建工具，它的目标是「复用构建工具的最佳实践」。
+Modern.js Builder 指的是 Modern.js 的构建层，它的目标是为 Modern.js 用户提供开箱即用的构建能力，并支持在 webpack 和 Rspack 间无缝切换。
 
-因为 webpack 等打包工具是比较底层的，如果我们基于 webpack 来构建一个项目，需要充分理解 webpack 的各个配置项和三方插件，并进行繁琐的配置组合和调试工作。
-
-而 Builder 比 Bundler 的封装程度更高，并默认集成代码转换、代码压缩等能力。通过接入 Builder，你可以快速获得构建 Web 应用的能力。
-
-Modern.js Builder 内部的分层如下：
-
-![](https://lf3-static.bytednsdoc.com/obj/eden-cn/zq-uylkvT/ljhwZthlaukjlkulzlp/builder-struct-10092.png)
+原本使用的是 `@modern-js/builder`, 目前已经升级为 [Rsbuild](https://rsbuild.dev/)。

--- a/packages/document/builder-doc/docs/zh/shared/rsbuild.md
+++ b/packages/document/builder-doc/docs/zh/shared/rsbuild.md
@@ -1,0 +1,3 @@
+[Rsbuild](https://rsbuild.dev/) 是一个基于 Rspack 的 web 构建工具，它的目标是为 Rspack 用户提供开箱即用的构建能力，使开发者能够在零配置的情况下启动一个 web 项目。
+
+Rsbuild 集成了社区中基于 Rust 的高性能工具，包括 Rspack 和 SWC，以提供一流的构建速度和开发体验。

--- a/packages/document/main-doc/docs/en/guides/get-started/glossary.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/glossary.mdx
@@ -46,6 +46,12 @@ import ModuleFederation from '@modern-js/builder-doc/docs/en/shared/module-feder
 
 <ModuleFederation />
 
+## Rsbuild
+
+import Rsbuild from '@modern-js/builder-doc/docs/en/shared/rsbuild.md';
+
+<Rsbuild />
+
 ## Rspack
 
 import Rspack from '@modern-js/builder-doc/docs/en/shared/rspack.md';

--- a/packages/document/main-doc/docs/zh/guides/get-started/glossary.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/glossary.mdx
@@ -46,6 +46,12 @@ import ModuleFederation from '@modern-js/builder-doc/docs/zh/shared/module-feder
 
 <ModuleFederation />
 
+## Rsbuild
+
+import Rsbuild from '@modern-js/builder-doc/docs/zh/shared/rsbuild.md';
+
+<Rsbuild />
+
 ## Rspack
 
 import Rspack from '@modern-js/builder-doc/docs/zh/shared/rspack.md';


### PR DESCRIPTION
## Summary

since we use rsbuild instead of modern builder, we need update builder glossary.

Related PR: https://github.com/web-infra-dev/modern.js/pull/5168

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
