### PR TITLE
fix(ts-checker): remove default include glob

### DIFF
--- a/.changeset/old-masks-flash.md
+++ b/.changeset/old-masks-flash.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(ts-checker): remove default include glob

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -70,21 +70,13 @@ export function createDefaultConfig(
     port: 8080,
   };
 
-  const tools = {
-    tsChecker: {
-      issue: {
-        include: [{ file: '**/src/**/*' }],
-      },
-    },
-  };
-
   return {
     source,
     output,
     server,
     dev,
     html,
-    tools,
+    tools: {},
     plugins: [],
     builderPlugins: [],
     runtime: {},


### PR DESCRIPTION
## Summary

Remove the default include glob for TS checker, this glob will cause some errors to not be output correctly.

After removing the default include glob, TS checker now runs according to the include and exclude rules in tsconfig file.
 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
