### PR TITLE
fix(uni-builder): html.templateParametersByEntries should merge with default value

### DIFF
--- a/.changeset/wicked-melons-boil.md
+++ b/.changeset/wicked-melons-boil.md
@@ -2,6 +2,6 @@
 '@modern-js/uni-builder': patch
 ---
 
-chore(uni-builder): html.templateParametersByEntries should merge with default value
+fix(uni-builder): html.templateParametersByEntries should merge with default value
 
-chore(uni-builder): html.templateParametersByEntries 返回值应与默认值合并
+fix(uni-builder): html.templateParametersByEntries 返回值应与默认值合并

--- a/.changeset/wicked-melons-boil.md
+++ b/.changeset/wicked-melons-boil.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+chore(uni-builder): html.templateParametersByEntries should merge with default value
+
+chore(uni-builder): html.templateParametersByEntries 返回值应与默认值合并

--- a/packages/cli/uni-builder/package.json
+++ b/packages/cli/uni-builder/package.json
@@ -33,7 +33,6 @@
     "@babel/types": "^7.23.0",
     "@modern-js/utils": "workspace:*",
     "@modern-js/server": "workspace:*",
-    "@modern-js/prod-server": "workspace:*",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@rsbuild/babel-preset": "0.4.8",
     "@rsbuild/core": "0.4.8",
@@ -78,6 +77,7 @@
   },
   "devDependencies": {
     "@rsbuild/plugin-swc": "0.4.8",
+    "@modern-js/prod-server": "workspace:*",
     "@scripts/build": "workspace:*",
     "@scripts/vitest-config": "workspace:*",
     "@types/lodash": "^4.14.202",

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -261,8 +261,10 @@ export async function parseCommonConfig(
   }
 
   if (templateParametersByEntries) {
-    extraConfig.html.templateParameters = (_, { entryName }) =>
-      templateParametersByEntries[entryName];
+    extraConfig.html.templateParameters = (defaultValue, { entryName }) => ({
+      ...defaultValue,
+      ...(templateParametersByEntries[entryName] || {}),
+    });
   }
 
   extraConfig.tools ??= {};

--- a/packages/document/builder-doc/docs/en/config/html/templateParameters.md
+++ b/packages/document/builder-doc/docs/en/config/html/templateParameters.md
@@ -55,4 +55,4 @@ export default {
 };
 ```
 
-For detailed usage, please refer to [Rsbuild#html.templateParameters](https://rsbuild.dev/config/html/template-parameters)。
+For detailed usage, please refer to [Rsbuild - html.templateParameters](https://rsbuild.dev/config/html/template-parameters).

--- a/packages/document/builder-doc/docs/en/config/html/templateParameters.md
+++ b/packages/document/builder-doc/docs/en/config/html/templateParameters.md
@@ -3,8 +3,6 @@
 
 ```ts
 type DefaultParameters = {
-  meta: string; // corresponding to html.meta config
-  title: string; // corresponding to html.title config
   mountId: string; // corresponding to html.mountId config
   entryName: string; // entry name
   assetPrefix: string; // corresponding to output.assetPrefix config
@@ -39,55 +37,22 @@ If it is a function, the default parameters will be passed in, and you can retur
 ```ts
 export default {
   html: {
-    templateParameters: defaultParameters => {
-      console.log(defaultParameters.compilation);
-      console.log(defaultParameters.title);
-      return {
-        title: 'My App',
+    templateParameters(defaultValue, { entryName }) {
+      const params = {
+        foo: {
+          ...defaultValue,
+          type: 'Foo',
+        },
+        bar: {
+          ...defaultValue,
+          type: 'Bar',
+          hello: 'world',
+        },
       };
+      return params[entryName] || defaultValue;
     },
   },
 };
 ```
 
-### Example
-
-To use the `foo` parameter in the HTML template, you can add the following config:
-
-```js
-export default {
-  html: {
-    templateParameters: {
-      foo: 'bar',
-    },
-  },
-};
-```
-
-Or you can use a function to dynamically generate the parameters:
-
-```js
-export default {
-  html: {
-    templateParameters: defaultParameters => {
-      return {
-        foo: 'bar',
-      };
-    },
-  },
-};
-```
-
-Then you can use the `foo` parameter in the HTML template by `<%= foo %>`:
-
-```html
-<script>
-  window.foo = '<%= foo %>';
-</script>
-```
-
-The compiled HTML is:
-
-```js
-<script>window.foo = 'bar'</script>
-```
+For detailed usage, please refer to [Rsbuild#html.templateParameters](https://rsbuild.dev/config/html/template-parameters)。

--- a/packages/document/builder-doc/docs/en/config/html/templateParametersByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/templateParametersByEntries.md
@@ -7,6 +7,10 @@ The usage is same as `templateParameters`, and you can use the "entry name" as t
 
 `templateParametersByEntries` will overrides the value set in `templateParameters`.
 
+:::warning
+**Deprecated**: This configuration is deprecated, please use `templateParameters` instead.
+:::
+
 ### Example
 
 ```js

--- a/packages/document/builder-doc/docs/en/config/html/templateParametersByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/templateParametersByEntries.md
@@ -8,7 +8,7 @@ The usage is same as `templateParameters`, and you can use the "entry name" as t
 `templateParametersByEntries` will overrides the value set in `templateParameters`.
 
 :::warning
-**Deprecated**: This configuration is deprecated, please use `templateParameters` instead.
+**Deprecated**: This configuration is deprecated, please use the function usage of `templateParameters` instead.
 :::
 
 ### Example

--- a/packages/document/builder-doc/docs/zh/config/html/templateParameters.md
+++ b/packages/document/builder-doc/docs/zh/config/html/templateParameters.md
@@ -55,4 +55,4 @@ export default {
 };
 ```
 
-详细用法可参考 [Rsbuild#html.templateParameters](https://rsbuild.dev/zh/config/html/template-parameters)。
+详细用法可参考 [Rsbuild - html.templateParameters](https://rsbuild.dev/zh/config/html/template-parameters)。

--- a/packages/document/builder-doc/docs/zh/config/html/templateParameters.md
+++ b/packages/document/builder-doc/docs/zh/config/html/templateParameters.md
@@ -3,8 +3,6 @@
 
 ```ts
 type DefaultParameters = {
-  meta: string; // 对应 html.meta 配置
-  title: string; // 对应 html.title 配置
   mountId: string; // 对应 html.mountId 配置
   entryName: string; // 入口名称
   assetPrefix: string; // 对应 output.assetPrefix 配置
@@ -39,53 +37,22 @@ export default {
 ```ts
 export default {
   html: {
-    templateParameters: defaultParameters => {
-      console.log(defaultParameters.compilation);
-      console.log(defaultParameters.title);
-      return {
-        title: 'My App',
+    templateParameters(defaultValue, { entryName }) {
+      const params = {
+        foo: {
+          ...defaultValue,
+          type: 'Foo',
+        },
+        bar: {
+          ...defaultValue,
+          type: 'Bar',
+          hello: 'world',
+        },
       };
+      return params[entryName] || defaultValue;
     },
   },
 };
 ```
 
-### 示例
-
-如果需要在 HTML 模板中使用 `foo` 参数，可以添加如下设置：
-
-```js
-export default {
-  html: {
-    templateParameters: {
-      foo: 'bar',
-    },
-  },
-};
-```
-
-或者使用函数配置：
-
-```js
-export default {
-  html: {
-    templateParameters: defaultParameters => {
-      return {
-        foo: 'bar',
-      };
-    },
-  },
-};
-```
-
-接下来，你可以在 HTML 模板中，通过 `<%= foo %>` 来读取参数：
-
-```js
-<script>window.foo = '<%= foo %>'</script>
-```
-
-经过编译后的最终 HTML 代码如下：
-
-```js
-<script>window.foo = 'bar'</script>
-```
+详细用法可参考 [Rsbuild#html.templateParameters](https://rsbuild.dev/zh/config/html/template-parameters)。

--- a/packages/document/builder-doc/docs/zh/config/html/templateParametersByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/templateParametersByEntries.md
@@ -8,7 +8,7 @@
 `templateParametersByEntries` 的优先级高于 `templateParameters`，因此会覆盖 `templateParameters` 中设置的值。
 
 :::warning
-**Deprecated**：该配置已废弃，请使用 `templateParameters` 代替。
+**Deprecated**：该配置已废弃，请使用 `templateParameters` 的函数用法代替。
 :::
 
 ### 示例

--- a/packages/document/builder-doc/docs/zh/config/html/templateParametersByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/templateParametersByEntries.md
@@ -7,6 +7,10 @@
 
 `templateParametersByEntries` 的优先级高于 `templateParameters`，因此会覆盖 `templateParameters` 中设置的值。
 
+:::warning
+**Deprecated**：该配置已废弃，请使用 `templateParameters` 代替。
+:::
+
 ### 示例
 
 ```js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,9 +637,6 @@ importers:
       '@babel/types':
         specifier: ^7.23.0
         version: 7.23.6
-      '@modern-js/prod-server':
-        specifier: workspace:*
-        version: link:../../server/prod-server
       '@modern-js/server':
         specifier: workspace:*
         version: link:../../server/server
@@ -770,6 +767,9 @@ importers:
         specifier: 5.1.0
         version: 5.1.0(html-webpack-plugin@5.5.3)(webpack@5.89.0)
     devDependencies:
+      '@modern-js/prod-server':
+        specifier: workspace:*
+        version: link:../../server/prod-server
       '@rsbuild/plugin-swc':
         specifier: 0.4.8
         version: 0.4.8(@rsbuild/core@0.4.8)


### PR DESCRIPTION
## Summary
 html.templateParametersByEntries value should merged with the default parameters (same as html.parameters object): 
https://rsbuild.dev/config/html/template-parameters#object-usage

<img width="1081" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/9e4afebc-763f-4f98-ac83-3d7ac18145a9">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
