### PR TITLE
docs: update source.include introduce

### DIFF
--- a/packages/document/builder-doc/docs/en/config/source/include.md
+++ b/packages/document/builder-doc/docs/en/config/source/include.md
@@ -1,9 +1,20 @@
-- **Type:** `Array<string | RegExp>`
-- **Default:** `[]`
+- **Type:** [RuleSetCondition[]](https://rspack.dev/config/module#condition)
+- **Default:**
 
-In order to maintain faster compilation speed, Builder will not compile JavaScript files under node_modules through `babel-loader` or `ts-loader` by default, as will as the JavaScript files outside the current project directory.
+```ts
+const defaultInclude = [
+  {
+    and: [rootPath, { not: /[\\/]node_modules[\\/]/ }],
+  },
+  /\.(?:ts|tsx|jsx|mts|cts)$/,
+];
+```
 
-Through the `source.include` config, you can specify directories or modules that need to be compiled by Builder. The usage of `source.include` is consistent with [Rule.include](https://webpack.js.org/configuration/module/#ruleinclude) in webpack, which supports passing in strings or regular expressions to match the module path.
+The `source.include` is used to specify additional JavaScript files that need to be compiled.
+
+To avoid redundant compilation, by default, Rsbuild only compiles JavaScript files in the current directory and TypeScript and JSX files in all directories. It does not compile JavaScript files under node_modules.
+
+Through the `source.include` config, you can specify directories or modules that need to be compiled by Rsbuild. The usage of `source.include` is consistent with [Rule.include](https://rspack.dev/config/module#ruleinclude) in Rspack, which supports passing in strings or regular expressions to match the module path.
 
 For example:
 
@@ -16,6 +27,7 @@ export default {
   },
 };
 ```
+
 
 ### Compile Npm Packages
 

--- a/packages/document/builder-doc/docs/en/config/source/include.md
+++ b/packages/document/builder-doc/docs/en/config/source/include.md
@@ -1,7 +1,7 @@
 - **Type:** `Array<string | RegExp>`
 - **Default:** `[]`
 
-In order to maintain faster compilation speed, Builder will not compile JavaScript/TypeScript files under node_modules through `babel-loader` or `ts-loader` by default, as will as the JavaScript/TypeScript files outside the current project directory.
+In order to maintain faster compilation speed, Builder will not compile JavaScript files under node_modules through `babel-loader` or `ts-loader` by default, as will as the JavaScript files outside the current project directory.
 
 Through the `source.include` config, you can specify directories or modules that need to be compiled by Builder. The usage of `source.include` is consistent with [Rule.include](https://webpack.js.org/configuration/module/#ruleinclude) in webpack, which supports passing in strings or regular expressions to match the module path.
 

--- a/packages/document/builder-doc/docs/zh/config/source/include.md
+++ b/packages/document/builder-doc/docs/zh/config/source/include.md
@@ -1,9 +1,20 @@
-- **类型：** `Array<string | RegExp>`
-- **默认值：** `[]`
+- **类型：** [RuleSetCondition[]](https://rspack.dev/zh/config/module#condition)
+- **默认值：**
 
-出于编译性能的考虑，默认情况下，Builder 不会编译 node_modules 下的 JavaScript 文件，也不会编译当前工程目录外部的 JavaScript 文件。
+```ts
+const defaultInclude = [
+  {
+    and: [rootPath, { not: /[\\/]node_modules[\\/]/ }],
+  },
+  /\.(?:ts|tsx|jsx|mts|cts)$/,
+];
+```
 
-通过 `source.include` 配置项，可以指定需要 Builder 额外进行编译的目录或模块。`source.include` 的用法与 webpack 中的 [Rule.include](https://webpack.js.org/configuration/module/#ruleinclude) 一致，支持传入字符串或正则表达式来匹配模块的路径。
+`source.include` 用于指定额外需要编译的 JavaScript 文件。
+
+为了避免二次编译，默认情况下，Rsbuild 只会编译当前目录下的 JavaScript 文件，以及所有目录下的 TypeScript 和 JSX 文件，不会编译 node_modules 下的 JavaScript 文件。
+
+通过 `source.include` 配置项，可以指定需要 Rsbuild 额外进行编译的目录或模块。`source.include` 的用法与 Rspack 中的 [Rule.include](https://rspack.dev/zh/config/module#ruleinclude) 一致，支持传入字符串、正则表达式来匹配模块的路径。
 
 比如:
 

--- a/packages/document/builder-doc/docs/zh/config/source/include.md
+++ b/packages/document/builder-doc/docs/zh/config/source/include.md
@@ -1,7 +1,7 @@
 - **类型：** `Array<string | RegExp>`
 - **默认值：** `[]`
 
-出于编译性能的考虑，默认情况下，Builder 不会编译 node_modules 下的 JavaScript/TypeScript 文件，也不会编译当前工程目录外部的 JavaScript/TypeScript 文件。
+出于编译性能的考虑，默认情况下，Builder 不会编译 node_modules 下的 JavaScript 文件，也不会编译当前工程目录外部的 JavaScript 文件。
 
 通过 `source.include` 配置项，可以指定需要 Builder 额外进行编译的目录或模块。`source.include` 的用法与 webpack 中的 [Rule.include](https://webpack.js.org/configuration/module/#ruleinclude) 一致，支持传入字符串或正则表达式来匹配模块的路径。
 


### PR DESCRIPTION
## Summary

since modern.js use rsbuild, the source.include default value is same as rsbuild.

https://rsbuild.dev/config/source/include

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
