### PR TITLE
feat(devtools): refactor DevtoolsPuller into Puller to support common deep link

### DIFF
--- a/packages/devtools/client/src/components/Devtools/Puller.tsx
+++ b/packages/devtools/client/src/components/Devtools/Puller.tsx
@@ -2,32 +2,25 @@ import React, { useEffect } from 'react';
 import { useNavigate } from '@modern-js/runtime/router';
 import { useThrowable } from '@/utils';
 import { $mountPoint } from '@/entries/client/routes/state';
-import { wallAgent } from '@/entries/client/routes/react/state';
 
-let _intendPullUp = false;
+let _intendPullUp = '';
 
 $mountPoint.then(({ hooks }) => {
-  hooks.hookOnce('pullUpReactInspector', async () => {
-    _intendPullUp = true;
+  hooks.hookOnce('pullUp', async target => {
+    _intendPullUp = target;
   });
 });
 
-export const DevtoolsPuller: React.FC = () => {
+export const Puller: React.FC = () => {
   const navigate = useNavigate();
   const mountPoint = useThrowable($mountPoint);
-  const handlePullUp = async () => {
-    navigate('/react');
-    if (wallAgent.status === 'active') {
-      wallAgent.send('startInspectingNative', null);
-    } else {
-      wallAgent.hookOnce('active', () => {
-        wallAgent.send('startInspectingNative', null);
-      });
-    }
-  };
   useEffect(() => {
-    _intendPullUp && handlePullUp();
-    mountPoint.hooks.hook('pullUpReactInspector', handlePullUp);
+    _intendPullUp && navigate(_intendPullUp);
+    console.log('_intendPullUp: ', _intendPullUp);
+    mountPoint.hooks.hook('pullUp', async target => {
+      console.log('target: ', target);
+      navigate(target);
+    });
   }, []);
   return null;
 };

--- a/packages/devtools/client/src/components/Devtools/Puller.tsx
+++ b/packages/devtools/client/src/components/Devtools/Puller.tsx
@@ -16,9 +16,7 @@ export const Puller: React.FC = () => {
   const mountPoint = useThrowable($mountPoint);
   useEffect(() => {
     _intendPullUp && navigate(_intendPullUp);
-    console.log('_intendPullUp: ', _intendPullUp);
     mountPoint.hooks.hook('pullUp', async target => {
-      console.log('target: ', target);
       navigate(target);
     });
   }, []);

--- a/packages/devtools/client/src/entries/client/routes/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/layout.tsx
@@ -16,7 +16,7 @@ import { $tabs } from './state';
 import { Theme } from '@/components/Theme';
 import { InternalTab } from '@/entries/client/types';
 import { Breadcrumbs } from '@/components/Breadcrumbs';
-import { DevtoolsPuller } from '@/components/Devtools/Puller';
+import { Puller } from '@/components/Devtools/Puller';
 
 const NavigateButton: React.FC<{ tab: InternalTab }> = ({ tab }) => {
   let to = '';
@@ -107,7 +107,7 @@ export default function Layout() {
       <ThemePanel defaultOpen={false} style={{ display }} />
       <Navigator />
       <Breadcrumbs className={styles.breadcrumbs} />
-      <DevtoolsPuller />
+      <Puller />
     </Theme>
   );
 }

--- a/packages/devtools/client/src/entries/client/routes/overview/page.module.scss
+++ b/packages/devtools/client/src/entries/client/routes/overview/page.module.scss
@@ -13,7 +13,7 @@
 .primary-card {
   flex: 4;
   min-width: max-content;
-  background-color: var(--blue-9);
+  background-color: var(--blue-10);
   :global(.dark) & {
     background-color: var(--blue-10);
   }

--- a/packages/devtools/client/src/entries/client/routes/overview/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/overview/page.tsx
@@ -16,9 +16,9 @@ import {
   $perf,
   VERSION,
 } from '../state';
+import '@/components/Card/Indicate.module.scss';
 import styles from './page.module.scss';
 import { IndicateCard } from '@/components/Card';
-import '@/components/Card/Indicate.module.scss';
 
 const BUNDLER_PACKAGE_NAMES = {
   webpack: 'webpack',

--- a/packages/devtools/client/src/entries/client/routes/overview/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/overview/page.tsx
@@ -1,9 +1,9 @@
-import { Box, Flex, Kbd, Link, Text, Theme, Heading } from '@radix-ui/themes';
+import { Box, Flex, Heading, Kbd, Link, Text, Theme } from '@radix-ui/themes';
 import React from 'react';
 import {
-  HiOutlineDocumentText,
   HiLink,
   HiOutlineClock,
+  HiOutlineDocumentText,
   HiOutlinePuzzlePiece,
 } from 'react-icons/hi2';
 import { parseURL } from 'ufo';
@@ -16,9 +16,9 @@ import {
   $perf,
   VERSION,
 } from '../state';
-import '@/components/Card/Indicate.module.scss';
 import styles from './page.module.scss';
 import { IndicateCard } from '@/components/Card';
+import '@/components/Card/Indicate.module.scss';
 
 const BUNDLER_PACKAGE_NAMES = {
   webpack: 'webpack',

--- a/packages/devtools/client/src/entries/client/routes/react/[tab]/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/react/[tab]/page.tsx
@@ -1,4 +1,4 @@
-import { useParams } from '@modern-js/runtime/router';
+import { useLocation, useNavigate, useParams } from '@modern-js/runtime/router';
 import { Box, useThemeContext } from '@radix-ui/themes';
 import React, { useEffect, useMemo } from 'react';
 import {
@@ -13,12 +13,29 @@ import { useThrowable } from '@/utils';
 const Page: React.FC = () => {
   const params = useParams();
   const ctx = useThemeContext();
+  const location = useLocation();
+  const navigate = useNavigate();
   const browserTheme = ctx.appearance === 'light' ? 'light' : 'dark';
 
   const mountPoint = useThrowable($mountPoint);
   useEffect(() => {
     mountPoint.remote.activateReactDevtools();
   }, []);
+
+  useEffect(() => {
+    // 检查URL的hash部分
+    if (location.hash === '#inspecting') {
+      const startInspecting = () => {
+        wallAgent.send('startInspectingNative', null);
+        navigate(location.pathname, { replace: true });
+      };
+      if (wallAgent.status === 'active') {
+        startInspecting();
+      } else {
+        wallAgent.hookOnce('active', startInspecting);
+      }
+    }
+  }, [location, navigate]);
 
   const InnerView = useMemo(() => {
     const bridge = createBridge(window.parent, wallAgent);

--- a/packages/devtools/client/src/entries/client/routes/state.tsx
+++ b/packages/devtools/client/src/entries/client/routes/state.tsx
@@ -37,8 +37,8 @@ export const $mountPointChannel = MessagePortChannel.link(
 export const $mountPoint = $mountPointChannel.then(async channel => {
   const hooks = createHooks<ToMountPointFunctions>();
   const definitions: ToMountPointFunctions = {
-    async pullUpReactInspector() {
-      await hooks.callHook('pullUpReactInspector');
+    async pullUp(target) {
+      await hooks.callHook('pullUp', target);
     },
   };
   const remote = createBirpc<MountPointFunctions, ToMountPointFunctions>(

--- a/packages/devtools/client/src/types/rpc.ts
+++ b/packages/devtools/client/src/types/rpc.ts
@@ -1,5 +1,5 @@
 export interface ClientFunctions {
-  pullUpReactInspector: () => Promise<void>;
+  pullUp: (target: string) => Promise<void>;
 }
 
 export interface MountPointFunctions {


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/modern.js/assets/18379948/72cba57a-3a7d-4133-a9ce-e18ef8ef700f

Refactor the existing `DevtoolsPuller` into `Puller` to support a common deep link. The URL hash that starts with `#/__devtools` will now open the devtools by default. It can also navigate to deeper routes of the devtools using subpaths. Helpful for debugging and community promotion.

```
- Why not sync location of devtools to deeplink?
- It may cause unexpected behaviour of the host application.

- Why not remove deep link hash from url?
- Same as above, it also makes deep links not transparent to users.
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
