### PR TITLE
docs: remove getCompiledPath of builder

### DIFF
--- a/packages/document/builder-doc/docs/en/api/plugin-hooks.mdx
+++ b/packages/document/builder-doc/docs/en/api/plugin-hooks.mdx
@@ -137,8 +137,7 @@ type ModifyWebpackChainUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
-  getCompiledPath: (name: string) => string;
-  HtmlWebpackPlugin: typeof import('html-webpack-plugin');
+  HtmlPlugin: typeof import('html-webpack-plugin');
 };
 
 function ModifyWebpackChain(
@@ -180,8 +179,7 @@ type ModifyWebpackConfigUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
-  getCompiledPath: (name: string) => string;
-  HtmlWebpackPlugin: typeof import('html-webpack-plugin');
+  HtmlPlugin: typeof import('html-webpack-plugin');
   addRules: (rules: RuleSetRule | RuleSetRule[]) => void;
   prependPlugins: (
     plugins: WebpackPluginInstance | WebpackPluginInstance[],
@@ -227,7 +225,6 @@ type ModifyRspackConfigUtils = {
   target: BuilderTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  getCompiledPath: (name: string) => string;
   rspack: typeof import('@rspack/core');
 };
 

--- a/packages/document/builder-doc/docs/en/config/tools/rspack.md
+++ b/packages/document/builder-doc/docs/en/config/tools/rspack.md
@@ -268,32 +268,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **Type:** `(name: string) => string`
-
-Get the path to the builder built-in dependencies, such as:
-
-- sass
-- sass-loader
-- less
-- less-loader
-- ...
-
-This method is usually used when you need to reuse the same dependency with the builder.
-
-:::tip
-Builder built-in dependencies are subject to change with version iterations, e.g. generate large version break changes. Please avoid using this API if it is not necessary.
-:::
-
-```js
-export default {
-  tools: {
-    rspack: (config, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```

--- a/packages/document/builder-doc/docs/en/config/tools/webpack.md
+++ b/packages/document/builder-doc/docs/en/config/tools/webpack.md
@@ -294,9 +294,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **Type:** `(name: string) => string`
-
-Get the path to the builder built-in dependencies, same as [webpackChain#getCompiledPath](https://modernjs.dev/builder/en/api/config-tools.html#toolswebpackchain).

--- a/packages/document/builder-doc/docs/en/config/tools/webpackChain.md
+++ b/packages/document/builder-doc/docs/en/config/tools/webpackChain.md
@@ -132,36 +132,6 @@ export default {
 };
 ```
 
-#### getCompiledPath
-
-- **Type:** `(name: string) => string`
-
-Get the path to the builder built-in dependencies, such as:
-
-- sass
-- sass-loader
-- less
-- less-loader
-- css-loader
-- ...
-
-This method is usually used when you need to reuse the same dependency with the builder.
-
-:::tip
-Builder built-in dependencies are subject to change with version iterations, e.g. generate large version break changes. Please avoid using this API if it is not necessary.
-:::
-
-```js
-export default {
-  tools: {
-    webpackChain: (chain, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```
-
 #### CHAIN_ID
 
 Some common Chain IDs are predefined in the Builder, and you can use these IDs to locate the built-in Rule or Plugin.

--- a/packages/document/builder-doc/docs/zh/api/plugin-hooks.mdx
+++ b/packages/document/builder-doc/docs/zh/api/plugin-hooks.mdx
@@ -140,8 +140,7 @@ type ModifyWebpackChainUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
-  getCompiledPath: (name: string) => string;
-  HtmlWebpackPlugin: typeof import('html-webpack-plugin');
+  HtmlPlugin: typeof import('html-webpack-plugin');
 };
 
 function ModifyWebpackChain(
@@ -183,8 +182,7 @@ type ModifyWebpackConfigUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
-  getCompiledPath: (name: string) => string;
-  HtmlWebpackPlugin: typeof import('html-webpack-plugin');
+  HtmlPlugin: typeof import('html-webpack-plugin');
   addRules: (rules: RuleSetRule | RuleSetRule[]) => void;
   prependPlugins: (
     plugins: WebpackPluginInstance | WebpackPluginInstance[],
@@ -230,7 +228,6 @@ type ModifyRspackConfigUtils = {
   target: BuilderTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  getCompiledPath: (name: string) => string;
   rspack: typeof import('@rspack/core');
 };
 

--- a/packages/document/builder-doc/docs/zh/config/tools/rspack.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/rspack.md
@@ -268,32 +268,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **类型：** `(name: string) => string`
-
-获取 builder 内置依赖的所在路径，例如：
-
-- sass
-- sass-loader
-- less
-- less-loader
-- ...
-
-该方法通常在需要与 builder 复用同一份依赖时会被用到。
-
-:::tip
-Builder 内部依赖会随着版本迭代而发生变化，例如产生大版本变更。在非必要的情况下，请避免使用此 API。
-:::
-
-```js
-export default {
-  tools: {
-    rspack: (config, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```

--- a/packages/document/builder-doc/docs/zh/config/tools/webpack.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/webpack.md
@@ -294,9 +294,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **类型：** `(name: string) => string`
-
-获取 builder 内置依赖的所在路径，等价于 [webpackChain#getCompiledPath](https://modernjs.dev/builder/api/config-tools.html#toolswebpackchain)。

--- a/packages/document/builder-doc/docs/zh/config/tools/webpackChain.md
+++ b/packages/document/builder-doc/docs/zh/config/tools/webpackChain.md
@@ -135,36 +135,6 @@ export default {
 };
 ```
 
-#### getCompiledPath
-
-- **类型：** `(name: string) => string`
-
-获取 builder 内置依赖的所在路径，例如：
-
-- sass
-- sass-loader
-- less
-- less-loader
-- css-loader
-- ...
-
-该方法通常在需要与 builder 复用同一份依赖时会被用到。
-
-:::tip
-Builder 内部依赖会随着版本迭代而发生变化，例如产生大版本变更。在非必要的情况下，请避免使用此 API。
-:::
-
-```js
-export default {
-  tools: {
-    webpackChain: (chain, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```
-
 #### CHAIN_ID
 
 Builder 中预先定义了一些常用的 Chain ID，你可以通过这些 ID 来定位到内置的 Rule 或 Plugin。


### PR DESCRIPTION
## Summary

`getCompiledPath` is a deprecated API of Rsbuild, we do not want users to depend on the internal packages of Rsbuild.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
