### PR TITLE
fix: render should handle api route when open enableHandleWeb

### DIFF
--- a/.changeset/happy-ducks-fly.md
+++ b/.changeset/happy-ducks-fly.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: render should handle api route when open enableHandleWeb
+fix: 当开启了 enableHandleWeb, render 应该处理 api 路由

--- a/packages/server/core/src/base/middlewares/renderHandler/render.ts
+++ b/packages/server/core/src/base/middlewares/renderHandler/render.ts
@@ -39,7 +39,7 @@ interface CreateRenderOptions {
 }
 
 function getRouter(routes: ServerRoute[]): Router<ServerRoute> {
-  const sorted = routes.filter(r => !r.isApi).sort(sortRoutes);
+  const sorted = routes.sort(sortRoutes);
 
   const router = new TrieRouter<ServerRoute>();
 


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
