### PR TITLE
docs: fix error anchor link

### DIFF
--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -116,7 +116,7 @@ export default defineConfig({
 
 ## asset.path
 
-Static resource output path, will be based on [outDir](/api/config/build-config#outDir)
+Static resource output path, will be based on [outDir](/api/config/build-config#outdir)
 
 - **Type**: `string`
 - **Default**: `assets`
@@ -471,7 +471,7 @@ When this configuration is disabled, there is no guarantee that the type files w
 
 ## dts.distPath
 
-The output path of the dts file, based on [outDir](/api/config/build-config#outDir)
+The output path of the dts file, based on [outDir](/api/config/build-config#outdir)
 
 - **Type**: `string`
 - **Default**: `./`
@@ -1485,7 +1485,7 @@ export default defineConfig({
 });
 ```
 
-Reference the [Import Plugin - Notes](plugins/official-list/plugin-import.html#Notes)
+Reference the [Import Plugin - Notes](plugins/official-list/plugin-import.html#notes)
 
 ## transformLodash
 

--- a/packages/document/module-doc/docs/en/guide/advance/copy.md
+++ b/packages/document/module-doc/docs/en/guide/advance/copy.md
@@ -69,7 +69,7 @@ export default defineConfig({
 });
 ```
 
-The `patterns.to` parameter is used to specify the output path for the copied files. By default, its value corresponds to [buildConfig.outDir](/api/config/build-config#outDir). Therefore, we can copy `src/index.html` to the `dist` directory as follows:
+The `patterns.to` parameter is used to specify the output path for the copied files. By default, its value corresponds to [buildConfig.outDir](/api/config/build-config#outdir). Therefore, we can copy `src/index.html` to the `dist` directory as follows:
 
 ```ts
 export default defineConfig({

--- a/packages/document/module-doc/docs/en/guide/basic/modify-output-product.md
+++ b/packages/document/module-doc/docs/en/guide/basic/modify-output-product.md
@@ -60,7 +60,7 @@ In addition, we can also fully customize the build configuration:
 - How the output type file is handled: the corresponding API is [`buildConfig.dts`](/api/config/build-config#dts).
 - How the sourceMap of the artifact is handled: the corresponding API is [`buildConfig.sourceMap`](/api/config/build-config#sourcemap).
 - The input (or source file) corresponding to the output: the corresponding API is [`buildConfig.input`](/api/config/build-config#input).
-- The directory of the output of the artifact: the corresponding API is [`buildConfig.outDir`](/api/config/build-config#outDir).
+- The directory of the output of the artifact: the corresponding API is [`buildConfig.outDir`](/api/config/build-config#outdir).
 - Build source directory: the corresponding API is [`buildConfig.sourceDir`](/api/config/build-config#sourcedir).
 
 **Common functions required for build artifacts include:**

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -115,7 +115,7 @@ export default defineConfig({
 
 ## asset.path
 
-静态资源输出路径，会基于 [outDir](/api/config/build-config#outDir) 进行输出。
+静态资源输出路径，会基于 [outDir](/api/config/build-config#outdir) 进行输出。
 
 - 类型： `string`
 - 默认值： `assets`
@@ -464,7 +464,7 @@ export default defineConfig({
 
 ## dts.distPath
 
-类型文件的输出路径，基于 [outDir](/api/config/build-config#outDir) 进行输出。
+类型文件的输出路径，基于 [outDir](/api/config/build-config#outdir) 进行输出。
 
 - 类型： `string`
 - 默认值： `./`

--- a/packages/document/module-doc/docs/zh/guide/advance/copy.md
+++ b/packages/document/module-doc/docs/zh/guide/advance/copy.md
@@ -68,7 +68,7 @@ export default defineConfig({
 });
 ```
 
-`patterns.to` 用于指定复制文件的输出路径，默认情况下它的值为 [`buildConfig.outDir`](/api/config/build-config#outDir)对应的值。因此我们按照如下方式将 `src/index.html` 复制到 `dist` 目录下：
+`patterns.to` 用于指定复制文件的输出路径，默认情况下它的值为 [`buildConfig.outDir`](/api/config/build-config#outdir)对应的值。因此我们按照如下方式将 `src/index.html` 复制到 `dist` 目录下：
 
 ```ts
 export default defineConfig({

--- a/packages/document/module-doc/docs/zh/guide/basic/modify-output-product.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/modify-output-product.md
@@ -61,7 +61,7 @@ Modern.js Module 主要内置了两套构建预设,包括:
 - 产物类型文件如何处理，对应的 API 是 [`buildConfig.dts`](/api/config/build-config#dts)。
 - 产物的 sourceMap 如何处理：对应的 API 是 [`buildConfig.sourceMap`](/api/config/build-config#sourcemap)。
 - 产物对应的输入（或者是源文件）：对应的 API 是 [`buildConfig.input`](/api/config/build-config#input)。
-- 产物输出的目录：对应的 API 是 [`buildConfig.outDir`](/api/config/build-config#outDir)。
+- 产物输出的目录：对应的 API 是 [`buildConfig.outDir`](/api/config/build-config#outdir)。
 - 构建的源码目录：对应的 API 是 [`buildConfig.sourceDir`](/api/config/build-config#sourcedir)。
 
 **构建产物所需的常用功能包括：**


### PR DESCRIPTION
## Summary

in module docs, all anchor link are lowercase.

<img width="657" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/9baeb80f-8040-45a9-b10e-51b1eef12952">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
