### PR TITLE
fix: pass props to custom bootstrap

### DIFF
--- a/.changeset/stale-sheep-scream.md
+++ b/.changeset/stale-sheep-scream.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix: parse props to custom bootstrap

--- a/packages/runtime/plugin-garfish/src/cli/utils.ts
+++ b/packages/runtime/plugin-garfish/src/cli/utils.ts
@@ -95,13 +95,19 @@ export const makeRenderFunction = (code: string) => {
       .replace(/MOUNT_ID/g, 'mountNode')
       .replace(`createApp({`, 'createApp({ props,')
       .replace(
-        `bootstrap(AppWrapper, mountNode, root, ReactDOM)`,
-        'bootstrap(AppWrapper, mountNode, root = IS_REACT18 ? ReactDOM.createRoot(mountNode) : null, ReactDOM), props',
+        `bootstrap(AppWrapper, mountNode, root`,
+        'bootstrap(AppWrapper, mountNode, root = IS_REACT18 ? ReactDOM.createRoot(mountNode) : null',
       )
       .replace(
         `customBootstrap(AppWrapper`,
         'customBootstrap(AppWrapper, mountNode',
       )
+      /*
+      传递 props 给 customBootstrap
+      (.*)：.代表任何字符（除了换行符），*代表前面的字符可以出现任意次数，包括0次。所以这部分匹配任何在 customBootstrap 括号中的内容，并且用括号()标记为一个捕获组，留待之后引用。
+      'customBootstrap($1, props)': 这是替换模式。$1是一个特殊的符号，用于引用前面正则表达式中的第一个捕获组。
+      */
+      .replace(/customBootstrap\((.*)\)/g, 'customBootstrap($1, props)')
   );
 };
 

--- a/packages/runtime/plugin-garfish/src/cli/utils.ts
+++ b/packages/runtime/plugin-garfish/src/cli/utils.ts
@@ -95,8 +95,8 @@ export const makeRenderFunction = (code: string) => {
       .replace(/MOUNT_ID/g, 'mountNode')
       .replace(`createApp({`, 'createApp({ props,')
       .replace(
-        `bootstrap(AppWrapper, mountNode, root`,
-        'bootstrap(AppWrapper, mountNode, root = IS_REACT18 ? ReactDOM.createRoot(mountNode) : null',
+        `bootstrap(AppWrapper, mountNode, root, ReactDOM)`,
+        'bootstrap(AppWrapper, mountNode, root = IS_REACT18 ? ReactDOM.createRoot(mountNode) : null, ReactDOM), props',
       )
       .replace(
         `customBootstrap(AppWrapper`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9219,7 +9219,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.23.6):
     resolution: {integrity: sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4338,8 +4338,8 @@ importers:
         specifier: ^0.8.0
         version: 0.8.1
       webpack-dev-middleware:
-        specifier: 7.2.1
-        version: 7.2.1(webpack@5.91.0)
+        specifier: 6.1.3
+        version: 6.1.3(webpack@5.91.0)
       webpack-hot-middleware:
         specifier: ^2.25.4
         version: 2.25.4
@@ -13092,37 +13092,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  /@jsonjoy.com/base64@1.1.1(tslib@2.6.2):
-    resolution: {integrity: sha512-LnFjVChaGY8cZVMwAIMjvA1XwQjZ/zIXHyh28IyJkyNkzof4Dkm1+KN9UIm3lHhREH4vs7XwZ0NpkZKnwOtEfg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@jsonjoy.com/json-pack@1.0.3(tslib@2.6.2):
-    resolution: {integrity: sha512-Q0SPAdmK6s5Fe3e1kcNvwNyk6e2+CxM8XZdGbf4abZG7nUO05KSie3/iX29loTBuY+75uVP6RixDSPVpotfzmQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-    dependencies:
-      '@jsonjoy.com/base64': 1.1.1(tslib@2.6.2)
-      '@jsonjoy.com/util': 1.1.2(tslib@2.6.2)
-      hyperdyperid: 1.2.0
-      thingies: 1.21.0(tslib@2.6.2)
-      tslib: 2.6.2
-    dev: false
-
-  /@jsonjoy.com/util@1.1.2(tslib@2.6.2):
-    resolution: {integrity: sha512-HOGa9wtE6LEz2I5mMQ2pMSjth85PmD71kPbsecs02nEUq3/Kw0wRK3gmZn5BCEB8mFLXByqPxjHgApoMwIPMKQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-    dependencies:
-      tslib: 2.6.2
-    dev: false
 
   /@juggle/resize-observer@3.3.1:
     resolution: {integrity: sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==}
@@ -25001,11 +24970,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  /hyperdyperid@1.2.0:
-    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
-    engines: {node: '>=10.18'}
-    dev: false
-
   /hyphenate-style-name@1.0.4:
     resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}
     dev: true
@@ -27374,16 +27338,6 @@ packages:
     engines: {node: '>= 4.0.0'}
     dependencies:
       fs-monkey: 1.0.3
-
-  /memfs@4.9.2:
-    resolution: {integrity: sha512-f16coDZlTG1jskq3mxarwB+fGRrd0uXWt+o1WIhRfOwbXQZqUDsTVxQBFK9JjRQHblg8eAG2JSbprDXKjc7ijQ==}
-    engines: {node: '>= 4.0.0'}
-    dependencies:
-      '@jsonjoy.com/json-pack': 1.0.3(tslib@2.6.2)
-      '@jsonjoy.com/util': 1.1.2(tslib@2.6.2)
-      sonic-forest: 1.0.2(tslib@2.6.2)
-      tslib: 2.6.2
-    dev: false
 
   /memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
@@ -32662,16 +32616,6 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /sonic-forest@1.0.2(tslib@2.6.2):
-    resolution: {integrity: sha512-2rICdwIJi5kVlehMUVtJeHn3ohh5YZV4pDv0P0c1M11cRz/gXNViItpM94HQwfvnXuzybpqK0LZJgTa3lEwtAw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-    dependencies:
-      tree-dump: 1.0.1(tslib@2.6.2)
-      tslib: 2.6.2
-    dev: false
-
   /source-list-map@2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
     dev: false
@@ -33561,15 +33505,6 @@ packages:
     dependencies:
       any-promise: 1.3.0
 
-  /thingies@1.21.0(tslib@2.6.2):
-    resolution: {integrity: sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==}
-    engines: {node: '>=10.18'}
-    peerDependencies:
-      tslib: ^2
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
   /throttle-debounce@3.0.1:
     resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
     engines: {node: '>=10'}
@@ -33702,15 +33637,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       punycode: 2.1.1
-
-  /tree-dump@1.0.1(tslib@2.6.2):
-    resolution: {integrity: sha512-WCkcRBVPSlHHq1dc/px9iOfqklvzCbdRwvlNfxGZsrHqf6aZttfPrd7DJTt6oR10dwUfpFFQeVTkPbBIZxX/YA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-    dependencies:
-      tslib: 2.6.2
-    dev: false
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -34986,9 +34912,9 @@ packages:
       - utf-8-validate
     dev: true
 
-  /webpack-dev-middleware@7.2.1(webpack@5.91.0):
-    resolution: {integrity: sha512-hRLz+jPQXo999Nx9fXVdKlg/aehsw1ajA9skAneGmT03xwmyuhvF93p6HUKKbWhXdcERtGTzUCtIQr+2IQegrA==}
-    engines: {node: '>= 18.12.0'}
+  /webpack-dev-middleware@6.1.3(webpack@5.91.0):
+    resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
+    engines: {node: '>= 14.15.0'}
     peerDependencies:
       webpack: ^5.0.0
     peerDependenciesMeta:
@@ -34996,9 +34922,8 @@ packages:
         optional: true
     dependencies:
       colorette: 2.0.20
-      memfs: 4.9.2
+      memfs: 3.5.1
       mime-types: 2.1.35
-      on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.2.0
       webpack: 5.91.0(esbuild@0.18.20)


### PR DESCRIPTION
## Summary
pass props to modern custom bootstrap [doc link]
(https://modernjs.dev/guides/concept/entries.html#%E8%87%AA%E5%AE%9A%E4%B9%89-bootstrap)

Effect
Users can get props from master app at the beginning to init something
<img width="893" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/65393845/1b803a57-ec48-4812-8009-fc31f314f949">

Before
<img width="1255" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/65393845/063d0256-0d9e-4480-bf3c-89d711dabcb6">

After
<img width="1251" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/65393845/fa292778-237b-4461-9df4-de45c4dfd126">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
