### PR TITLE
fix: we should override server.baseUrl when merge it

### DIFF
--- a/.changeset/ninety-dragons-care.md
+++ b/.changeset/ninety-dragons-care.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/utils': patch
+'@modern-js/core': patch
+---
+
+fix: we should override server.baseUrl when merge it
+fix: 在合并 server.baseUrl 时，我们应该覆盖他

--- a/packages/cli/core/tests/mergeConfig.test.ts
+++ b/packages/cli/core/tests/mergeConfig.test.ts
@@ -87,6 +87,24 @@ describe('merge config', () => {
     ).toEqual({
       source: { envVars: ['a', 'b'] },
     });
+
+    expect(
+      mergeConfig([
+        { server: { baseUrl: ['/'] } },
+        { server: { baseUrl: ['/a', '/b'] } },
+      ]),
+    ).toEqual({
+      server: { baseUrl: ['/a', '/b'] },
+    });
+
+    expect(
+      mergeConfig([
+        { server: { baseUrl: '/' } },
+        { server: { baseUrl: ['/a', '/b'] } },
+      ]),
+    ).toEqual({
+      server: { baseUrl: ['/a', '/b'] },
+    });
   });
 
   test(`should keep single function value`, () => {

--- a/packages/toolkit/utils/src/cli/config.ts
+++ b/packages/toolkit/utils/src/cli/config.ts
@@ -2,4 +2,9 @@
  * When merging config, some properties prefer `override` rather than `merge to array`
  */
 export const isOverriddenConfigKey = (key: string) =>
-  ['removeConsole', 'enableInlineScripts', 'enableInlineStyles'].includes(key);
+  [
+    'removeConsole',
+    'enableInlineScripts',
+    'enableInlineStyles',
+    'baseUrl',
+  ].includes(key);


### PR DESCRIPTION
## Summary

We should overrides `server.baseUrl` when user set it as `['/a', '/b']`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
