### PR TITLE
📝 docs(storybook): Replace storybook/main.js in storybook/main.ts

### DIFF
--- a/packages/document/builder-doc/docs/en/guide/advanced/storybook.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/storybook.mdx
@@ -65,7 +65,7 @@ Addon some scripts in your package.json
 {
   "scripts": {
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build"
   }
 }
 ```
@@ -76,7 +76,7 @@ To Start, run `npm run storybook`
 
 Modern.js Builder only support Storybook 7, so you need to upgrade from Storybook version 6 to version 7, please follow the steps outlined in the official Storybook documentation at [storybook migrate doc](https://storybook.js.org/docs/react/migration-guide).
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
 -  framework: '@storybook/react-webapck5',
 +  framework: {
@@ -95,7 +95,7 @@ If the original project includes configurations for Babel, they need to be writt
 
 Rspack is known for its fast build speed. To use Rspack as a build tool in Modern.js, you only need to configure it as follows:
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -119,7 +119,7 @@ Before starting, make sure that you have installed the @modern-js/builder-rspack
 
 ## Configurations
 
-There are some configurations in `.storybook/main.js`.
+There are some configurations in `.storybook/main.ts`.
 
 ### configPath
 
@@ -130,14 +130,14 @@ Specify the path of Modern.js Builder configuration.
 
 Example:
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
     options: {
-      configPath: 'modern.storybook.config.ts'
-    }
-  }
+      configPath: 'modern.storybook.config.ts',
+    },
+  },
 };
 
 export default config;
@@ -152,14 +152,14 @@ Specify the underlying build tool to use either Webpack or Rspack. Please make s
 
 Example:
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
     options: {
-      bundler: 'rspack'
-    }
-  }
+      bundler: 'rspack',
+    },
+  },
 };
 
 export default config;
@@ -174,7 +174,7 @@ To modify the configuration of the builder, which has a higher priority than the
 
 Example:
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -183,10 +183,10 @@ const config = {
         alias: {
           react: require.resolve('react'),
           'react-dom': require.resolve('react-dom'),
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  },
 };
 
 export default config;
@@ -213,7 +213,7 @@ import { defineConfig } from '@modern-js/storybook';
 import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
 
 const config = defineConfig({
-  builderPlugins: [builderPluginSwc()]
+  builderPlugins: [builderPluginSwc()],
 });
 
 export default config;
@@ -236,16 +236,16 @@ The powerful capabilities of Modern.js builder can be directly used in Storybook
 ## Trouble Shooting
 
 1. Modern.js builder won't load your other configurations like `babel.config.json`, babel config needs to be set in Modern.js config, [tools.babel](/api/config-tools.html#toolsbabel).
-Webpack configuration can be written in either [tools.webpack](/api/config-tools.html#toolswebpack) or [tools.webpackChain](/api/config-tools.html#toolswebpackchain).
+   Webpack configuration can be written in either [tools.webpack](/api/config-tools.html#toolswebpack) or [tools.webpackChain](/api/config-tools.html#toolswebpackchain).
 
 2. If you find that the build performance is not good, please check if the Storybook automatic documentation generation feature is enabled. For optimal performance, configure it to use `react-docgen`. The difference between `react-docgen` and `react-docgen-typescript` is that the former is implemented based on Babel, while the latter is implemented based on TypeScript. The former has better performance but weaker type inference capabilities. If you are using Rspack for the build, only `react-docgen` is supported.
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   typescript: {
-    reactDocgen: 'react-docgen'
-  }
-}
+    reactDocgen: 'react-docgen',
+  },
+};
 
-export default config
+export default config;
 ```

--- a/packages/document/builder-doc/docs/zh/guide/advanced/storybook.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/storybook.mdx
@@ -65,7 +65,7 @@ export default config;
 {
   "scripts": {
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build"
   }
 }
 ```
@@ -76,7 +76,7 @@ export default config;
 
 若当前 Storybook 版本还是 6，需要先按照 Storybook 官网文档升级到版本 7 ，参考[storybook 迁移文档](https://storybook.js.org/docs/react/migration-guide)。
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
 -  framework: '@storybook/react-webapck5',
 +  framework: {
@@ -97,7 +97,7 @@ Modern.js 的配置文件默认为 `modern.config.(j|t)s`，配置请查看 [bui
 
 Rspack 构建速度非常快，在 Modern.js 中只需要如下配置即可使用 Rspack 作为构建工具。
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -120,7 +120,7 @@ export default config;
 
 ## 配置
 
-在 `.storybook/main.js` 中包含一些配置。
+在 `.storybook/main.ts` 中包含一些配置。
 
 ### configPath
 
@@ -131,14 +131,14 @@ export default config;
 
 例如
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
     options: {
-      configPath: 'modern.storybook.config.ts'
-    }
-  }
+      configPath: 'modern.storybook.config.ts',
+    },
+  },
 };
 
 export default config;
@@ -153,14 +153,14 @@ export default config;
 
 例如
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
     options: {
-      bundler: 'rspack'
-    }
-  }
+      bundler: 'rspack',
+    },
+  },
 };
 
 export default config;
@@ -175,7 +175,7 @@ export default config;
 
 例如
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -184,10 +184,10 @@ const config = {
         alias: {
           react: require.resolve('react'),
           'react-dom': require.resolve('react-dom'),
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  },
 };
 
 export default config;
@@ -214,7 +214,7 @@ import { defineConfig } from '@modern-js/storybook';
 import { builderPluginSwc } from '@modern-js/builder-plugin-swc';
 
 const config = defineConfig({
-  builderPlugins: [builderPluginSwc()]
+  builderPlugins: [builderPluginSwc()],
 });
 
 export default config;
@@ -237,16 +237,16 @@ Modern.js builder 强大的能力都可以直接在 Storybook 项目中使用。
 ## Trouble Shooting
 
 1. 使用 Modern.js builder 时不会读取 babel.config.json 等配置文件，因此 babel 配置需要在 [tools.babel](/api/config-tools.html#toolsbabel) 中进行配置。
-同样的 webpack 配置需要写在 [tools.webpack](/api/config-tools.html#toolswebpack) 或 [tools.webpackChain](/api/config-tools.html#toolswebpackchain) 中。
+   同样的 webpack 配置需要写在 [tools.webpack](/api/config-tools.html#toolswebpack) 或 [tools.webpackChain](/api/config-tools.html#toolswebpackchain) 中。
 
 2. 如果发现构建速度很慢，请检查是否开启了自动文档生成功能，如果想要最高的性能，请配置为 `react-docgen`。`react-docgen` 和 `react-docgen-typescript` 的区别是，前者基于 Babel 实现，后者基于 TypeScript 实现，前者性能会更好，但类型推断能力更弱。如果使用 Rspack 构建，则只支持 `react-docgen`。
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   typescript: {
-    reactDocgen: 'react-docgen'
-  }
-}
+    reactDocgen: 'react-docgen',
+  },
+};
 
-export default config
+export default config;
 ```

--- a/packages/document/main-doc/docs/en/apis/app/hooks/config/storybook.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/hooks/config/storybook.mdx
@@ -15,10 +15,10 @@ Enabling the Storybook function requires running the new command to enable it un
 
 #### Example
 
-For the webpack configuration of the Storybook Manager app section, you can configure it by adding the `./config/storybook/main.js` file to configure it.
+For the webpack configuration of the Storybook Manager app section, you can configure it by adding the `./config/storybook/main.ts` file to configure it.
 
 ```js
-// ./config/storybook/main.js
+// ./config/storybook/main.ts
 
 module.exports = {
   // it controls the Storybook manager app

--- a/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/using-storybook.mdx
@@ -38,7 +38,7 @@ To start, run `npm run storybook`.
 
 Rspack is known for its fast build speed. To use Rspack as a build tool in Modern.js, you only need to configure it as follows:
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -60,7 +60,7 @@ Note that in the above configuration, the reactDocgen configuration has been cha
 
 ## Configurations
 
-There are some configurations in `.storybook/main.js`.
+There are some configurations in `.storybook/main.ts`.
 
 ### configPath
 
@@ -71,7 +71,7 @@ Specify the path of Modern.js configuration.
 
 Example:
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -93,7 +93,7 @@ Specify the underlying build tool to use either Webpack or Rspack.
 
 Example:
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -115,7 +115,7 @@ To modify the configuration of build, which has a higher priority than the confi
 
 Example:
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -166,7 +166,7 @@ The powerful build capabilities of Modern.js can be directly used in Storybook p
 
 2. If you find that the build performance is not good, please check if the Storybook automatic documentation generation feature is enabled. For optimal performance, configure it to use `react-docgen`. The difference between `react-docgen` and `react-docgen-typescript` is that the former is implemented based on Babel, while the latter is implemented based on TypeScript. The former has better performance but weaker type inference capabilities. If you are using Rspack for the build, only `react-docgen` is supported.
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   typescript: {
     reactDocgen: 'react-docgen',
@@ -214,7 +214,7 @@ Follow the official Storybook documentation to make the necessary updates for so
 
 Modern.js only support Storybook 7, so you need to upgrade from Storybook version 6 to version 7, please follow the steps outlined in the official Storybook documentation at [storybook migrate doc](https://storybook.js.org/docs/react/migration-guide).
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
 -  framework: '@storybook/react-webapck5',
 +  framework: {

--- a/packages/document/main-doc/docs/zh/apis/app/hooks/config/storybook.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/hooks/config/storybook.mdx
@@ -16,10 +16,10 @@ Storybook 配置请查看：[Storybook 配置](https://storybook.js.org/docs/rea
 
 ### 示例
 
-对于 Storybook Manager app 部分的 webpack 配置，可以通过增加 `./config/storybook/main.js` 文件进行配置。
+对于 Storybook Manager app 部分的 webpack 配置，可以通过增加 `./config/storybook/main.ts` 文件进行配置。
 
 ```js
-// ./config/storybook/main.js
+// ./config/storybook/main.ts
 
 module.exports = {
   // it controls the Storybook manager app

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/using-storybook.mdx
@@ -38,7 +38,7 @@ $ npx modern new
 
 Rspack 构建速度非常快，在 Modern.js 中只需要如下配置即可使用 Rspack 作为构建工具。
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -60,7 +60,7 @@ export default config;
 
 ## 配置
 
-在 `.storybook/main.js` 中包含一些配置。
+在 `.storybook/main.ts` 中包含一些配置。
 
 ### configPath
 
@@ -71,7 +71,7 @@ export default config;
 
 例如
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -93,7 +93,7 @@ export default config;
 
 例如
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -115,7 +115,7 @@ export default config;
 
 例如
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -166,7 +166,7 @@ Modern.js 的构建能力和配置都可以直接在 Storybook 项目中使用�
 
 2. 如果发现构建速度很慢，请检查是否开启了自动文档生成功能，如果想要最高的性能，请配置为 `react-docgen`。`react-docgen` 和 `react-docgen-typescript` 的区别是，前者基于 Babel 实现，后者基于 TypeScript 实现，前者性能会更好，但类型推断能力更弱。如果使用 Rspack 构建，则只支持 `react-docgen`。
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   typescript: {
     reactDocgen: 'react-docgen',
@@ -214,7 +214,7 @@ export default config;
 
 若当前 Storybook 版本还是 6，需要先按照 Storybook 官网文档升级到版本 7，参考 [storybook 迁移文档](https://storybook.js.org/docs/react/migration-guide)。
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
 -  framework: '@storybook/react-webapck5',
 +  framework: {

--- a/packages/document/module-doc/docs/en/api/config/dev.md
+++ b/packages/document/module-doc/docs/en/api/config/dev.md
@@ -9,7 +9,7 @@ This section describes all configuration of Modern.js Module related to debuggin
 ## storybook
 
 :::warning
-**Deprecated**: This configuration is deprecated and only applicable to Storybook V6. Please see [使用Storybook](/guide/basic/using-storybook) to get more info.
+**Deprecated**: This configuration is deprecated and only applicable to Storybook V6. Please see [使用 Storybook](/guide/basic/using-storybook) to get more info.
 :::
 
 ### storybook.webpack
@@ -35,10 +35,10 @@ You can modify the webpack configuration of the Storybook Preview-iframe via `de
 
 #### Configure Manager App
 
-For the webpack configuration of the Storybook Manager app section, you can configure it by adding the `./config/storybook/main.js` file to configure it.
+For the webpack configuration of the Storybook Manager app section, you can configure it by adding the `./config/storybook/main.ts` file to configure it.
 
 ```js
-// ./config/storybook/main.js
+// ./config/storybook/main.ts
 
 module.exports = {
   // it controls the Storybook manager app

--- a/packages/document/module-doc/docs/en/guide/basic/using-storybook.mdx
+++ b/packages/document/module-doc/docs/en/guide/basic/using-storybook.mdx
@@ -80,7 +80,7 @@ For npm and Yarn projects, the `types` value of `package.json` can only be modif
 
 Rspack is known for its fast build speed. To use Rspack as a build tool in Modern.js, you only need to configure it as follows:
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -102,7 +102,7 @@ Note that in the above configuration, the reactDocgen configuration has been cha
 
 ### Configurations
 
-There are some separate configurations in `.storybook/main.js`.
+There are some separate configurations in `.storybook/main.ts`.
 
 #### bundler
 
@@ -113,7 +113,7 @@ Specify the underlying bundler to use either Webpack or Rspack.
 
 Example:
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -133,7 +133,7 @@ export default config;
 
 The Storybook build capability of Modern.js is provided by [Rsbuild](https://rsbuild.dev/), and the Rsbuild configuration can be modified through builderConfig.
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',

--- a/packages/document/module-doc/docs/zh/api/config/dev.md
+++ b/packages/document/module-doc/docs/zh/api/config/dev.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 ## storybook
 
 :::warning
-**Deprecated**：该配置已过时，只适用于 StorybookV6，详情请看[使用Storybook](/guide/basic/using-storybook)。
+**Deprecated**：该配置已过时，只适用于 StorybookV6，详情请看[使用 Storybook](/guide/basic/using-storybook)。
 :::
 
 ### storybook.webpack
@@ -35,10 +35,10 @@ export default {
 
 #### 配置 Manager App
 
-对于 Storybook Manager App 部分的 webpack 配置，可以通过增加 `./config/storybook/main.js` 文件进行配置。
+对于 Storybook Manager App 部分的 webpack 配置，可以通过增加 `./config/storybook/main.ts` 文件进行配置。
 
 ```js
-// ./config/storybook/main.js
+// ./config/storybook/main.ts
 
 module.exports = {
   // it controls the Storybook manager app

--- a/packages/document/module-doc/docs/zh/guide/basic/using-storybook.mdx
+++ b/packages/document/module-doc/docs/zh/guide/basic/using-storybook.mdx
@@ -81,7 +81,7 @@ modern build --watch
 
 Rspack 构建速度非常快，只需要如下配置即可使用 Rspack 作为构建工具。
 
-```diff filename='.storybook/main.js'
+```diff filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -103,7 +103,7 @@ export default config;
 
 ### 配置
 
-在 `.storybook/main.js` 中包含一些独有的配置。
+在 `.storybook/main.ts` 中包含一些独有的配置。
 
 #### bundler
 
@@ -112,7 +112,7 @@ export default config;
 
 指定底层打包工具使用 Webpack 还是 Rspack。
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',
@@ -132,7 +132,7 @@ export default config;
 
 Modern.js 的 Storybook 构建能力由 [Rsbuild](https://rsbuild.dev/) 提供，可通过 builderConfig 修改 Rsbuild 构建配置。
 
-```javascript filename='.storybook/main.js'
+```javascript filename='.storybook/main.ts'
 const config = {
   framework: {
     name: '@modern-js/storybook',


### PR DESCRIPTION
Replace storybook/main.js in the document with the actual storybook/main.ts generated   

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
