### PR TITLE
perf(module-tools): log error detail which may throw by own plugin and complete error stack

### DIFF
--- a/.changeset/odd-dryers-compare.md
+++ b/.changeset/odd-dryers-compare.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+perf(module-tools): log error detail which may throw by own plugin and complete error stack
+perf(module-tools): 补齐错误栈并且打印错误细节，因为这错误可能并不是 esbuild 抛出的，而是我们自己的插件抛出的

--- a/packages/solutions/module-tools/src/builder/esbuild/index.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/index.ts
@@ -9,6 +9,7 @@ import {
   ImportKind,
   formatMessages,
   Format,
+  BuildFailure,
 } from 'esbuild';
 import * as tapable from 'tapable';
 import { FSWatcher, chalk, logger, fs, lodash } from '@modern-js/utils';
@@ -292,6 +293,14 @@ export class EsbuildCompiler implements ICompiler {
         });
       }
     } catch (error: any) {
+      if ('errors' in error) {
+        // log error detail which may throw by own plugins
+        (error as BuildFailure)?.errors?.forEach(err => {
+          if (err?.detail) {
+            logger.error(err.detail.toString());
+          }
+        });
+      }
       if (watch) {
         this.instance?.cancel();
         logger.error(error);

--- a/packages/solutions/module-tools/src/error.ts
+++ b/packages/solutions/module-tools/src/error.ts
@@ -39,8 +39,6 @@ export class InternalBuildError extends Error {
 
   public format: Format;
 
-  private e: Error;
-
   constructor(
     e: Error,
     opts: {
@@ -49,11 +47,10 @@ export class InternalBuildError extends Error {
       target: Target;
     },
   ) {
-    super(e.message);
+    super(e.stack);
 
     Error.captureStackTrace(this, this.constructor);
 
-    this.e = e;
     this.buildType = opts.buildType;
     this.target = opts.target;
     this.format = opts.format;
@@ -65,7 +62,7 @@ export class InternalBuildError extends Error {
 
   formatError() {
     const msgs: string[] = [];
-    const { e, buildType, target, format } = this;
+    const { buildType, target, format } = this;
     const textL = 25;
     const title = `│ ${padSpaceWith(`${buildType} failed:`, textL - 2, {
       style: chalk.red.underline,
@@ -92,11 +89,8 @@ export class InternalBuildError extends Error {
       chalk.blue.bold.underline(`\nDetailed Information: `),
     );
 
-    if (e.stack) {
-      msgs.push(e.stack);
-    } else {
-      msgs.push(e.message);
-    }
+    // remove 'Error: '
+    msgs.push(this.stack?.substring(7) || this.message);
 
     return msgs;
   }


### PR DESCRIPTION
## less error
### before
![image](https://github.com/web-infra-dev/modern.js/assets/50694858/02d8a205-cf2c-4200-b11b-1e1192c0e9a2)

### after
![image](https://github.com/web-infra-dev/modern.js/assets/50694858/db84320b-02d3-4b38-90b8-cc251b597d64)

And then we found that our error stack is complete. The ModuleBuildError has extended the esbuild error stack.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
