### PR TITLE
fix: server middleware ctx status should be set when return response

### DIFF
--- a/.changeset/new-tigers-jam.md
+++ b/.changeset/new-tigers-jam.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: server middleware ctx status should be set when return response
+fix: server 中间件的 ctx.status 应该被设置当返回 response 时

--- a/packages/server/core/src/base/middlewares/customServer/index.ts
+++ b/packages/server/core/src/base/middlewares/customServer/index.ts
@@ -108,6 +108,9 @@ export class CustomServer {
       }
 
       // TODO: fix by hono
+      // c.res must sync with c.#status
+      // but hono not do it,
+      // so we sync it manually
       if (c.res) {
         c.status(c.res.status);
       }

--- a/packages/server/core/src/base/middlewares/customServer/index.ts
+++ b/packages/server/core/src/base/middlewares/customServer/index.ts
@@ -107,6 +107,11 @@ export class CustomServer {
         return undefined;
       }
 
+      // TODO: fix by hono
+      if (c.res) {
+        c.status(c.res.status);
+      }
+
       if (routeInfo.isStream) {
         // run afterStreamingRender hook
         const afterStreamingRenderContext = createAfterStreamingRenderContext(
@@ -143,10 +148,7 @@ export class CustomServer {
 
         const newBody = afterRenderCtx.template.get();
 
-        c.res = c.body(newBody, {
-          status: c.res.status,
-          headers: c.res.headers,
-        });
+        c.res = c.body(newBody);
       }
     };
   }


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
