### PR TITLE
chore(uni-builder): set babel-post plugin order to post

### DIFF
--- a/.changeset/tasty-humans-train.md
+++ b/.changeset/tasty-humans-train.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+chore(uni-builder): set babel-post plugin order to 'post'
+
+chore(uni-builder): 将 babel-post 顺序调整为 'post'

--- a/packages/builder/uni-builder/src/rspack/plugins/babel-post.ts
+++ b/packages/builder/uni-builder/src/rspack/plugins/babel-post.ts
@@ -8,27 +8,29 @@ import { getDefaultBabelOptions } from '@rsbuild/plugin-babel';
 export const pluginBabelPost = (): RsbuildPlugin => ({
   name: 'uni-builder:babel-post',
 
-  pre: ['rsbuild:babel'],
-
   setup(api) {
-    api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
-      if (chain.module.rules.get(CHAIN_ID.RULE.JS)) {
-        const babelLoaderOptions = chain.module
-          .rule(CHAIN_ID.RULE.JS)
-          .use(CHAIN_ID.USE.BABEL)
-          .get('options');
-        const config = api.getNormalizedConfig();
+    api.modifyBundlerChain({
+      handler: async (chain, { CHAIN_ID }) => {
+        if (chain.module.rules.get(CHAIN_ID.RULE.JS)) {
+          const babelLoaderOptions = chain.module
+            .rule(CHAIN_ID.RULE.JS)
+            .use(CHAIN_ID.USE.BABEL)
+            .get('options');
+          const config = api.getNormalizedConfig();
 
-        if (
-          babelLoaderOptions &&
-          lodash.isEqual(
-            getDefaultBabelOptions(config.source.decorators),
-            babelLoaderOptions,
-          )
-        ) {
-          chain.module.rule(CHAIN_ID.RULE.JS).uses.delete(CHAIN_ID.USE.BABEL);
+          if (
+            babelLoaderOptions &&
+            lodash.isEqual(
+              getDefaultBabelOptions(config.source.decorators),
+              babelLoaderOptions,
+            )
+          ) {
+            chain.module.rule(CHAIN_ID.RULE.JS).uses.delete(CHAIN_ID.USE.BABEL);
+          }
         }
-      }
+      },
+      // other plugins can modify babel config in modifyBundlerChain 'default order'
+      order: 'post',
     });
   },
 });


### PR DESCRIPTION
## Summary

set babel-post plugin order to 'post', so other plugins can modify babel config in modifyBundlerChain 'default order'

see: https://rsbuild.dev/plugins/dev/hooks#order-field

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
