### PR TITLE
chore(module-tools): add babel dep, because @svgr/plugin-jsx depended after prebundle

### DIFF
--- a/.changeset/ten-camels-retire.md
+++ b/.changeset/ten-camels-retire.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+chore(module-tools): add babel dep, because @svgr/plugin-jsx depended after prebundle
+chore(module-tools): 新增 babel 依赖，因为预打包后的 @svgr/plugin-jsx 需要这些依赖

--- a/packages/solutions/module-tools/package.json
+++ b/packages/solutions/module-tools/package.json
@@ -57,6 +57,8 @@
   "dependencies": {
     "@ampproject/remapping": "^2.2.1",
     "@ast-grep/napi": "0.16.0",
+    "@babel/core": "^7.23.2",
+    "@babel/types": "^7.23.0",
     "@modern-js/core": "workspace:*",
     "@modern-js/new-action": "workspace:*",
     "@modern-js/plugin": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4759,6 +4759,12 @@ importers:
       '@ast-grep/napi':
         specifier: 0.16.0
         version: 0.16.0
+      '@babel/core':
+        specifier: ^7.23.2
+        version: 7.23.6
+      '@babel/types':
+        specifier: ^7.23.0
+        version: 7.23.6
       '@modern-js/core':
         specifier: workspace:*
         version: link:../../cli/core


### PR DESCRIPTION
## Summary
when remove `@modern-js/eslint-config`, we will get:
![image](https://github.com/web-infra-dev/modern.js/assets/50694858/1cfa60f7-5703-4ba9-b666-26fe2f33eca2)
so we need add this deps


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
