### PR TITLE
feat(module-tools): improve svg typing for SVGR

### DIFF
--- a/.changeset/tough-icons-help.md
+++ b/.changeset/tough-icons-help.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/module-tools': patch
+---
+
+types(module-tools): improve svg typing for SVGR
+
+types(module-tools): 优化 svg 类型定义

--- a/.changeset/tough-icons-help.md
+++ b/.changeset/tough-icons-help.md
@@ -2,6 +2,6 @@
 '@modern-js/module-tools': patch
 ---
 
-types(module-tools): improve svg typing for SVGR
+feat(module-tools): improve svg typing for SVGR
 
-types(module-tools): 优化 svg 类型定义
+feat(module-tools): 优化 svg 类型定义

--- a/packages/solutions/module-tools/lib/types.d.ts
+++ b/packages/solutions/module-tools/lib/types.d.ts
@@ -34,8 +34,18 @@ declare module '*.webp' {
 }
 
 declare module '*.svg' {
-  const src: string;
-  export default src;
+  import * as React from 'react';
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement>
+  >;
+
+  /**
+   * The default export type depends on the asset.svgr.exportType config,
+   * it can be a string or a ReactComponent
+   * */
+  const content: any;
+  export default content;
 }
 
 declare module '*.css' {


### PR DESCRIPTION
## Summary

The default export type depends on the asset.svgr.exportType config, it can be a string or a ReactComponent, so we need to use `any` here.

## Related Links

the same as app-tools: https://github.com/web-infra-dev/modern.js/pull/3688

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
