### PR TITLE
fix(uni-builder): disable default publicDir

### DIFF
--- a/.changeset/six-dolls-begin.md
+++ b/.changeset/six-dolls-begin.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): disable default publicDir
+
+fix(uni-builder): 默认禁用 publicDir

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -239,8 +239,11 @@ export async function parseCommonConfig(
   dev.liveReload = devServer.liveReload;
 
   const server: ServerConfig = isProd()
-    ? {}
+    ? {
+        publicDir: false,
+      }
     : {
+        publicDir: false,
         port: dev.port,
         host: dev.host,
         https: dev.https ? (dev.https as ServerConfig['https']) : undefined,

--- a/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -39,6 +39,7 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
       "key": "xxxx",
     },
     "port": 8081,
+    "publicDir": false,
   },
   "tools": {
     "htmlPlugin": [Function],
@@ -78,7 +79,9 @@ exports[`parseCommonConfig > dev.xxx 2`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -118,7 +121,9 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -161,7 +166,9 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -201,7 +208,9 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -244,7 +253,9 @@ exports[`parseCommonConfig > html.faviconByEntries 4`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -284,7 +295,9 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -331,7 +344,9 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -371,7 +386,9 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -414,7 +431,9 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -454,7 +473,9 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -499,7 +520,9 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -541,7 +564,9 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -583,7 +608,9 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -625,7 +652,9 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -668,7 +697,9 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -708,7 +739,9 @@ exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },
@@ -748,7 +781,9 @@ exports[`parseCommonConfig > output.enableInlineStyles 1`] = `
       "web",
     ],
   },
-  "server": {},
+  "server": {
+    "publicDir": false,
+  },
   "tools": {
     "htmlPlugin": [Function],
   },


### PR DESCRIPTION
## Summary

rsbuild server.publicDir is a new feature (not very stable...), and it repeat with app-tools `/config/public` 

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
