### PR TITLE
test(workflow): using new M1 macOS runner

### DIFF
--- a/.github/workflows/test-macOS.yml
+++ b/.github/workflows/test-macOS.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   ut-mac:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-14
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/vitest-macOS.yml
+++ b/.github/workflows/vitest-macOS.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   ut-mac:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-14
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
## Summary

Using new M1 macOS runner to make CI faster.

see: https://github.com/web-infra-dev/rsbuild/pull/1486

## Related Issue

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
