### PR TITLE
fix(plugin-swc): missing `@rsbuild/core` peer dep

### DIFF
--- a/.changeset/six-ads-talk.md
+++ b/.changeset/six-ads-talk.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-swc': patch
+---
+
+fix(plugin-swc): missing `@rsbuild/core` peer dep

--- a/packages/cli/plugin-swc/package.json
+++ b/packages/cli/plugin-swc/package.json
@@ -37,6 +37,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@rsbuild/core": "0.6.6",
     "@rsbuild/plugin-swc": "0.6.6",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.5.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,9 @@ importers:
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
+      '@rsbuild/core':
+        specifier: 0.6.6
+        version: 0.6.6
       '@rsbuild/plugin-swc':
         specifier: 0.6.6
         version: 0.6.6(@rsbuild/core@0.6.6)


### PR DESCRIPTION
## Summary

Fix `@modern-js/plugin-swc` missing `@rsbuild/core` peer dep.

This PR can ensure the `@rsbuild/plugin-swc` resolves to the correct `@rsbuild/core`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
