### PR TITLE
fix(module-tools): only invoke svgr in load hook

### DIFF
--- a/.changeset/poor-pandas-share.md
+++ b/.changeset/poor-pandas-share.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools': patch
+---
+
+fix: only invoke svgr in load hook
+fix: 只在 load hook 里调用 svgr 逻辑

--- a/packages/solutions/module-tools/src/builder/feature/asset.ts
+++ b/packages/solutions/module-tools/src/builder/feature/asset.ts
@@ -116,7 +116,7 @@ export async function getAssetContents(
     typeof svgr === 'boolean' ? defaultConfig : _.merge(defaultConfig, svgr);
 
   const filter = createFilter(config.include || SVG_REGEXP, config.exclude);
-  if (svgr && filter(assetPath)) {
+  if (svgr && filter(assetPath) && calledOnLoad) {
     // svgr jsx-loader
 
     // HACK: only support public path, the same as url-loader of webpack and rollup,

--- a/packages/solutions/module-tools/src/builder/feature/redirect.ts
+++ b/packages/solutions/module-tools/src/builder/feature/redirect.ts
@@ -161,7 +161,8 @@ async function redirectImport(
           // asset
           const absPath = resolve(dirname(filePath), name);
           const { contents: relativeImportPath, loader } =
-            await getAssetContents.apply(compiler, [absPath, outputDir]);
+            // HACK: set callOnLoad true to invoke svgr
+            await getAssetContents.apply(compiler, [absPath, outputDir, true]);
           if (loader === 'jsx') {
             // svgr
             const ext = extname(name);


### PR DESCRIPTION
## Summary
Fix https://github.com/web-infra-dev/modern.js/pull/5108/files#diff-9e8d633690bde6a43076949c999e876036a958d232f685a3dc42e6f7ff1f57c2R97

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
