### PR TITLE
feat(server): support modify rsbuild server config in rsbuild hook

### DIFF
--- a/.changeset/dull-fireants-vanish.md
+++ b/.changeset/dull-fireants-vanish.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/uni-builder': patch
+'@modern-js/server': patch
+---
+
+feat(server): support modify Rsbuild server config in Rsbuild modifyRsbuildConfig hook
+
+feat(server): 支持在 Rsbuild modifyRsbuildConfig hook 中修改 Rsbuild server 相关配置

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@vitest/ui": "^0.33.0",
+    "antd": "^5",
     "check-dependency-version-consistency": "4.1.0",
     "cross-env": "^7.0.3",
     "esbuild": "0.17.19",

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -1,15 +1,11 @@
 /* eslint-disable max-lines */
 /* eslint-disable complexity */
 import {
-  deepmerge,
   NODE_MODULES_REGEX,
   CSS_MODULES_REGEX,
-  isProd,
-  ServerConfig,
   RsbuildTarget,
   OverrideBrowserslist,
   getBrowserslist,
-  mergeChainedOptions,
   type SourceConfig,
 } from '@rsbuild/shared';
 import {
@@ -35,6 +31,7 @@ import { pluginDevtool } from './plugins/devtools';
 import { pluginEmitRouteFile } from './plugins/emitRouteFile';
 import { pluginAntd } from './plugins/antd';
 import { pluginArco } from './plugins/arco';
+import { transformToRsbuildServerOptions } from './devServer';
 
 const GLOBAL_CSS_REGEX = /\.global\.\w+$/;
 
@@ -152,7 +149,7 @@ export async function parseCommonConfig(
       resolveExtensionPrefix,
       ...sourceConfig
     } = {},
-    dev: { port, host, https, ...devConfig } = {},
+    dev,
     security: { checkSyntax, sri, ...securityConfig } = {},
     tools: { devServer, tsChecker, minifyCss, ...toolsConfig } = {},
   } = uniBuilderConfig;
@@ -167,11 +164,10 @@ export async function parseCommonConfig(
     performance: performanceConfig,
     html: htmlConfig,
     tools: toolsConfig,
-    dev: devConfig,
     security: securityConfig,
   };
 
-  const { dev = {}, html = {}, output = {}, source = {} } = rsbuildConfig;
+  const { html = {}, output = {}, source = {} } = rsbuildConfig;
 
   if (enableLatestDecorators) {
     source.decorators = {
@@ -285,50 +281,14 @@ export async function parseCommonConfig(
     }
   };
 
-  // more dev & server config will compat in modern-js/server
-
-  // enable progress bar by default
-  if (dev.progressBar === undefined) {
-    dev.progressBar = true;
-  }
-
-  const newDevServerConfig = mergeChainedOptions({
-    defaults: {
-      devMiddleware: {
-        writeToDisk: (file: string) => !file.includes('.hot-update.'),
-      },
-      hot: dev?.hmr ?? true,
-      liveReload: true,
-      client: {
-        path: '/webpack-hmr',
-      },
-    },
-    options: devServer,
-    mergeFn: deepmerge,
-  });
-
-  dev.writeToDisk = newDevServerConfig.devMiddleware?.writeToDisk;
-
-  dev.hmr = newDevServerConfig.hot;
-
-  dev.client = newDevServerConfig.client;
-
-  dev.liveReload = newDevServerConfig.liveReload;
-
-  const server: ServerConfig = isProd()
-    ? {
-        publicDir: false,
-      }
-    : {
-        publicDir: false,
-        port,
-        host,
-        https: https ? (https as ServerConfig['https']) : undefined,
-      };
+  const { dev: RsbuildDev, server } = transformToRsbuildServerOptions(
+    dev || {},
+    devServer || {},
+  );
 
   rsbuildConfig.server = removeUndefinedKey(server);
 
-  rsbuildConfig.dev = removeUndefinedKey(dev);
+  rsbuildConfig.dev = removeUndefinedKey(RsbuildDev);
   rsbuildConfig.html = html;
   rsbuildConfig.output = output;
 

--- a/packages/cli/uni-builder/src/shared/plugins/antd.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/antd.ts
@@ -1,10 +1,14 @@
 import { isServerTarget, type RsbuildPlugin } from '@rsbuild/shared';
 
 const getAntdMajorVersion = (appDirectory: string) => {
+  console.log('appDirectory', appDirectory);
+
   try {
     const pkgJsonPath = require.resolve('antd/package.json', {
       paths: [appDirectory],
     });
+    console.log('pkgJsonPath', pkgJsonPath);
+
     const { version } = require(pkgJsonPath);
     return Number(version.split('.')[0]);
   } catch (err) {

--- a/packages/cli/uni-builder/src/shared/plugins/antd.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/antd.ts
@@ -1,13 +1,10 @@
 import { isServerTarget, type RsbuildPlugin } from '@rsbuild/shared';
 
 const getAntdMajorVersion = (appDirectory: string) => {
-  console.log('appDirectory', appDirectory);
-
   try {
     const pkgJsonPath = require.resolve('antd/package.json', {
       paths: [appDirectory],
     });
-    console.log('pkgJsonPath', pkgJsonPath);
 
     const { version } = require(pkgJsonPath);
     return Number(version.split('.')[0]);

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -68,25 +68,27 @@ export type DisableSourceMapOption =
       css?: boolean;
     };
 
+export type ToolsDevServerConfig = ChainedConfig<{
+  before?: RequestHandler[];
+  after?: RequestHandler[];
+  client?: DevConfig['client'];
+  compress?: ServerConfig['compress'];
+  devMiddleware?: {
+    writeToDisk?: DevConfig['writeToDisk'];
+  };
+  liveReload?: boolean;
+  headers?: ServerConfig['headers'];
+  historyApiFallback?: ServerConfig['historyApiFallback'];
+  hot?: boolean;
+  https?: DevServerHttpsOptions;
+  setupMiddlewares?: DevConfig['setupMiddlewares'];
+  proxy?: ServerConfig['proxy'];
+}>;
+
 export type UniBuilderExtraConfig = {
   tools?: {
     styledComponents?: false | PluginStyledComponentsOptions;
-    devServer?: ChainedConfig<{
-      before?: RequestHandler[];
-      after?: RequestHandler[];
-      client?: DevConfig['client'];
-      compress?: ServerConfig['compress'];
-      devMiddleware?: {
-        writeToDisk?: DevConfig['writeToDisk'];
-      };
-      liveReload?: boolean;
-      headers?: ServerConfig['headers'];
-      historyApiFallback?: ServerConfig['historyApiFallback'];
-      hot?: boolean;
-      https?: DevServerHttpsOptions;
-      setupMiddlewares?: DevConfig['setupMiddlewares'];
-      proxy?: ServerConfig['proxy'];
-    }>;
+    devServer?: ToolsDevServerConfig;
     /**
      * Configure the [Pug](https://pugjs.org/) template engine.
      */

--- a/packages/cli/uni-builder/tests/__snapshots__/babel.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/babel.test.ts.snap
@@ -58,11 +58,6 @@ exports[`plugin-babel (rspack mode) > should not set babel-loader when babel con
           "rspackExperiments": {
             "import": [
               {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              {
                 "camelToDashComponentName": false,
                 "libraryDirectory": "es",
                 "libraryName": "@arco-design/web-react",
@@ -146,11 +141,6 @@ exports[`plugin-babel (rspack mode) > should set babel-loader when babel config 
           },
           "rspackExperiments": {
             "import": [
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
               {
                 "camelToDashComponentName": false,
                 "libraryDirectory": "es",
@@ -265,15 +255,6 @@ exports[`plugin-babel > should add core-js-entry when output.polyfill is entry 1
               },
             ],
             "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -408,15 +389,6 @@ exports[`plugin-babel > should adjust browserslist when target is node 1`] = `
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
-                "libraryDirectory": "lib",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
                 "camel2DashComponentName": false,
                 "libraryDirectory": "lib",
                 "libraryName": "@arco-design/web-react",
@@ -541,15 +513,6 @@ exports[`plugin-babel > should apply exclude condition when using source.exclude
               },
             ],
             "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -688,15 +651,6 @@ exports[`plugin-babel > should not add core-js-entry when output.polyfill is usa
               },
             ],
             "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1044,15 +998,6 @@ exports[`plugin-babel > should not set default pluginImport for Babel 1`] = `
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
                 "camel2DashComponentName": false,
                 "libraryDirectory": "es",
                 "libraryName": "@arco-design/web-react",
@@ -1174,15 +1119,6 @@ exports[`plugin-babel > should not set default pluginImport for Babel 1`] = `
               },
             ],
             "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1315,15 +1251,6 @@ exports[`plugin-babel > should override targets of babel-preset-env when using o
               },
             ],
             "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1460,15 +1387,6 @@ exports[`plugin-babel > should set babel-loader 1`] = `
               },
             ],
             "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1614,15 +1532,6 @@ exports[`plugin-babel > should set include/exclude 1`] = `
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
                 "camel2DashComponentName": false,
                 "libraryDirectory": "es",
                 "libraryName": "@arco-design/web-react",
@@ -1763,15 +1672,6 @@ exports[`plugin-babel > should set proper pluginImport option in Babel 1`] = `
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
                 "camel2DashComponentName": false,
                 "libraryDirectory": "es",
                 "libraryName": "@arco-design/web-react",
@@ -1900,15 +1800,6 @@ exports[`plugin-babel > should set proper pluginImport option in Babel 1`] = `
                 "libraryName": "foo",
               },
               "foo",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
             ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",

--- a/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
@@ -89,11 +89,6 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
               "rspackExperiments": {
                 "import": [
                   {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  {
                     "camelToDashComponentName": false,
                     "libraryDirectory": "es",
                     "libraryName": "@arco-design/web-react",
@@ -162,11 +157,6 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
               },
               "rspackExperiments": {
                 "import": [
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
                   {
                     "camelToDashComponentName": false,
                     "libraryDirectory": "es",
@@ -692,11 +682,6 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                   "rspackExperiments": {
                     "import": [
                       {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
-                      {
                         "camelToDashComponentName": false,
                         "libraryDirectory": "es",
                         "libraryName": "@arco-design/web-react",
@@ -793,11 +778,6 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
                   },
                   "rspackExperiments": {
                     "import": [
-                      {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
                       {
                         "camelToDashComponentName": false,
                         "libraryDirectory": "es",
@@ -1203,11 +1183,6 @@ exports[`uni-builder rspack > should generator rspack config correctly when prod
               "rspackExperiments": {
                 "import": [
                   {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  {
                     "camelToDashComponentName": false,
                     "libraryDirectory": "es",
                     "libraryName": "@arco-design/web-react",
@@ -1276,11 +1251,6 @@ exports[`uni-builder rspack > should generator rspack config correctly when prod
               },
               "rspackExperiments": {
                 "import": [
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
                   {
                     "camelToDashComponentName": false,
                     "libraryDirectory": "es",
@@ -1806,11 +1776,6 @@ exports[`uni-builder rspack > should generator rspack config correctly when prod
                   "rspackExperiments": {
                     "import": [
                       {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
-                      {
                         "camelToDashComponentName": false,
                         "libraryDirectory": "es",
                         "libraryName": "@arco-design/web-react",
@@ -1907,11 +1872,6 @@ exports[`uni-builder rspack > should generator rspack config correctly when prod
                   },
                   "rspackExperiments": {
                     "import": [
-                      {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
                       {
                         "camelToDashComponentName": false,
                         "libraryDirectory": "es",
@@ -2342,15 +2302,6 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "antd",
-                ],
-                [
-                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                  {
                     "camel2DashComponentName": false,
                     "libraryDirectory": "es",
                     "libraryName": "@arco-design/web-react",
@@ -2472,15 +2423,6 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                   },
                 ],
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-                [
-                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "antd",
-                ],
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
@@ -2922,15 +2864,6 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
-                      "antd",
-                    ],
-                    [
-                      "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                      {
                         "camel2DashComponentName": false,
                         "libraryDirectory": "es",
                         "libraryName": "@arco-design/web-react",
@@ -3065,15 +2998,6 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                       },
                     ],
                     "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-                    [
-                      "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                      {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
-                      "antd",
-                    ],
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {
@@ -3478,15 +3402,6 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "antd",
-                ],
-                [
-                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                  {
                     "camel2DashComponentName": false,
                     "libraryDirectory": "es",
                     "libraryName": "@arco-design/web-react",
@@ -3608,15 +3523,6 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                   },
                 ],
                 "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-                [
-                  "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "antd",
-                    "style": true,
-                  },
-                  "antd",
-                ],
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
@@ -4064,15 +3970,6 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
-                      "antd",
-                    ],
-                    [
-                      "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                      {
                         "camel2DashComponentName": false,
                         "libraryDirectory": "es",
                         "libraryName": "@arco-design/web-react",
@@ -4222,15 +4119,6 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                       },
                     ],
                     "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-                    [
-                      "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-                      {
-                        "libraryDirectory": "es",
-                        "libraryName": "antd",
-                        "style": true,
-                      },
-                      "antd",
-                    ],
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {

--- a/packages/cli/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -39,7 +39,13 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "compress": false,
+    "headers": {
+      "X-Custom-Foo": "bar",
+    },
+    "historyApiFallback": true,
     "host": "xxx.xxx",
+    "htmlFallback": false,
     "https": {
       "cert": "xxx",
       "key": "xxxx",
@@ -92,6 +98,7 @@ exports[`parseCommonConfig > dev.xxx 2`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -143,6 +150,7 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -197,6 +205,7 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -248,6 +257,7 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -302,6 +312,7 @@ exports[`parseCommonConfig > html.faviconByEntries 4`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -353,6 +364,7 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -411,6 +423,7 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -462,6 +475,7 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -516,6 +530,7 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -567,6 +582,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -623,6 +639,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -676,6 +693,7 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -729,6 +747,7 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -782,6 +801,7 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -835,6 +855,7 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -883,6 +904,7 @@ exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {
@@ -931,6 +953,7 @@ exports[`parseCommonConfig > output.enableInlineStyles 1`] = `
   "plugins": [],
   "security": {},
   "server": {
+    "htmlFallback": false,
     "publicDir": false,
   },
   "source": {

--- a/packages/cli/uni-builder/tests/__snapshots__/postcssLegacy.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/postcssLegacy.test.ts.snap
@@ -64,11 +64,6 @@ exports[`plugin-postcssLegacy > should allow tools.postcss to override the plugi
             "rspackExperiments": {
               "import": [
                 {
-                  "libraryDirectory": "es",
-                  "libraryName": "antd",
-                  "style": true,
-                },
-                {
                   "camelToDashComponentName": false,
                   "libraryDirectory": "es",
                   "libraryName": "@arco-design/web-react",
@@ -137,11 +132,6 @@ exports[`plugin-postcssLegacy > should allow tools.postcss to override the plugi
             },
             "rspackExperiments": {
               "import": [
-                {
-                  "libraryDirectory": "es",
-                  "libraryName": "antd",
-                  "style": true,
-                },
                 {
                   "camelToDashComponentName": false,
                   "libraryDirectory": "es",
@@ -511,11 +501,6 @@ exports[`plugin-postcssLegacy > should allow tools.postcss to override the plugi
                 "rspackExperiments": {
                   "import": [
                     {
-                      "libraryDirectory": "es",
-                      "libraryName": "antd",
-                      "style": true,
-                    },
-                    {
                       "camelToDashComponentName": false,
                       "libraryDirectory": "es",
                       "libraryName": "@arco-design/web-react",
@@ -612,11 +597,6 @@ exports[`plugin-postcssLegacy > should allow tools.postcss to override the plugi
                 },
                 "rspackExperiments": {
                   "import": [
-                    {
-                      "libraryDirectory": "es",
-                      "libraryName": "antd",
-                      "style": true,
-                    },
                     {
                       "camelToDashComponentName": false,
                       "libraryDirectory": "es",
@@ -737,11 +717,6 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
             "rspackExperiments": {
               "import": [
                 {
-                  "libraryDirectory": "es",
-                  "libraryName": "antd",
-                  "style": true,
-                },
-                {
                   "camelToDashComponentName": false,
                   "libraryDirectory": "es",
                   "libraryName": "@arco-design/web-react",
@@ -808,11 +783,6 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
             },
             "rspackExperiments": {
               "import": [
-                {
-                  "libraryDirectory": "es",
-                  "libraryName": "antd",
-                  "style": true,
-                },
                 {
                   "camelToDashComponentName": false,
                   "libraryDirectory": "es",
@@ -1288,11 +1258,6 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                 "rspackExperiments": {
                   "import": [
                     {
-                      "libraryDirectory": "es",
-                      "libraryName": "antd",
-                      "style": true,
-                    },
-                    {
                       "camelToDashComponentName": false,
                       "libraryDirectory": "es",
                       "libraryName": "@arco-design/web-react",
@@ -1387,11 +1352,6 @@ exports[`plugin-postcssLegacy > should register postcss plugin by browserslist 1
                 },
                 "rspackExperiments": {
                   "import": [
-                    {
-                      "libraryDirectory": "es",
-                      "libraryName": "antd",
-                      "style": true,
-                    },
                     {
                       "camelToDashComponentName": false,
                       "libraryDirectory": "es",

--- a/packages/cli/uni-builder/tests/__snapshots__/react.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/react.test.ts.snap
@@ -54,15 +54,6 @@ exports[`plugins/react > should work with babel-loader 1`] = `
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
                 "camel2DashComponentName": false,
                 "libraryDirectory": "es",
                 "libraryName": "@arco-design/web-react",

--- a/packages/cli/uni-builder/tests/__snapshots__/styledComponents.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/styledComponents.test.ts.snap
@@ -47,15 +47,6 @@ exports[`plugins/styled-components > should enable ssr when target contain node 
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
-                "libraryDirectory": "lib",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
                 "camel2DashComponentName": false,
                 "libraryDirectory": "lib",
                 "libraryName": "@arco-design/web-react",
@@ -177,15 +168,6 @@ exports[`plugins/styled-components > should enable ssr when target contain node 
               },
             ],
             "<WORKSPACE>/node_modules/<PNPM_INNER>/@rsbuild/babel-preset/dist/pluginLockCorejsVersion",
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
-                "libraryDirectory": "lib",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -327,15 +309,6 @@ exports[`plugins/styled-components > should works in webpack babel mode 1`] = `
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
-              "antd",
-            ],
-            [
-              "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
-              {
                 "camel2DashComponentName": false,
                 "libraryDirectory": "es",
                 "libraryName": "@arco-design/web-react",
@@ -468,11 +441,6 @@ exports[`plugins/styled-components > should works in webpack swc mode 1`] = `
               ],
             },
             "pluginImport": [
-              {
-                "libraryDirectory": "es",
-                "libraryName": "antd",
-                "style": true,
-              },
               {
                 "camelToDashComponentName": false,
                 "libraryDirectory": "es",

--- a/packages/server/server/src/types.ts
+++ b/packages/server/server/src/types.ts
@@ -61,7 +61,7 @@ export type ExtraOptions = {
 export type ModernDevServerOptions = ModernServerOptions & ExtraOptions;
 
 export type ExtraOptionsNew = {
-  dev: Partial<DevServerOptions>;
+  dev: Pick<DevServerOptions, 'watch' | 'https' | 'compress' | 'devMiddleware'>;
   useSSRWorker?: boolean;
   rsbuild: RsbuildInstance;
   getMiddlewares: (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@vitest/ui':
         specifier: ^0.33.0
         version: 0.33.0(vitest@0.33.0)
+      antd:
+        specifier: ^5
+        version: 5.3.0(react-dom@18.2.0)(react@18.2.0)
       check-dependency-version-consistency:
         specifier: 4.1.0
         version: 4.1.0
@@ -7706,7 +7709,6 @@ packages:
     resolution: {integrity: sha512-iVm/9PfGCbC0dSMBrz7oiEXZaaGH7ceU40OJEfKmyuzR9R5CRimJYPlRiFtMQGQcbNMea/ePcoIebi4ASGYXtg==}
     dependencies:
       '@ctrl/tinycolor': 3.6.0
-    dev: false
 
   /@ant-design/cssinjs@1.6.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-kmUo5xrfjOtDBp6LcBwPqPXei3Zar4SZfg7FpuahS1Fm9NyWckrxEVge6MjBgmZrpAnaJn00zy2jMELL7HuY6w==}
@@ -7723,11 +7725,9 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       stylis: 4.3.0
-    dev: false
 
   /@ant-design/icons-svg@4.2.1:
     resolution: {integrity: sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw==}
-    dev: false
 
   /@ant-design/icons@4.7.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==}
@@ -7759,7 +7759,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@ant-design/react-slick@0.28.4(react@18.2.0):
     resolution: {integrity: sha512-j9eAHTn7GxbXUFNknJoHS2ceAsqrQi2j8XykjZE1IXCD8kJF+t28EvhBLniDpbOsBk/3kjalnhriTfZcjBHNqg==}
@@ -7785,7 +7784,6 @@ packages:
       react: 18.2.0
       resize-observer-polyfill: 1.5.1
       throttle-debounce: 5.0.0
-    dev: false
 
   /@arco-design/color@0.4.0:
     resolution: {integrity: sha512-s7p9MSwJgHeL8DwcATaXvWT3m2SigKpxx4JA1BGPHL4gfvaQsmQfrLBDpjOJFJuJ2jG2dMt3R3P8Pm9E65q18g==}
@@ -9909,7 +9907,6 @@ packages:
   /@ctrl/tinycolor@3.6.0:
     resolution: {integrity: sha512-/Z3l6pXthq0JvMYdUFyX9j0MaCltlIn6mfh9jLyQwg5aPKxkyNa0PTHtU1AlFXLNk55ZuAeJRcpvq+tmLfKmaQ==}
     engines: {node: '>=10'}
-    dev: false
 
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -9917,7 +9914,6 @@ packages:
 
   /@emotion/hash@0.8.0:
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
-    dev: false
 
   /@emotion/is-prop-valid@1.2.1:
     resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
@@ -13171,14 +13167,12 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@rc-component/mini-decimal@1.0.1:
     resolution: {integrity: sha512-9N8nRk0oKj1qJzANKl+n9eNSMUGsZtjwNuDCiZ/KA+dt1fE3zq5x2XxclRcAbOIXnZcJ53ozP2Pa60gyELXagA==}
     engines: {node: '>=8.x'}
     dependencies:
       '@babel/runtime': 7.23.2
-    dev: false
 
   /@rc-component/mutate-observer@1.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-okqRJSfNisXdI6CUeOLZC5ukBW/8kir2Ii4PJiKpUt+3+uS7dxwJUMxsUZquxA1rQuL8YcEmKVp/TCnR+yUdZA==}
@@ -13192,7 +13186,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@rc-component/portal@1.1.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-tbXM9SB1r5FOuZjRCljERFByFiEUcMmCWMXLog/NmgCzlAzreXyf23Vei3ZpSMxSMavzPnhCovfZjZdmxS3d1w==}
@@ -13206,7 +13199,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@rc-component/tour@1.8.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-rrRGioHTLQlGca27G2+lw7QpRb3uuMYCUIJjj31/B44VCJS0P2tqYhOgtzvWQmaLMlWH3ZlpzotkKX13NT4XEA==}
@@ -13222,7 +13214,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@rc-component/trigger@1.6.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-MxIokdiDnBACGYGWtGp19pnBVKPKmrP7yDjGfkE+HtyATLs9T8DOdd53EZnk1DbuEUn+6EMYigKMmXOqffTYxw==}
@@ -13240,7 +13231,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@react-hook/intersection-observer@3.1.1(react@18.2.0):
     resolution: {integrity: sha512-OTDx8/wFaRvzFtKl1dEUEXSOqK2zVJHporiTTdC2xO++0e9FEx9wIrPis5q3lqtXeZH9zYGLbk+aB75qNFbbuw==}
@@ -17313,7 +17303,6 @@ packages:
     transitivePeerDependencies:
       - date-fns
       - moment
-    dev: false
 
   /any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -17395,7 +17384,6 @@ packages:
 
   /array-tree-filter@2.1.0:
     resolution: {integrity: sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==}
-    dev: false
 
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -17495,7 +17483,6 @@ packages:
 
   /async-validator@4.2.5:
     resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
-    dev: false
 
   /async@2.6.4:
     resolution: {integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==}
@@ -18699,7 +18686,6 @@ packages:
 
   /compute-scroll-into-view@2.0.4:
     resolution: {integrity: sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==}
-    dev: false
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -19323,7 +19309,6 @@ packages:
 
   /dayjs@1.11.3:
     resolution: {integrity: sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==}
-    dev: false
 
   /dayjs@1.11.6:
     resolution: {integrity: sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==}
@@ -19680,7 +19665,6 @@ packages:
 
   /dom-align@1.12.3:
     resolution: {integrity: sha512-Gj9hZN3a07cbR6zviMUBOMPdWxYhbMI+x+WS0NAIu2zFZmbK8ys9R79g+iG9qLnlCwpFoaB+fKy8Pdv470GsPA==}
-    dev: false
 
   /dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
@@ -24096,7 +24080,6 @@ packages:
     resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
     dependencies:
       string-convert: 0.2.1
-    dev: false
 
   /json3@3.3.3:
     resolution: {integrity: sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==}
@@ -27425,7 +27408,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
-    dev: false
 
   /qs@6.10.3:
     resolution: {integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==}
@@ -27530,7 +27512,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       resize-observer-polyfill: 1.5.1
-    dev: false
 
   /rc-cascader@2.2.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4saWcwpmxxh5fhUdaDgOLF2gWL8KNxLwWqELX702HNXEt2yU7AixjfvgEORNsnQZleT2W2AaGMkRDeWrwt8fMw==}
@@ -27562,7 +27543,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-checkbox@2.3.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==}
@@ -27574,7 +27554,6 @@ packages:
       classnames: 2.3.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-collapse@3.1.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-WayrhswKMwuJab9xbqFxXTgV0m6X8uOPEO6zm/GJ5YJiJ/wIh/Dd2VtWeI06HYUEnTFv0HNcYv+zWbB+p6OD2A==}
@@ -27603,7 +27582,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-dialog@8.6.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-GSbkfqjqxpZC5/zc+8H332+q5l/DKUhpQr0vdX2uDsxo5K0PhvaMEVjyoJUTkZ3+JstEADQji1PVLVb/2bJeOQ==}
@@ -27632,7 +27610,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-drawer@4.4.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-FYztwRs3uXnFOIf1hLvFxIQP9MiZJA+0w+Os8dfDh/90X7z/HqP/Yg+noLCIeHEbKln1Tqelv8ymCAN24zPcfQ==}
@@ -27660,7 +27637,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-dropdown@3.2.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-dVO2eulOSbEf+F4OyhCY5iGiMVhUYY/qeXxL7Ex2jDBt/xc89jU07mNoowV6aWxwVOc70pxEINff0oM2ogjluA==}
@@ -27687,7 +27663,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-field-form@1.21.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-LR/bURt/Tf5g39mb0wtMtQuWn42d/7kEzpzlC5fNC7yaRVmLTtlPP4sBBlaViETM9uZQKLoaB0Pt9Mubhm9gow==}
@@ -27715,7 +27690,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-image@5.15.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-QaeWP20v51eGyrkl24PyusTmbMk42A3vGPl7hEa15jcQjECOX36tLtvLk5sjl3vaLQpMskB8BbwiqPsN7I7aow==}
@@ -27731,7 +27705,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-image@5.2.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qUfZjYIODxO0c8a8P5GeuclYXZjzW4hV/5hyo27XqSFo1DmTCs2HkVeQObkcIk5kNsJtgsj1KoPThVsSc/PXOw==}
@@ -27772,7 +27745,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-input@0.2.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xgkVcFgtRO0Hl9hmvslZhObNyxbSpTmy3nR1Tk4XrjjZ9lFJ7GcJBy6ss30Pdb0oX36cHzLN8I7VCjBGeRNB9A==}
@@ -27785,7 +27757,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-mentions@1.6.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-CUU4+q+awG2pA0l/tG2kPB2ytWbKQUkFxVeKwacr63w7crE/yjfzrFXxs/1fxhyEbQUWdAZt/L25QBieukYQ5w==}
@@ -27818,7 +27789,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-menu@9.0.14(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-CIox5mZeLDAi32SlHrV7UeSjv7tmJJhwRyxQtZCKt351w3q59XlL4WMFOmtT9gwIfP9h0XoxdBZUMe/xzkp78A==}
@@ -27868,7 +27838,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-motion@2.6.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xFLkes3/7VL/J+ah9jJruEW/Akbx5F6jVa2wG5o/ApGKQKSOd5FR3rseHLL9+xtJg4PmCwo6/1tqhDO/T+jFHA==}
@@ -27881,7 +27850,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-notification@4.5.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-zhTGUjBIItbx96SiRu3KVURcLOydLUHZCPpYEn1zvh+re//Tnq/wSxN4FKgp38n4HOgHSVxcLEeSxBMTeBBDdw==}
@@ -27911,7 +27879,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-overflow@1.2.8(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-QJ0UItckWPQ37ZL1dMEBAdY1dhfTXFL9k6oTTcyydVwoUNMnMqCGqnRNA98axSr/OeDKqR6DVFyi8eA5RQI/uQ==}
@@ -27925,7 +27892,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-pagination@3.1.17(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-/BQ5UxcBnW28vFAcP2hfh+Xg15W0QZn8TWYwdCApchMH1H0CxiaUUcULP8uXcFM1TygcdKWdt3JqsL9cTAfdkQ==}
@@ -27949,7 +27915,6 @@ packages:
       classnames: 2.3.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-picker@2.5.19(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-u6myoCu/qiQ0vLbNzSzNrzTQhs7mldArCpPHrEI6OUiifs+IPXmbesqSm0zilJjfzrZJLgYeyyOMSznSlh0GKA==}
@@ -27994,7 +27959,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-progress@3.1.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-XBAif08eunHssGeIdxMXOmRQRULdHaDdIFENQ578CMb4dyewahmmfJRyab+hw4KH4XssEzzYOkAInTLS7JJG+Q==}
@@ -28019,7 +27983,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-rate@2.9.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-SaiZFyN8pe0Fgphv8t3+kidlej+cq/EALkAJAc3A0w0XcPaH2L1aggM8bhe1u6GAGuQNAoFvTLjw4qLPGRKV5g==}
@@ -28033,7 +27996,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-resize-observer@1.3.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-iFUdt3NNhflbY3mwySv5CA1TC06zdJ+pfo0oc27xpf4PIOvfZwZGtD9Kz41wGYqC4SLio93RVAirSSpYlV/uYg==}
@@ -28047,7 +28009,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       resize-observer-polyfill: 1.5.1
-    dev: false
 
   /rc-segmented@2.1.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qGo1bCr83ESXpXVOCXjFe1QJlCAQXyi9KCiy8eX3rIMYlTeJr/ftySIaTnYsitL18SvWf5ZEHsfqIWoX0EMfFQ==}
@@ -28061,7 +28022,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-select@13.1.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Oy4L27x5QgGR8902pw0bJVjrTWFnKPKvdLHzJl5pjiA+jM1hpzDfLGg/bY2ntk5ElxxQKZUwbFKUeqfCQU7SrQ==}
@@ -28097,7 +28057,6 @@ packages:
       rc-virtual-list: 3.4.13(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-slider@10.1.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-gn8oXazZISEhnmRinI89Z/JD/joAaM35jp+gDtIVSTD/JJMCCBqThqLk1SVJmvtfeiEF/kKaFY0+qt4SDHFUDw==}
@@ -28111,7 +28070,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-slider@9.7.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-LV/MWcXFjco1epPbdw1JlLXlTgmWpB9/Y/P2yinf8Pg3wElHxA9uajN21lJiWtZjf5SCUekfSP6QMJfDo4t1hg==}
@@ -28155,7 +28113,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-switch@3.2.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==}
@@ -28181,7 +28138,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-table@7.19.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-NdpnoM50MK02H5/hGOsObfxCvGFUG5cHB9turE5BKJ81T5Ycbq193w5tLhnpILXe//Oanzr47MdMxkUnVGP+qg==}
@@ -28213,7 +28169,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-tabs@11.10.8(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-uK+x+eJ8WM4jiXoqGa+P+JUQX2Wlkj9f0o/5dyOw42B6YLnHJN80uTVcCeAmtA1N0xjPW0GNSZvUm4SU3jAYpw==}
@@ -28248,7 +28203,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-textarea@0.3.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-yCdZ6binKmAQB13hc/oehh0E/QRwoPP1pjF21aHBxlgXO3RzPF6dUu4LG2R4FZ1zx/fQd2L1faktulrXOM/2rw==}
@@ -28278,7 +28232,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-tooltip@5.1.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==}
@@ -28316,7 +28269,6 @@ packages:
       classnames: 2.3.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-tree-select@4.7.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xcc2yPpQieTW6BcRkcKbT1dcAYCQ7ARtkoHlS9EsNdd6xgw9LA6rek6PMed8r/VRMfiKtWV4c4xijW5PI6s4Rw==}
@@ -28346,7 +28298,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-tree@5.3.8(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-YuobEryPymqPmHFUOvsoOrYdm24psaj0CrGEUuDUQUeG/nNcTGw6FA2YmF4NsEaNBvNSJUSzwfZnFHrKa/xv0A==}
@@ -28378,7 +28329,6 @@ packages:
       rc-virtual-list: 3.4.13(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-trigger@5.3.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-mQv+vas0TwKcjAO2izNPkqR4j86OemLRmvL2nOzdP9OWNWA1ivoTt5hzFqYNW9zACwmTezRiN8bttrC7cZzYSw==}
@@ -28394,7 +28344,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-upload@4.3.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-uVbtHFGNjHG/RyAfm9fluXB6pvArAGyAx8z7XzXXyorEgVIWj6mOlriuDm0XowDHYz4ycNK0nE0oP3cbFnzxiQ==}
@@ -28407,7 +28356,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /rc-util@5.29.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xHT9Dr3RD6tyvCibnH10l3mudC6TJjWNr9UDy3CrOGZqTY354OfdwP87ahKNe0b3A1dsysDldvx0SBuswhlOeA==}
@@ -28419,7 +28367,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 16.13.1
-    dev: false
 
   /rc-virtual-list@3.4.13(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-cPOVDmcNM7rH6ANotanMDilW/55XnFPw0Jh/GQYtrzZSy3AmWvCnqVNyNC/pgg3lfVmX2994dlzAhuUrd4jG7w==}
@@ -28434,7 +28381,6 @@ packages:
       rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /react-base16-styling@0.6.0:
     resolution: {integrity: sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==}
@@ -29599,7 +29545,6 @@ packages:
     resolution: {integrity: sha512-s+/F50jwTOUt+u5oEIAzum9MN2lUQNvWBe/zfEsVQcbaERjGkKLq1s+2wCHkahMLC8nMLbzMVKivx9JhunXaZg==}
     dependencies:
       compute-scroll-into-view: 2.0.4
-    dev: false
 
   /seamless-scroll-polyfill@1.2.4:
     resolution: {integrity: sha512-1CwHvQRS88m/HwN76hnjFu9dzU2HUJmGbvUkKMoRq70o6Pd1DcD4aGvsku0OqRhUuFKQOsjm0Imo1cC/PWWOfA==}
@@ -30211,7 +30156,6 @@ packages:
 
   /string-convert@0.2.1:
     resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
-    dev: false
 
   /string-hash@1.1.3:
     resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
@@ -30867,7 +30811,6 @@ packages:
   /throttle-debounce@5.0.0:
     resolution: {integrity: sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==}
     engines: {node: '>=12.22'}
-    dev: false
 
   /through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}


### PR DESCRIPTION
## Summary

Move transformToRsbuildServerOptions method from modern.js server to uni-builder parseCommonConfig stage.

So users can modify Rsbuild server config in Rsbuild modifyRsbuildConfig hook, and the modern.js server does not need to care about some rsbuild server configs.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
