### PR TITLE
fix(workflow): should build uni-builder deps before run test

### DIFF
--- a/.github/workflows/update-rsbuild.yml
+++ b/.github/workflows/update-rsbuild.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm install --ignore-scripts --no-frozen-lockfile
 
       - name: Update Rsbuild Snapshot
-        run: cd packages/cli/uni-builder && pnpm run test -u
+        run: pnpm run build:required && cd packages/cli/uni-builder && pnpm run test -u
 
       - name: Create commits
         run: |


### PR DESCRIPTION
## Summary

fix: https://github.com/web-infra-dev/modern.js/actions/runs/8076994984/job/22066423981

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
