### PR TITLE
fix(module-tools): target es5 not work for mjs chunks

### DIFF
--- a/.changeset/healthy-terms-wait.md
+++ b/.changeset/healthy-terms-wait.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix(module-tools): target es5 not work for mjs chunk

--- a/packages/solutions/module-tools/src/builder/feature/swc.ts
+++ b/packages/solutions/module-tools/src/builder/feature/swc.ts
@@ -138,13 +138,15 @@ export const swcTransform = (userTsconfig: ITsconfig) => ({
   },
 });
 
+const JS_REGEX = /\.(?:js|mjs|cjs)$/;
+
 export const swcRenderChunk = {
   name: 'swc:renderChunk',
   apply(compiler: ICompiler) {
     compiler.hooks.renderChunk.tapPromise(
       { name: 'swc:renderChunk' },
       async chunk => {
-        if (chunk.fileName.endsWith('.js') && chunk.type === 'chunk') {
+        if (JS_REGEX.test(chunk.fileName) && chunk.type === 'chunk') {
           const { umdModuleName, format } = compiler.config;
           const name =
             typeof umdModuleName === 'function'

--- a/tests/integration/module/fixtures/build/target/es5-mjs.config.ts
+++ b/tests/integration/module/fixtures/build/target/es5-mjs.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    target: 'es5',
+    buildType: 'bundle',
+    format: 'esm',
+    autoExtension: true,
+  },
+});

--- a/tests/integration/module/fixtures/build/target/target.test.ts
+++ b/tests/integration/module/fixtures/build/target/target.test.ts
@@ -6,6 +6,7 @@ initBeforeTest();
 
 describe('target usage', () => {
   const fixtureDir = __dirname;
+
   it('target is es5', async () => {
     const configFile = 'es5.config.ts';
     await runCli({
@@ -14,6 +15,18 @@ describe('target usage', () => {
       appDirectory: fixtureDir,
     });
     const distFilePath = path.join(fixtureDir, './dist/index.js');
+    const content = await fs.readFile(distFilePath, 'utf-8');
+    expect(content.includes(`function(`)).toBeTruthy();
+  });
+
+  it('target is es5 and use mjs extension', async () => {
+    const configFile = 'es5-mjs.config.ts';
+    await runCli({
+      argv: ['build'],
+      configFile,
+      appDirectory: fixtureDir,
+    });
+    const distFilePath = path.join(fixtureDir, './dist/index.mjs');
     const content = await fs.readFile(distFilePath, 'utf-8');
     expect(content.includes(`function(`)).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

Fix `target: 'es5'` not work for mjs chunks.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/1804

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
