### PR TITLE
fix(uni-builder): allow tools.postcss to override the plugins

### DIFF
--- a/.changeset/silent-apricots-play.md
+++ b/.changeset/silent-apricots-play.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): allow tools.postcss to override the plugins
+
+fix(uni-builder): 允许通过 tools.postcss 覆盖内置 plugins

--- a/packages/cli/uni-builder/src/shared/plugins/postcssLegacy.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/postcssLegacy.ts
@@ -41,13 +41,17 @@ export const pluginPostcssLegacy = (
           : false,
       ].filter(Boolean);
 
-      return mergeRsbuildConfig(config, {
-        tools: {
-          postcss: opts => {
-            opts.postcssOptions!.plugins!.push(...plugins);
+      return mergeRsbuildConfig(
+        {
+          tools: {
+            postcss: opts => {
+              opts.postcssOptions!.plugins!.push(...plugins);
+            },
           },
         },
-      });
+        // user config has higher priority than builtin config
+        config,
+      );
     });
   },
 });

--- a/packages/cli/uni-builder/tests/__snapshots__/postcssLegacy.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/postcssLegacy.test.ts.snap
@@ -1,5 +1,592 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`plugin-postcssLegacy > should allow tools.postcss to override the plugins 1`] = `
+{
+  "parser": {
+    "javascript": {
+      "exportsPresence": "error",
+    },
+  },
+  "rules": [
+    {
+      "resolve": {
+        "fullySpecified": false,
+      },
+      "test": /\\\\\\.m\\?js/,
+    },
+    {
+      "include": [
+        {
+          "and": [
+            "",
+            {
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+            },
+          ],
+        },
+        /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+      ],
+      "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.32",
+              "mode": "entry",
+              "targets": [
+                "> 0.01%",
+                "not dead",
+                "not op_mini all",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "rspackExperiments": {
+              "import": [
+                {
+                  "libraryDirectory": "es",
+                  "libraryName": "antd",
+                  "style": true,
+                },
+                {
+                  "camelToDashComponentName": false,
+                  "libraryDirectory": "es",
+                  "libraryName": "@arco-design/web-react",
+                  "style": true,
+                },
+                {
+                  "camelToDashComponentName": false,
+                  "libraryDirectory": "react-icon",
+                  "libraryName": "@arco-design/web-react/icon",
+                },
+              ],
+              "styledComponents": {
+                "displayName": true,
+                "pure": false,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+      ],
+    },
+    {
+      "mimetype": {
+        "or": [
+          "text/javascript",
+          "application/javascript",
+        ],
+      },
+      "resolve": {
+        "fullySpecified": false,
+      },
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.32",
+              "mode": "entry",
+              "targets": [
+                "> 0.01%",
+                "not dead",
+                "not op_mini all",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "rspackExperiments": {
+              "import": [
+                {
+                  "libraryDirectory": "es",
+                  "libraryName": "antd",
+                  "style": true,
+                },
+                {
+                  "camelToDashComponentName": false,
+                  "libraryDirectory": "es",
+                  "libraryName": "@arco-design/web-react",
+                  "style": true,
+                },
+                {
+                  "camelToDashComponentName": false,
+                  "libraryDirectory": "react-icon",
+                  "libraryName": "@arco-design/web-react/icon",
+                },
+              ],
+              "styledComponents": {
+                "displayName": true,
+                "pure": false,
+                "ssr": false,
+                "transpileTemplateLiterals": true,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+      ],
+    },
+    {
+      "oneOf": [
+        {
+          "generator": {
+            "filename": "static/image/[name].[contenthash:8][ext]",
+          },
+          "resourceQuery": /\\(__inline=false\\|url\\)/,
+          "type": "asset/resource",
+        },
+        {
+          "resourceQuery": /inline/,
+          "type": "asset/inline",
+        },
+        {
+          "generator": {
+            "filename": "static/image/[name].[contenthash:8][ext]",
+          },
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 10000,
+            },
+          },
+          "type": "asset",
+        },
+      ],
+      "test": /\\\\\\.\\(\\?:png\\|jpg\\|jpeg\\|pjpeg\\|pjp\\|gif\\|bmp\\|webp\\|ico\\|apng\\|avif\\|tif\\|tiff\\|jfif\\)\\$/i,
+    },
+    {
+      "oneOf": [
+        {
+          "generator": {
+            "filename": "static/media/[name].[contenthash:8][ext]",
+          },
+          "resourceQuery": /\\(__inline=false\\|url\\)/,
+          "type": "asset/resource",
+        },
+        {
+          "resourceQuery": /inline/,
+          "type": "asset/inline",
+        },
+        {
+          "generator": {
+            "filename": "static/media/[name].[contenthash:8][ext]",
+          },
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 10000,
+            },
+          },
+          "type": "asset",
+        },
+      ],
+      "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
+    },
+    {
+      "oneOf": [
+        {
+          "generator": {
+            "filename": "static/font/[name].[contenthash:8][ext]",
+          },
+          "resourceQuery": /\\(__inline=false\\|url\\)/,
+          "type": "asset/resource",
+        },
+        {
+          "resourceQuery": /inline/,
+          "type": "asset/inline",
+        },
+        {
+          "generator": {
+            "filename": "static/font/[name].[contenthash:8][ext]",
+          },
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 10000,
+            },
+          },
+          "type": "asset",
+        },
+      ],
+      "test": /\\\\\\.\\(\\?:woff\\|woff2\\|eot\\|ttf\\|otf\\|ttc\\)\\$/i,
+    },
+    {
+      "dependency": "url",
+      "generator": {
+        "filename": "static/wasm/[hash].module.wasm",
+      },
+      "test": /\\\\\\.wasm\\$/,
+      "type": "asset/resource",
+    },
+    {
+      "oneOf": [
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "sideEffects": true,
+          "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
+          "type": "css/module",
+          "use": [
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/postcss-loader",
+              "options": {
+                "postcssOptions": {
+                  "config": false,
+                  "plugins": [],
+                },
+                "sourceMap": true,
+              },
+            },
+          ],
+        },
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "sideEffects": true,
+          "type": "css",
+          "use": [
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/postcss-loader",
+              "options": {
+                "postcssOptions": {
+                  "config": false,
+                  "plugins": [],
+                },
+                "sourceMap": true,
+              },
+            },
+          ],
+        },
+      ],
+      "test": /\\\\\\.css\\$/,
+    },
+    {
+      "oneOf": [
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "sideEffects": true,
+          "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
+          "type": "css/module",
+          "use": [
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/postcss-loader",
+              "options": {
+                "postcssOptions": {
+                  "config": false,
+                  "plugins": [],
+                },
+                "sourceMap": true,
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/less-loader",
+              "options": {
+                "implementation": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/less",
+                "lessOptions": {
+                  "javascriptEnabled": true,
+                  "paths": [
+                    "node_modules",
+                  ],
+                },
+                "sourceMap": true,
+              },
+            },
+          ],
+        },
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "sideEffects": true,
+          "type": "css",
+          "use": [
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/postcss-loader",
+              "options": {
+                "postcssOptions": {
+                  "config": false,
+                  "plugins": [],
+                },
+                "sourceMap": true,
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/less-loader",
+              "options": {
+                "implementation": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/less",
+                "lessOptions": {
+                  "javascriptEnabled": true,
+                  "paths": [
+                    "node_modules",
+                  ],
+                },
+                "sourceMap": true,
+              },
+            },
+          ],
+        },
+      ],
+      "test": /\\\\\\.less\\$/,
+    },
+    {
+      "oneOf": [
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "sideEffects": true,
+          "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
+          "type": "css/module",
+          "use": [
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/postcss-loader",
+              "options": {
+                "postcssOptions": {
+                  "config": false,
+                  "plugins": [],
+                },
+                "sourceMap": true,
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/resolve-url-loader",
+              "options": {
+                "join": [Function],
+                "sourceMap": false,
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/sass-loader",
+              "options": {
+                "implementation": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/sass",
+                "sourceMap": true,
+              },
+            },
+          ],
+        },
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "sideEffects": true,
+          "type": "css",
+          "use": [
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/postcss-loader",
+              "options": {
+                "postcssOptions": {
+                  "config": false,
+                  "plugins": [],
+                },
+                "sourceMap": true,
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/resolve-url-loader",
+              "options": {
+                "join": [Function],
+                "sourceMap": false,
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/sass-loader",
+              "options": {
+                "implementation": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/shared/compiled/sass",
+                "sourceMap": true,
+              },
+            },
+          ],
+        },
+      ],
+      "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
+    },
+    {
+      "test": /\\\\\\.toml\\$/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/plugin-toml/compiled/toml-loader",
+        },
+      ],
+    },
+    {
+      "test": /\\\\\\.ya\\?ml\\$/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/plugin-yaml/compiled/yaml-loader",
+        },
+      ],
+    },
+    {
+      "oneOf": [
+        {
+          "generator": {
+            "filename": "static/svg/[name].[contenthash:8].svg",
+          },
+          "resourceQuery": /\\(__inline=false\\|url\\)/,
+          "type": "asset/resource",
+        },
+        {
+          "resourceQuery": /inline/,
+          "type": "asset/inline",
+        },
+        {
+          "generator": {
+            "filename": "static/svg/[name].[contenthash:8].svg",
+          },
+          "issuer": {
+            "not": [
+              /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+            ],
+          },
+          "parser": {
+            "dataUrlCondition": {
+              "maxSize": 10000,
+            },
+          },
+          "type": "asset",
+        },
+        {
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "builtin:swc-loader",
+              "options": {
+                "env": {
+                  "coreJs": "3.32",
+                  "mode": "entry",
+                  "targets": [
+                    "> 0.01%",
+                    "not dead",
+                    "not op_mini all",
+                  ],
+                },
+                "isModule": "unknown",
+                "jsc": {
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": true,
+                  },
+                  "preserveAllComments": true,
+                  "transform": {
+                    "decoratorMetadata": true,
+                    "legacyDecorator": true,
+                    "react": {
+                      "development": false,
+                      "refresh": true,
+                      "runtime": "automatic",
+                    },
+                    "useDefineForClassFields": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "import": [
+                    {
+                      "libraryDirectory": "es",
+                      "libraryName": "antd",
+                      "style": true,
+                    },
+                    {
+                      "camelToDashComponentName": false,
+                      "libraryDirectory": "es",
+                      "libraryName": "@arco-design/web-react",
+                      "style": true,
+                    },
+                    {
+                      "camelToDashComponentName": false,
+                      "libraryDirectory": "react-icon",
+                      "libraryName": "@arco-design/web-react/icon",
+                    },
+                  ],
+                  "styledComponents": {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                },
+                "sourceMaps": true,
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/plugin-svgr/dist/loader",
+              "options": {
+                "svgo": true,
+                "svgoConfig": {
+                  "plugins": [
+                    {
+                      "name": "preset-default",
+                      "params": {
+                        "overrides": {
+                          "removeViewBox": false,
+                        },
+                      },
+                    },
+                    "prefixIds",
+                  ],
+                },
+              },
+            },
+            {
+              "loader": "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/plugin-svgr/compiled/url-loader",
+              "options": {
+                "limit": 10000,
+                "name": "static/svg/[name].[contenthash:8].svg",
+              },
+            },
+          ],
+        },
+      ],
+      "test": /\\\\\\.svg\\$/,
+    },
+  ],
+}
+`;
+
 exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1`] = `
 {
   "parser": {

--- a/packages/cli/uni-builder/tests/postcssLegacy.test.ts
+++ b/packages/cli/uni-builder/tests/postcssLegacy.test.ts
@@ -19,4 +19,24 @@ describe('plugin-postcssLegacy', () => {
 
     expect(bundlerConfigs[0].module).toMatchSnapshot();
   });
+
+  it('should allow tools.postcss to override the plugins', async () => {
+    const rsbuild = await createUniBuilder({
+      bundlerType: 'rspack',
+      config: {
+        tools: {
+          postcss(config) {
+            config.postcssOptions!.plugins = [];
+          },
+        },
+      },
+      cwd: '',
+    });
+
+    const {
+      origin: { bundlerConfigs },
+    } = await rsbuild.inspectConfig();
+
+    expect(bundlerConfigs[0].module).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

Should allow tools.postcss to override the builtin plugins of uni-builder.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
