### PR TITLE
fix: swc can not transform dynamic import in cjs normally

### DIFF
--- a/.changeset/friendly-maps-smell.md
+++ b/.changeset/friendly-maps-smell.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: swc can not transform dynamic import in cjs normally

--- a/packages/server/core/src/base/adapters/node/middlewares/serverManifest.ts
+++ b/packages/server/core/src/base/adapters/node/middlewares/serverManifest.ts
@@ -15,7 +15,7 @@ async function getServerManifest(
   const loaderBundles: Record<string, any> = {};
   const renderBundles: Record<string, any> = {};
 
-  await Promise.all([
+  await Promise.all(
     routes.map(async route => {
       const entryName = route.entryName || MAIN_ENTRY_NAME;
 
@@ -26,10 +26,15 @@ async function getServerManifest(
       );
 
       const renderBundlePath = path.join(pwd, route.bundle || '');
-
+      const dynamicImport = (filePath: string) => {
+        if (typeof require !== 'undefined') {
+          return Promise.resolve(require(filePath));
+        }
+        return import(filePath);
+      };
       await Promise.allSettled([
-        import(loaderBundlePath),
-        import(renderBundlePath),
+        dynamicImport(loaderBundlePath),
+        dynamicImport(renderBundlePath),
       ]).then(results => {
         const { status: loaderStatus } = results[0];
 
@@ -44,7 +49,7 @@ async function getServerManifest(
         }
       });
     }),
-  ]);
+  );
 
   const loadableUri = path.join(pwd, LOADABLE_STATS_FILE);
 


### PR DESCRIPTION
## Summary

 ModuleFederation renderBundle is Promise , but swc can not transform dynamic import in cjs normally.

previous
```js
  const results = await Promise.allSettled([
     Promise.resolve().then(() => __toESM(require(loaderBundlePath))),
     Promise.resolve().then(() => __toESM(require(renderBundlePath)))
  ]);
  
  // __toESM(require(renderBundlePath)).then() will throw error : 'Method Promise.prototype.then called on incompatible receiver #<Promise>'

```


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
