### PR TITLE
fix(uni-builder): repeatedly insert babel plugin when using tsLoader

### DIFF
--- a/.changeset/ninety-apricots-rhyme.md
+++ b/.changeset/ninety-apricots-rhyme.md
@@ -2,6 +2,6 @@
 '@modern-js/uni-builder': patch
 ---
 
-fix(uni-builder): repeatedly insert babel plugin when using tsLoader
+fix(uni-builder): repeatedly insert babel plugin when using tsLoader in some edge case
 
-fix(uni-builder): 修复在使用 tsLoader 是会重复添加 babel plugin 的问题
+fix(uni-builder): 修复在一些边界场景下使用 tsLoader 时会重复添加 babel plugin 的问题

--- a/.changeset/ninety-apricots-rhyme.md
+++ b/.changeset/ninety-apricots-rhyme.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): repeatedly insert babel plugin when using tsLoader
+
+fix(uni-builder): 修复在使用 tsLoader 是会重复添加 babel plugin 的问题

--- a/packages/builder/uni-builder/src/webpack/plugins/tsLoader.ts
+++ b/packages/builder/uni-builder/src/webpack/plugins/tsLoader.ts
@@ -119,7 +119,12 @@ export const pluginTsLoader = (
           .test(TS_REGEX)
           .use(CHAIN_ID.USE.BABEL)
           .loader(require.resolve('babel-loader'))
-          .options(babelLoaderOptions)
+          .options({
+            ...babelLoaderOptions,
+            // fix repeatedly insert babel plugin in some boundary cases
+            plugins: [...(babelLoaderOptions.plugins || [])],
+            presets: [...(babelLoaderOptions.presets || [])],
+          })
           .end()
           .use(CHAIN_ID.USE.TS)
           .loader(require.resolve('ts-loader'))

--- a/packages/builder/uni-builder/tests/__snapshots__/tsLoader.test.ts.snap
+++ b/packages/builder/uni-builder/tests/__snapshots__/tsLoader.test.ts.snap
@@ -1,5 +1,194 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`plugin-ts-loader > should insert babel plugin correctly in some edge case 1`] = `
+[
+  {
+    "resolve": {
+      "fullySpecified": false,
+    },
+    "test": /\\\\\\.m\\?js/,
+  },
+  {
+    "include": [
+      {
+        "and": [
+          "",
+          {
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+          },
+        ],
+      },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:js\\|mjs\\|cjs\\|jsx\\)\\$/,
+    "use": [
+      {
+        "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-loader/lib/index.js",
+        "options": {
+          "babelrc": false,
+          "compact": true,
+          "configFile": false,
+          "plugins": [
+            [
+              "babel-plugin-xxx",
+            ],
+            [
+              "babel-plugin-import",
+              {
+                "libraryDirectory": "es",
+                "libraryName": "xxx-components",
+                "style": true,
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+              {
+                "displayName": true,
+                "pure": true,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
+            ],
+          ],
+          "presets": [
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+              {
+                "bugfixes": true,
+                "corejs": {
+                  "proposals": true,
+                  "version": "3.32",
+                },
+                "exclude": [
+                  "transform-typeof-symbol",
+                ],
+                "modules": false,
+                "targets": [
+                  "> 0.01%",
+                  "not dead",
+                  "not op_mini all",
+                ],
+                "useBuiltIns": "entry",
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+              {
+                "allExtensions": true,
+                "allowDeclareFields": true,
+                "allowNamespaces": true,
+                "isTSX": true,
+                "optimizeConstEnums": true,
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-react/lib/index.js",
+              {
+                "development": false,
+                "runtime": "automatic",
+                "useBuiltIns": true,
+                "useSpread": false,
+              },
+            ],
+          ],
+        },
+      },
+    ],
+  },
+]
+`;
+
+exports[`plugin-ts-loader > should insert babel plugin correctly in some edge case 2`] = `
+[
+  {
+    "include": [
+      {
+        "and": [
+          "",
+          {
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+          },
+        ],
+      },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:ts\\|mts\\|cts\\|tsx\\)\\$/,
+    "use": [
+      {
+        "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-loader/lib/index.js",
+        "options": {
+          "plugins": [
+            [
+              "babel-plugin-xxx",
+            ],
+            [
+              "babel-plugin-import",
+              {
+                "libraryDirectory": "es",
+                "libraryName": "xxx-components",
+                "style": true,
+              },
+            ],
+          ],
+          "presets": [
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+              {
+                "bugfixes": true,
+                "corejs": {
+                  "proposals": true,
+                  "version": "3.32",
+                },
+                "exclude": [
+                  "transform-typeof-symbol",
+                ],
+                "modules": false,
+                "targets": [
+                  "> 0.01%",
+                  "not dead",
+                  "not op_mini all",
+                ],
+                "useBuiltIns": "entry",
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+              {
+                "allExtensions": true,
+                "allowDeclareFields": true,
+                "allowNamespaces": true,
+                "isTSX": true,
+                "optimizeConstEnums": true,
+              },
+            ],
+            [
+              "<WORKSPACE>/node_modules/<PNPM_INNER>/@babel/preset-react/lib/index.js",
+              {
+                "development": false,
+                "runtime": "automatic",
+                "useBuiltIns": true,
+                "useSpread": false,
+              },
+            ],
+          ],
+        },
+      },
+      {
+        "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/ts-loader/index.js",
+        "options": {
+          "allowTsInNodeModules": true,
+          "compilerOptions": {
+            "module": "esnext",
+            "target": "esnext",
+          },
+          "transpileOnly": true,
+        },
+      },
+    ],
+  },
+]
+`;
+
 exports[`plugin-ts-loader > should set include/exclude 1`] = `
 [
   {


### PR DESCRIPTION
## Summary

in some edge case, uni-builder inserts babel plugin repeatedly  when using tsLoader and the user config babel as follow:

```
export default {
  tools: {
    babel: {
      plugins: [
        [
          'babel-plugin-import',
          {
            libraryName: 'xxx-components',
            libraryDirectory: 'es',
            style: true,
          },
        ],
      ],
    },
  },
};
```

this makes babel.plugin have the same address in js rule and ts rule.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
