### PR TITLE
feat(uni-builder): support passing source build options

### DIFF
--- a/.changeset/tender-carrots-compete.md
+++ b/.changeset/tender-carrots-compete.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+feat(uni-builder): support passing source build options
+
+feat(uni-builder): 支持传入 source build 配置项

--- a/packages/builder/uni-builder/src/index.ts
+++ b/packages/builder/uni-builder/src/index.ts
@@ -40,4 +40,3 @@ export {
 } from '@rsbuild/core';
 export type { webpack, WebpackChain, WebpackConfig } from '@rsbuild/webpack';
 export { RUNTIME_CHUNK_NAME } from './shared/constants';
-export type { PluginSourceBuildOptions } from '@rsbuild/plugin-source-build';

--- a/packages/builder/uni-builder/src/index.ts
+++ b/packages/builder/uni-builder/src/index.ts
@@ -40,3 +40,4 @@ export {
 } from '@rsbuild/core';
 export type { webpack, WebpackChain, WebpackConfig } from '@rsbuild/webpack';
 export { RUNTIME_CHUNK_NAME } from './shared/constants';
+export type { PluginSourceBuildOptions } from '@rsbuild/plugin-source-build';

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -310,10 +310,13 @@ export async function parseCommonConfig(
     pluginRuntimeChunk(uniBuilderConfig.output?.disableInlineRuntimeChunk),
   );
 
-  if (uniBuilderConfig.experiments?.sourceBuild) {
+  const { sourceBuild } = uniBuilderConfig.experiments || {};
+  if (sourceBuild) {
     const { pluginSourceBuild } = await import('@rsbuild/plugin-source-build');
 
-    rsbuildPlugins.push(pluginSourceBuild());
+    rsbuildPlugins.push(
+      pluginSourceBuild(sourceBuild === true ? {} : sourceBuild),
+    );
   }
 
   rsbuildPlugins.push(pluginReact());

--- a/packages/builder/uni-builder/src/types.ts
+++ b/packages/builder/uni-builder/src/types.ts
@@ -30,6 +30,7 @@ import type {
   StartDevServerOptions,
   UniBuilderStartServerResult,
 } from './shared/devServer';
+import type { PluginSourceBuildOptions } from '@rsbuild/plugin-source-build';
 
 export type CreateBuilderCommonOptions = {
   entry?: RsbuildEntry;
@@ -261,7 +262,9 @@ export type UniBuilderExtraConfig = {
     /**
      * Enable the ability for source code building
      */
-    sourceBuild?: boolean;
+    sourceBuild?:
+      | boolean
+      | Pick<PluginSourceBuildOptions, 'sourceField' | 'resolvePriority'>;
   };
 };
 

--- a/packages/document/builder-doc/docs/en/config/experiments/sourceBuild.md
+++ b/packages/document/builder-doc/docs/en/config/experiments/sourceBuild.md
@@ -1,6 +1,6 @@
-- **Type:** `boolean`
+- **Type:** `boolean | PluginSourceBuildOptions`
 - **Default:** `false`
-- **Version:** `MAJOR_VERSION.26.0`
+- **Version:** `MAJOR_VERSION.46.0`
 
 Used to enable the ability for source code building. When this configuration option is enabled, Builder will read the source code files corresponding to the `source` field in the sub-project's package.json and compile them.
 
@@ -13,3 +13,18 @@ export default {
 ```
 
 More detail can see ["Source Code Build Mode"](https://modernjs.dev/en/guides/advanced-features/source-build.html)。
+
+### Options
+
+`experiments.sourceBuild` is implemented based on Rsbuild's [Source Build plugin](https://rsbuild.dev/plugins/list/plugin-source-build#options). You can pass plugin options like this:
+
+```ts
+export default {
+  experiments: {
+    sourceBuild: {
+      sourceField: 'my-source',
+      resolvePriority: 'output',
+    },
+  },
+};
+```

--- a/packages/document/builder-doc/docs/zh/config/experiments/sourceBuild.md
+++ b/packages/document/builder-doc/docs/zh/config/experiments/sourceBuild.md
@@ -1,6 +1,6 @@
-- **类型：** `boolean`
+- **类型：** `boolean | PluginSourceBuildOptions`
 - **默认值：** `false`
-- **版本：** `MAJOR_VERSION.26.0`
+- **版本：** `MAJOR_VERSION.46.0`
 
 用于开启源码构建的能力。当开启此配置项时，Builder 会读取子项目 package.json 的 `source` 字段对应的源码文件，并进行编译。
 
@@ -13,3 +13,18 @@ export default {
 ```
 
 更多信息可参考[「源码构建模式」](https://modernjs.dev/guides/advanced-features/source-build.html)。
+
+### 选项
+
+`experiments.sourceBuild` 底层基于 Rsbuild 的 [Source Build 插件](https://rsbuild.dev/plugins/list/plugin-source-build#options) 实现，你可以传入插件选项，比如：
+
+```ts
+export default {
+  experiments: {
+    sourceBuild: {
+      sourceField: 'my-source',
+      resolvePriority: 'output',
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

Support passing source build options via `experiments.sourceBuild` config, this allows user to set `resolvePriority` in some cases.

## Related Links

https://rsbuild.dev/plugins/list/plugin-source-build#options

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
