### PR TITLE
fix(uni-builder): tools.devServer client options not works

### DIFF
--- a/.changeset/ninety-ducks-count.md
+++ b/.changeset/ninety-ducks-count.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): tools.devServer client options not works
+
+fix(uni-builder): 修复 tools.devServer client 配置项不生效问题

--- a/packages/builder/uni-builder/src/shared/devServer.ts
+++ b/packages/builder/uni-builder/src/shared/devServer.ts
@@ -51,13 +51,8 @@ const getDevServerOptions = async ({
 }> => {
   const defaultDevConfig = deepmerge(
     {
-      hot: builderConfig.dev?.hmr ?? true,
       watch: true,
-      client: {
-        port: port.toString(),
-      },
       port,
-      liveReload: builderConfig.dev?.hmr ?? true,
       https: builderConfig.dev?.https,
     },
     // merge devServerOptions from serverOptions

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -220,12 +220,23 @@ export async function parseCommonConfig(
       devMiddleware: {
         writeToDisk: (file: string) => !file.includes('.hot-update.'),
       },
+      hot: dev?.hmr ?? true,
+      liveReload: true,
+      client: {
+        path: '/webpack-hmr',
+      },
     },
     options: tools.devServer,
     mergeFn: deepmerge,
   });
 
   dev.writeToDisk = devServer.devMiddleware?.writeToDisk;
+
+  dev.hmr = devServer.hot;
+
+  dev.client = devServer.client;
+
+  dev.liveReload = devServer.liveReload;
 
   const server: ServerConfig = isProd()
     ? {}

--- a/packages/builder/uni-builder/src/types.ts
+++ b/packages/builder/uni-builder/src/types.ts
@@ -79,6 +79,7 @@ export type UniBuilderExtraConfig = {
       devMiddleware?: {
         writeToDisk?: DevConfig['writeToDisk'];
       };
+      liveReload?: boolean;
       headers?: ServerConfig['headers'];
       historyApiFallback?: ServerConfig['historyApiFallback'];
       hot?: boolean;

--- a/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`parseCommonConfig > dev.xxx 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/aaaa",
+    },
+    "hmr": false,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -40,6 +45,11 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
 exports[`parseCommonConfig > dev.xxx 2`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -74,6 +84,11 @@ exports[`parseCommonConfig > dev.xxx 2`] = `
 exports[`parseCommonConfig > html.faviconByEntries 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -109,6 +124,11 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
 exports[`parseCommonConfig > html.faviconByEntries 2`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -147,6 +167,11 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
 exports[`parseCommonConfig > html.faviconByEntries 3`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -182,6 +207,11 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
 exports[`parseCommonConfig > html.faviconByEntries 4`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -220,6 +250,11 @@ exports[`parseCommonConfig > html.faviconByEntries 4`] = `
 exports[`parseCommonConfig > html.metaByEntries 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -255,6 +290,11 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
 exports[`parseCommonConfig > html.metaByEntries 2`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -297,6 +337,11 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
 exports[`parseCommonConfig > html.templateByEntries 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -332,6 +377,11 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
 exports[`parseCommonConfig > html.templateByEntries 2`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -370,6 +420,11 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
 exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -405,6 +460,11 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
 exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -445,6 +505,11 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
 exports[`parseCommonConfig > html.titleByEntries 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -482,6 +547,11 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
 exports[`parseCommonConfig > html.titleByEntries 2`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -519,6 +589,11 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
 exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -556,6 +631,11 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
 exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -594,6 +674,11 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
 exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },
@@ -629,6 +714,11 @@ exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
 exports[`parseCommonConfig > output.enableInlineStyles 1`] = `
 {
   "dev": {
+    "client": {
+      "path": "/webpack-hmr",
+    },
+    "hmr": true,
+    "liveReload": true,
     "progressBar": true,
     "writeToDisk": [Function],
   },

--- a/packages/builder/uni-builder/tests/parseConfig.test.ts
+++ b/packages/builder/uni-builder/tests/parseConfig.test.ts
@@ -288,6 +288,9 @@ describe('parseCommonConfig', () => {
             },
             tools: {
               devServer: {
+                client: {
+                  path: '/aaaa',
+                },
                 compress: false,
                 hot: false,
                 headers: {


### PR DESCRIPTION
## Summary

fix tools.devServer client options not works in rsbuild server
- update devServer.client.path default value as : `/webpack-hmr`
- tools.devServer client / liveReload / hot not works in rsbuild server

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
