### PR TITLE
docs: use rsbuild link instead of builder

### DIFF
--- a/packages/document/main-doc/docs/en/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/commands.mdx
@@ -195,7 +195,7 @@ Options:
 
 ## modern inspect
 
-The `modern inspect` command is used to view the [Modern.js Builder config](https://modernjs.dev/builder/en/guide/basic/builder-config.html) and webpack config of the project.
+The `modern inspect` command is used to view the [Rsbuild config](https://rsbuild.dev/config/index) and webpack or Rspack config of the project.
 
 ```bash
 Usage: modern inspect [options]
@@ -210,16 +210,16 @@ Options:
 
 After executing the command `npx modern inspect` in the project root directory, the following files will be generated in the `dist` directory of the project:
 
-- `builder.config.js`: The Modern.js Builder config to use at build time.
-- `webpack.config.web.js`: The webpack config used by to use at build time.
+- `rsbuild.config.mjs`: The Rsbuild config to use at build time.
+- `webpack.config.web.mjs`: The webpack config used by to use at build time.
 
 ```bash
 ➜ npx modern inspect
 
 Inspect config succeed, open following files to view the content:
 
-  - Builder Config: /root/my-project/dist/builder.config.js
-  - Webpack Config (web): /root/my-project/dist/webpack.config.web.js
+  - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
+  - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
 ```
 
 ### Configuration Env
@@ -240,16 +240,16 @@ modern inspect --verbose
 
 ### SSR Configuration
 
-If the project has enabled SSR, an additional `webpack.config.node.js` file will be generated in the `dist/`, corresponding to the webpack configuration at SSR build time.
+If the project has enabled SSR, an additional `webpack.config.node.mjs` file will be generated in the `dist/`, corresponding to the webpack configuration at SSR build time.
 
 ```bash
 ➜ npx modern inspect
 
 Inspect config succeed, open following files to view the content:
 
-  - Builder Config: /root/my-project/dist/builder.config.js
-  - Webpack Config (web): /root/my-project/dist/webpack.config.web.js
-  - Webpack Config (node): /root/my-project/dist/webpack.config.node.js
+  - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
+  - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
+  - Webpack Config (node): /root/my-project/dist/webpack.config.node.mjs
 ```
 
 ## modern lint

--- a/packages/document/main-doc/docs/en/configure/app/output/disable-node-polyfill.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/disable-node-polyfill.mdx
@@ -19,4 +19,4 @@ export default defineConfig({
 });
 ```
 
-This config is implemented based on the Node Polyfill plugin of Modern.js Builder, you can read [Modern.js Builder - Node Polyfill Plugin](https://modernjs.dev/builder/en/plugins/plugin-node-polyfill.html) documentation for details.
+This config is implemented based on the Node Polyfill plugin of Rsbuild, you can read [Rsbuild - Node Polyfill Plugin](https://rsbuild.dev/plugins/list/plugin-node-polyfill) documentation for details.

--- a/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/compatibility.mdx
@@ -19,7 +19,7 @@ ios_saf >= 10
 ```
 
 :::tip
-Please refer to [Modern.js Builder - Browserslist](https://modernjs.dev/builder/en/guide/advanced/browserslist) for more information.
+Please refer to [Rsbuild - Browserslist](https://rsbuild.dev/guide/advanced/browserslist) for more information.
 :::
 
 ## Polyfill

--- a/packages/document/main-doc/docs/en/guides/advanced-features/optimize-bundle.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/optimize-bundle.mdx
@@ -4,7 +4,7 @@ sidebar_position: 13
 
 # Bundle Size Optimization
 
-Bundle size optimization is an important part in production environment because it directly affects the user experience of online users. In this document, we will introduce some common bundle size optimization methods in Builder.
+Bundle size optimization is an important part in production environment because it directly affects the user experience of online users. In this document, we will introduce some common bundle size optimization methods in Modern.js.
 
 ## Reduce duplicate dependencies
 
@@ -59,7 +59,7 @@ For example, if you only need to be compatible with browsers above Chrome 61, yo
 ```
 
 :::tip
-Please read the [Browserslist](https://modernjs.dev/builder/en/guide/advanced/browserslist.html) chapter to know more about the usage of Browserslist.
+Please read the [Browserslist](https://rsbuild.dev/guide/advanced/browserslist) chapter to know more about the usage of Browserslist.
 :::
 
 ## Usage polyfill
@@ -82,23 +82,23 @@ Please read the [Browser Compatibility](/guides/advanced-features/compatibility)
 
 ## Image Compression
 
-In general front-end projects, the size of image often accounts for a large proportion of the total bundle size of the project.So if the image size can be reduced as much as possible, it will have a significant optimization effect on the project bundle size. You can enable image compression by registering a plugin in the Builder:
+In general front-end projects, the size of image often accounts for a large proportion of the total bundle size of the project.So if the image size can be reduced as much as possible, it will have a significant optimization effect on the project bundle size. You can enable image compression by registering a plugin in Modern.js:
 
 ```ts title="modern.config.ts"
-import { builderPluginImageCompress } from '@modern-js/builder-plugin-image-compress';
+import { pluginImageCompress } from '@rsbuild/plugin-image-compress';
 
 export default {
-  builderPlugins: [builderPluginImageCompress()],
+  builderPlugins: [pluginImageCompress()],
 };
 ```
 
-See details in [plugin-image-compress](https://modernjs.dev/builder/en/plugins/plugin-image-compress.html).
+See details in [plugin-image-compress](https://rsbuild.dev/plugins/list/plugin-image-compress).
 
 ## Split Chunk
 
 A great chunk splitting strategy is very important to improve the loading performance of the application. It can make full use of the browser's caching mechanism to reduce the number of requests and improve the loading speed of the application.
 
-A variety of [chunk splitting strategies](https://modernjs.dev/builder/en/guide/optimization/split-chunk) are built into Builder, which can meet the needs of most applications. You can also customize the chunk splitting config according to your own business scenarios.
+A variety of [chunk splitting strategies](https://rsbuild.dev/guide/optimization/split-chunk) are built into Modern.js, which can meet the needs of most applications. You can also customize the chunk splitting config according to your own business scenarios.
 
 For example, split the `axios` library under node_modules into `axios.js`:
 

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -55,8 +55,6 @@ import RspackPrecautions from '@modern-js/builder-doc/docs/en/shared/rspackPreca
 
 ## Migrating configuration
 
-After enabling Rspack building capability, further configuration migration is needed by referring to the [Configuration Differences](https://modernjs.dev/builder/en/guide/advanced/rspack-start.html#migrating-from-webpack-to-rspack).
-
 In Modern.js, the [tools.webpack](/configure/app/tools/webpack) and [tools.webpackChain](/configure/app/tools/webpack-chain) configurations only take effect in webpack mode, after turning on the Rspack build, you can modify it to [tools.rspack](/configure/app/tools/rspack) and [tools.bundlerChain](/configure/app/tools/bundler-chain).
 
 ```diff

--- a/packages/document/main-doc/docs/en/guides/basic-features/css.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/css.mdx
@@ -12,13 +12,13 @@ Modern.js has built-in popular community CSS preprocessors, including Less and S
 
 By default, you don't need to configure Less and Sass. If you have custom loader configuration requirements, you can set them up by configuring [tools.less](/configure/app/tools/less) and [tools.sass](/configure/app/tools/sass).
 
-You can also use Stylus in Modern.js by installing the Stylus plugin provided by Modern.js Builder. For usage, please refer to [Stylus Plugin](https://modernjs.dev/builder/plugins/plugin-stylus.html).
+You can also use Stylus in Modern.js by installing the Stylus plugin provided by Rsbuild. For usage, please refer to [Stylus Plugin](https://rsbuild.dev/plugins/list/plugin-stylus).
 
 ## Using PostCSS
 
 Modern.js has built-in [PostCSS](https://postcss.org/) to transform CSS code.
 
-Please refer to [Modern.js Builder - Using PostCSS](https://modernjs.dev/builder/en/guide/basic/css-usage.html#using-postcss) for detailed usage.
+Please refer to [Rsbuild - Using PostCSS](https://rsbuild.dev/guide/basic/css-usage#using-postcss) for detailed usage.
 
 ## Using CSS Modules
 

--- a/packages/document/main-doc/docs/en/guides/get-started/tech-stack.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/tech-stack.mdx
@@ -89,7 +89,7 @@ Modern.js supports enabling ["Tailwind CSS"](/en/guides/basic-features/css.html#
 Modern.js supports three CSS preprocessors: [Sass](https://sass-lang.com/), [Less](https://lesscss.org/), and [Stylus](https://stylus-lang.com/):
 
 - Sass and Less are supported by default and ready to use.
-- Stylus is optional and can be used by referring to the ["Stylus Plugin"](https://modernjs.dev/builder/en/plugins/plugin-stylus.html).
+- Stylus is optional and can be used by referring to the ["Stylus Plugin"](https://rsbuild.dev/plugins/list/plugin-stylus).
 
 ---
 

--- a/packages/document/main-doc/docs/zh/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/commands.mdx
@@ -195,7 +195,7 @@ Options:
 
 ## modern inspect
 
-`modern inspect` 命令用于查看项目的 [Modern.js Builder 配置](https://modernjs.dev/builder/guide/basic/builder-config.html) 以及 webpack 配置。
+`modern inspect` 命令用于查看项目的 [Rsbuild 配置](https://rsbuild.dev/zh/config/index) 以及 webpack 或 Rspack 配置。
 
 ```bash
 Usage: modern inspect [options]
@@ -210,16 +210,16 @@ Options:
 
 在项目根目录下执行命令 `npx modern inspect` 后，会在项目的 `dist` 目录生成以下文件：
 
-- `builder.config.js`: 表示在构建时使用的 Modern.js Builder 配置。
-- `webpack.config.web.js`: 表示在构建时使用的 webpack 配置。
+- `rsbuild.config.mjs`: 表示在构建时使用的 Rsbuild 配置。
+- `webpack.config.web.mjs`: 表示在构建时使用的 webpack 配置。
 
 ```bash
 ➜ npx modern inspect
 
 Inspect config succeed, open following files to view the content:
 
-  - Builder Config: /root/my-project/dist/builder.config.js
-  - Webpack Config (web): /root/my-project/dist/webpack.config.web.js
+  - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
+  - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
 ```
 
 ### 指定环境
@@ -240,16 +240,16 @@ modern inspect --verbose
 
 ### SSR 构建配置
 
-如果项目开启了 SSR 能力，则在 `dist` 目录会另外生成一份 `webpack.config.node.js` 文件，对应 SSR 构建时的 webpack 配置。
+如果项目开启了 SSR 能力，则在 `dist` 目录会另外生成一份 `webpack.config.node.mjs` 文件，对应 SSR 构建时的 webpack 配置。
 
 ```bash
 ➜ npx modern inspect
 
 Inspect config succeed, open following files to view the content:
 
-  - Builder Config: /root/my-project/dist/builder.config.js
-  - Webpack Config (web): /root/my-project/dist/webpack.config.web.js
-  - Webpack Config (node): /root/my-project/dist/webpack.config.node.js
+  - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
+  - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
+  - Webpack Config (node): /root/my-project/dist/webpack.config.node.mjs
 ```
 
 ## modern lint

--- a/packages/document/main-doc/docs/zh/configure/app/output/disable-node-polyfill.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/disable-node-polyfill.mdx
@@ -19,4 +19,4 @@ export default defineConfig({
 });
 ```
 
-该配置项基于 Modern.js Builder 的 Node Polyfill 插件实现，你可以阅读 [Modern.js Builder - Node Polyfill 插件](https://modernjs.dev/builder/plugins/plugin-node-polyfill.html) 文档来了解详细信息。
+该配置项基于 Rsbuild 的 Node Polyfill 插件实现，你可以阅读 [Rsbuild - Node Polyfill 插件](https://rsbuild.dev/zh/plugins/list/plugin-node-polyfill) 文档来了解详细信息。

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/compatibility.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/compatibility.mdx
@@ -19,7 +19,7 @@ ios_saf >= 10
 ```
 
 :::tip
-请查看 [Modern.js Builder - 设置浏览器范围](https://modernjs.dev/builder/guide/advanced/browserslist) 来了解更多内容。
+请查看 [Rsbuild - 设置浏览器范围](https://rsbuild.dev/zh/guide/advanced/browserslist) 来了解更多内容。
 :::
 
 ## Polyfill

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/optimize-bundle.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/optimize-bundle.mdx
@@ -44,9 +44,9 @@ BUNDLE_ANALYZE=true pnpm build
 
 ## 提升 Browserslist 范围
 
-Builder 会根据项目的 Browserslist 配置范围进行代码编译，并注入相应的 Polyfill。如果项目不需要兼容旧版浏览器，可以根据实际情况来提升 Browserslist 范围，从而减少在语法和 Polyfill 上的编译开销。
+Modern.js 会根据项目的 Browserslist 配置范围进行代码编译，并注入相应的 Polyfill。如果项目不需要兼容旧版浏览器，可以根据实际情况来提升 Browserslist 范围，从而减少在语法和 Polyfill 上的编译开销。
 
-Builder 默认的 Browserslist 配置为：
+Modern.js 默认的 Browserslist 配置为：
 
 ```js
 ['> 0.01%', 'not dead', 'not op_mini all'];
@@ -59,14 +59,14 @@ Builder 默认的 Browserslist 配置为：
 ```
 
 :::tip
-请阅读 [设置浏览器范围](https://modernjs.dev/builder/guide/advanced/browserslist.html) 章节来了解更多关于 Browserslist 的用法。
+请阅读 [设置浏览器范围](https://rsbuild.dev/zh/guide/advanced/browserslist) 章节来了解更多关于 Browserslist 的用法。
 :::
 
 ## 按需引入 polyfill
 
 在明确第三方依赖不需要额外 polyfill 的情况下，你可以将 [output.polyfill](/configure/app/output/polyfill.html) 设置为 `usage`。
 
-在 `usage` 模式下，Builder 会分析源代码中使用的语法，按需注入所需的 polyfill 代码，从而减少 polyfill 的代码量。
+在 `usage` 模式下，Modern.js 会分析源代码中使用的语法，按需注入所需的 polyfill 代码，从而减少 polyfill 的代码量。
 
 ```js
 export default {
@@ -85,20 +85,20 @@ export default {
 在一般的前端项目中，图片资源的体积往往是项目产物体积的大头，因此如果能尽可能精简图片的体积，那么将会对项目的打包产物体积起到明显的优化效果。你可以在 Modern.js 中注册插件来启用图片压缩功能:
 
 ```js title="modern.config.ts"
-import { builderPluginImageCompress } from '@modern-js/builder-plugin-image-compress';
+import { pluginImageCompress } from '@rsbuild/plugin-image-compress';
 
 export default {
-  builderPlugins: [builderPluginImageCompress()],
+  builderPlugins: [pluginImageCompress()],
 };
 ```
 
-详见 [Image Compress 插件](https://modernjs.dev/builder/plugins/plugin-image-compress.html)。
+详见 [Image Compress 插件](https://rsbuild.dev/zh/plugins/list/plugin-image-compress)。
 
 ## 代码拆包
 
 良好的拆包策略对于提升应用的加载性能是十分重要的，可以充分利用浏览器的缓存机制，减少请求数量，加快页面加载速度。
 
-在 Modern.js 中内置了[多种拆包策略](https://modernjs.dev/builder/guide/optimization/split-chunk)，可以满足大部分应用的需求，你也可以根据自己的业务场景，自定义拆包配置。
+在 Modern.js 中内置了[多种拆包策略](https://rsbuild.dev/zh/guide/optimization/split-chunk)，可以满足大部分应用的需求，你也可以根据自己的业务场景，自定义拆包配置。
 
 比如将 node_modules 下的 `axios` 库拆分到 `axios.js` 中：
 

--- a/packages/document/main-doc/docs/zh/guides/basic-features/css.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/css.mdx
@@ -12,13 +12,13 @@ Modern.js 内置了社区流行的 CSS 预处理器，包括 Less 和 Sass。
 
 默认情况下，你不需要对 Less 和 Sass 进行任何配置。如果你有自定义 loader 配置的需求，可以通过配置 [tools.less](/configure/app/tools/less)、[tools.sass](/configure/app/tools/sass) 来进行设置。
 
-你也可以在 Modern.js 中使用 Stylus，只需要安装 Modern.js Builder 提供的 Stylus 插件即可，使用方式请参考 [Stylus 插件](https://modernjs.dev/builder/plugins/plugin-stylus.html)。
+你也可以在 Modern.js 中使用 Stylus，只需要安装 Rsbuild 提供的 Stylus 插件即可，使用方式请参考 [Stylus 插件](https://rsbuild.dev/zh/plugins/list/plugin-stylus)。
 
 ## 使用 PostCSS
 
 Modern.js 内置了 [PostCSS](https://postcss.org/) 来转换 CSS 代码。
 
-请阅读 [Modern.js Builder - 使用 PostCSS](https://modernjs.dev/builder/guide/basic/css-usage.html#%E4%BD%BF%E7%94%A8-postcss) 了解更多用法。
+请阅读 [Rsbuild - 使用 PostCSS](https://rsbuild.dev/zh/guide/basic/css-usage#%E4%BD%BF%E7%94%A8-postcss) 了解更多用法。
 
 ## 使用 CSS Modules
 

--- a/packages/document/main-doc/docs/zh/guides/get-started/tech-stack.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/tech-stack.mdx
@@ -89,7 +89,7 @@ Modern.js 支持[「启用 Tailwind CSS」](/guides/basic-features/css.html#使�
 Modern.js 支持 [Sass](https://sass-lang.com/)、[Less](https://lesscss.org/) 和 [Stylus](https://stylus-lang.com/) 三种 CSS 预处理器：
 
 - 默认支持 Sass 和 Less，开箱即用。
-- 可选支持 Stylus，请参考[「Stylus 插件」](https://modernjs.dev/builder/plugins/plugin-stylus.html) 来使用。
+- 可选支持 Stylus，请参考[「Stylus 插件」](https://rsbuild.dev/zh/plugins/list/plugin-stylus) 来使用。
 
 ---
 


### PR DESCRIPTION
## Summary

Modern.js app-tools's builder has been upgraded to rsbuild, so some builder link should update to rsbuild link.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
