### PR TITLE
Feat(plugin-module-vue): Add support for *.vue files to modern build --watch

### DIFF
--- a/.changeset/smart-horses-deny.md
+++ b/.changeset/smart-horses-deny.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-module-vue': minor
+---
+
+Add support for \*.vue files to modern build --watch

--- a/packages/module/plugin-module-vue/src/index.ts
+++ b/packages/module/plugin-module-vue/src/index.ts
@@ -2,6 +2,7 @@ import type { CliPlugin, ModuleTools } from '@modern-js/module-tools';
 import vuePlugin from 'esbuild-plugin-vue3';
 import { modulePluginBabel } from '@modern-js/plugin-module-babel';
 import type { VueJSXPluginOptions } from '@vue/babel-plugin-jsx';
+import { vueWatchAdapterPlugin } from './watchAdapter';
 
 export const modulePluginVue = (options?: {
   vueJsxPluginOptions?: VueJSXPluginOptions;
@@ -26,6 +27,9 @@ export const modulePluginVue = (options?: {
       config.esbuildOptions = c => {
         const lastEsbuildConfig = lastEsbuildOptions(c);
         lastEsbuildConfig.plugins?.unshift(vuePlugin() as any);
+        lastEsbuildConfig.plugins?.unshift(
+          vueWatchAdapterPlugin(config) as any,
+        );
         return lastEsbuildConfig;
       };
       config.jsx = 'preserve';

--- a/packages/module/plugin-module-vue/src/watchAdapter.ts
+++ b/packages/module/plugin-module-vue/src/watchAdapter.ts
@@ -13,9 +13,7 @@ export const vueWatchAdapterPlugin = (config: BaseBuildConfig): Plugin => {
     name: 'esbuild:vue-watch-adapter',
     setup(build) {
       build.onLoad({ filter: /\.vue$/ }, async args => {
-        if (compiler) {
-          compiler.addWatchFile(args.path);
-        }
+        compiler?.addWatchFile?.(args.path);
         return undefined;
       });
     },

--- a/packages/module/plugin-module-vue/src/watchAdapter.ts
+++ b/packages/module/plugin-module-vue/src/watchAdapter.ts
@@ -1,10 +1,5 @@
-import { dirname } from 'path';
-import {
-  resolvePathAndQuery,
-  type BaseBuildConfig,
-  type ICompiler,
-} from '@modern-js/module-tools';
-import { ImportKind, Plugin } from 'esbuild';
+import type { BaseBuildConfig, ICompiler } from '@modern-js/module-tools';
+import { Plugin } from 'esbuild';
 
 export const vueWatchAdapterPlugin = (config: BaseBuildConfig): Plugin => {
   let compiler = null as unknown as ICompiler;
@@ -17,27 +12,11 @@ export const vueWatchAdapterPlugin = (config: BaseBuildConfig): Plugin => {
   return {
     name: 'esbuild:vue-watch-adapter',
     setup(build) {
-      build.onResolve({ filter: /\.vue$/ }, args => {
+      build.onLoad({ filter: /\.vue$/ }, async args => {
         if (compiler) {
-          const { context } = compiler;
-          const { root } = context;
-          const getResultPath = (id: string, dir: string, kind: ImportKind) => {
-            return id.endsWith('.css')
-              ? compiler.css_resolve(id, dir)
-              : compiler.node_resolve(id, dir, kind);
-          };
-          const { originalFilePath } = resolvePathAndQuery(args.path);
-          const dir =
-            args.resolveDir ?? (args.importer ? dirname(args.importer) : root);
-          const path = getResultPath(originalFilePath, dir, args.kind);
-          if (path) {
-            compiler.addWatchFile(path);
-          }
+          compiler.addWatchFile(args.path);
         }
-        return {
-          path: undefined,
-          namespace: undefined,
-        };
+        return undefined;
       });
     },
   };

--- a/packages/module/plugin-module-vue/src/watchAdapter.ts
+++ b/packages/module/plugin-module-vue/src/watchAdapter.ts
@@ -1,0 +1,44 @@
+import { dirname } from 'path';
+import {
+  resolvePathAndQuery,
+  type BaseBuildConfig,
+  type ICompiler,
+} from '@modern-js/module-tools';
+import { ImportKind, Plugin } from 'esbuild';
+
+export const vueWatchAdapterPlugin = (config: BaseBuildConfig): Plugin => {
+  let compiler = null as unknown as ICompiler;
+  config.hooks.push({
+    name: 'vue-watch-adapter',
+    apply(_compiler: ICompiler) {
+      compiler = _compiler;
+    },
+  });
+  return {
+    name: 'esbuild:vue-watch-adapter',
+    setup(build) {
+      build.onResolve({ filter: /\.vue$/ }, args => {
+        if (compiler) {
+          const { context } = compiler;
+          const { root } = context;
+          const getResultPath = (id: string, dir: string, kind: ImportKind) => {
+            return id.endsWith('.css')
+              ? compiler.css_resolve(id, dir)
+              : compiler.node_resolve(id, dir, kind);
+          };
+          const { originalFilePath } = resolvePathAndQuery(args.path);
+          const dir =
+            args.resolveDir ?? (args.importer ? dirname(args.importer) : root);
+          const path = getResultPath(originalFilePath, dir, args.kind);
+          if (path) {
+            compiler.addWatchFile(path);
+          }
+        }
+        return {
+          path: undefined,
+          namespace: undefined,
+        };
+      });
+    },
+  };
+};

--- a/packages/solutions/module-tools/src/index.ts
+++ b/packages/solutions/module-tools/src/index.ts
@@ -7,4 +7,3 @@ export { moduleTools };
 export default moduleTools;
 
 export * from './utils/assert';
-export * from './utils/builder';

--- a/packages/solutions/module-tools/src/index.ts
+++ b/packages/solutions/module-tools/src/index.ts
@@ -7,3 +7,4 @@ export { moduleTools };
 export default moduleTools;
 
 export * from './utils/assert';
+export * from './utils/builder';


### PR DESCRIPTION
## Summary

The original @modern-js/plugin-module-vue plugin will not watch `*.vue` files modifications when running `modern build --watch` . I added an esbuild plugin that can add `*.vue` files to modern.js built-in watcher in the file list.


One thing to note is that compiler.addWatchFile requires the compiler object (type: `class EsbuildCompiler implements ICompiler` in [EsbuildCompiler declaration](https://github.com/web-infra-dev/modern.js/blob/main/packages/solutions/module-tools/src/builder/esbuild/index.ts#L37)). I got the compiler object through config.hooks. The code is as follows:

```ts
  let compiler = null as unknown as ICompiler;
  config.hooks.push({
    name: 'vue-watch-adapter',
    apply(_compiler: ICompiler) {
      compiler = _compiler;
    },
  });
```

I think this might be unstable. I'm wondering if there is a more stable way to get the compiler object for external plugins?

Thanks!


## Related Links

[EsbuildCompiler declaration](https://github.com/web-infra-dev/modern.js/blob/main/packages/solutions/module-tools/src/builder/esbuild/index.ts#L37)

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
