### PR TITLE
fix(generator): do not bump builder deps when use upgrade command

### DIFF
--- a/.changeset/hungry-turkeys-kiss.md
+++ b/.changeset/hungry-turkeys-kiss.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/upgrade-generator': patch
+---
+
+chore(deps): should not bump builder deps when use upgrade command
+
+chore(deps): 使用 upgrade 命令时不升级 builder 依赖并添加 builder 插件废弃提示

--- a/packages/generator/generators/upgrade-generator/src/index.ts
+++ b/packages/generator/generators/upgrade-generator/src/index.ts
@@ -28,6 +28,14 @@ const SpecialModernDeps = [
   '@modern-js/builder-rspack-provider', // need be removed after 2.46.1
 ];
 
+const DeprecatedModernBuilderDeps = [
+  '@modern-js/builder-plugin-image-compress',
+  '@modern-js/builder-plugin-swc',
+  '@modern-js/builder-plugin-esbuild',
+  '@modern-js/builder-plugin-node-polyfill',
+  '@modern-js/builder-plugin-stylus',
+];
+
 const handleSpecialModernDeps = async (dep: string, modernVersion: string) => {
   const version = await getAvailableVersion(dep, modernVersion);
   if (!(await isPackageExist(`${dep}@${version}`))) {
@@ -146,6 +154,10 @@ export const handleTemplateFile = async (
           dep,
           modernVersion,
         );
+      } else if (DeprecatedModernBuilderDeps.includes(dep)) {
+        generator.logger.warn(
+          `[Deprecated] ${dep} is no longer maintained, please use Rsbuild plugin instead`,
+        );
       } else {
         updateInfo[`dependencies.${dep}`] = await getAvailableVersion(
           dep,
@@ -161,6 +173,10 @@ export const handleTemplateFile = async (
         updateInfo[`devDependencies.${dep}`] = await handleSpecialModernDeps(
           dep,
           modernVersion,
+        );
+      } else if (DeprecatedModernBuilderDeps.includes(dep)) {
+        generator.logger.warn(
+          `[Deprecated] ${dep} is no longer maintained, please use Rsbuild plugin instead`,
         );
       } else {
         updateInfo[`devDependencies.${dep}`] = await getAvailableVersion(


### PR DESCRIPTION
## Summary

Since mdoern.js 2.46.0, builder plugin is no longer maintained,should use Rsbuild plugin instead.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
