### PR TITLE
fix: correct check-syntax test case script

### DIFF
--- a/tests/e2e/builder/cases/check-syntax/index.test.ts
+++ b/tests/e2e/builder/cases/check-syntax/index.test.ts
@@ -8,11 +8,6 @@ function getCommonBuildConfig(cwd: string): RsbuildConfig {
     source: {
       exclude: [path.resolve(cwd, './src/test.js')],
     },
-    tools: {
-      rspack: config => {
-        config.target = ['web'];
-      },
-    },
   };
 }
 


### PR DESCRIPTION
## Summary

When we only specify Rspack target "web", the builder runtime code does not degrade.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
