### PR TITLE
chore(server): set devServer.compress config value in app-tools

### DIFF
--- a/.changeset/smooth-tools-grow.md
+++ b/.changeset/smooth-tools-grow.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/uni-builder': patch
+'@modern-js/server': patch
+---
+
+chore(server): set devServer.compress config value in app-tools
+
+chore(server): 在 app-tools 中设置 ssr 场景下 devServer compress 配置的值

--- a/packages/cli/uni-builder/src/shared/devServer.ts
+++ b/packages/cli/uni-builder/src/shared/devServer.ts
@@ -95,10 +95,12 @@ export const transformToRsbuildServerOptions = (
     ? {
         publicDir: false,
         htmlFallback: false,
+        printUrls: false,
       }
     : {
         publicDir: false,
         htmlFallback: false,
+        printUrls: false,
         compress: newDevServerConfig.compress,
         headers: newDevServerConfig.headers,
         historyApiFallback: newDevServerConfig.historyApiFallback,
@@ -171,11 +173,9 @@ export async function startDevServer(
     pwd: rsbuild.context.rootPath,
     ...serverOptions,
     rsbuild,
-    getMiddlewares: config =>
+    getMiddlewares: () =>
       rsbuildServer.getMiddlewares({
         compileMiddlewareAPI,
-        // TODO: To be removed. should update all rsbuild config in parseCommonConfig stage
-        overrides: config,
       }),
     dev: {
       watch: serverOptions.dev?.watch ?? true,

--- a/packages/server/server/src/server/devServer.ts
+++ b/packages/server/server/src/server/devServer.ts
@@ -16,12 +16,7 @@ import {
   BuildOptions,
   createRenderHandler,
 } from '@modern-js/prod-server';
-import type {
-  ModernServerContext,
-  RequestHandler,
-  ServerRoute,
-} from '@modern-js/types';
-import type { SSR } from '@modern-js/server-core';
+import type { ModernServerContext, RequestHandler } from '@modern-js/types';
 import { merge as deepMerge } from '@modern-js/utils/lodash';
 import { RenderHandler } from '@modern-js/prod-server/src/libs/render';
 import type { RsbuildInstance } from '@rsbuild/shared';
@@ -88,36 +83,11 @@ export class ModernDevServer extends ModernServer {
   // Complete the preparation of services
   public async onInit(runner: ServerHookRunner, app: Server) {
     this.runner = runner;
-    const { dev, conf } = this;
-
-    // the http-compression can't handler stream http.
-    // so we disable compress when user use stream ssr temporarily.
-    const isUseStreamingSSR = (routes?: ServerRoute[]) =>
-      routes?.some(r => r.isStream === true);
-
-    const isUseSSRPreload = () => {
-      const {
-        server: { ssr, ssrByEntries },
-      } = conf;
-
-      const checkUsePreload = (ssr?: SSR) =>
-        typeof ssr === 'object' && Boolean(ssr.preload);
-
-      return (
-        checkUsePreload(ssr) ||
-        Object.values(ssrByEntries || {}).some(ssr => checkUsePreload(ssr))
-      );
-    };
+    const { dev } = this;
 
     const { middlewares: rsbuildMiddlewares, close, onUpgrade } =
       // https://github.com/web-infra-dev/rsbuild/blob/32fbb85e22158d5c4655505ce75e3452ce22dbb1/packages/shared/src/types/server.ts#L112
-      await this.getMiddlewares({
-        // TODO: move to uni-builder
-        compress:
-          !isUseStreamingSSR(this.getRoutes()) &&
-          !isUseSSRPreload() &&
-          dev.compress,
-      });
+      await this.getMiddlewares();
 
     app.on('upgrade', onUpgrade);
 

--- a/packages/server/server/src/types.ts
+++ b/packages/server/server/src/types.ts
@@ -5,11 +5,7 @@ import type {
   NextFunction,
 } from '@modern-js/types';
 import type { ModernServerOptions } from '@modern-js/prod-server';
-import type {
-  RsbuildInstance,
-  DevServerAPIs,
-  DevMiddlewaresConfig,
-} from '@rsbuild/shared';
+import type { RsbuildInstance, DevServerAPIs } from '@rsbuild/shared';
 
 export type { DevServerOptions, DevServerHttpsOptions };
 
@@ -64,9 +60,7 @@ export type ExtraOptionsNew = {
   dev: Pick<DevServerOptions, 'watch' | 'https' | 'compress' | 'devMiddleware'>;
   useSSRWorker?: boolean;
   rsbuild: RsbuildInstance;
-  getMiddlewares: (
-    overrides?: DevMiddlewaresConfig,
-  ) => ReturnType<DevServerAPIs['getMiddlewares']>;
+  getMiddlewares: () => ReturnType<DevServerAPIs['getMiddlewares']>;
 };
 
 export type ModernDevServerOptionsNew = ModernServerOptions & ExtraOptionsNew;


### PR DESCRIPTION
## Summary

Overrides rsbuild server config in modern.js server is not required, we can set `devServer.compress` config value in app-tools.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
