### PR TITLE
fix(create-request): fix incorrect types path

### DIFF
--- a/.changeset/brave-dragons-serve.md
+++ b/.changeset/brave-dragons-serve.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/create-request': patch
+---
+
+fix(create-request): 修复错误的 types 指向

--- a/packages/server/create-request/package.json
+++ b/packages/server/create-request/package.json
@@ -49,7 +49,7 @@
   "typesVersions": {
     "*": {
       ".": [
-        "./dist/types/index.d.ts"
+        "./dist/types/browser.d.ts"
       ],
       "client": [
         "./dist/types/browser.d.ts"
@@ -92,6 +92,6 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public",
     "provenance": true,
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/types/browser.d.ts"
   }
 }


### PR DESCRIPTION
## Summary
修复@modern-js/create-request中types文件指向不存在的index.d.ts文件

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
