### PR TITLE
[WIP] feat(devtools): extract runtime global variables to keep a singular

### DIFF
--- a/packages/devtools/client/src/entries/mount/index.tsx
+++ b/packages/devtools/client/src/entries/mount/index.tsx
@@ -1,15 +1,9 @@
 import './react-devtools-backend';
 import './state';
 import { createRoot } from 'react-dom/client';
-import { SetupClientParams } from '@modern-js/devtools-kit/runtime';
+import { globals } from '@modern-js/devtools-kit/runtime';
 import styles from './index.module.scss';
 import { DevtoolsCapsule } from '@/components/Devtools/Capsule';
-
-declare global {
-  interface Window {
-    __MODERN_JS_DEVTOOLS_OPTIONS__: SetupClientParams;
-  }
-}
 
 document.addEventListener('DOMContentLoaded', () => {
   const outer = document.createElement('div');
@@ -32,7 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
   );
   shadow.appendChild(container);
 
-  const options = window.__MODERN_JS_DEVTOOLS_OPTIONS__;
   const root = createRoot(container);
-  root.render(<DevtoolsCapsule {...options} />);
+  root.render(<DevtoolsCapsule {...globals.options} />);
 });

--- a/packages/devtools/kit/src/node.ts
+++ b/packages/devtools/kit/src/node.ts
@@ -5,3 +5,4 @@ export * from './utils';
 export * from './constants';
 export * from './channel';
 export * from './rsdoctor';
+export * from './runtime-globals';

--- a/packages/devtools/kit/src/runtime-globals.ts
+++ b/packages/devtools/kit/src/runtime-globals.ts
@@ -1,0 +1,30 @@
+import type { SetupClientParams } from './mount-point';
+
+export const RUNTIME_GLOBALS = '__modern_js_global';
+
+export interface RuntimeGlobals {
+  options?: SetupClientParams;
+}
+
+declare global {
+  interface Window {
+    [RUNTIME_GLOBALS]?: RuntimeGlobals;
+  }
+}
+
+export const globals = {
+  get options() {
+    window[RUNTIME_GLOBALS] ||= {};
+    const { options } = window[RUNTIME_GLOBALS];
+    if (!options || typeof options !== 'object') {
+      throw new TypeError(
+        `Unexpected type of window.${RUNTIME_GLOBALS}.options.`,
+      );
+    }
+    return options;
+  },
+  set options(value: SetupClientParams) {
+    window[RUNTIME_GLOBALS] ||= {};
+    window[RUNTIME_GLOBALS].options = value;
+  },
+};

--- a/packages/devtools/kit/src/runtime.ts
+++ b/packages/devtools/kit/src/runtime.ts
@@ -5,3 +5,4 @@ export * from './utils';
 export * from './constants';
 export * from './channel';
 export type * from './rsdoctor';
+export * from './runtime-globals';

--- a/packages/devtools/plugin/src/cli.ts
+++ b/packages/devtools/plugin/src/cli.ts
@@ -1,11 +1,15 @@
+import assert from 'assert';
 import http from 'http';
 import path from 'path';
-import assert from 'assert';
+import type { AppTools, CliPlugin } from '@modern-js/app-tools';
+import {
+  ClientDefinition,
+  ROUTE_BASENAME,
+  RUNTIME_GLOBALS,
+} from '@modern-js/devtools-kit/node';
 import { ProxyDetail } from '@modern-js/types';
 import { getPort, logger } from '@modern-js/utils';
 import createServeMiddleware from 'serve-static';
-import type { AppTools, CliPlugin } from '@modern-js/app-tools';
-import { ClientDefinition, ROUTE_BASENAME } from '@modern-js/devtools-kit/node';
 import { DevtoolsPluginOptions, resolveContext } from './config';
 import { setupClientConnection } from './rpc';
 import { SocketServer } from './utils/socket';
@@ -68,10 +72,14 @@ export const devtoolsPlugin = (
 
           // Inject options to client.
           const serializedOptions = JSON.stringify(ctx);
+          const _global = `window[${JSON.stringify(RUNTIME_GLOBALS)}]`;
           const tags: AppTools['normalizedConfig']['html']['tags'] = [
             {
               tag: 'script',
-              children: `window.__MODERN_JS_DEVTOOLS_OPTIONS__ = ${serializedOptions};`,
+              children: [
+                `${_global} = ${_global} || ${serializedOptions};`,
+                `${_global}.options = ${serializedOptions};`,
+              ].join(''),
               head: true,
               append: false,
             },


### PR DESCRIPTION
## Summary

Extract all runtime variables into a singular variable `window.__modern_js_global`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
