### PR TITLE
feat: remove runtime reference

### DIFF
--- a/.changeset/wild-fans-deliver.md
+++ b/.changeset/wild-fans-deliver.md
@@ -1,0 +1,18 @@
+---
+'@modern-js/router-v5-generator': minor
+'@modern-js/module-generator': minor
+'@modern-js/bff-generator': minor
+'@modern-js/doc-plugin-auto-sidebar': minor
+'@modern-js/node-bundle-require': minor
+'@modern-js/generator-common': minor
+'@modern-js/plugin-router-v5': minor
+'@modern-js/new-action': minor
+'@modern-js/plugin-server': minor
+'@modern-js/module-tools-docs': minor
+'@modern-js/prod-server': minor
+'@modern-js/main-doc': minor
+---
+
+feat: remove reference when enable runtime plugin，recommended to use the `@modern-js/plugin-xx/runtime` path directly
+
+feat: 当开启 runtime 能力时移除 reference 配置，推荐直接使用 `plugin-xx/runtime` 路径

--- a/packages/cli/doc-plugin-auto-sidebar/src/modern-app-env.d.ts
+++ b/packages/cli/doc-plugin-auto-sidebar/src/modern-app-env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types='@modern-js/module-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/document/main-doc/docs/en/apis/app/runtime/bff/hook.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/bff/hook.mdx
@@ -7,10 +7,10 @@ Used to add framework middleware under BFF function mode, the middleware will ex
 
 ## Usage
 
-according to the framework extend plugin, export from the corresponding namespace:
+according to the framework extend plugin, export from the corresponding framework:
 
 ```ts
-import { hook } from '@modern-js/runtime/{namespace}';
+import { hook } from '@modern-js/plugin-{framework}/runtime';
 ```
 
 ## Function Signature

--- a/packages/document/main-doc/docs/en/apis/app/runtime/bff/hook.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/bff/hook.mdx
@@ -33,7 +33,7 @@ function hook(options: HookOptions): void;
 middleware for different frameworks should be different(an example is when using the koa framework):
 
 ```ts title=api/_app.ts
-import { hook } from '@modern-js/runtime/koa';
+import { hook } from '@modern-js/plugin-koa/runtime';
 
 export default hook(({ addMiddleware }) => {
   addMiddleware(async (ctx, next) => {

--- a/packages/document/main-doc/docs/en/apis/app/runtime/bff/use-context.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/bff/use-context.mdx
@@ -7,10 +7,10 @@ Used to get the request context in the BFF function.
 
 ## Usage
 
-according to the framework extend plugin, export from the corresponding namespace:
+according to the framework extend plugin, export from the corresponding framework:
 
 ```ts
-import { useContext } from '@modern-js/runtime/{namespace}';
+import { useContext } from '@modern-js/plugin-{framework}/runtime';
 ```
 
 ## Function Signature
@@ -22,7 +22,7 @@ import { useContext } from '@modern-js/runtime/{namespace}';
 Developers can get more request information through `context`, such as browser UA(an example is when using the koa framework):
 
 ```ts
-import { useContext } from '@modern-js/runtime/koa';
+import { useContext } from '@modern-js/plugin-koa/runtime';
 
 export async function get() {
   const ctx = useContext();

--- a/packages/document/main-doc/docs/en/apis/app/runtime/testing/act.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/testing/act.mdx
@@ -8,7 +8,7 @@ Used to ensure that behaviors such as rendering, events, data fetching, etc. hav
 ## Usage
 
 ```ts
-import { act } from '@modern-js/runtime/testing';
+import { act } from '@modern-js/plugin-testing/runtime';
 ```
 
 ## Function Signature
@@ -19,7 +19,7 @@ import { act } from '@modern-js/runtime/testing';
 
 ```tsx
 import ReactDOM from 'react-dom';
-import { act } from '@modern-js/runtime/testing';
+import { act } from '@modern-js/plugin-testing/runtime';
 import { Foo } from '@/components/Foo';
 
 describe('test act', () => {

--- a/packages/document/main-doc/docs/en/apis/app/runtime/testing/cleanup.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/testing/cleanup.mdx
@@ -26,7 +26,7 @@ Note that if you are using a testing framework that supports afterEach and it is
 For example, if you use the [ava](https://github.com/avajs/ava) test framework, then you need to use the `test.after Each` hook like this.
 
 ```tsx
-import { cleanup, render } from '@modern-js/runtime/testing';
+import { cleanup, render } from '@modern-js/plugin-testing/runtime';
 import test from 'ava';
 
 test.afterEach(cleanup);

--- a/packages/document/main-doc/docs/en/apis/app/runtime/testing/render.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/testing/render.mdx
@@ -8,7 +8,7 @@ Used to render the component in the test case.
 ## Usage
 
 ```ts
-import { render } from '@modern-js/runtime/testing';
+import { render } from '@modern-js/plugin-testing/runtime';
 ```
 
 ## Function Signature
@@ -58,7 +58,7 @@ function render(ui: React.ReactElement<any>, options: Options): RenderResult;
 ## Example
 
 ```ts
-import { render } from '@modern-js/runtime/testing';
+import { render } from '@modern-js/plugin-testing/runtime';
 import App from './App';
 
 test('renders a message', () => {

--- a/packages/document/main-doc/docs/en/apis/app/runtime/testing/renderApp.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/runtime/testing/renderApp.mdx
@@ -8,7 +8,7 @@ The `render` function is used to test normal components, and the `renderApp` fun
 ## Usage
 
 ```ts
-import { renderApp } from '@modern-js/runtime/testing';
+import { renderApp } from '@modern-js/plugin-testing/runtime';
 ```
 
 App components refer to components that contain some Modern.js contexts, such as App root components, Containers using Models, etc.
@@ -22,7 +22,7 @@ For the testing of such components, you can use the `renderApp` function, which 
 ## Example
 
 ```ts
-import { renderApp } from '@modern-js/runtime/testing';
+import { renderApp } from '@modern-js/plugin-testing/runtime';
 import App from './App';
 
 describe('test', () => {

--- a/packages/document/main-doc/docs/en/guides/advanced-features/testing.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/testing.mdx
@@ -33,10 +33,10 @@ If you need to customize the test directory, you can configure it with [tools.je
 
 ## Usage
 
-Modern.js test support [testing-library](https://testing-library.com/docs/). API can be imported from `@modern-js/runtime/testing`.
+Modern.js test support [testing-library](https://testing-library.com/docs/). API can be imported from `@modern-js/plugin-testing/runtime`.
 
 ```ts
-import { render, screen } from '@modern-js/runtime/testing';
+import { render, screen } from '@modern-js/plugin-testing/runtime';
 ```
 
 Other testing APIs supported by Modern.js can be referred to [here](/apis/app/runtime/testing/cleanup).

--- a/packages/document/main-doc/docs/en/guides/topic-detail/model/test-model.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/model/test-model.mdx
@@ -18,7 +18,7 @@ This will enable testing feature support.
 Create a new file called `count.test.ts` with the following code:
 
 ```ts
-import { createStore } from '@modern-js/runtime/testing';
+import { createStore } from '@modern-js/plugin-testing/runtime';
 import countModel from './count';
 
 describe('test model', () => {
@@ -36,7 +36,7 @@ describe('test model', () => {
 ```
 
 :::info
-The [`createStore`](/apis/app/runtime/model/create-store) used here is imported from `@modern-js/runtime/testing`, which internally uses the configuration of [`runtime.state`](/configure/app/runtime/state) to create a `store`.
+The [`createStore`](/apis/app/runtime/model/create-store) used here is imported from `@modern-js/plugin-testing/runtime`, which internally uses the configuration of [`runtime.state`](/configure/app/runtime/state) to create a `store`.
 
 :::
 

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/bff/hook.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/bff/hook.mdx
@@ -7,10 +7,10 @@ title: hook
 
 ## 使用姿势
 
-根据使用的框架拓展插件，从对应的命名空间中导出：
+根据使用的框架拓展插件，从对应的插件中导出：
 
 ```ts
-import { hook } from '@modern-js/runtime/{namespace}';
+import { hook } from '@modern-js/plugin-{framework}/runtime';
 ```
 
 ## 函数签名

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/bff/hook.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/bff/hook.mdx
@@ -33,7 +33,7 @@ function hook(options: HookOptions): void;
 使用不同的框架，应添加不同框架的中间件（示例为使用 koa 框架时）：
 
 ```ts title=api/_app.ts
-import { hook } from '@modern-js/runtime/koa';
+import { hook } from '@modern-js/plugin-koa/runtime';
 
 export default hook(({ addMiddleware }) => {
   addMiddleware(async (ctx, next) => {

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/bff/use-context.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/bff/use-context.mdx
@@ -7,10 +7,10 @@ title: useContext
 
 ## 使用姿势
 
-根据使用的框架拓展插件，从对应的命名空间中导出：
+根据使用的框架拓展插件，从对应的插件中导出：
 
 ```ts
-import { useContext } from '@modern-js/runtime/{namespace}';
+import { useContext } from '@modern-js/plugin-{framework}/runtime';
 ```
 
 ## 函数签名
@@ -22,7 +22,7 @@ import { useContext } from '@modern-js/runtime/{namespace}';
 开发者可以通过 `context` 获取更多的请求信息，例如获取请求 UA（示例为使用 koa 框架时）：
 
 ```ts
-import { useContext } from '@modern-js/runtime/koa';
+import { useContext } from '@modern-js/plugin-koa/runtime';
 
 export async function get() {
   const ctx = useContext();

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/testing/act.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/testing/act.mdx
@@ -8,7 +8,7 @@ title: act
 ## 使用姿势
 
 ```ts
-import { act } from '@modern-js/runtime/testing';
+import { act } from '@modern-js/plugin-testing/runtime';
 ```
 
 ## 函数签名
@@ -19,7 +19,7 @@ import { act } from '@modern-js/runtime/testing';
 
 ```tsx
 import ReactDOM from 'react-dom';
-import { act } from '@modern-js/runtime/testing';
+import { act } from '@modern-js/plugin-testing/runtime';
 import { Foo } from '@/components/Foo';
 
 describe('test act', () => {

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/testing/cleanup.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/testing/cleanup.mdx
@@ -26,7 +26,7 @@ import { cleanup } from '@modenr-js/runtime/testing';
 例如，如果你使用[ava](https://github.com/avajs/ava)测试框架，那么你需要像这样使用 test.afterEach 钩子。
 
 ```tsx
-import { cleanup, render } from '@modern-js/runtime/testing';
+import { cleanup, render } from '@modern-js/plugin-testing/runtime';
 import test from 'ava';
 
 test.afterEach(cleanup);

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/testing/render.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/testing/render.mdx
@@ -8,7 +8,7 @@ title: render
 ## 使用姿势
 
 ```ts
-import { render } from '@modern-js/runtime/testing';
+import { render } from '@modern-js/plugin-testing/runtime';
 ```
 
 ## 函数签名
@@ -58,7 +58,7 @@ function render(ui: React.ReactElement<any>, options: Options): RenderResult;
 ## 示例
 
 ```ts
-import { render } from '@modern-js/runtime/testing';
+import { render } from '@modern-js/plugin-testing/runtime';
 import App from './App';
 
 test('renders a message', () => {

--- a/packages/document/main-doc/docs/zh/apis/app/runtime/testing/renderApp.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/runtime/testing/renderApp.mdx
@@ -8,7 +8,7 @@ title: renderApp
 ## 使用姿势
 
 ```ts
-import { renderApp } from '@modern-js/runtime/testing';
+import { renderApp } from '@modern-js/plugin-testing/runtime';
 ```
 
 应用组件指包含一些 Modern.js 上下文的组件，如 App 根组件，使用了 Model 的 Container 等。对于这类组件的测试，可以使用 `renderApp` 函数，会自动按照当前 `modern.config.js` 配置，包裹上对应的上下文信息。
@@ -20,7 +20,7 @@ import { renderApp } from '@modern-js/runtime/testing';
 ## 示例
 
 ```ts
-import { renderApp } from '@modern-js/runtime/testing';
+import { renderApp } from '@modern-js/plugin-testing/runtime';
 import App from './App';
 
 describe('test', () => {

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/testing.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/testing.mdx
@@ -34,10 +34,10 @@ Modern.js 默认识别的测试文件路径为：`<rootDir>/src/**/*.test.[jt]s?
 
 ## 使用姿势
 
-Modern.js test 支持使用 [testing-library](https://testing-library.com/docs/) 相关包 API，可直接通过 `@modern-js/runtime/testing` 进行导入:
+Modern.js test 支持使用 [testing-library](https://testing-library.com/docs/) 相关包 API，可直接通过 `@modern-js/plugin-testing/runtime` 进行导入:
 
 ```ts
-import { render, screen } from '@modern-js/runtime/testing';
+import { render, screen } from '@modern-js/plugin-testing/runtime';
 ```
 
 其他 Modern.js 支持的 testing API 可参考[这里](/apis/app/runtime/testing/cleanup)。

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/model/test-model.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/model/test-model.mdx
@@ -18,7 +18,7 @@ title: 测试 Model
 新增 `count.test.ts` 文件，代码如下：
 
 ```ts
-import { createStore } from '@modern-js/runtime/testing';
+import { createStore } from '@modern-js/plugin-testing/runtime';
 import countModel from './count';
 
 describe('test model', () => {
@@ -36,7 +36,7 @@ describe('test model', () => {
 ```
 
 :::info
-这里使用的 [`createStore`](/apis/app/runtime/model/create-store) 是从 `@modern-js/runtime/testing` 导入的，内部会使用 [`runtime.state`](/configure/app/runtime/state) 的配置去创建 `store`。
+这里使用的 [`createStore`](/apis/app/runtime/model/create-store) 是从 `@modern-js/plugin-testing/runtime` 导入的，内部会使用 [`runtime.state`](/configure/app/runtime/state) 的配置去创建 `store`。
 
 :::
 

--- a/packages/document/module-doc/docs/en/guide/basic/test-your-project.mdx
+++ b/packages/document/module-doc/docs/en/guide/basic/test-your-project.mdx
@@ -79,7 +79,7 @@ npm run test
 
 ### Components
 
-For components, Modern.js's Runtime API provides functionality for testing UI components, which is provided by `@modern-js/runtime/testing`.
+For components, Modern.js's Runtime API provides functionality for testing UI components, which is provided by `@modern-js/plugin-testing/runtime`.
 
 :::tip
 If you need to use the Runtime API, then you can turn it on via [microgenerator](/guide/basic/command-preview).
@@ -97,7 +97,7 @@ export default () => {
 - Then in the test file, we can import source code as the following way. Where `@` points to the source directory, defined in `tests/tsconfig.json` in the initialization project.
 
 ```tsx title="./tests/index.test.tsx"
-import { render, screen } from '@modern-js/runtime/testing';
+import { render, screen } from '@modern-js/plugin-testing/runtime';
 
 import Component from '@/index';
 

--- a/packages/document/module-doc/docs/zh/guide/basic/test-your-project.mdx
+++ b/packages/document/module-doc/docs/zh/guide/basic/test-your-project.mdx
@@ -95,7 +95,7 @@ npm run test
 
 {/* 链接待补充 */}
 
-对于组件，Modern.js 的 Runtime API 提供了用于测试 UI 组件的功能，其功能由 `@modern-js/runtime/testing` 提供。
+对于组件，Modern.js 的 Runtime API 提供了用于测试 UI 组件的功能，其功能由 `@modern-js/plugin-testing/runtime` 提供。
 
 :::tip
 如果需要使用 Runtime API，那么可以通过 [微生成器](/guide/basic/command-preview) 开启。
@@ -112,7 +112,7 @@ export default () => {
 - 然后在测试文件中，我们可以按以下方式引用，其中 `@` 指向了源码目录，在初始化项目的 `tests/tsconfig.json` 的 `paths` 中定义了。
 
 ```tsx title="./tests/index.test.tsx"
-import { render, screen } from '@modern-js/runtime/testing';
+import { render, screen } from '@modern-js/plugin-testing/runtime';
 
 import Component from '@/index';
 

--- a/packages/generator/generator-common/src/mwa/common.ts
+++ b/packages/generator/generator-common/src/mwa/common.ts
@@ -36,8 +36,3 @@ export const getBuildToolsSchema = (
     })),
   };
 };
-
-export const FrameworkAppendTypeContent: Record<Framework, string> = {
-  [Framework.Express]: `/// <reference types='@modern-js/plugin-express/types' />`,
-  [Framework.Koa]: `/// <reference types='@modern-js/plugin-koa/types' />`,
-};

--- a/packages/generator/generator-common/src/newAction/mwa/index.ts
+++ b/packages/generator/generator-common/src/newAction/mwa/index.ts
@@ -142,12 +142,6 @@ export const MWAActionFunctionsDependencies: Partial<
   [ActionFunction.Polyfill]: '@modern-js/plugin-polyfill',
 };
 
-export const MWAActionFunctionsAppendTypeContent: Partial<
-  Record<ActionFunction, string>
-> = {
-  [ActionFunction.MicroFrontend]: `/// <reference types='@modern-js/plugin-garfish/types' />`,
-};
-
 export const MWAActionRefactorDependencies: Partial<
   Record<ActionRefactor, string>
 > = {

--- a/packages/generator/generator-common/src/newAction/mwa/index.ts
+++ b/packages/generator/generator-common/src/newAction/mwa/index.ts
@@ -146,7 +146,6 @@ export const MWAActionFunctionsAppendTypeContent: Partial<
   Record<ActionFunction, string>
 > = {
   [ActionFunction.MicroFrontend]: `/// <reference types='@modern-js/plugin-garfish/types' />`,
-  [ActionFunction.Test]: `/// <reference types='@modern-js/plugin-testing/types' />`,
 };
 
 export const MWAActionRefactorDependencies: Partial<

--- a/packages/generator/generators/bff-generator/src/index.ts
+++ b/packages/generator/generators/bff-generator/src/index.ts
@@ -17,7 +17,6 @@ import {
   i18n as commonI18n,
   Framework,
   Language,
-  FrameworkAppendTypeContent,
   Solution,
   BFFPluginName,
   BFFPluginDependence,
@@ -209,21 +208,6 @@ export const handleTemplateFile = async (
             framework === Framework.Express ? `.${language}` : '',
           ),
     );
-  }
-
-  const appendTypeContent = FrameworkAppendTypeContent[framework as Framework];
-
-  if (appendTypeContent && language === Language.TS) {
-    const typePath = path.join(appDir, 'src', 'modern-app-env.d.ts');
-    if (fs.existsSync(typePath)) {
-      const npmrc = fs.readFileSync(typePath, 'utf-8');
-      if (!npmrc.includes(appendTypeContent)) {
-        fs.writeFileSync(typePath, `${npmrc}${appendTypeContent}\n`, 'utf-8');
-      }
-    } else {
-      fs.ensureFileSync(typePath);
-      fs.writeFileSync(typePath, appendTypeContent, 'utf-8');
-    }
   }
 };
 

--- a/packages/generator/generators/module-generator/templates/ts-template/src/modern-app-env.d.ts.handlebars
+++ b/packages/generator/generators/module-generator/templates/ts-template/src/modern-app-env.d.ts.handlebars
@@ -1,2 +1,1 @@
 /// <reference types='@modern-js/module-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/generator/generators/router-v5-generator/src/index.ts
+++ b/packages/generator/generators/router-v5-generator/src/index.ts
@@ -131,7 +131,7 @@ module.exports = {
       }
       console.info(
         `${i18n.t(localeKeys.successTooltip)} ${chalk.yellow.bold(
-          `@modern-js/runtime/router-v5`,
+          `@modern-js/plugin-router-v5/runtime`,
         )} ${i18n.t(localeKeys.successTooltipSuffix)}`,
       );
     }

--- a/packages/generator/new-action/src/mwa.ts
+++ b/packages/generator/new-action/src/mwa.ts
@@ -7,7 +7,6 @@ import {
   MWAActionReactors,
   ActionFunction,
   MWAActionFunctionsDependencies,
-  MWAActionFunctionsAppendTypeContent,
   MWAActionReactorAppendTypeContent,
   MWAActionFunctionsDevDependencies,
   MWANewActionGenerators,
@@ -161,7 +160,6 @@ export const MWANewAction = async (options: IMWANewActionOption) => {
           }
         : {},
       appendTypeContent:
-        MWAActionFunctionsAppendTypeContent[action as ActionFunction] ||
         MWAActionReactorAppendTypeContent[action as ActionRefactor],
       pluginName: MWANewActionPluginName[actionType][action],
       pluginDependence: MWANewActionPluginDependence[actionType][action],

--- a/packages/runtime/plugin-router-v5/types/index.d.ts
+++ b/packages/runtime/plugin-router-v5/types/index.d.ts
@@ -10,3 +10,9 @@ declare module '@modern-js/runtime' {
     router?: RouterConfig | boolean;
   }
 }
+
+declare module '@modern-js/app-tools' {
+  interface RuntimeUserConfig {
+    router?: Partial<RouterConfig> | boolean;
+  }
+}

--- a/packages/server/plugin-server/src/modern-app-env.d.ts
+++ b/packages/server/plugin-server/src/modern-app-env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types='@modern-js/module-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/server/prod-server/src/modern-app-env.d.ts
+++ b/packages/server/prod-server/src/modern-app-env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types='@modern-js/module-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />

--- a/packages/toolkit/node-bundle-require/src/modern-app-env.d.ts
+++ b/packages/toolkit/node-bundle-require/src/modern-app-env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types='@modern-js/module-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />

--- a/tests/e2e/garfish/fixtures/dashboard-router-v6/src/modern-app-env.d.ts
+++ b/tests/e2e/garfish/fixtures/dashboard-router-v6/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/plugin-testing/type' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/e2e/garfish/fixtures/dashboard/src/App.tsx
+++ b/tests/e2e/garfish/fixtures/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route, Link } from '@modern-js/runtime/router-v5';
+import { Switch, Route, Link } from '@modern-js/plugin-router-v5/runtime';
 import './App.css';
 
 const App = (props: {

--- a/tests/e2e/garfish/fixtures/dashboard/src/modern-app-env.d.ts
+++ b/tests/e2e/garfish/fixtures/dashboard/src/modern-app-env.d.ts
@@ -2,5 +2,4 @@
 /// <reference types='@modern-js/plugin-testing/type' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />
 /// <reference types='@modern-js/plugin-router-v5/types' />

--- a/tests/e2e/garfish/fixtures/main-router-v6/src/modern-app-env.d.ts
+++ b/tests/e2e/garfish/fixtures/main-router-v6/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/plugin-testing/type' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/e2e/garfish/fixtures/main/src/App.tsx
+++ b/tests/e2e/garfish/fixtures/main/src/App.tsx
@@ -1,5 +1,5 @@
 import { useModuleApps } from '@modern-js/plugin-garfish/runtime';
-import { Switch, Route, Link } from '@modern-js/runtime/router-v5';
+import { Switch, Route, Link } from '@modern-js/plugin-router-v5/runtime';
 import DashboardButton from 'dashboardApp/share-button';
 import './App.css';
 

--- a/tests/e2e/garfish/fixtures/main/src/App.tsx
+++ b/tests/e2e/garfish/fixtures/main/src/App.tsx
@@ -1,4 +1,4 @@
-import { useModuleApps } from '@modern-js/runtime/garfish';
+import { useModuleApps } from '@modern-js/plugin-garfish/runtime';
 import { Switch, Route, Link } from '@modern-js/runtime/router-v5';
 import DashboardButton from 'dashboardApp/share-button';
 import './App.css';

--- a/tests/e2e/garfish/fixtures/main/src/modern-app-env.d.ts
+++ b/tests/e2e/garfish/fixtures/main/src/modern-app-env.d.ts
@@ -1,8 +1,6 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/plugin-testing/type' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />
 /// <reference types='@modern-js/plugin-router-v5/types' />
 
 declare module 'dashboardApp/share-button' {

--- a/tests/e2e/garfish/fixtures/table/src/App.tsx
+++ b/tests/e2e/garfish/fixtures/table/src/App.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route } from '@modern-js/runtime/router-v5';
+import { Switch, Route } from '@modern-js/plugin-router-v5/runtime';
 import './App.css';
 
 const App = () => (

--- a/tests/e2e/garfish/fixtures/table/src/modern-app-env.d.ts
+++ b/tests/e2e/garfish/fixtures/table/src/modern-app-env.d.ts
@@ -1,6 +1,4 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/plugin-testing/type' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />
 /// <reference types='@modern-js/plugin-router-v5/types' />

--- a/tests/integration/api-service-koa/api/context/index.ts
+++ b/tests/integration/api-service-koa/api/context/index.ts
@@ -1,4 +1,4 @@
-import { useContext } from '@modern-js/runtime/koa';
+import { useContext } from '@modern-js/plugin-koa/runtime';
 
 export const get = async () => {
   const ctx = useContext();

--- a/tests/integration/api-service-koa/api/modern-app-env.d.ts
+++ b/tests/integration/api-service-koa/api/modern-app-env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/api-service-koa/api/modern-app-env.d.ts
+++ b/tests/integration/api-service-koa/api/modern-app-env.d.ts
@@ -1,3 +1,2 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/api-service-koa/api/tests/index.test.ts
+++ b/tests/integration/api-service-koa/api/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { testBff } from '@modern-js/runtime/testing/bff';
+import { testBff } from '@modern-js/plugin-testing/bff';
 
 describe('basic usage', () => {
   it('should support get', async () => {

--- a/tests/integration/api-service-koa/api/tests/mock-context.test.ts
+++ b/tests/integration/api-service-koa/api/tests/mock-context.test.ts
@@ -1,4 +1,4 @@
-jest.mock('@modern-js/runtime/koa', () => {
+jest.mock('@modern-js/plugin-koa/runtime', () => {
   return {
     __esModule: true,
     useContext: jest.fn(() => ({

--- a/tests/integration/app-document/src/differentProperities/pages/index.tsx
+++ b/tests/integration/app-document/src/differentProperities/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@modern-js/runtime/router-v5';
+import { Link } from '@modern-js/plugin-router-v5/runtime';
 
 const App = () => (
   <>

--- a/tests/integration/app-document/src/sub/App.tsx
+++ b/tests/integration/app-document/src/sub/App.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@modern-js/runtime/router-v5';
+import { Link } from '@modern-js/plugin-router-v5/runtime';
 
 const App = () => (
   <>

--- a/tests/integration/app-document/src/sub/pages/a/index.tsx
+++ b/tests/integration/app-document/src/sub/pages/a/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@modern-js/runtime/router-v5';
+import { Link } from '@modern-js/plugin-router-v5/runtime';
 import './a.less';
 
 export default function A() {

--- a/tests/integration/app-document/src/sub/pages/b/index.tsx
+++ b/tests/integration/app-document/src/sub/pages/b/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@modern-js/runtime/router-v5';
+import { Link } from '@modern-js/plugin-router-v5/runtime';
 
 export default function B() {
   return (

--- a/tests/integration/app-document/src/sub/pages/index.tsx
+++ b/tests/integration/app-document/src/sub/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@modern-js/runtime/router-v5';
+import { Link } from '@modern-js/plugin-router-v5/runtime';
 
 const App = () => (
   <>

--- a/tests/integration/basic-app/src/modern-app-env.d.ts
+++ b/tests/integration/basic-app/src/modern-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/basic-app/src/modern-app-env.d.ts
+++ b/tests/integration/basic-app/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/bff-express/src/modern-app-env.d.ts
+++ b/tests/integration/bff-express/src/modern-app-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-micro-frontend/type' />
 /// <reference types='@modern-js/plugin-bff/types' />
 /// <reference types='@modern-js/plugin-express/types' />

--- a/tests/integration/bff-koa/api/info.ts
+++ b/tests/integration/bff-koa/api/info.ts
@@ -1,4 +1,4 @@
-import { useContext } from '@modern-js/runtime/koa';
+import { useContext } from '@modern-js/plugin-koa/runtime';
 
 export const get = () => {
   const context = useContext();

--- a/tests/integration/bff-koa/src/modern-app-env.d.ts
+++ b/tests/integration/bff-koa/src/modern-app-env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types='@modern-js/app-tools/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/bff-koa/src/modern-app-env.d.ts
+++ b/tests/integration/bff-koa/src/modern-app-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/bff-koa/src/routes/page.loader.ts
+++ b/tests/integration/bff-koa/src/routes/page.loader.ts
@@ -1,5 +1,5 @@
 import { defer } from '@modern-js/runtime/router';
-import { useContext } from '@modern-js/plugin-koa/runtime';
+import { useContext } from '@modern-js/runtime/koa';
 
 interface User {
   name: string;

--- a/tests/integration/bff-koa/src/routes/page.loader.ts
+++ b/tests/integration/bff-koa/src/routes/page.loader.ts
@@ -1,5 +1,5 @@
 import { defer } from '@modern-js/runtime/router';
-import { useContext } from '@modern-js/runtime/koa';
+import { useContext } from '@modern-js/plugin-koa/runtime';
 
 interface User {
   name: string;

--- a/tests/integration/main-entry-name/src/modern-app-env.d.ts
+++ b/tests/integration/main-entry-name/src/modern-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/main-entry-name/src/modern-app-env.d.ts
+++ b/tests/integration/main-entry-name/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/nonce/src/modern-app-env.d.ts
+++ b/tests/integration/nonce/src/modern-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/nonce/src/modern-app-env.d.ts
+++ b/tests/integration/nonce/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/routes/src/modern-app-env.d.ts
+++ b/tests/integration/routes/src/modern-app-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/routes/src/modern-app-env.d.ts
+++ b/tests/integration/routes/src/modern-app-env.d.ts
@@ -2,5 +2,3 @@
 /// <reference types='@modern-js/runtime/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/runtime/fixtures/file-based-router/src/home/pages/_app.jsx
+++ b/tests/integration/runtime/fixtures/file-based-router/src/home/pages/_app.jsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import { Link } from '@modern-js/runtime/router-v5';
+import { Link } from '@modern-js/plugin-router-v5/runtime';
 
 const App = ({ Component, ...pageProps }) => {
   return (

--- a/tests/integration/runtime/fixtures/file-based-router/src/home/pages/users/[userName]/index.jsx
+++ b/tests/integration/runtime/fixtures/file-based-router/src/home/pages/users/[userName]/index.jsx
@@ -1,4 +1,4 @@
-import { useParams } from '@modern-js/runtime/router-v5';
+import { useParams } from '@modern-js/plugin-router-v5/runtime';
 
 export default () => {
   const params = useParams();

--- a/tests/integration/server-config/src/modern-app-env.d.ts
+++ b/tests/integration/server-config/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/plugin-testing/type' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/source-code-build/app-ts-loader/src/modern-app-env.d.ts
+++ b/tests/integration/source-code-build/app-ts-loader/src/modern-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/source-code-build/app-ts-loader/src/modern-app-env.d.ts
+++ b/tests/integration/source-code-build/app-ts-loader/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/source-code-build/app/src/modern-app-env.d.ts
+++ b/tests/integration/source-code-build/app/src/modern-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/source-code-build/app/src/modern-app-env.d.ts
+++ b/tests/integration/source-code-build/app/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/temp-dir/src/modern-app-env.d.ts
+++ b/tests/integration/temp-dir/src/modern-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/temp-dir/src/modern-app-env.d.ts
+++ b/tests/integration/temp-dir/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/write-to-dist/src/modern-app-env.d.ts
+++ b/tests/integration/write-to-dist/src/modern-app-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
-/// <reference types='@modern-js/plugin-testing/types' />
 /// <reference types='@modern-js/plugin-garfish/type' />
 /// <reference types='@modern-js/plugin-express/types' />
 /// <reference types='@modern-js/plugin-koa/types' />

--- a/tests/integration/write-to-dist/src/modern-app-env.d.ts
+++ b/tests/integration/write-to-dist/src/modern-app-env.d.ts
@@ -1,5 +1,3 @@
 /// <reference types='@modern-js/app-tools/types' />
 /// <reference types='@modern-js/runtime/types/router' />
 /// <reference types='@modern-js/plugin-garfish/type' />
-/// <reference types='@modern-js/plugin-express/types' />
-/// <reference types='@modern-js/plugin-koa/types' />


### PR DESCRIPTION
## Summary

For the runtime plugin of Modern.js, it is recommended to use the `@modern-js/plugin-xx/runtime` path directly, remove the added reference configuration after enabling the function each time, and avoid the problem of not finding the `@modern-js/runtime/**` path.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
