### PR TITLE
fix: useLoader should run normally in csr when webpack build

### DIFF
--- a/.changeset/happy-fans-roll.md
+++ b/.changeset/happy-fans-roll.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: useLoader should run normally in csr when webpack build
+fix: useLoader 当使用 webpack 构建是，在 csr 下应该需要正常跑

--- a/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/ssr/cli/index.ts
@@ -63,7 +63,6 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
     return {
       config() {
         const appContext = api.useAppContext();
-        const userConfig = api.useConfigContext();
 
         pluginsExportsUtils = createRuntimeExportsUtils(
           appContext.internalDirectory,
@@ -93,15 +92,11 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
             // so we only use useLoader in CSR on Rspack build temporarily.
             return (config: any) => {
               const userConfig = api.useResolvedConfigContext();
-              if (isUseSSRBundle(userConfig)) {
+              if (isUseSSRBundle(userConfig) && checkUseStringSSR(userConfig)) {
                 config.plugins?.push(
                   path.join(__dirname, './babel-plugin-ssr-loader-id'),
                 );
-                if (checkUseStringSSR(userConfig)) {
-                  config.plugins?.push(
-                    require.resolve('@loadable/babel-plugin'),
-                  );
-                }
+                config.plugins?.push(require.resolve('@loadable/babel-plugin'));
               }
             };
           }
@@ -142,10 +137,7 @@ export const ssrPlugin = (): CliPlugin<AppTools> => ({
                   ]);
               }
             },
-            babel:
-              isUseSSRBundle(userConfig) && checkUseStringSSR(userConfig as any)
-                ? babelHandler
-                : undefined,
+            babel: babelHandler,
           },
         };
       },


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
