### PR TITLE
docs(module-doc): align `define` description to actual behavior

### DIFF
--- a/.changeset/slow-years-reply.md
+++ b/.changeset/slow-years-reply.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/module-tools-docs': patch
+---
+
+docs(module-doc): align `define` description to actual behavior
+docs(module-doc): 对齐 `define` 的文档描述和实际行为一致

--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -376,16 +376,23 @@ Define global variables that will be injected into the code
 - **Type**: `Record<string, string>`
 - **Default**: `{}`
 
-Since the `define` function is implemented by global text replacement, you need to ensure that the global variable values are strings. A safer approach is to convert the value of each global variable to a string, using `JSON.stringify`, as follows.
+Since the `define` function is implemented by global text replacement, you need to ensure that the global variable values are strings. A safer approach is to convert the value of each global variable to a string, as follows.
+
+:::info
+Modern.js automatically performs JSON serialization handling internally, so manual serialization is not required.
+
+If automatic serialization is not needed, you can define [`alias`](https://esbuild.github.io/api/#alias) using [`esbuildOptions`](/api/config/build-config.html#esbuildoptions) configuration.
+
+:::
 
 ```js title="modern.config.ts"
-export default {
+export default defineConfig({
   buildConfig: {
     define: {
-      VERSION: JSON.stringify('1.0'),
+      VERSION: require('./package.json').version || '0.0.0',
     },
   },
-};
+});
 ```
 
 If the project is a TypeScript project, then you may need to add the following to the `.d.ts` file in the project source directory.
@@ -403,7 +410,7 @@ import { defineConfig } from '@modern-js/module-tools';
 export default defineConfig({
   buildConfig: {
     define: {
-      'process.env.VERSION': JSON.stringify(process.env.VERSION || '0.0.0'),
+      'process.env.VERSION': process.env.VERSION || '0.0.0',
     },
   },
 });

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -369,13 +369,19 @@ type Options = {
 - 类型： `Record<string, string>`
 - 默认值： `{}`
 
-由于 `define` 功能是由全局文本替换实现的，所以需要保证全局变量值为字符串，更为安全的做法是将每个全局变量的值转化为字符串，使用 `JSON.stringify` 进行转换，如下所示：
+由于 `define` 功能是由全局文本替换实现的，所以需要保证全局变量值为字符串，更为安全的做法是将每个全局变量的值转化为字符串，如下所示：
+
+:::info
+框架内部会自动进行 JSON 序列化处理，因此不需要手动执行序列化。
+
+如果不需要自动序列化，可以通过配置 [`esbuildOptions`](/api/config/build-config.html#esbuildoptions) 定义 [`alias`](https://esbuild.github.io/api/#alias) 来实现。
+:::
 
 ```js title="modern.config.ts"
 export default defineConfig({
   buildConfig: {
     define: {
-      VERSION: JSON.stringify(require('./package.json').version || '0.0.0'),
+      VERSION: require('./package.json').version || '0.0.0',
     },
   },
 });
@@ -396,7 +402,7 @@ import { defineConfig } from '@modern-js/module-tools';
 export default defineConfig({
   buildConfig: {
     define: {
-      'process.env.VERSION': JSON.stringify(process.env.VERSION || '0.0.0'),
+      'process.env.VERSION': process.env.VERSION || '0.0.0',
     },
   },
 });


### PR DESCRIPTION
## Summary

~~To align with the behavior on document and most other tools' `define` convention.~~

align `define` description to actual behavior

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
