### PR TITLE
fix: resolve warning 'Failed to resolve encoding' in node-fetch

### DIFF
--- a/.changeset/short-gifts-search.md
+++ b/.changeset/short-gifts-search.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/create-request': patch
+---
+
+fix: resolve warning 'Failed to resolve encoding' in node-fetch
+
+fix: 修复在使用 node-fetch 时的 'Failed to resolve encoding' resolve warning

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -70,6 +70,7 @@
     "@modern-js/utils": "workspace:*",
     "@modern-js/runtime-utils": "workspace:*",
     "node-fetch": "^2.6.1",
+    "encoding": "^0.1.0",
     "path-to-regexp": "^6.2.0",
     "query-string": "^7.1.1",
     "@swc/helpers": "0.5.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,7 +1163,7 @@ importers:
         version: 2.0.12
       isomorphic-fetch:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(encoding@0.1.13)
       jest:
         specifier: ^29
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.2)
@@ -4086,9 +4086,12 @@ importers:
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
+      encoding:
+        specifier: ^0.1.0
+        version: 0.1.13
       node-fetch:
         specifier: ^2.6.1
-        version: 2.6.7
+        version: 2.6.7(encoding@0.1.13)
       path-to-regexp:
         specifier: ^6.2.0
         version: 6.2.1
@@ -4116,7 +4119,7 @@ importers:
         version: 2.6.7
       isomorphic-fetch:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(encoding@0.1.13)
       jest:
         specifier: ^29
         version: 29.5.0(@types/node@14.18.35)(ts-node@10.9.2)
@@ -6489,7 +6492,7 @@ importers:
         version: 18.0.6
       isomorphic-fetch:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(encoding@0.1.13)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@swc/core@1.3.42)(@types/node@14.18.35)(typescript@5.3.3)
@@ -15743,7 +15746,7 @@ packages:
       glob: 10.3.10
       handlebars: 4.7.7
       lazy-universal-dotenv: 4.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       picomatch: 2.3.1
       pkg-dir: 5.0.0
       pretty-hrtime: 1.0.3
@@ -20079,7 +20082,7 @@ packages:
   /cross-fetch@3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -20960,6 +20963,11 @@ packages:
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
+
+  /encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    dependencies:
+      iconv-lite: 0.6.3
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -24286,10 +24294,10 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  /isomorphic-fetch@3.0.0:
+  /isomorphic-fetch@3.0.0(encoding@0.1.13):
     resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
     dependencies:
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       whatwg-fetch: 3.6.2
     transitivePeerDependencies:
       - encoding
@@ -26821,7 +26829,7 @@ packages:
     resolution: {integrity: sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==}
     dev: false
 
-  /node-fetch@2.6.7:
+  /node-fetch@2.6.7(encoding@0.1.13):
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
@@ -26830,6 +26838,7 @@ packages:
       encoding:
         optional: true
     dependencies:
+      encoding: 0.1.13
       whatwg-url: 5.0.0
 
   /node-fetch@3.3.0:


### PR DESCRIPTION
## Summary

fix encoding resolve warning when call node-fetch in build, `encoding` is a peerDeps in `node-fetch`: 
![img_v3_0276_67314fb9-6a42-437f-854b-b0b58bdb3a8g](https://github.com/web-infra-dev/modern.js/assets/22373761/7158956b-4124-4986-8269-dad5280ef8a0)

![img_v3_0276_b39b21c0-0b6c-4e1f-bcfc-c2847a48645g](https://github.com/web-infra-dev/modern.js/assets/22373761/ab0fa036-9a63-49cc-b3fa-c78316f7b51a)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
