### PR TITLE
chore: remove enable-rspack action in generator run new

### DIFF
--- a/.changeset/fuzzy-ants-destroy.md
+++ b/.changeset/fuzzy-ants-destroy.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/rspack-generator': patch
+'@modern-js/generator-common': patch
+---
+
+chore: remove enable-rspack action in generator run new
+
+chore: 在生成器 run new 中移除 ‘启用 Rspack’ 的功能

--- a/packages/generator/generator-cases/tests/index.test.ts
+++ b/packages/generator/generator-cases/tests/index.test.ts
@@ -22,7 +22,7 @@ describe('test generator cases', () => {
   });
   test('test getMWANewCases', async () => {
     const mwaNewCases = getMWANewCases();
-    expect(mwaNewCases.length).toBe(14);
+    expect(mwaNewCases.length).toBe(13);
   });
   test('test getModuleNewCases', async () => {
     const moduleNewCases = getModuleNewCases();

--- a/packages/generator/generator-common/src/locale/en.ts
+++ b/packages/generator/generator-common/src/locale/en.ts
@@ -35,7 +35,6 @@ export const EN_LOCALE = {
       polyfill: 'Enable UA-based Polyfill Feature',
       proxy: 'Enable Global Proxy',
       swc: 'Enable SWC Compile',
-      rspack: 'Enable Rspack Build (experimental)',
       module_doc: 'Enable Module Doc',
     },
     element: {

--- a/packages/generator/generator-common/src/locale/zh.ts
+++ b/packages/generator/generator-common/src/locale/zh.ts
@@ -34,7 +34,6 @@ export const ZH_LOCALE = {
       polyfill: '启用「基于 UA 的 Polyfill」功能',
       proxy: '启用「全局代理」',
       swc: '启用「SWC 编译」',
-      rspack: '启用「Rspack 构建」(实验性)',
       module_doc: '启动「模块文档」功能',
     },
     element: {

--- a/packages/generator/generator-common/src/newAction/common/index.ts
+++ b/packages/generator/generator-common/src/newAction/common/index.ts
@@ -25,7 +25,6 @@ export enum ActionFunction {
   Polyfill = 'polyfill',
   Proxy = 'proxy',
   SWC = 'swc',
-  Rspack = 'rspack',
   ModuleDoc = 'module_doc',
 }
 
@@ -69,7 +68,6 @@ export const ActionFunctionText: Record<ActionFunction, () => string> = {
   [ActionFunction.Polyfill]: () => i18n.t(localeKeys.action.function.polyfill),
   [ActionFunction.Proxy]: () => i18n.t(localeKeys.action.function.proxy),
   [ActionFunction.SWC]: () => i18n.t(localeKeys.action.function.swc),
-  [ActionFunction.Rspack]: () => i18n.t(localeKeys.action.function.rspack),
   [ActionFunction.ModuleDoc]: () =>
     i18n.t(localeKeys.action.function.module_doc),
 };

--- a/packages/generator/generator-common/src/newAction/mwa/index.ts
+++ b/packages/generator/generator-common/src/newAction/mwa/index.ts
@@ -20,7 +20,6 @@ export const MWAActionTypes = [
 ];
 
 export const MWAActionFunctions = [
-  ActionFunction.Rspack,
   ActionFunction.TailwindCSS,
   ActionFunction.BFF,
   ActionFunction.SSG,
@@ -186,7 +185,6 @@ export const MWANewActionGenerators: Record<
     [ActionFunction.Polyfill]: '@modern-js/dependence-generator',
     [ActionFunction.Proxy]: '@modern-js/dependence-generator',
     [ActionFunction.SWC]: '@modern-js/dependence-generator',
-    [ActionFunction.Rspack]: '@modern-js/rspack-generator',
   },
   [ActionType.Refactor]: {
     [ActionRefactor.ReactRouter5]: '@modern-js/router-v5-generator',

--- a/packages/generator/generator-common/tests/newAction.test.ts
+++ b/packages/generator/generator-common/tests/newAction.test.ts
@@ -8,6 +8,6 @@ describe('new action test', () => {
     expect(ActionFunctionText[ActionFunction.Proxy]()).toBe('启用「全局代理」');
   });
   it('mwa', () => {
-    expect(MWAActionFunctions.length).toBe(11);
+    expect(MWAActionFunctions.length).toBe(10);
   });
 });

--- a/packages/generator/generators/rspack-generator/src/index.ts
+++ b/packages/generator/generators/rspack-generator/src/index.ts
@@ -1,17 +1,12 @@
 import path from 'path';
 import { GeneratorContext, GeneratorCore } from '@modern-js/codesmith';
 import { AppAPI } from '@modern-js/codesmith-api-app';
-import {
-  chalk,
-  getModernConfigFile,
-  isTsProject,
-} from '@modern-js/generator-utils';
+import { isTsProject } from '@modern-js/generator-utils';
 import {
   DependenceGenerator,
   i18n as commonI18n,
   Language,
 } from '@modern-js/generator-common';
-import { i18n, localeKeys } from './locale';
 
 const getGeneratorPath = (generator: string, distTag: string) => {
   if (process.env.CODESMITH_ENV === 'development') {
@@ -69,37 +64,5 @@ export default async (context: GeneratorContext, generator: GeneratorCore) => {
 
   await handleTemplateFile(context, generator, appApi);
 
-  if (!context.config.isSubGenerator) {
-    await appApi.runInstall(undefined, { ignoreScripts: true });
-    const appDir = context.materials.default.basePath;
-    const configFile = await getModernConfigFile(appDir);
-    const isTS = configFile.endsWith('ts');
-    console.info(
-      chalk.green(`\n[INFO]`),
-      `${i18n.t(localeKeys.success)}`,
-      chalk.yellow.bold(`${configFile}`),
-      ':',
-      '\n',
-    );
-    if (isTS) {
-      console.info(`
-export default defineConfig${chalk.yellow.bold("<'rspack'>")}({
-  ...,
-  plugins: [appTools(${chalk.yellow.bold(
-    `{ bundler: 'experimental-rspack' }`,
-  )}), ...],
-});
-`);
-    } else {
-      console.info(`
-module.exports = {
-  ...,
-  plugins: [appTools(${chalk.yellow.bold(
-    `{ bundler: 'experimental-rspack' }`,
-  )}), ...],
-};
-`);
-    }
-  }
   generator.logger.debug(`forge @modern-js/rspack-generator succeed `);
 };

--- a/packages/generator/generators/rspack-generator/src/locale/en.ts
+++ b/packages/generator/generators/rspack-generator/src/locale/en.ts
@@ -1,3 +1,0 @@
-export const EN_LOCALE = {
-  success: `Enable Rspack build capability successful! Please add the following code to`,
-};

--- a/packages/generator/generators/rspack-generator/src/locale/index.ts
+++ b/packages/generator/generators/rspack-generator/src/locale/index.ts
@@ -1,9 +1,0 @@
-import { I18n } from '@modern-js/plugin-i18n';
-import { ZH_LOCALE } from './zh';
-import { EN_LOCALE } from './en';
-
-const i18n = new I18n();
-
-const localeKeys = i18n.init('en', { zh: ZH_LOCALE, en: EN_LOCALE });
-
-export { i18n, localeKeys };

--- a/packages/generator/generators/rspack-generator/src/locale/zh.ts
+++ b/packages/generator/generators/rspack-generator/src/locale/zh.ts
@@ -1,3 +1,0 @@
-export const ZH_LOCALE = {
-  success: `启用 Rspack 构建能力成功！请添加如下代码至`,
-};


### PR DESCRIPTION
## Summary

just one line of configuration to start rspack build, no need to use run new function.

```diff
export default defineConfig({
  plugins: [
    appTools({
+     bundler: 'experimental-rspack',
    }),
  ],
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
