### PR TITLE
chore(uni-builder): avoid import JSON_REGEX

### DIFF
--- a/packages/cli/uni-builder/src/shared/plugins/fallback.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/fallback.ts
@@ -3,7 +3,6 @@ import {
   JS_REGEX,
   TS_REGEX,
   HTML_REGEX,
-  JSON_REGEX,
   getDistPath,
   getFilename,
   type Rspack,
@@ -57,7 +56,7 @@ const resourceRuleFallback = (
       TS_REGEX,
       // exclude `html` and `json`, they get processed by webpack internal loaders.
       HTML_REGEX,
-      JSON_REGEX,
+      /\.json$/,
     ],
     type: 'asset/resource',
   };


### PR DESCRIPTION
## Summary

Avoid import JSON_REGEX from `@rsbuild/shared`, as it will be removed soon.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1662

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
