### PR TITLE
chore(server): ignore .hot-update.json 404 error log

### DIFF
--- a/.changeset/warm-coins-draw.md
+++ b/.changeset/warm-coins-draw.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+---
+
+chore(server): should ignore some expected 404 error logs, such as xxx.hot-update.json
+
+chore(server): 不打印 .hot-update.json 404 的错误日志

--- a/packages/server/prod-server/src/server/modernServer.ts
+++ b/packages/server/prod-server/src/server/modernServer.ts
@@ -287,7 +287,10 @@ export class ModernServer implements ModernServerInterface {
 
   // return 404 page
   protected render404(context: ModernServerContext) {
-    context.error(ERROR_DIGEST.ENOTF, '404 Not Found');
+    // ignore some expected 404 errors
+    if (!context.path.endsWith('.hot-update.json')) {
+      context.error(ERROR_DIGEST.ENOTF, '404 Not Found');
+    }
     this.renderErrorPage(context, 404);
   }
 


### PR DESCRIPTION
## Summary

`xxxx.hot-update.json` file 404 is expected, because runtime hash will change in common cases.

<img width="860" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/eaba9eb0-9719-4932-b84e-75cae83b591d">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
