### PR TITLE
perf(module-tools): skip build js and d.ts when input is empty

### DIFF
--- a/.changeset/breezy-eyes-poke.md
+++ b/.changeset/breezy-eyes-poke.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+perf(module-tools): skip build js and d.ts when input is empty
+perf(module-tools): 当没有入口时跳过构建 js 和 d.ts 文件

--- a/packages/solutions/module-tools/src/builder/build.ts
+++ b/packages/solutions/module-tools/src/builder/build.ts
@@ -34,6 +34,11 @@ export const runBuildTask = async (
   const { watch } = buildCmdOptions;
   const existTsconfig = await fs.pathExists(buildConfig.tsconfig);
 
+  if (Object.keys(buildConfig.input).length === 0) {
+    logger.info('If input is empty, js and dts task will be skipped');
+    return;
+  }
+
   if (dts && existTsconfig) {
     const tasks = dts.only ? [generatorDts] : [buildLib, generatorDts];
     await pMap(tasks, async task => {


### PR DESCRIPTION
## Summary
Avoid rollup error when input is empty.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
