### PR TITLE
fix(module-tools): add js extension when pkg type is module

### DIFF
--- a/.changeset/silent-candles-teach.md
+++ b/.changeset/silent-candles-teach.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): add js extension when pkg type is module
+fix(module-tools): 当包类型为 module 时，给产物里的相对路径补全文件后缀

--- a/packages/solutions/module-tools/src/builder/feature/redirect.ts
+++ b/packages/solutions/module-tools/src/builder/feature/redirect.ts
@@ -46,6 +46,7 @@ async function redirectImport(
   filePath: string,
   outputDir: string,
   jsExtension: string,
+  isModule?: boolean,
   matchPath?: MatchPath,
 ): Promise<MagicString> {
   const str: MagicString = new MagicString(code);
@@ -94,7 +95,11 @@ async function redirectImport(
       }
 
       if (redirect.autoExtension) {
-        if (ext === '' && jsExtension !== '.js' && name.startsWith('.')) {
+        if (
+          ext === '' &&
+          name.startsWith('.') &&
+          (jsExtension !== '.js' || isModule)
+        ) {
           // add extension for relative path, no check if it's a directory.
           str.overwrite(start, end, `${name}${jsExtension}`);
           return;
@@ -267,7 +272,7 @@ export const redirect = {
       if (!matchModule.length) {
         return args;
       }
-      const { jsExtension } = getDefaultOutExtension({
+      const { jsExtension, isModule } = getDefaultOutExtension({
         format,
         root,
         autoExtension,
@@ -281,6 +286,7 @@ export const redirect = {
         id,
         dirname(outputPath),
         jsExtension,
+        isModule,
         matchPath,
       );
       return {

--- a/packages/solutions/module-tools/src/utils/outExtension.ts
+++ b/packages/solutions/module-tools/src/utils/outExtension.ts
@@ -41,5 +41,6 @@ export const getDefaultOutExtension = (options: {
   return {
     jsExtension,
     dtsExtension,
+    isModule,
   };
 };

--- a/tests/integration/module/fixtures/build/autoExtension/type-module/modern.config.ts
+++ b/tests/integration/module/fixtures/build/autoExtension/type-module/modern.config.ts
@@ -8,13 +8,21 @@ export default defineConfig({
       autoExtension: true,
       format: 'cjs',
       sourceMap: true,
+      outDir: 'dist/cjs',
     },
-
     {
       buildType: 'bundleless',
       autoExtension: true,
       format: 'cjs',
       sourceMap: true,
+      outDir: 'dist/cjs',
+    },
+    {
+      buildType: 'bundleless',
+      autoExtension: true,
+      format: 'esm',
+      sourceMap: true,
+      outDir: 'dist/esm',
     },
   ],
 });

--- a/tests/integration/module/fixtures/build/autoExtension/type-module/type-module.test.ts
+++ b/tests/integration/module/fixtures/build/autoExtension/type-module/type-module.test.ts
@@ -12,7 +12,7 @@ describe('autoExtension', () => {
       appDirectory: fixtureDir,
       enableDts: true,
     });
-    const cwd = path.join(fixtureDir, 'dist');
+    const cwd = path.join(fixtureDir, 'dist/cjs');
     const outputDeclarationFile = await globby('*.d.cts', {
       cwd,
     });
@@ -31,6 +31,12 @@ describe('autoExtension', () => {
     expect(
       content.includes('./common.cjs') &&
         content.includes('//# sourceMappingURL=index.cjs.map'),
+    ).toBeTruthy();
+
+    const esmContent = await fs.readFile(
+      path.join(fixtureDir, 'dist/esm', 'index.js'),
+      'utf-8',
     );
+    expect(esmContent.includes('./common.js')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
When type is module and format is esm, we will generate js files, but it can not running in node, because node esm need file extension.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
