### PR TITLE
feat(devtools): apply loading animation for each tab

### DIFF
--- a/packages/devtools/client/src/components/Devtools/FrameBox.module.scss
+++ b/packages/devtools/client/src/components/Devtools/FrameBox.module.scss
@@ -41,15 +41,3 @@
   align-items: center;
 }
 
-.loading {
-  animation: rotate 1s linear infinite;
-}
-
-@keyframes rotate {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}

--- a/packages/devtools/client/src/components/Devtools/FrameBox.tsx
+++ b/packages/devtools/client/src/components/Devtools/FrameBox.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Box } from '@radix-ui/themes';
 import type { BoxProps } from '@radix-ui/themes/dist/cjs/components/box';
 import { HiMiniXMark } from 'react-icons/hi2';
-import { LoaderIcon } from '../LoadingIcon';
+import { Loading } from '../Loading';
 import styles from './FrameBox.module.scss';
 
 export interface FrameBoxProps
@@ -31,7 +31,7 @@ export const FrameBox: React.FC<FrameBoxProps> = ({
         className={styles.backdrop}
         style={{ display: showFrame ? 'none' : undefined }}
       >
-        <LoaderIcon className={styles.loading} />
+        <Loading />
       </div>
     </Box>
   );

--- a/packages/devtools/client/src/components/Loading/Icon.module.scss
+++ b/packages/devtools/client/src/components/Loading/Icon.module.scss
@@ -1,0 +1,13 @@
+.loading {
+  animation: rotate 1s linear infinite;
+  stroke: #555;
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/devtools/client/src/components/Loading/Icon.tsx
+++ b/packages/devtools/client/src/components/Loading/Icon.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import styles from './Icon.module.scss';
 
-export const LoaderIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => (
+export const LoadingIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
+    className={styles.loading}
     width="24"
     height="24"
     viewBox="0 0 24 24"
-    strokeWidth="2"
+    strokeWidth="3"
     fill="none"
     strokeLinecap="round"
     strokeLinejoin="round"

--- a/packages/devtools/client/src/components/Loading/Loading.module.scss
+++ b/packages/devtools/client/src/components/Loading/Loading.module.scss
@@ -1,0 +1,5 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/devtools/client/src/components/Loading/Loading.tsx
+++ b/packages/devtools/client/src/components/Loading/Loading.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react';
+import { Box } from '@radix-ui/themes';
+import type { BoxProps } from '@radix-ui/themes/dist/cjs/components/box';
+import { LoadingIcon } from './Icon';
+import styles from './Loading.module.scss';
+
+export type LoadingProps = BoxProps;
+
+export const Loading: FC<LoadingProps> = props => {
+  return (
+    <Box className={styles.container} {...props}>
+      <LoadingIcon />
+    </Box>
+  );
+};

--- a/packages/devtools/client/src/components/Loading/index.ts
+++ b/packages/devtools/client/src/components/Loading/index.ts
@@ -1,0 +1,2 @@
+export * from './Icon';
+export * from './Loading';

--- a/packages/devtools/client/src/entries/client/routes/loading.tsx
+++ b/packages/devtools/client/src/entries/client/routes/loading.tsx
@@ -1,0 +1,10 @@
+import { Loading } from '@/components/Loading';
+
+export default () => {
+  return (
+    <Loading
+      width="100%"
+      style={{ height: 'calc(100vh - var(--breadcrumb-height))' }}
+    />
+  );
+};


### PR DESCRIPTION
## Summary

Apply loading animation for each tab when suspensing.

![image](https://github.com/web-infra-dev/modern.js/assets/18379948/02b65001-5968-422f-a61c-7c01dd1ffa0d)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
