### PR TITLE
feat(devtools/client): refactor root layout & styling storage preset page

### DIFF
--- a/packages/devtools/client/src/components/Breadcrumbs.tsx
+++ b/packages/devtools/client/src/components/Breadcrumbs.tsx
@@ -84,7 +84,6 @@ export const Breadcrumbs: React.FC<BreadcrumbProps> = props => {
       }),
     );
   }
-  console.log('items: ', items);
 
   for (const [i, item] of Object.entries(items)) {
     const keyParts = [item.id, item.pathname, i];

--- a/packages/devtools/client/src/entries/client/routes/context/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/context/layout.tsx
@@ -3,7 +3,7 @@ import { Box } from '@radix-ui/themes';
 
 export default function Layout() {
   return (
-    <Box px="4">
+    <Box width="100%" height="100%" p="4" style={{ overflowY: 'scroll' }}>
       <Outlet />
     </Box>
   );

--- a/packages/devtools/client/src/entries/client/routes/headers/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/headers/layout.tsx
@@ -1,11 +1,12 @@
 import { Outlet } from '@modern-js/runtime/router';
 import { Box } from '@radix-ui/themes';
-import styles from './layout.module.scss';
 
 export default function Layout() {
   return (
-    <Box px="4" mx="auto" pb="4" className={styles.container}>
-      <Outlet />
+    <Box width="100%" height="100%" pt="6" style={{ overflowY: 'scroll' }}>
+      <Box mx="auto" style={{ maxWidth: '40rem' }}>
+        <Outlet />
+      </Box>
     </Box>
   );
 }

--- a/packages/devtools/client/src/entries/client/routes/layout.module.scss
+++ b/packages/devtools/client/src/entries/client/routes/layout.module.scss
@@ -2,17 +2,13 @@
 
 .wrapper {
   --navigator-width: var(--space-8);
-  --breadcrumb-height: var(--space-7);
-}
-
-.inner {
   width: 100vw;
-  min-height: 100vh;
-  padding-left: var(--navigator-width);
-}
-
-.inner-right {
-  padding-top: var(--breadcrumb-height);
+  height: 100vh;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  position: relative;
 }
 
 .container {
@@ -20,10 +16,6 @@
 }
 
 .navigator {
-  position: fixed;
-  left: 0;
-  top: 0;
-  bottom: 0;
   width: var(--navigator-width);
   border-right: solid 1px var(--gray-3);
   padding: var(--space-1) 0;
@@ -31,12 +23,6 @@
 }
 
 .breadcrumbs {
-  position: fixed;
-  top: 0;
-  left: var(--navigator-width);
-  right: 0;
-  width: auto;
-  height: var(--breadcrumb-height);
   background-image: linear-gradient(
     to bottom,
     var(--color-panel-solid),
@@ -54,7 +40,8 @@
   transition: color 100ms;
   align-items: center;
   cursor: pointer;
-  &:global(.active), &:hover {
+  &:global(.active),
+  &:hover {
     color: var(--gray-11);
   }
 }

--- a/packages/devtools/client/src/entries/client/routes/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/layout.tsx
@@ -100,16 +100,21 @@ const Layout = () => {
       accentColor="blue"
       panelBackground="solid"
     >
-      <Box className={styles.inner}>
-        <Box className={styles.innerRight}>
-          <Box className={styles.container}>
-            <Outlet />
-          </Box>
+      <Navigator />
+      <Box width="100%" position="relative" pt="4">
+        <Box width="100%" height="100%" position="relative">
+          <Outlet />
         </Box>
+        <Breadcrumbs
+          className={styles.breadcrumbs}
+          height="7"
+          position="absolute"
+          top="0"
+          left="0"
+          right="0"
+        />
       </Box>
       <ThemePanel defaultOpen={false} style={{ display }} />
-      <Navigator />
-      <Breadcrumbs className={styles.breadcrumbs} />
       <Puller />
     </Theme>
   );

--- a/packages/devtools/client/src/entries/client/routes/overview/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/overview/layout.tsx
@@ -3,7 +3,7 @@ import { Box } from '@radix-ui/themes';
 
 export default function Layout() {
   return (
-    <Box width="100%" height="100%" p="4" style={{ overflowY: 'scroll' }}>
+    <Box width="100%" height="100%" pt="6" style={{ overflowY: 'scroll' }}>
       <Outlet />
     </Box>
   );

--- a/packages/devtools/client/src/entries/client/routes/overview/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/overview/page.tsx
@@ -46,7 +46,7 @@ const Page: React.FC = () => {
   // const numFrameworkPlugin = store.framework.config.transformed.plugins.length;
 
   return (
-    <Flex direction="column" align="center" p="4">
+    <Flex direction="column" align="center">
       <Flex
         wrap="wrap"
         gap="4"

--- a/packages/devtools/client/src/entries/client/routes/pages/layout.module.scss
+++ b/packages/devtools/client/src/entries/client/routes/pages/layout.module.scss
@@ -1,3 +1,0 @@
-.container {
-  max-width: 40rem;
-}

--- a/packages/devtools/client/src/entries/client/routes/pages/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/pages/layout.tsx
@@ -1,10 +1,9 @@
 import { Outlet } from '@modern-js/runtime/router';
 import { Box } from '@radix-ui/themes';
-import styles from './layout.module.scss';
 
 export default function Layout() {
   return (
-    <Box px="4" mx="auto" pb="4" className={styles.container}>
+    <Box width="100%" height="100%" pt="9" style={{ overflowY: 'scroll' }}>
       <Outlet />
     </Box>
   );

--- a/packages/devtools/client/src/entries/client/routes/pages/page.module.scss
+++ b/packages/devtools/client/src/entries/client/routes/pages/page.module.scss
@@ -1,9 +1,12 @@
 .input {
   position: fixed;
-  padding-top: var(--breadcrumb-height);
-  padding-bottom: 10px;
   top: 0;
   left: var(--navigator-width);
   right: 0;
+  padding-top: 2.5rem;
   background-image: linear-gradient(to bottom, var(--gray-2), 95%, transparent);
+}
+
+.list {
+  max-width: 40rem;
 }

--- a/packages/devtools/client/src/entries/client/routes/pages/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/pages/page.tsx
@@ -29,43 +29,39 @@ const Page: React.FC = () => {
   };
 
   return (
-    <MatchUrlContext.Provider value={matchContext}>
+    <>
       <Flex
-        position="relative"
+        className={styles.list}
         direction="column"
         gap="2"
         align="stretch"
         justify="between"
-        pt="8"
+        mx="auto"
       >
-        {serverRoutes.map(route => (
-          <ServerRoute key={route.entryPath} route={route} />
-        ))}
-        <Box mb="2" className={styles.input}>
-          <Box
-            style={{
-              maxWidth: '40rem',
-              margin: '0 auto',
-              padding: '0 var(--space-4)',
-            }}
-          >
-            <TextField.Root>
-              <TextField.Slot>
-                <HiOutlineArrowsRightLeft />
-              </TextField.Slot>
-              <TextField.Input
-                placeholder="/foo?bar#baz"
-                onChange={e => handleUrlInput(e.target.value)}
-                type="url"
-                autoComplete="false"
-                autoCapitalize="false"
-                autoCorrect="false"
-              />
-            </TextField.Root>
-          </Box>
-        </Box>
+        <MatchUrlContext.Provider value={matchContext}>
+          {serverRoutes.map(route => (
+            <ServerRoute key={route.entryPath} route={route} />
+          ))}
+        </MatchUrlContext.Provider>
       </Flex>
-    </MatchUrlContext.Provider>
+      <Box className={styles.input}>
+        <Box mx="auto" style={{ maxWidth: '40rem' }}>
+          <TextField.Root>
+            <TextField.Slot>
+              <HiOutlineArrowsRightLeft />
+            </TextField.Slot>
+            <TextField.Input
+              placeholder="/foo?bar#baz"
+              onChange={e => handleUrlInput(e.target.value)}
+              type="url"
+              autoComplete="false"
+              autoCapitalize="false"
+              autoCorrect="false"
+            />
+          </TextField.Root>
+        </Box>
+      </Box>
+    </>
   );
 };
 

--- a/packages/devtools/client/src/entries/client/routes/react/[tab]/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/react/[tab]/page.tsx
@@ -45,15 +45,7 @@ const Page: React.FC = () => {
   }, []);
 
   return (
-    <Box
-      style={{
-        position: 'fixed',
-        left: 'var(--navigator-width)',
-        top: 'var(--breadcrumb-height)',
-        bottom: 0,
-        right: 0,
-      }}
-    >
+    <Box width="100%" height="100%" pt="5">
       {InnerView && (
         <InnerView
           browserTheme={browserTheme}

--- a/packages/devtools/client/src/entries/client/routes/storage.preset/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage.preset/layout.tsx
@@ -3,7 +3,7 @@ import { Box } from '@radix-ui/themes';
 
 export default function Layout() {
   return (
-    <Box width="100%" height="100%" p="4" style={{ overflowY: 'scroll' }}>
+    <Box width="100%" height="100%" pt="4">
       <Outlet />
     </Box>
   );

--- a/packages/devtools/client/src/entries/client/routes/storage.preset/page.module.scss
+++ b/packages/devtools/client/src/entries/client/routes/storage.preset/page.module.scss
@@ -2,7 +2,8 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-  padding: var(--space-2);
+  width: 100%;
+  height: 100%;
   @media screen and (min-width: 520px) {
     flex-direction: row;
   }
@@ -10,7 +11,12 @@
 
 .side-panel {
   width: 15rem;
-  overflow: hidden;
+  height: 100%;
+}
+
+.preset-list {
+  overflow: scroll;
+  scrollbar-width: none;
 }
 
 .overflow-badge {
@@ -22,9 +28,9 @@
   line-height: 0;
 }
 
-.preset-card,
-.btn-create-preset {
+.smallCard {
   --bg: var(--gray-1);
+  user-select: none;
   border: solid 1px var(--gray-4);
   border-radius: var(--radius-4);
   padding: var(--space-3);
@@ -57,4 +63,8 @@
 
 .btn-create-preset {
   color: var(--gray-7);
+}
+
+.divider {
+  border-top: solid 1px var(--gray-4);
 }

--- a/packages/devtools/client/src/entries/client/routes/storage.preset/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage.preset/page.tsx
@@ -1,10 +1,11 @@
 import { useLoaderData } from '@modern-js/runtime/router';
 import { Badge, Box, Flex, Text } from '@radix-ui/themes';
 import _ from 'lodash';
-import { HiPlus } from 'react-icons/hi2';
+import { HiPlus, HiMiniFlag } from 'react-icons/hi2';
 import { StoragePresetContext } from '@modern-js/devtools-kit/runtime';
 import { FC } from 'react';
 import { FlexProps } from '@radix-ui/themes/dist/cjs/components/flex';
+import clsx from 'clsx';
 import styles from './page.module.scss';
 import type { Data } from './page.data';
 
@@ -52,12 +53,16 @@ interface UnwindPreset {
   items: UnwindStorageRecord[];
 }
 
+const CardButton: FC<FlexProps> = ({ className, ...props }) => {
+  return <Flex className={clsx(styles.smallCard, className)} {...props} />;
+};
+
 const PresetCard: FC<{ preset: UnwindPreset }> = props => {
   const { preset } = props;
   const isSaved = !preset.filename.match(/[/\\]node_modules[/\\]/);
 
   return (
-    <Box className={styles.presetCard}>
+    <CardButton direction="column">
       <Text size="1" weight="bold" as="p" mb="2">
         {preset.name}{' '}
         {isSaved || (
@@ -78,20 +83,7 @@ const PresetCard: FC<{ preset: UnwindPreset }> = props => {
           ))}
         </Flex>
       </Flex>
-    </Box>
-  );
-};
-
-const CreatePresetButton: FC<FlexProps> = props => {
-  return (
-    <Flex
-      className={styles.btnCreatePreset}
-      justify="center"
-      align="center"
-      {...props}
-    >
-      <HiPlus />
-    </Flex>
+    </CardButton>
   );
 };
 
@@ -122,14 +114,31 @@ const Page: FC = () => {
 
   return (
     <Box className={styles.container}>
-      <Flex direction="column" gap="2" className={styles.sidePanel}>
-        {presets.map(preset => (
-          <PresetCard
-            key={`${preset.name}@${preset.filename}`}
-            preset={preset}
-          />
-        ))}
-        <CreatePresetButton />
+      <Flex direction="column" p="2" pb="0" className={styles.sidePanel}>
+        <CardButton align="center" gap="1">
+          <Text size="1" weight="bold">
+            Current Storage
+          </Text>
+          <Text size="1" color="red" asChild>
+            <HiMiniFlag />
+          </Text>
+        </CardButton>
+        <Box mt="2" className={styles.divider} />
+        <Flex direction="column" py="2" gap="2" className={styles.presetList}>
+          {presets.map(preset => (
+            <PresetCard
+              key={`${preset.name}@${preset.filename}`}
+              preset={preset}
+            />
+          ))}
+          <CardButton
+            justify="center"
+            align="center"
+            className={styles.btnCreatePreset}
+          >
+            <HiPlus />
+          </CardButton>
+        </Flex>
       </Flex>
       <Box grow={'1'} />
     </Box>

--- a/tests/integration/devtools/modern.devtools.json
+++ b/tests/integration/devtools/modern.devtools.json
@@ -24,6 +24,31 @@
       "cookie": {
         "x-tt-jwt": "5ZWG5a62566h55CG5ZGY"
       }
+    },
+    {
+      "name": "用户assdfs",
+      "cookie": {
+        "lang": "zh",
+        "x-tt-jwt": "eC10dC1q3e109d3Q="
+      },
+      "localStorage": {
+        "__cache_first_1161": "1"
+      }
+    },
+    {
+      "name": "商家运营B",
+      "cookie": {
+        "x-tt-jwt": "5ZWG5F13626L+Q6JCl"
+      }
+    },
+    {
+      "name": "商家管理员2",
+      "localStorage": {
+        "__cache_first_1161": "1"
+      },
+      "cookie": {
+        "x-tt-jwt": "5ZWG5a625asd66h55CG5ZGY"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/modern.js/assets/18379948/94e23c30-e17a-45fb-8ec1-10369093b8a2)

- Refactor root layout, allowing sub-routes to have their own scrollable/non-scrollable layout.
- Styling storage preset page.
- Fix: breadcrumb normalization failed when getting an array.
- TODO: Mess layout of loading animation.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
