### PR TITLE
fix(CI): avoid rspack version in rspack-provider overrides by rspack-ecosystem-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,12 @@
   "pnpm": {
     "overrides": {
       "@types/react": "^18",
-      "@types/react-dom": "^18"
+      "@types/react-dom": "^18",
+      "@modern-js/builder-rspack-provider>@rspack/core": "0.4.5",
+      "@modern-js/builder-rspack-provider>@rspack/plugin-react-refresh": "0.4.5",
+      "@modern-js/builder-rspack-provider>@rspack/plugin-html": "0.4.5",
+      "@modern-js/storybook-builder>@rspack/plugin-react-refresh": "0.4.5",
+      "@rspack/core@0.4.5>@rspack/binding": "0.4.5"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   '@types/react': ^18
   '@types/react-dom': ^18
+  '@modern-js/builder-rspack-provider>@rspack/core': 0.4.5
+  '@modern-js/builder-rspack-provider>@rspack/plugin-react-refresh': 0.4.5
+  '@modern-js/builder-rspack-provider>@rspack/plugin-html': 0.4.5
+  '@modern-js/storybook-builder>@rspack/plugin-react-refresh': 0.4.5
+  '@rspack/core@0.4.5>@rspack/binding': 0.4.5
 
 importers:
 


### PR DESCRIPTION
## Summary

fix rspack-ecosystem-ci error: the rspack version in rspack-provider should not be override

<img width="1032" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/f1c5e097-bbe1-4c7d-832a-c1ec3eb2e51a">


https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/7509196132/job/20445962320

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
