### PR TITLE
fix: remove node: prefix

### DIFF
--- a/.changeset/dull-melons-tickle.md
+++ b/.changeset/dull-melons-tickle.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/utils': patch
+---
+
+fix: remove `node:` prefix
+fix: 移除 `node:` 前缀

--- a/packages/toolkit/utils/src/cli/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/cli/prettyInstructions.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import { isIPv6 } from 'node:net';
+import { isIPv6 } from 'net';
 import { chalk } from '../compiled';
 import { isDev, isSingleEntry } from './is';
 import { DEFAULT_DEV_HOST } from './constants';


### PR DESCRIPTION
## Summary

We should support node v14.17.6

But node v14.17.6 don't support require('node:xx')



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
