### PR TITLE
fix(server): print ipv6 url correctly

### DIFF
--- a/.changeset/good-hats-grin.md
+++ b/.changeset/good-hats-grin.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+---
+
+fix(server): print ipv6 url correctly
+
+fix(server): 正确打印 ipv6 url

--- a/packages/toolkit/utils/src/cli/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/cli/prettyInstructions.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import { isIPv6 } from 'node:net';
 import { chalk } from '../compiled';
 import { isDev, isSingleEntry } from './is';
 import { DEFAULT_DEV_HOST } from './constants';
@@ -35,6 +36,13 @@ const getIpv4Interfaces = () => {
 
 export type AddressUrl = { label: string; url: string };
 
+const getHostInUrl = (host: string) => {
+  if (isIPv6(host)) {
+    return host === '::' ? '[::1]' : `[${host}]`;
+  }
+  return host;
+};
+
 export const getAddressUrls = (
   protocol = 'http',
   port: number,
@@ -48,7 +56,7 @@ export const getAddressUrls = (
     return [
       {
         label: isLocalhost(host) ? LOCAL_LABEL : NETWORK_LABEL,
-        url: `${protocol}://${host}:${port}`,
+        url: `${protocol}://${getHostInUrl(host)}:${port}`,
       },
     ];
   }


### PR DESCRIPTION
## Summary

should print `http://[::1]:8080/` instead of `http://::1:8080/`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
