### PR TITLE
docs: add deprecated warning for html.xxxByEntries

### DIFF
--- a/packages/document/builder-doc/docs/en/config/html/favicon.md
+++ b/packages/document/builder-doc/docs/en/config/html/favicon.md
@@ -1,4 +1,4 @@
-- **Type:** `string`
+- **Type:** `string ｜ Function`
 - **Default:** `undefined`
 
 Set the favicon icon path for all pages, can be set as:
@@ -50,3 +50,5 @@ After recompiling, the following tags are automatically generated in the HTML:
 ```html
 <link rel="icon" href="/favicon.ico" />
 ```
+
+For detailed usage, please refer to [Rsbuild - html.favicon](https://rsbuild.dev/config/html/favicon).

--- a/packages/document/builder-doc/docs/en/config/html/faviconByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/faviconByEntries.md
@@ -7,6 +7,10 @@ The usage is same as `favicon`, and you can use the "entry name" as the key to s
 
 `faviconByEntries` will overrides the value set in `favicon`.
 
+:::warning
+**Deprecated**: This configuration is deprecated, please use the function usage of `favicon` instead.
+:::
+
 ### Example
 
 ```js

--- a/packages/document/builder-doc/docs/en/config/html/inject.md
+++ b/packages/document/builder-doc/docs/en/config/html/inject.md
@@ -1,4 +1,4 @@
-- **Type:** `'head' | 'body' | 'true' | false`
+- **Type:** `'head' | 'body' | boolean | Function`
 - **Default:** `'head'`
 
 Set the inject position of the `<script>` tag.
@@ -55,3 +55,5 @@ You will see that the script tag is generated at the end of the body tag:
   </body>
 </html>
 ```
+
+For detailed usage, please refer to [Rsbuild - html.inject](https://rsbuild.dev/config/html/inject).

--- a/packages/document/builder-doc/docs/en/config/html/injectByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/injectByEntries.md
@@ -7,6 +7,10 @@ The usage is same as `inject`, and you can use the "entry name" as the key to se
 
 `injectByEntries` will overrides the value set in `inject`.
 
+:::warning
+**Deprecated**: This configuration is deprecated, please use the function usage of `inject` instead.
+:::
+
 ### Example
 
 ```js

--- a/packages/document/builder-doc/docs/en/config/html/meta.md
+++ b/packages/document/builder-doc/docs/en/config/html/meta.md
@@ -1,9 +1,9 @@
-- **Type:** `Record<string, false | string | Record<string, string | boolean>>`
+- **Type:** `Object | Function`
 - **Default:** `undefined`
 
 Configure the `<meta>` tag of the HTML.
 
-### String Type
+### Example
 
 When the `value` of a `meta` object is a string, the `key` of the object is automatically mapped to `name`, and the `value` is mapped to `content`.
 
@@ -25,45 +25,4 @@ The generated `meta` tag in HTML is:
 <meta name="description" content="a description of the page" />
 ```
 
-### Object Type
-
-When the `value` of a `meta` object is an object, the `key: value` of the object is mapped to the attribute of the `meta` tag.
-
-In this case, the `name` and `content` properties will not be set by default.
-
-For example to set `http-equiv`:
-
-```js
-export default {
-  html: {
-    meta: {
-      'http-equiv': {
-        'http-equiv': 'x-ua-compatible',
-        content: 'ie=edge',
-      },
-    },
-  },
-};
-```
-
-The `meta` tag in HTML is:
-
-```html
-<meta http-equiv="x-ua-compatible" content="ie=edge" />
-```
-
-### Remove Default Value
-
-Setting the `value` of the `meta` object to `false` and the meta tag will not be generated.
-
-For example to remove the `imagemode`:
-
-```ts
-export default {
-  html: {
-    meta: {
-      imagemode: false,
-    },
-  },
-};
-```
+For detailed usage, please refer to [Rsbuild - html.meta](https://rsbuild.dev/config/html/meta).

--- a/packages/document/builder-doc/docs/en/config/html/metaByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/metaByEntries.md
@@ -7,6 +7,10 @@ The usage is same as `meta`, and you can use the "entry name" as the key to set 
 
 `metaByEntries` will overrides the value set in `meta`.
 
+:::warning
+**Deprecated**: This configuration is deprecated, please use the function usage of `meta` instead.
+:::
+
 ### Example
 
 ```js

--- a/packages/document/builder-doc/docs/en/config/html/template.md
+++ b/packages/document/builder-doc/docs/en/config/html/template.md
@@ -1,4 +1,4 @@
-- **Type:** `string`
+- **Type:** `string | Function`
 - **Default:**
 
 Define the path to the HTML template, corresponding to the `template` config of [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).
@@ -14,3 +14,5 @@ export default {
   },
 };
 ```
+
+For detailed usage, please refer to [Rsbuild - html.template](https://rsbuild.dev/config/html/template).

--- a/packages/document/builder-doc/docs/en/config/html/templateByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/templateByEntries.md
@@ -7,6 +7,10 @@ The usage is same as `template`, and you can use the "entry name" as the key to 
 
 `templateByEntries` will overrides the value set in `template`.
 
+:::warning
+**Deprecated**: This configuration is deprecated, please use the function usage of `template` instead.
+:::
+
 ### Example
 
 ```js

--- a/packages/document/builder-doc/docs/en/config/html/title.md
+++ b/packages/document/builder-doc/docs/en/config/html/title.md
@@ -1,4 +1,4 @@
-- **Type:** `string`
+- **Type:** `string ｜ Function`
 - **Default:** `undefined`
 
 Set the title tag of the HTML page, for example:
@@ -10,3 +10,5 @@ export default {
   },
 };
 ```
+
+For detailed usage, please refer to [Rsbuild - html.title](https://rsbuild.dev/config/html/title).

--- a/packages/document/builder-doc/docs/en/config/html/titleByEntries.md
+++ b/packages/document/builder-doc/docs/en/config/html/titleByEntries.md
@@ -7,6 +7,10 @@ The usage is same as `title`, and you can use the "entry name" as the key to set
 
 `titleByEntries` will overrides the value set in `title`.
 
+:::warning
+**Deprecated**: This configuration is deprecated, please use the function usage of `title` instead.
+:::
+
 ### Example
 
 ```js

--- a/packages/document/builder-doc/docs/zh/config/html/favicon.md
+++ b/packages/document/builder-doc/docs/zh/config/html/favicon.md
@@ -1,4 +1,4 @@
-- **类型：** `string`
+- **类型：** `string ｜ Function`
 - **默认值：** `undefined`
 
 设置页面的 favicon 图标，可以设置为：
@@ -50,3 +50,5 @@ export default {
 ```html
 <link rel="icon" href="/favicon.ico" />
 ```
+
+详细用法可参考 [Rsbuild - html.favicon](https://rsbuild.dev/zh/config/html/favicon)。

--- a/packages/document/builder-doc/docs/zh/config/html/faviconByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/faviconByEntries.md
@@ -7,6 +7,10 @@
 
 `faviconByEntries` 的优先级高于 `favicon`，因此会覆盖 `favicon` 中设置的值。
 
+:::warning
+**Deprecated**：该配置已废弃，请使用 `favicon` 的函数用法代替。
+:::
+
 ### 示例
 
 ```js

--- a/packages/document/builder-doc/docs/zh/config/html/inject.md
+++ b/packages/document/builder-doc/docs/zh/config/html/inject.md
@@ -1,4 +1,4 @@
-- **类型：** `'head' | 'body'| 'true' | false`
+- **类型：** `'head' | 'body' | boolean | Function`
 - **默认值：** `'head'`
 
 修改构建产物中 `<script>` 标签在 HTML 中的插入位置。
@@ -55,3 +55,5 @@ export default {
   </body>
 </html>
 ```
+
+详细用法可参考 [Rsbuild - html.inject](https://rsbuild.dev/zh/config/html/inject)。

--- a/packages/document/builder-doc/docs/zh/config/html/injectByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/injectByEntries.md
@@ -7,6 +7,10 @@
 
 `injectByEntries` 的优先级高于 `inject`，因此会覆盖 `inject` 中设置的值。
 
+:::warning
+**Deprecated**：该配置已废弃，请使用 `inject` 的函数用法代替。
+:::
+
 ### 示例
 
 ```js

--- a/packages/document/builder-doc/docs/zh/config/html/meta.md
+++ b/packages/document/builder-doc/docs/zh/config/html/meta.md
@@ -1,9 +1,9 @@
-- **类型：** `Record<string, false | string | Record<string, string | boolean>>`
+- **类型：** `Object | Function`
 - **默认值：** `undefined`
 
 配置 HTML 页面的 `<meta>` 标签。
 
-### String 类型
+### 示例
 
 当 `meta` 对象的 `value` 为字符串时，会自动将对象的 `key` 映射为 `name`，`value` 映射为 `content`。
 
@@ -25,45 +25,4 @@ export default {
 <meta name="description" content="a description of the page" />
 ```
 
-### Object 类型
-
-当 `meta` 对象的 `value` 为对象时，会将该对象的 `key: value` 映射为 `meta` 标签的属性。
-
-这种情况下默认不会设置 `name` 和 `content` 属性。
-
-比如设置 `http-equiv`：
-
-```js
-export default {
-  html: {
-    meta: {
-      'http-equiv': {
-        'http-equiv': 'x-ua-compatible',
-        content: 'ie=edge',
-      },
-    },
-  },
-};
-```
-
-最终在 HTML 中生成的 `meta` 标签为：
-
-```html
-<meta http-equiv="x-ua-compatible" content="ie=edge" />
-```
-
-### 移除默认值
-
-将 `meta` 对象的 `value` 设置为 `false`，则表示不生成对应的 meta 标签。
-
-比如移除框架预设的 `imagemode`：
-
-```ts
-export default {
-  html: {
-    meta: {
-      imagemode: false,
-    },
-  },
-};
-```
+详细用法可参考 [Rsbuild - html.meta](https://rsbuild.dev/zh/config/html/meta)。

--- a/packages/document/builder-doc/docs/zh/config/html/metaByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/metaByEntries.md
@@ -7,6 +7,10 @@
 
 `metaByEntries` 的优先级高于 `meta`，因此会覆盖 `meta` 中设置的值。
 
+:::warning
+**Deprecated**：该配置已废弃，请使用 `meta` 的函数用法代替。
+:::
+
 ### 示例
 
 ```js

--- a/packages/document/builder-doc/docs/zh/config/html/template.md
+++ b/packages/document/builder-doc/docs/zh/config/html/template.md
@@ -1,4 +1,4 @@
-- **类型：** `string`
+- **类型：** `string | Function`
 - **默认值：**
 
 定义 HTML 模板的文件路径，对应 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 的 `template` 配置项。
@@ -14,3 +14,5 @@ export default {
   },
 };
 ```
+
+详细用法可参考 [Rsbuild - html.template](https://rsbuild.dev/zh/config/html/template)。

--- a/packages/document/builder-doc/docs/zh/config/html/templateByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/templateByEntries.md
@@ -7,6 +7,10 @@
 
 `templateByEntries` 的优先级高于 `template`，因此会覆盖 `template` 设置的值。
 
+:::warning
+**Deprecated**：该配置已废弃，请使用 `template` 的函数用法代替。
+:::
+
 ### 示例
 
 ```js

--- a/packages/document/builder-doc/docs/zh/config/html/title.md
+++ b/packages/document/builder-doc/docs/zh/config/html/title.md
@@ -1,4 +1,4 @@
-- **类型：** `string`
+- **类型：** `string | Function`
 - **默认值：** `undefined`
 
 配置 HTML 页面的 title 标签，例如：
@@ -10,3 +10,5 @@ export default {
   },
 };
 ```
+
+详细用法可参考 [Rsbuild - html.title](https://rsbuild.dev/zh/config/html/title)。

--- a/packages/document/builder-doc/docs/zh/config/html/titleByEntries.md
+++ b/packages/document/builder-doc/docs/zh/config/html/titleByEntries.md
@@ -7,6 +7,10 @@
 
 `titleByEntries` 的优先级高于 `title`，因此会覆盖 `title` 中设置的值。
 
+:::warning
+**Deprecated**：该配置已废弃，请使用 `title` 的函数用法代替。
+:::
+
 ### 示例
 
 ```js


### PR DESCRIPTION
## Summary

some html.xxxByEntries configurations are deprecated, should use the function usage of `favicon` instead.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
