### PR TITLE
fix: new server should return 404 when can't found html template

### DIFF
--- a/.changeset/three-peas-fly.md
+++ b/.changeset/three-peas-fly.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix(server-core): new server should return 404 when can't found html template & 404,500 response shouldn't run afterRenderHook
+fix(server-core): 新 server 在找不到 html 模版时应该返回 404, 且 404，500 响应不应该被 afterRenderHook 处理

--- a/packages/server/core/src/base/middlewares/customServer/index.ts
+++ b/packages/server/core/src/base/middlewares/customServer/index.ts
@@ -97,7 +97,12 @@ export class CustomServer {
 
       await next();
 
-      if (c.finalized && (!c.res.body || !isHtmlResponse(c.res))) {
+      if (
+        c.finalized &&
+        (!c.res.body ||
+          !isHtmlResponse(c.res) ||
+          [404, 500].includes(c.res.status))
+      ) {
         // We shouldn't handle response.body, if response body == null
         return undefined;
       }

--- a/packages/server/core/src/base/middlewares/renderHandler/render.ts
+++ b/packages/server/core/src/base/middlewares/renderHandler/render.ts
@@ -48,7 +48,12 @@ export async function createRender({
     const html = templates[routeInfo.entryName!];
 
     if (!html) {
-      throw new Error(`Can't found entry ${routeInfo.entryName!} html `);
+      return new Response(createErrorHtml(404), {
+        status: 404,
+        headers: {
+          'content-type': 'text/html; charset=UTF-8',
+        },
+      });
     }
 
     const renderMode = getRenderMode(


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
