### PR TITLE
fix: bff.enableHandleWeb should support no prefix route

### DIFF
--- a/packages/server/core/src/base/adapters/node/bff.ts
+++ b/packages/server/core/src/base/adapters/node/bff.ts
@@ -13,6 +13,7 @@ export const bindBFFHandler = async (
   options: ServerBaseOptions & BindRenderHandleOptions,
 ) => {
   const prefix = options.config.bff.prefix || '/api';
+  const { enableHandleWeb } = options.config.bff;
   const { httpMethodDecider } = options.config.bff;
   const runtimeEnv = getRuntimeEnv();
   if (runtimeEnv !== 'node') {
@@ -42,5 +43,12 @@ export const bindBFFHandler = async (
     );
   }
 
-  server.all(`${prefix}/*`, handler);
+  // In order to support bff.enableHandleWeb, this should be a global middleware
+  server.all(`*`, (c, next) => {
+    if (!c.req.path.startsWith(prefix) && !enableHandleWeb) {
+      return next();
+    } else {
+      return handler(c, next);
+    }
+  });
 };

--- a/tests/integration/bff-koa/modern.config.ts
+++ b/tests/integration/bff-koa/modern.config.ts
@@ -5,7 +5,6 @@ import koa from '@modern-js/plugin-koa';
 // https://modernjs.dev/docs/apis/app/config
 export default defineConfig({
   bff: {
-    prefix: '/',
     enableHandleWeb: true,
   },
   runtime: {


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
