### PR TITLE
fix: no need to emit assets for SSR bundles

### DIFF
--- a/.changeset/two-bananas-run.md
+++ b/.changeset/two-bananas-run.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+no need to emit assets for SSR bundles

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -21,6 +21,8 @@ export function createDefaultConfig(
       server: 'bundles',
       worker: 'worker',
     },
+    // no need to emit assets for SSR bundles
+    emitAssets: ({ target }) => target !== 'node',
     cleanDistPath: true,
     disableNodePolyfill: true,
     enableInlineRouteManifests: true,


### PR DESCRIPTION
## Summary

No need to emit assets for SSR bundles, use the `output.emitAssets` option of Rsbuild to ignore assets for node target.

## Related Links

https://rsbuild.dev/config/output/emit-assets

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
