### PR TITLE
fix(module-tools): should not remove SVG viewBox attribute

### DIFF
--- a/.changeset/tall-elephants-cross.md
+++ b/.changeset/tall-elephants-cross.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): should not remove SVG viewBox attribute
+
+fix(module-tools): 避免移除 SVG viewBox 属性

--- a/tests/integration/module/fixtures/build/asset/asset.test.ts
+++ b/tests/integration/module/fixtures/build/asset/asset.test.ts
@@ -54,6 +54,8 @@ describe('asset.svgr', () => {
     const distFilePath = path.join(fixtureDir, './dist/bundle/index.js');
     const content = await fs.readFile(distFilePath, 'utf-8');
     expect(content.includes(`jsx("svg"`)).toBeTruthy();
+    // should not remove SVG viewBox attribute
+    expect(content.includes('viewBox: "0 0 841.9 595.3"')).toBeTruthy();
   });
   it('bundleless', async () => {
     const configFile = 'bundleless.config.ts';


### PR DESCRIPTION
## Summary

Module tools should not remove SVG viewBox attribute, we can add some default SVGR options as `@modern-js/app-tools` and Rsbuild, see https://github.com/web-infra-dev/rsbuild/blob/main/packages/plugin-svgr/src/index.ts#L31-L47.

This change can fix the Rspress copy icon.

- Current:

![img_v3_027i_e02275f0-d3eb-4a6d-aeaa-00f0570d5fag](https://github.com/web-infra-dev/modern.js/assets/7237365/dfbc75e6-586d-4200-9459-bdb50739b4de)

- Fixed:

![img_v3_027i_11313b93-0715-4d68-ab16-e8cc0677bdcg](https://github.com/web-infra-dev/modern.js/assets/7237365/7a615ed8-3bce-4db3-98b1-624117103bf9)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
