### PR TITLE
fix(workflow): remove update-rsbuild-snapshot step

### DIFF
--- a/.github/workflows/update-rsbuild.yml
+++ b/.github/workflows/update-rsbuild.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --ignore-scripts --no-frozen-lockfile
 
-      - name: Update Rsbuild Snapshot
-        run: pnpm run build:required && cd packages/cli/uni-builder && pnpm run test -u
-
       - name: Create commits
         run: |
           git config user.name 'github-actions[bot]'


### PR DESCRIPTION
## Summary

`update-rsbuild-snapshot` failed in CI
https://github.com/web-infra-dev/modern.js/actions/runs/8173091592/job/22372655812

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
