### PR TITLE
fix: some builder e2e cases unstable when distPath conflict

### DIFF
--- a/tests/e2e/builder/cases/performance/removeConsole.test.ts
+++ b/tests/e2e/builder/cases/performance/removeConsole.test.ts
@@ -26,6 +26,11 @@ test('should remove specified console correctly', async () => {
       main: join(cwd, 'src/index.js'),
     },
     builderConfig: {
+      output: {
+        distPath: {
+          root: 'dist-1',
+        },
+      },
       performance: {
         removeConsole: ['log', 'warn'],
       },
@@ -47,6 +52,11 @@ test('should remove all console correctly', async () => {
       main: join(cwd, 'src/index.js'),
     },
     builderConfig: {
+      output: {
+        distPath: {
+          root: 'dist-2',
+        },
+      },
       performance: {
         removeConsole: true,
       },

--- a/tests/e2e/builder/cases/top-level-await/index.swc.test.ts
+++ b/tests/e2e/builder/cases/top-level-await/index.swc.test.ts
@@ -11,6 +11,13 @@ test('should run top level await correctly when using SWC', async ({
     entry: {
       index: path.resolve(__dirname, './src/index.ts'),
     },
+    builderConfig: {
+      output: {
+        distPath: {
+          root: 'dist-swc',
+        },
+      },
+    },
     plugins: [pluginSwc()],
     runServer: true,
   });


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/modern.js/actions/runs/7720734842/job/21046104474
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
