### PR TITLE
fix: require bundle maybe failed

### DIFF
--- a/.changeset/good-cheetahs-wink.md
+++ b/.changeset/good-cheetahs-wink.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: require bundle maybe failed
+fix: require bundle 有可能是失败的

--- a/packages/server/core/src/base/adapters/node/middlewares/serverManifest.ts
+++ b/packages/server/core/src/base/adapters/node/middlewares/serverManifest.ts
@@ -27,10 +27,12 @@ async function getServerManifest(
 
       const renderBundlePath = path.join(pwd, route.bundle || '');
       const dynamicImport = (filePath: string) => {
-        if (typeof require !== 'undefined') {
-          return Promise.resolve(require(filePath));
+        try {
+          const module = require(filePath);
+          return Promise.resolve(module);
+        } catch (e) {
+          return Promise.reject(e);
         }
-        return import(filePath);
       };
       await Promise.allSettled([
         dynamicImport(loaderBundlePath),


### PR DESCRIPTION
## Summary

- require bundle maybe failed, so we need use try..catch
- the serverManifest middleware is only use in node.js, so we can use `require` directly

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
