### PR TITLE
fix(uni-builder): splitChunks.overrides not effective for inner cacheGroups

### DIFF
--- a/.changeset/wise-pianos-film.md
+++ b/.changeset/wise-pianos-film.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): splitChunks.overrides not effective for inner cacheGroups
+
+fix(uni-builder): splitChunks.overrides 配置项对内置 cacheGroups 无效

--- a/packages/cli/uni-builder/src/shared/plugins/splitChunk.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/splitChunk.ts
@@ -44,8 +44,8 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
         // rspack chunks type mismatch with webpack
         // @ts-expect-error
         cacheGroups: {
-          ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
           ...createCacheGroups(groups),
+          ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         },
       });
     });


### PR DESCRIPTION
## Summary

should use currentConfig overrides uni-builder inner cacheGroups if the cacheGroups name is exist.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
