### PR TITLE
docs: update buildConfig in plugin-vue docs

### DIFF
--- a/.changeset/thin-singers-remember.md
+++ b/.changeset/thin-singers-remember.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/module-tools-docs': minor
+---
+
+docs: update buildConfig in plugin-vue docs

--- a/.changeset/thin-singers-remember.md
+++ b/.changeset/thin-singers-remember.md
@@ -1,5 +1,5 @@
 ---
-'@modern-js/module-tools-docs': minor
+'@modern-js/module-tools-docs': patch
 ---
 
 docs: update buildConfig in plugin-vue docs

--- a/packages/document/module-doc/docs/en/plugins/official-list/plugin-vue.mdx
+++ b/packages/document/module-doc/docs/en/plugins/official-list/plugin-vue.mdx
@@ -29,10 +29,12 @@ import { modulePluginVue } from '@modern-js/plugin-module-vue';
 
 export default defineConfig({
   plugins: [moduleTools(), modulePluginVue()],
-  buildType: 'bundle',
-  format: 'esm',
-  input: ['src/index.vue'],
-  dts: false,
+  buildConfig: {
+    buildType: 'bundle',
+    format: 'esm',
+    input: ['src/index.vue'],
+    dts: false,
+  },
 });
 ```
 

--- a/packages/document/module-doc/docs/zh/plugins/official-list/plugin-vue.mdx
+++ b/packages/document/module-doc/docs/zh/plugins/official-list/plugin-vue.mdx
@@ -29,10 +29,12 @@ import { modulePluginVue } from '@modern-js/plugin-module-vue';
 
 export default defineConfig({
   plugins: [moduleTools(), modulePluginVue()],
-  buildType: 'bundle',
-  format: 'esm',
-  input: ['src/index.vue'],
-  dts: false,
+  buildConfig: {
+    buildType: 'bundle',
+    format: 'esm',
+    input: ['src/index.vue'],
+    dts: false,
+  },
 });
 ```
 


### PR DESCRIPTION
## Summary

The documentation about the vue plugin in modern.js seems a bit old, some configurations are not placed in buildConfig. I encountered this problem and fixed it.

## Related Links

https://modernjs.dev/module-tools/plugins/official-list/plugin-vue.html#%E6%B3%A8%E5%86%8C%E6%8F%92%E4%BB%B6

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
