### PR TITLE
docs: fix missing translation in English doc

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/source/enable-async-entry.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/enable-async-entry.mdx
@@ -13,7 +13,7 @@ When this option is enabled, Modern.js will wrap the automatically generated ent
 
 ## Background
 
-import ModuleFederation from '@modern-js/builder-doc/docs/zh/shared/module-federation.md';
+import ModuleFederation from '@modern-js/builder-doc/docs/en/shared/module-federation.md';
 
 <ModuleFederation />
 


### PR DESCRIPTION
## Summary

Fix missing translation in English doc:

![image](https://github.com/web-infra-dev/modern.js/assets/7237365/32f22f28-ebcf-4eb7-83ba-49c0c64434fe)

## Related Links

https://modernjs.dev/en/configure/app/source/enable-async-entry.html

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
