### PR TITLE
feat(devtools/storage-preset): improve typings

### DIFF
--- a/packages/devtools/client/src/entries/client/routes/layout.data.tsx
+++ b/packages/devtools/client/src/entries/client/routes/layout.data.tsx
@@ -62,6 +62,12 @@ export const loader = async () => {
       icon: <RiShieldCrossLine />,
       view: { type: 'builtin', src: '/doctor' },
     },
+    {
+      name: 'storage',
+      title: 'Storage',
+      icon: <RiShieldCrossLine />,
+      view: { type: 'builtin', src: '/storage/preset' },
+    },
   ];
   await globals.callHook('tab:list', tabs);
   for (const tab of tabs) {

--- a/packages/devtools/client/src/entries/client/routes/storage.preset/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage.preset/page.tsx
@@ -1,0 +1,19 @@
+import { proxy, useSnapshot } from 'valtio';
+import type { StoragePresetContext } from '@modern-js/devtools-kit/runtime';
+import { $server } from '../state';
+
+const $presets = proxy<StoragePresetContext[]>([]);
+
+$server.then(async ({ remote }) => {
+  const presets = await remote.getStoragePresets();
+  $presets.splice(0, $presets.length, ...presets);
+});
+
+export default () => {
+  const presets = useSnapshot($presets);
+  return (
+    <div>
+      <pre>{JSON.stringify(presets, null, 2)}</pre>
+    </div>
+  );
+};

--- a/packages/devtools/kit/package.json
+++ b/packages/devtools/kit/package.json
@@ -70,6 +70,7 @@
     "ufo": "^1.3.0",
     "flatted": "^3.2.9",
     "ws": "^8.13.0",
+    "cookie-es": "^1.0.0",
     "@rsdoctor/types": "^0.1.3",
     "@rsdoctor/utils": "^0.1.3"
   },

--- a/packages/devtools/kit/src/node.ts
+++ b/packages/devtools/kit/src/node.ts
@@ -6,3 +6,4 @@ export * from './constants';
 export * from './channel';
 export * from './rsdoctor';
 export * from './runtime-globals';
+export type * from './storage-preset';

--- a/packages/devtools/kit/src/runtime.ts
+++ b/packages/devtools/kit/src/runtime.ts
@@ -6,3 +6,4 @@ export * from './constants';
 export * from './channel';
 export type * from './rsdoctor';
 export * from './runtime-globals';
+export type * from './storage-preset';

--- a/packages/devtools/kit/src/server.ts
+++ b/packages/devtools/kit/src/server.ts
@@ -12,6 +12,7 @@ import { NormalizedConfig } from '@modern-js/core';
 import { RouteLegacy, NestedRouteForCli, PageRoute } from '@modern-js/types';
 import type { Manifest } from '@rsdoctor/types';
 import type { ClientDefinition } from './client';
+import type { StoragePresetContext } from './storage-preset';
 
 export type BuilderContext = RsbuildContext;
 
@@ -63,5 +64,6 @@ export interface ServerFunctions {
   getCompileTimeCost: () => Promise<number>;
   getClientDefinition: () => Promise<ClientDefinition>;
   getDoctorOverview: () => Promise<DoctorManifestOverview>;
+  getStoragePresets: () => Promise<StoragePresetContext[]>;
   echo: (content: string) => string;
 }

--- a/packages/devtools/kit/src/storage-preset.ts
+++ b/packages/devtools/kit/src/storage-preset.ts
@@ -28,3 +28,7 @@ export interface StoragePresetOptions {
   name: string;
   items: StoragePreset[];
 }
+
+export interface StoragePresetContext extends StoragePresetOptions {
+  filename: string;
+}

--- a/packages/devtools/plugin/package.json
+++ b/packages/devtools/plugin/package.json
@@ -50,16 +50,17 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "birpc": "0.2.13",
-    "@modern-js/devtools-kit": "workspace:*",
     "@modern-js/devtools-client": "workspace:*",
-    "flatted": "^3.2.9",
+    "@modern-js/devtools-kit": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "serve-static": "^1.14.1",
-    "p-defer": "^3.0.0",
-    "ws": "^8.13.0",
+    "birpc": "0.2.13",
     "cookie-es": "^1.0.0",
-    "ufo": "^1.3.0"
+    "flatted": "^3.2.9",
+    "hono": "^4.1.0",
+    "p-defer": "^3.0.0",
+    "serve-static": "^1.14.1",
+    "ufo": "^1.3.0",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",
@@ -70,9 +71,9 @@
     "@modern-js/types": "workspace:*",
     "@modern-js/uni-builder": "workspace:*",
     "@scripts/build": "workspace:*",
-    "@types/serve-static": "^1.13.10",
     "@swc/helpers": "0.5.3",
     "@types/node": "^14",
+    "@types/serve-static": "^1.13.10",
     "@types/ws": "^8.5.5",
     "type-fest": "^4.1.0",
     "typescript": "^5"

--- a/packages/devtools/plugin/src/cli.ts
+++ b/packages/devtools/plugin/src/cli.ts
@@ -42,8 +42,8 @@ export const devtoolsPlugin = (
       });
       const rpc = await setupClientConnection({
         api,
+        ctx,
         server: socketServer,
-        def: ctx.def,
       });
 
       return {

--- a/packages/devtools/plugin/src/cli.ts
+++ b/packages/devtools/plugin/src/cli.ts
@@ -68,7 +68,8 @@ export const devtoolsPlugin = (
           const appCtx = api.useAppContext();
           const { devtools: options = {} } = appConfig;
           updateContext(ctx, options);
-          updateContext(ctx, ...(await loadConfigFiles(appCtx.appDirectory)));
+          const storagePresets = await loadConfigFiles(appCtx.appDirectory);
+          ctx.storagePresets.push(...storagePresets);
           logger.info(`${ctx.def.name.formalName} DevTools is enabled`);
 
           const swProxyEntry = require.resolve(

--- a/packages/devtools/plugin/src/options.ts
+++ b/packages/devtools/plugin/src/options.ts
@@ -1,5 +1,8 @@
-import { ClientDefinition, ROUTE_BASENAME } from '@modern-js/devtools-kit/node';
-import { StoragePresetContext } from './types';
+import {
+  ClientDefinition,
+  ROUTE_BASENAME,
+  StoragePresetContext,
+} from '@modern-js/devtools-kit/node';
 
 export interface DevtoolsPluginOptions {
   enable?: boolean;

--- a/packages/devtools/plugin/src/options.ts
+++ b/packages/devtools/plugin/src/options.ts
@@ -1,7 +1,7 @@
 import { ClientDefinition, ROUTE_BASENAME } from '@modern-js/devtools-kit/node';
-import { DevtoolsConfig } from './types';
+import { StoragePresetContext } from './types';
 
-export interface DevtoolsPluginOptions extends DevtoolsConfig {
+export interface DevtoolsPluginOptions {
   enable?: boolean;
   endpoint?: string;
   dataSource?: string;
@@ -9,6 +9,7 @@ export interface DevtoolsPluginOptions extends DevtoolsConfig {
 
 export interface DevtoolsContext extends Required<DevtoolsPluginOptions> {
   def: ClientDefinition;
+  storagePresets: StoragePresetContext[];
 }
 
 export const resolveContext = (

--- a/packages/devtools/plugin/src/types/config.ts
+++ b/packages/devtools/plugin/src/types/config.ts
@@ -1,4 +1,4 @@
-import { StoragePresetOptions } from './preset';
+import { StoragePresetOptions } from '@modern-js/devtools-kit/node';
 
 export interface DevtoolsConfig {
   storagePresets?: StoragePresetOptions[];

--- a/packages/devtools/plugin/src/types/index.ts
+++ b/packages/devtools/plugin/src/types/index.ts
@@ -1,3 +1,2 @@
 export type * from './common';
-export type * from './preset';
 export type * from './config';

--- a/packages/devtools/plugin/src/utils/config.ts
+++ b/packages/devtools/plugin/src/utils/config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from '@modern-js/utils/fs-extra';
-import { DevtoolsConfig } from '../types';
+import { StoragePresetContext } from '@modern-js/devtools-kit';
 
 const CONFIG_FILENAME = 'modern.devtools.json';
 
@@ -37,17 +37,14 @@ export async function resolveConfigFiles(
   return files;
 }
 
-export async function loadConfigFile(dir = process.cwd()) {
-  const filename = await resolveConfigFile(dir);
-  if (!filename) {
-    return null;
-  }
-  const raw = await fs.readJson(filename);
-  return raw as DevtoolsConfig;
+export async function loadConfigFile(filename: string) {
+  const raw = await fs.readJSON(filename);
+  const ret: StoragePresetContext = { ...raw, filename };
+  return ret;
 }
 
 export async function loadConfigFiles(dir = process.cwd()) {
   const filenames = await resolveConfigFiles(dir);
-  const configs = await Promise.all(filenames.map(loadConfigFile));
-  return configs.filter(Boolean) as DevtoolsConfig[];
+  const ret = await Promise.all(filenames.map(loadConfigFile));
+  return ret;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1048,6 +1048,9 @@ importers:
       flatted:
         specifier: ^3.2.9
         version: 3.2.9
+      hono:
+        specifier: ^4.1.0
+        version: 4.1.0
       p-defer:
         specifier: ^3.0.0
         version: 3.0.0
@@ -22263,6 +22266,11 @@ packages:
     dependencies:
       parse-passwd: 1.0.0
     dev: true
+
+  /hono@4.1.0:
+    resolution: {integrity: sha512-9no6DCHb4ijB1tWdFXU6JnrnFgzwVZ1cnIcS1BjAFnMcjbtBTOMsQrDrPH3GXbkNEEEkj8kWqcYBy8Qc0bBkJQ==}
+    engines: {node: '>=16.0.0'}
+    dev: false
 
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -957,6 +957,9 @@ importers:
       birpc:
         specifier: 0.2.13
         version: 0.2.13
+      cookie-es:
+        specifier: ^1.0.0
+        version: 1.0.0
       flatted:
         specifier: ^3.2.9
         version: 3.2.9

--- a/tests/integration/devtools/modern.config.ts
+++ b/tests/integration/devtools/modern.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   runtime: {
     router: true,
   },
+  dev: {
+    hmr: false,
+  },
   source: {
     mainEntryName: 'main',
     preEntry: ['./src/prelude.css'],

--- a/tests/integration/devtools/modern.devtools.json
+++ b/tests/integration/devtools/modern.devtools.json
@@ -1,0 +1,18 @@
+{
+  "storagePresets": [
+    {
+      "name": "用户asdasd",
+      "items": [
+        {
+          "type": "cookie",
+          "key": "x-tt-jwt",
+          "value": "eC10dC1qd3Q=",
+          "httpOnly": true,
+          "secure": true
+        },
+        { "type": "cookie", "key": "lang", "value": "zh" },
+        { "type": "local-storage", "key": "__cache_first_1161", "value": "1" }
+      ]
+    }
+  ]
+}

--- a/tests/integration/devtools/src/prelude.css
+++ b/tests/integration/devtools/src/prelude.css
@@ -1,4 +1,0 @@
-html, :root {
-  background-color: #121212;
-  color: #fafafa;
-}


### PR DESCRIPTION
## Summary

- Extract typings of storage preset to `@modern-js/devtools-kit`.
- `DevtoolsOptions` no longer inherits from `DevtoolsConfig`.
- New interface `StoragePresetContext` for internal usages, replacing the previous `StoragePresetOptions`.
- New tab page `storage/preset` for stub.
- WIP: Use hono to implement an HTTP server instead of doing it manually.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
