### PR TITLE
chore(app-tools): use builder.startDevServer instead of ModernOldServer when call api-only

### DIFF
--- a/.changeset/quick-jokes-turn.md
+++ b/.changeset/quick-jokes-turn.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+chore(app-tools): use builder.startDevServer instead of ModernOldServer when call api-only
+
+chore(app-tools): 当仅启动 API 接口服务时，使用 builder.startDevServer 代替老的 ModernServer 方法

--- a/packages/solutions/app-tools/src/analyze/index.ts
+++ b/packages/solutions/app-tools/src/analyze/index.ts
@@ -78,6 +78,28 @@ export default ({
             serverRoutes: routes,
           };
           api.setAppContext(appContext);
+
+          if (checkIsBuildCommands()) {
+            const normalizedConfig = api.useResolvedConfigContext();
+            const createBuilderForModern = await createBuilderGenerator(
+              bundler,
+            );
+            const builder = await createBuilderForModern({
+              normalizedConfig,
+              appContext,
+            });
+
+            appContext = {
+              ...api.useAppContext(),
+              builder,
+            };
+            api.setAppContext(appContext);
+
+            builder.onAfterStartDevServer(async () => {
+              const hookRunners = api.useHookRunners();
+              printInstructions(hookRunners, appContext, normalizedConfig);
+            });
+          }
           return;
         }
 

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -1,11 +1,5 @@
 import { PluginAPI, ResolvedConfigContext } from '@modern-js/core';
-import { DEFAULT_DEV_HOST } from '@modern-js/utils';
-import { printInstructions } from '../utils/printInstructions';
-import {
-  setServer,
-  createServer,
-  injectDataLoaderPlugin,
-} from '../utils/createServer';
+import { setServer, injectDataLoaderPlugin } from '../utils/createServer';
 import { generateRoutes } from '../utils/routes';
 import { DevOptions } from '../utils/types';
 import { buildServerConfig } from '../utils/config';
@@ -50,7 +44,7 @@ export const dev = async (
 
   await hookRunners.beforeDev();
 
-  if (!appContext.builder && !apiOnly) {
+  if (!appContext.builder) {
     throw new Error(
       'Expect the Builder to have been initialized, But the appContext.builder received `undefined`',
     );
@@ -80,30 +74,10 @@ export const dev = async (
     ...devServerOptions,
   };
 
-  if (apiOnly) {
-    const app = await createServer({
-      ...(serverOptions as any),
-      compiler: null,
-    });
+  const { server } = await appContext.builder.startDevServer({
+    serverOptions: serverOptions as any,
+    apiOnly,
+  });
 
-    const host = normalizedConfig.dev?.host || DEFAULT_DEV_HOST;
-
-    app.listen(
-      {
-        port,
-        host,
-      },
-      async (err: Error) => {
-        if (err) {
-          throw err;
-        }
-        printInstructions(hookRunners, appContext, normalizedConfig);
-      },
-    );
-  } else {
-    const { server } = await appContext.builder!.startDevServer({
-      serverOptions: serverOptions as any,
-    });
-    setServer(server);
-  }
+  setServer(server);
 };

--- a/packages/solutions/app-tools/src/utils/createServer.ts
+++ b/packages/solutions/app-tools/src/utils/createServer.ts
@@ -1,4 +1,4 @@
-import { Server, ModernDevServerOptions } from '@modern-js/server';
+import { Server } from '@modern-js/server';
 import type { InternalPlugins } from '@modern-js/types';
 
 let server: Server | null = null;
@@ -14,17 +14,6 @@ export const closeServer = async () => {
     await server.close();
     server = null;
   }
-};
-
-export const createServer = async (options: ModernDevServerOptions) => {
-  if (server) {
-    await server.close();
-  }
-  server = new Server(options);
-
-  const app = await server.init();
-
-  return app;
 };
 
 export const injectDataLoaderPlugin = (internalPlugins: InternalPlugins) => {

--- a/packages/solutions/app-tools/tests/utils.test.ts
+++ b/packages/solutions/app-tools/tests/utils.test.ts
@@ -1,10 +1,4 @@
-import { Server } from '@modern-js/server';
 import { chalk } from '@modern-js/utils';
-import {
-  closeServer,
-  createServer,
-  getServer,
-} from '../src/utils/createServer';
 import { getSelectedEntries } from '../src/utils/getSelectedEntries';
 import { safeReplacer } from '../src/utils/config';
 
@@ -58,24 +52,6 @@ describe('test app-tools utils', () => {
       );
       resolve();
     });
-  });
-
-  it('should create and close server correctly', async () => {
-    const app = await createServer({
-      dev: false,
-      pwd: __dirname,
-      config: {
-        output: {
-          path: 'dist',
-        },
-      },
-    } as any);
-
-    expect(app instanceof Server).toBe(true);
-    expect(getServer()).toBe(app);
-
-    await closeServer();
-    expect(getServer()).toBeNull();
   });
 
   it('safeReplacer should handle circular object', () => {


### PR DESCRIPTION
## Summary

use builder.startDevServer instead of ModernOldServer when call with `--api-only`, ModernOldServer will be removed soon

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
