### PR TITLE
feat(devtools): highlight active storage presets

### DIFF
--- a/packages/devtools/client/src/components/Error/Fallback.tsx
+++ b/packages/devtools/client/src/components/Error/Fallback.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FallbackProps } from 'react-error-boundary';
 import { useRouteError } from '@modern-js/runtime/router';
 import { Box, Heading, Text, TextArea } from '@radix-ui/themes';
@@ -28,5 +28,10 @@ export const ErrorFallback: React.FC<ErrorFallbackProps> = props => {
 
 export const ErrorRouteHandler: React.FC = () => {
   const error = useRouteError();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
   return <ErrorFallback resetErrorBoundary={() => null} error={error} />;
 };

--- a/packages/devtools/client/src/entries/client/routes/state.tsx
+++ b/packages/devtools/client/src/entries/client/routes/state.tsx
@@ -37,7 +37,7 @@ export const $mountPoint = $mountPointChannel.then(async channel => {
   };
   const remote = createBirpc<MountPointFunctions, ToMountPointFunctions>(
     definitions,
-    { ...channel.handlers, timeout: 500 },
+    { ...channel.handlers, timeout: 8_000 },
   );
   return { remote, hooks };
 });

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.data.ts
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.data.ts
@@ -1,0 +1,16 @@
+import { LoaderFunctionArgs, redirect } from '@modern-js/runtime/router';
+import _ from 'lodash';
+import { $serverExported } from '../../../state';
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const { id } = params;
+  if (!id) throw new TypeError('storage preset id is required');
+  const { context } = await Promise.resolve($serverExported);
+  const { storagePresets } = await Promise.resolve(context);
+  const preset = _.find(storagePresets, { id });
+  if (preset) {
+    return preset;
+  } else {
+    return redirect('/storage/preset');
+  }
+};

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
@@ -1,15 +1,17 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import {
   HiMiniClipboard,
   HiMiniClipboardDocumentList,
   HiMiniFolderOpen,
   HiMiniFire,
 } from 'react-icons/hi2';
-import { useParams, useRevalidator } from '@modern-js/runtime/router';
+import { useLoaderData, useRevalidator } from '@modern-js/runtime/router';
 import { Badge, Box, Flex, IconButton, Text, Tooltip } from '@radix-ui/themes';
-import _ from 'lodash';
-import { useSnapshot } from 'valtio';
-import { StoragePresetWithIdent } from '@modern-js/devtools-kit/runtime';
+import {
+  StoragePresetContext,
+  StoragePresetWithIdent,
+} from '@modern-js/devtools-kit/runtime';
+import { subscribe } from 'valtio';
 import type { FlexProps } from '@radix-ui/themes/dist/cjs/components/flex';
 import type { BadgeProps } from '@radix-ui/themes/dist/cjs/components/badge';
 import {
@@ -106,12 +108,12 @@ const PresetRecordsCard: FC<PresetRecordsCardProps> = props => {
 };
 
 const Page = () => {
-  const { id } = useParams();
-  if (!id) throw new TypeError('storage preset id is required');
   const { revalidate } = useRevalidator();
-  const { storagePresets } = useSnapshot($serverExported).context;
-  const preset = _.find(storagePresets, { id });
-  if (!preset) throw new TypeError('storage preset not found');
+  useEffect(() => {
+    const unwatch = subscribe($serverExported, revalidate);
+    return unwatch;
+  }, []);
+  const preset = useLoaderData() as StoragePresetContext;
   const unwindRecords = [
     ...unwindRecord(preset, 'cookie'),
     ...unwindRecord(preset, 'localStorage'),

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
@@ -5,7 +5,7 @@ import {
   HiMiniFolderOpen,
   HiMiniFire,
 } from 'react-icons/hi2';
-import { useParams } from '@modern-js/runtime/router';
+import { useParams, useRevalidator } from '@modern-js/runtime/router';
 import { Badge, Box, Flex, IconButton, Text, Tooltip } from '@radix-ui/themes';
 import _ from 'lodash';
 import { useSnapshot } from 'valtio';
@@ -108,6 +108,7 @@ const PresetRecordsCard: FC<PresetRecordsCardProps> = props => {
 const Page = () => {
   const { id } = useParams();
   if (!id) throw new TypeError('storage preset id is required');
+  const { revalidate } = useRevalidator();
   const { storagePresets } = useSnapshot($serverExported).context;
   const preset = _.find(storagePresets, { id });
   if (!preset) throw new TypeError('storage preset not found');
@@ -125,6 +126,7 @@ const Page = () => {
   const handleApplyAction = async () => {
     await applyPreset(preset);
     applyActionToast.open();
+    revalidate();
   };
 
   const handleCopyAction = async () => {

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
@@ -41,22 +41,22 @@ const PresetToolbar: FC<PresetToolbarProps> = props => {
 
   return (
     <Flex position="relative" gap="3" height="5" align="center" {...rest}>
-      <Tooltip content="Copy as Data URL">
+      <Tooltip content="Copy as Data URL" delayDuration={200}>
         <IconButton onClick={onCopyAction} variant="ghost" color="gray">
           <HiMiniClipboard />
         </IconButton>
       </Tooltip>
-      <Tooltip content="Paste from Data URL">
+      <Tooltip content="Paste from Data URL" delayDuration={200}>
         <IconButton onClick={onPasteAction} variant="ghost" color="gray">
           <HiMiniClipboardDocumentList />
         </IconButton>
       </Tooltip>
-      <Tooltip content="Open File">
+      <Tooltip content="Open File" delayDuration={200}>
         <IconButton onClick={onOpenAction} variant="ghost" color="gray">
           <HiMiniFolderOpen />
         </IconButton>
       </Tooltip>
-      <Tooltip content="Apply Preset">
+      <Tooltip content="Apply Preset" delayDuration={200}>
         <IconButton onClick={onApplyAction} variant="ghost" color="gray">
           <HiMiniFire />
         </IconButton>

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/layout.data.ts
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/layout.data.ts
@@ -1,0 +1,8 @@
+import { ActionFunction, LoaderFunctionArgs } from '@modern-js/runtime/router';
+import { applyStorage } from './shared';
+
+export const loader = async (_args: LoaderFunctionArgs) => {
+  return await applyStorage();
+};
+
+export const action: ActionFunction = () => null;

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/shared.ts
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/shared.ts
@@ -1,4 +1,7 @@
-import { StoragePresetWithIdent } from '@modern-js/devtools-kit/runtime';
+import {
+  StoragePresetContext,
+  StoragePresetWithIdent,
+} from '@modern-js/devtools-kit/runtime';
 import _ from 'lodash';
 import { $mountPoint } from '../../state';
 
@@ -40,7 +43,7 @@ export const unwindPreset = (preset: StoragePresetWithIdent) => {
   return ret;
 };
 
-export interface UnwindPreset {
+export interface UnwindPreset extends StoragePresetContext {
   id: string;
   name: string;
   filename: string;


### PR DESCRIPTION
## Summary

![image](https://github.com/web-infra-dev/modern.js/assets/18379948/7c488b71-92a6-4fde-b177-39b765906cb6)

- Highlight active storage presets (by comparing key-value records).
- Fallback and redirect to `/storage/preset` when delete the current preset and route `/storage/preset/{id}`.
- Reduce the `delayDuration` of display to tooltip component.

Pending by https://github.com/web-infra-dev/modern.js/pull/5748.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
