### PR TITLE
fix(uni-builder): should not apply babel-loader when use rspack build

### DIFF
--- a/.changeset/tidy-comics-appear.md
+++ b/.changeset/tidy-comics-appear.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): should not apply babel-loader in modern.js basic app when use rspack build
+
+fix(uni-builder): 在 modern.js 基础 demo 中使用 rspack 构建时不应该用到 babel-loader

--- a/packages/cli/uni-builder/src/rspack/plugins/babel-post.ts
+++ b/packages/cli/uni-builder/src/rspack/plugins/babel-post.ts
@@ -12,10 +12,11 @@ export const pluginBabelPost = (): RsbuildPlugin => ({
     api.modifyBundlerChain({
       handler: async (chain, { CHAIN_ID }) => {
         if (chain.module.rules.get(CHAIN_ID.RULE.JS)) {
-          const babelLoaderOptions = chain.module
+          const { cacheIdentifier, ...babelLoaderOptions } = chain.module
             .rule(CHAIN_ID.RULE.JS)
             .use(CHAIN_ID.USE.BABEL)
             .get('options');
+
           const config = api.getNormalizedConfig();
 
           if (

--- a/tests/integration/basic-app/tests/index.test.ts
+++ b/tests/integration/basic-app/tests/index.test.ts
@@ -57,6 +57,7 @@ describe('test build', () => {
     await curSequence.waitUntil('dev');
     port = await getPort();
 
+    process.env.DEBUG = 'rsbuild';
     buildRes = await modernBuild(appDir);
 
     app = await modernServe(appDir, port, {
@@ -66,12 +67,20 @@ describe('test build', () => {
 
   afterAll(async () => {
     await killApp(app);
+    delete process.env.DEBUG;
   });
 
   test(`should get right alias build!`, async () => {
     expect(buildRes.code === 0).toBe(true);
     expect(existsSync('route.json')).toBe(true);
     expect(existsSync('html/main/index.html')).toBe(true);
+  });
+
+  test(`should not use babel-loader`, async () => {
+    const configPath = path.join(appDir, 'dist', 'rspack.config.web.mjs');
+    const configContent = fs.readFileSync(configPath, { encoding: 'utf-8' });
+
+    expect(configContent.includes('babel-loader')).toBeFalsy();
   });
 
   test('should support enableInlineScripts', async () => {


### PR DESCRIPTION
## Summary

cacheIdentifier is an addition config and it should ignore when we check isBabelConfigModified.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
