### PR TITLE
fix: afterMatch & afterRender share a common Context

### DIFF
--- a/packages/server/core/src/base/middlewares/customServer/base.ts
+++ b/packages/server/core/src/base/middlewares/customServer/base.ts
@@ -1,19 +1,17 @@
 import {
   CookieAPI,
   HookContext,
-  Metrics,
   ModernRequest,
   ModernResponse,
 } from '@modern-js/types';
 import { getCookie } from 'hono/cookie';
-import { HonoContext, HonoRequest, Logger } from '../../../core/server';
+import type { HonoContext, HonoRequest, ServerEnv } from '../../../core/server';
 import { getHost } from '../../utils';
 
-export function createBaseHookContext(
-  c: HonoContext,
-  logger: Logger,
-  metrics?: Metrics,
-): HookContext {
+export function createBaseHookContext(c: HonoContext<ServerEnv>): HookContext {
+  const logger = c.get('logger');
+  const metrics = c.get('metrics');
+
   return {
     request: new BaseHookRequest(c),
     response: new BaseHookResponse(c),

--- a/packages/server/core/src/base/middlewares/customServer/context.ts
+++ b/packages/server/core/src/base/middlewares/customServer/context.ts
@@ -65,11 +65,12 @@ export function createAfterStreamingRenderContext(
   baseHookCtx: HookContext,
   route: Partial<ServerRoute>,
 ): (chunk: string) => AfterStreamingRenderContext {
+  const streamingRenderCtx =
+    baseHookCtx as unknown as AfterStreamingRenderContext;
+
+  streamingRenderCtx.route = route;
   return (chunk: string) => {
-    return {
-      ...baseHookCtx,
-      route,
-      chunk,
-    };
+    streamingRenderCtx.chunk = chunk;
+    return streamingRenderCtx;
   };
 }

--- a/packages/server/core/src/base/middlewares/customServer/context.ts
+++ b/packages/server/core/src/base/middlewares/customServer/context.ts
@@ -1,11 +1,10 @@
 import {
   AfterMatchContext,
   AfterRenderContext,
-  Metrics,
   MiddlewareContext,
-  Logger,
   AfterStreamingRenderContext,
   ServerRoute,
+  HookContext,
 } from '@modern-js/types';
 import { HonoContext, ServerEnv } from '../../../core/server';
 import type { ServerNodeEnv } from '../../adapters/node/hono';
@@ -13,40 +12,38 @@ import { RouterAPI } from './routerApi';
 import { TemplateApi } from './template';
 import { createBaseHookContext } from './base';
 
-export function createAfterMatchCtx(
-  c: HonoContext,
+export function getAfterMatchCtx(
   entryName: string,
-  logger: Logger,
-  metrics?: Metrics,
+  baseHookCtx: HookContext,
 ): AfterMatchContext {
-  const baseContext = createBaseHookContext(c, logger, metrics);
+  const afterMatchCtx = baseHookCtx as unknown as AfterMatchContext;
 
-  return {
-    ...baseContext,
-    router: new RouterAPI(entryName),
-  };
+  afterMatchCtx.router = new RouterAPI(entryName);
+
+  return afterMatchCtx;
 }
 
-export async function createAfterRenderCtx(
+export async function getAfterRenderCtx(
   c: HonoContext,
-  logger: Logger,
-  metrics?: Metrics,
+  baseHookCtx: HookContext,
+  route: Partial<ServerRoute>,
 ): Promise<AfterRenderContext> {
-  const baseContext = createBaseHookContext(c, logger, metrics);
+  const afterRenderCtx = baseHookCtx as unknown as AfterRenderContext;
+
   const resBody = await c.res.text();
-  return {
-    ...baseContext,
-    template: new TemplateApi(resBody),
-  };
+  afterRenderCtx.template = new TemplateApi(resBody);
+  afterRenderCtx.route = route;
+
+  return afterRenderCtx;
 }
 
 export function createCustomMiddlewaresCtx(
   c: HonoContext<ServerNodeEnv & ServerEnv>,
-  logger: Logger,
   locals: Record<string, any>,
-  metrics?: Metrics,
 ): MiddlewareContext {
-  const baseContext = createBaseHookContext(c, logger, metrics);
+  const baseContext = createBaseHookContext(
+    c as unknown as HonoContext<ServerEnv>,
+  );
 
   const reporter = c.get('reporter');
 
@@ -65,15 +62,12 @@ export function createCustomMiddlewaresCtx(
 }
 
 export function createAfterStreamingRenderContext(
-  c: HonoContext,
-  logger: Logger,
+  baseHookCtx: HookContext,
   route: Partial<ServerRoute>,
-  metrics?: Metrics,
 ): (chunk: string) => AfterStreamingRenderContext {
-  const baseContext = createBaseHookContext(c, logger, metrics);
   return (chunk: string) => {
     return {
-      ...baseContext,
+      ...baseHookCtx,
       route,
       chunk,
     };

--- a/tests/integration/server-hook/response/server/index.ts
+++ b/tests/integration/server-hook/response/server/index.ts
@@ -1,4 +1,10 @@
-import { AfterRenderHook } from '@modern-js/runtime/server';
+import { AfterRenderHook, AfterMatchHook } from '@modern-js/runtime/server';
+
+export const afterMatch: AfterMatchHook = (c, next) => {
+  (c as any).payload = 'modern_payload';
+
+  next();
+};
 
 export const afterRender: AfterRenderHook = (ctx, next) => {
   const { response, request } = ctx;
@@ -27,7 +33,10 @@ export const afterRender: AfterRenderHook = (ctx, next) => {
       },
       status: 201,
     });
-
-    next();
+  } else if (pathname === '/payload') {
+    response.raw((ctx as any).payload || '', {
+      status: 200,
+    });
   }
+  next();
 };

--- a/tests/integration/server-hook/response/tests/index.test.ts
+++ b/tests/integration/server-hook/response/tests/index.test.ts
@@ -69,4 +69,11 @@ describe('test status code page', () => {
     expect(headers['x-modern-name']).toBe('hello-modern');
     expect(response!.status()).toBe(201);
   });
+
+  test('should pass payload correctly', async () => {
+    const response = await page.goto(`http://localhost:${port}/payload`);
+
+    const text = await response!.text();
+    expect(text).toBe('modern_payload');
+  });
 });


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
