### PR TITLE
docs: update Rspack precautions

### DIFF
--- a/packages/document/builder-doc/docs/en/shared/rspackPrecautions.md
+++ b/packages/document/builder-doc/docs/en/shared/rspackPrecautions.md
@@ -1,10 +1,9 @@
 ## Precautions
 
-Before using Rspack, please be aware that Rspack is still an early stage project and is currently in a rapid iteration phase. Therefore, you need to be aware of the following:
+Before using Rspack, please be aware that Rspack is currently in the rapid iteration phase. Therefore, you need to be aware of the following:
 
-- The API and configuration options of Rspack are still unstable, and the support for Rspack in Modern.js is experimental. Therefore, incompatible updates may be introduced in non-major releases in the future.
-- Rspack does not currently provide complete optimization capabilities like tree shaking, bundle splitting, and scope hoisting, which are available in webpack. We will continue to enhance these optimization capabilities in Rspack from June to December. Therefore, when migrating to Rspack, you may notice a certain level of increase in the bundle size compared to webpack.
-- Rspack currently relies on SWC for code compilation and compression. Due to the lower maturity of SWC compared to Babel and Terser, you may encounter SWC bugs.
+- The API and configuration items of Rspack are not completely stable yet, so non-major versions may introduce some incompatible changes.
+- Rspack currently relies on SWC for code transformation and compression. Due to the lower maturity of SWC compared to Babel and Terser, you may encounter bugs of SWC in edge cases.
 - Rspack is compatible with most plugins and loaders in the webpack ecosystem, but there are still some plugins and loaders that cannot be used temporarily.
 
 Rspack is actively working to improve the above issues and plans to address them in future releases. We recommend that you evaluate your project requirements and risk tolerance before deciding whether to use Rspack. If your project requires high stability and performance, you should choose the more mature webpack. If you are willing to try new tools and contribute to their development, we welcome you to use Rspack and provide feedback and bug reports to help improve its stability and functionality.

--- a/packages/document/builder-doc/docs/zh/shared/rspackPrecautions.md
+++ b/packages/document/builder-doc/docs/zh/shared/rspackPrecautions.md
@@ -1,10 +1,9 @@
 ## 注意事项
 
-在使用 Rspack 之前，请留意 Rspack 仍然是一个早期项目，当前还处于快速迭代阶段。因此，你需要预先了解以下事项：
+在使用 Rspack 之前，请留意 Rspack 当前还处于快速迭代阶段。因此，你需要预先了解以下事项：
 
-- Rspack 的 API 和配置项还不稳定，同时 Modern.js 对 Rspack 的支持属于实验性的，因此在后续的非 major 版本中，可能会引入不兼容更新。
-- Rspack 并未实现完整的 webpack 优化能力（如 tree shaking、bundle splitting、scope hoist 等能力，我们将在 6 ～ 12 月持续补齐相关优化能力），迁移到 Rspack 后，你可能会发现产物的包体积相较 webpack 有一定程度的增加。
-- Rspack 目前基于 SWC 进行代码编译和压缩，由于 SWC 的成熟度不及 babel 和 terser，因此你可能会遇到 SWC 的 bug。
-- Rspack 模式兼容了大部分 webpack 生态的插件和 loaders，但仍有部分插件和 loaders 暂时无法使用。
+- Rspack 的 API 和配置项尚未完全稳定，因此在后续的非 major 版本中，可能会引入个别不兼容更新。
+- Rspack 目前基于 SWC 进行代码编译和压缩，由于 SWC 的成熟度不及 babel 和 terser，因此你可能会遇到 SWC 在边界场景下的 bug。
+- Rspack 模式兼容了大部分 webpack 生态的插件和 loaders，但仍有少部分插件和 loaders 暂时无法使用。
 
 Rspack 正在积极改善上述问题，并计划在未来的版本中逐步解决它们。我们建议在决定是否使用 Rspack 之前，评估你的项目需求和风险承受能力。如果你的项目对稳定性和性能要求较高，可以先选择更成熟的 webpack。如果你愿意尝试新的工具并为其发展做出贡献，我们欢迎你使用 Rspack，并提供反馈和报告问题，以帮助改进它的稳定性和功能。


### PR DESCRIPTION
## Summary

Update the Rspack precautions documentation. Since Rspack already supports new tree shaking and is aligned with webpack, we can remove some precautions here.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
