### PR TITLE
fix(uni-builder): missing css sourcemap when dev

### DIFF
--- a/.changeset/stupid-rules-judge.md
+++ b/.changeset/stupid-rules-judge.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): missing css sourcemap when dev
+
+fix(uni-builder): dev 构建时缺失 css sourcemap

--- a/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/builder/uni-builder/src/shared/parseCommonConfig.ts
@@ -17,7 +17,11 @@ import {
   type RsbuildPlugin,
   type RsbuildConfig,
 } from '@rsbuild/core';
-import type { CreateBuilderCommonOptions, UniBuilderConfig } from '../types';
+import type {
+  CreateBuilderCommonOptions,
+  UniBuilderConfig,
+  DisableSourceMapOption,
+} from '../types';
 import { pluginToml } from '@rsbuild/plugin-toml';
 import { pluginYaml } from '@rsbuild/plugin-yaml';
 import { pluginReact } from '@rsbuild/plugin-react';
@@ -85,6 +89,20 @@ async function getBrowserslistWithDefault(
 
   return DEFAULT_BROWSERSLIST[target];
 }
+
+const isUseCssSourceMap = (disableSourceMap: DisableSourceMapOption = {}) => {
+  if (typeof disableSourceMap === 'boolean') {
+    return !disableSourceMap;
+  }
+
+  // If the disableSourceMap.css option is not specified, we will enable it in development mode.
+  // We do not need CSS Source Map in production mode.
+  if (disableSourceMap.css === undefined) {
+    return process.env.NODE_ENV !== 'production';
+  }
+
+  return !disableSourceMap.css;
+};
 
 export async function parseCommonConfig(
   uniBuilderConfig: UniBuilderConfig,
@@ -161,6 +179,11 @@ export async function parseCommonConfig(
   if (cssModuleLocalIdentName) {
     output.cssModules ||= {};
     output.cssModules.localIdentName = cssModuleLocalIdentName;
+  }
+
+  if (isUseCssSourceMap(disableSourceMap)) {
+    output.sourceMap ||= {};
+    output.sourceMap.css = true;
   }
 
   output.distPath ??= {};

--- a/packages/builder/uni-builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/default.test.ts.snap
@@ -321,7 +321,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                       [Function],
                     ],
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
             ],
@@ -366,7 +366,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                       [Function],
                     ],
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
             ],
@@ -417,7 +417,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                       [Function],
                     ],
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
               {
@@ -427,7 +427,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                   "lessOptions": {
                     "javascriptEnabled": true,
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
             ],
@@ -472,7 +472,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                       [Function],
                     ],
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
               {
@@ -482,7 +482,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                   "lessOptions": {
                     "javascriptEnabled": true,
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
             ],
@@ -533,7 +533,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                       [Function],
                     ],
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
               {
@@ -592,7 +592,7 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                       [Function],
                     ],
                   },
-                  "sourceMap": false,
+                  "sourceMap": true,
                 },
               },
               {
@@ -892,9 +892,6 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
       },
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
-    },
-    RemoveCssSourcemapPlugin {
-      "name": "RemoveCssSourcemapPlugin",
     },
     ProgressPlugin {
       "_options": {
@@ -2177,7 +2174,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                 "exportLocalsConvention": "camelCase",
                 "localIdentName": "[path][name]__[local]-[hash:base64:6]",
               },
-              "sourceMap": false,
+              "sourceMap": true,
             },
           },
           {
@@ -2213,7 +2210,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                   [Function],
                 ],
               },
-              "sourceMap": false,
+              "sourceMap": true,
             },
           },
         ],
@@ -2237,7 +2234,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                 "exportLocalsConvention": "camelCase",
                 "localIdentName": "[path][name]__[local]-[hash:base64:6]",
               },
-              "sourceMap": false,
+              "sourceMap": true,
             },
           },
           {
@@ -2273,7 +2270,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                   [Function],
                 ],
               },
-              "sourceMap": false,
+              "sourceMap": true,
             },
           },
           {
@@ -2311,7 +2308,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                 "exportLocalsConvention": "camelCase",
                 "localIdentName": "[path][name]__[local]-[hash:base64:6]",
               },
-              "sourceMap": false,
+              "sourceMap": true,
             },
           },
           {
@@ -2347,7 +2344,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                   [Function],
                 ],
               },
-              "sourceMap": false,
+              "sourceMap": true,
             },
           },
           {
@@ -2357,7 +2354,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
               "lessOptions": {
                 "javascriptEnabled": true,
               },
-              "sourceMap": false,
+              "sourceMap": true,
             },
           },
         ],

--- a/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -28,6 +28,9 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -129,6 +132,9 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -180,6 +186,9 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -228,6 +237,9 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -279,6 +291,9 @@ exports[`parseCommonConfig > html.faviconByEntries 4`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -327,6 +342,9 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -382,6 +400,9 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -430,6 +451,9 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -481,6 +505,9 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -529,6 +556,9 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -582,6 +612,9 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -632,6 +665,9 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -682,6 +718,9 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -732,6 +771,9 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],
@@ -782,6 +824,9 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
       ],
     },
     "polyfill": "entry",
+    "sourceMap": {
+      "css": true,
+    },
     "targets": [
       "web",
     ],

--- a/packages/builder/uni-builder/tests/__snapshots__/postcssLegacy.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/postcssLegacy.test.ts.snap
@@ -284,7 +284,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                     [Function],
                   ],
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
           ],
@@ -321,7 +321,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                     [Function],
                   ],
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
           ],
@@ -364,7 +364,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                     [Function],
                   ],
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
             {
@@ -374,7 +374,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                 "lessOptions": {
                   "javascriptEnabled": true,
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
           ],
@@ -411,7 +411,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                     [Function],
                   ],
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
             {
@@ -421,7 +421,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                 "lessOptions": {
                   "javascriptEnabled": true,
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
           ],
@@ -464,7 +464,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                     [Function],
                   ],
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
             {
@@ -515,7 +515,7 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                     [Function],
                   ],
                 },
-                "sourceMap": false,
+                "sourceMap": true,
               },
             },
             {


### PR DESCRIPTION
## Summary

css sourcemap should be true when dev or user specify

<img width="1018" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/224ece6c-3de4-43d6-8340-2dd2af28cfa3">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
