### PR TITLE
fix(uni-builder): modernjs should extend "ua" type in output.polyfill

### DIFF
--- a/.changeset/famous-years-sell.md
+++ b/.changeset/famous-years-sell.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix(uni-builder): modernjs should extend "ua" type in output.polyfill

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -134,6 +134,7 @@ export async function parseCommonConfig(
       disableSourceMap,
       convertToRem,
       disableMinimize,
+      polyfill,
       ...outputConfig
     } = {},
     html: {
@@ -162,7 +163,10 @@ export async function parseCommonConfig(
 
   const rsbuildConfig: RsbuildConfig = {
     plugins,
-    output: outputConfig,
+    output: {
+      polyfill: polyfill === 'ua' ? 'off' : polyfill,
+      ...outputConfig,
+    },
     source: {
       alias: alias as unknown as SourceConfig['alias'],
       ...sourceConfig,

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -14,6 +14,7 @@ import type {
   RsbuildPluginAPI,
   ArrayOrNot,
   HtmlTagDescriptor,
+  Polyfill,
 } from '@rsbuild/shared';
 import type { RsbuildConfig } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
@@ -380,7 +381,9 @@ export type UniBuilderPlugin = {
 export type UniBuilderConfig = {
   dev?: RsbuildConfig['dev'];
   html?: RsbuildConfig['html'];
-  output?: RsbuildConfig['output'];
+  output?: Omit<NonNullable<RsbuildConfig['output']>, 'polyfill'> & {
+    polyfill?: Polyfill | 'ua';
+  };
   performance?: RsbuildConfig['performance'];
   security?: RsbuildConfig['security'];
   tools?: RsbuildConfig['tools'];


### PR DESCRIPTION
## Summary

Related to https://github.com/web-infra-dev/rsbuild/issues/2091.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
