### PR TITLE
fix(uni-builder): missing security config

### DIFF
--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -131,6 +131,7 @@ export async function parseCommonConfig(
       ...sourceConfig
     } = {},
     dev: { port, host, https, ...devConfig } = {},
+    security: { checkSyntax, sri, ...securityConfig } = {},
     tools: { devServer, tsChecker, minifyCss, ...toolsConfig } = {},
   } = uniBuilderConfig;
 
@@ -145,6 +146,7 @@ export async function parseCommonConfig(
     html: htmlConfig,
     tools: toolsConfig,
     dev: devConfig,
+    security: securityConfig,
   };
 
   const { dev = {}, html = {}, output = {} } = rsbuildConfig;
@@ -307,14 +309,10 @@ export async function parseCommonConfig(
     pluginYaml(),
   ];
 
-  const checkSyntaxOptions = uniBuilderConfig.security?.checkSyntax;
-
-  if (checkSyntaxOptions) {
+  if (checkSyntax) {
     const { pluginCheckSyntax } = await import('@rsbuild/plugin-check-syntax');
     rsbuildPlugins.push(
-      pluginCheckSyntax(
-        typeof checkSyntaxOptions === 'boolean' ? {} : checkSyntaxOptions,
-      ),
+      pluginCheckSyntax(typeof checkSyntax === 'boolean' ? {} : checkSyntax),
     );
   }
 

--- a/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -34,6 +34,7 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "host": "xxx.xxx",
     "https": {
@@ -86,6 +87,7 @@ exports[`parseCommonConfig > dev.xxx 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -133,6 +135,7 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -183,6 +186,7 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -230,6 +234,7 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -280,6 +285,7 @@ exports[`parseCommonConfig > html.faviconByEntries 4`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -327,6 +333,7 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -381,6 +388,7 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -428,6 +436,7 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -478,6 +487,7 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -525,6 +535,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -577,6 +588,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -626,6 +638,7 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -675,6 +688,7 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -724,6 +738,7 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -773,6 +788,7 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -820,6 +836,7 @@ exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },
@@ -867,6 +884,7 @@ exports[`parseCommonConfig > output.enableInlineStyles 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "security": {},
   "server": {
     "publicDir": false,
   },


### PR DESCRIPTION
## Summary

fix: missing security config when parse rsbuild config, and `security.nonce` is also missing in rsbuild doc...

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
