### PR TITLE
fix(uni-builder): should print https url when enable dev.https

### DIFF
--- a/.changeset/clean-pumpkins-guess.md
+++ b/.changeset/clean-pumpkins-guess.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): should print https url when enable dev.https
+
+fix(uni-builder): 应该打印 https url 当开启 dev.https 时

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
       "source-map-url": "0.4.1",
       "urix": "0.1.0",
       "resolve-url": "0.2.1",
-      "devcert": "1.0.0",
+      "devcert": "1.2.2",
       "superagent": "6.1.0",
       "@types/sass": "1.45.0",
       "trim": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
       "source-map-url": "0.4.1",
       "urix": "0.1.0",
       "resolve-url": "0.2.1",
-      "devcert": "1.2.2",
       "superagent": "6.1.0",
       "@types/sass": "1.45.0",
       "trim": "0.0.1"

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -232,6 +232,7 @@ export async function parseCommonConfig(
     : {
         port: dev.port,
         host: dev.host,
+        https: dev.https ? (dev.https as ServerConfig['https']) : undefined,
       };
 
   delete tools.devServer;

--- a/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -29,6 +29,10 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
   },
   "server": {
     "host": "xxx.xxx",
+    "https": {
+      "cert": "xxx",
+      "key": "xxxx",
+    },
     "port": 8081,
   },
   "tools": {

--- a/packages/server/server/package.json
+++ b/packages/server/server/package.json
@@ -80,7 +80,7 @@
     "websocket": "^1"
   },
   "peerDependencies": {
-    "devcert": "^1.0.0",
+    "devcert": "^1.2.2",
     "ts-node": "^10.1.0",
     "tsconfig-paths": ">= 3.0.0 || >= 4.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4571,8 +4571,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       devcert:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.2.2
+        version: 1.2.2
       http-compression:
         specifier: 1.0.6
         version: 1.0.6
@@ -19626,18 +19626,6 @@ packages:
       typedarray: 0.0.6
     dev: false
 
-  /configstore@3.1.5:
-    resolution: {integrity: sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==}
-    engines: {node: '>=4'}
-    dependencies:
-      dot-prop: 4.2.1
-      graceful-fs: 4.2.11
-      make-dir: 1.3.0
-      unique-string: 1.0.0
-      write-file-atomic: 2.4.3
-      xdg-basedir: 3.0.0
-    dev: false
-
   /connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
@@ -20125,11 +20113,6 @@ packages:
       public-encrypt: 4.0.3
       randombytes: 2.1.0
       randomfill: 1.0.4
-    dev: false
-
-  /crypto-random-string@1.0.0:
-    resolution: {integrity: sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg==}
-    engines: {node: '>=4'}
     dev: false
 
   /crypto-random-string@2.0.0:
@@ -20666,9 +20649,8 @@ packages:
       minimist: 1.2.6
     dev: false
 
-  /devcert@1.0.0:
-    resolution: {integrity: sha512-M7hoNTVSD0ol+49plNERd+hZdkS9vetRDENZ63Ry++a5OKpADuXrMLuzTbNENOEH+9ZbwPRGZ9bLJvHWy/GdFQ==}
-    deprecated: critical regex denial of service bug fixed in 1.2.1 patch
+  /devcert@1.2.2:
+    resolution: {integrity: sha512-UsLqvtJGPiGwsIZnJINUnFYaWgK7CroreGRndWHZkRD58tPFr3pVbbSyHR8lbh41+azR4jKvuNZ+eCoBZGA5kA==}
     dependencies:
       '@types/configstore': 2.1.1
       '@types/debug': 0.0.30
@@ -20681,11 +20663,11 @@ packages:
       '@types/tmp': 0.0.33
       application-config-path: 0.1.1
       command-exists: 1.2.9
-      configstore: 3.1.5
       debug: 3.2.7
       eol: 0.9.1
       get-port: 3.2.0
       glob: 7.2.0
+      is-valid-domain: 0.1.6
       lodash: 4.17.21
       mkdirp: 0.5.6
       password-prompt: 1.1.2
@@ -20838,13 +20820,6 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.6.2
-
-  /dot-prop@4.2.1:
-    resolution: {integrity: sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      is-obj: 1.0.1
-    dev: false
 
   /dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -24089,11 +24064,6 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  /is-obj@1.0.1:
-    resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
@@ -24222,6 +24192,12 @@ packages:
 
   /is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+    dev: false
+
+  /is-valid-domain@0.1.6:
+    resolution: {integrity: sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==}
+    dependencies:
+      punycode: 2.1.1
     dev: false
 
   /is-weakref@1.0.2:
@@ -25754,13 +25730,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  /make-dir@1.3.0:
-    resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      pify: 3.0.0
-    dev: false
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -27587,6 +27556,7 @@ packages:
   /pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
+    dev: true
 
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -32722,13 +32692,6 @@ packages:
       vfile: 4.2.1
     dev: false
 
-  /unique-string@1.0.0:
-    resolution: {integrity: sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg==}
-    engines: {node: '>=4'}
-    dependencies:
-      crypto-random-string: 1.0.0
-    dev: false
-
   /unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -34017,11 +33980,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  /xdg-basedir@3.0.0:
-    resolution: {integrity: sha512-1Dly4xqlulvPD3fZUQJLY+FUIeqN3N2MM3uqe4rCJftAvOjFa3jFGfctOgluGx4ahPbUCsZkmJILiP0Vi4T6lQ==}
-    engines: {node: '>=4'}
-    dev: false
 
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}


### PR DESCRIPTION
## Summary

<img width="727" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/369f88c4-32e4-4de0-9492-980d3c3f90a9">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
