### PR TITLE
CI: should run more tests when branch is feat-update-rsbuild-*

### DIFF
--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -4,7 +4,7 @@ name: Integration Test(Linux)
 on:
   # Triggers the workflow on pull request events but only for the main branch
   push:
-    branches: [main, feat-update-rsbuild-version]
+    branches: [main, feat-update-rsbuild-*]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -4,7 +4,7 @@ name: Integration Test(Windows)
 on:
   # Triggers the workflow on pull request events but only for the main branch
   push:
-    branches: [main, feat-update-rsbuild-version]
+    branches: [main, feat-update-rsbuild-*]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -2,7 +2,7 @@ name: E2E Test (Builder)
 
 on:
   push:
-    branches: [main, update-rspack-**]
+    branches: [main, feat-update-rsbuild-*]
 
   workflow_dispatch:
 

--- a/.github/workflows/test-garfish-e2e.yml
+++ b/.github/workflows/test-garfish-e2e.yml
@@ -2,7 +2,7 @@ name: E2E Test (Garfish)
 
 on:
   push:
-    branches: [main]
+    branches: [main, feat-update-rsbuild-*]
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

When we update the rsbuild version we want to run more tests, so we can find some bugs early.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
