### PR TITLE
feat(devtools): migrate to `@radix-ui/themes@3`

### DIFF
--- a/packages/devtools/client/package.json
+++ b/packages/devtools/client/package.json
@@ -41,7 +41,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-tabs": "^1.0.4",
-    "@radix-ui/themes": "^2.0.0",
+    "@radix-ui/themes": "^3.0.5",
     "@scripts/jest-config": "workspace:*",
     "@rsbuild/core": "0.6.13",
     "@types/jest": "^29",

--- a/packages/devtools/client/src/components/Breadcrumbs.tsx
+++ b/packages/devtools/client/src/components/Breadcrumbs.tsx
@@ -103,7 +103,7 @@ export const Breadcrumbs: React.FC<BreadcrumbProps> = props => {
     }
   }
   return (
-    <Flex align="center" height="8" gap="1" px="4" {...props}>
+    <Flex align="center" height="var(--space-8)" gap="1" px="4" {...props}>
       {elements}
     </Flex>
   );

--- a/packages/devtools/client/src/components/Devtools/Capsule.tsx
+++ b/packages/devtools/client/src/components/Devtools/Capsule.tsx
@@ -81,7 +81,12 @@ export const DevtoolsCapsule: React.FC<SetupClientParams> = props => {
   }, []);
 
   return (
-    <Theme appearance={appearance} className={appearance} hasBackground={false}>
+    <Theme
+      appearance={appearance}
+      className={appearance}
+      hasBackground={false}
+      style={{ height: 0, width: 0, minHeight: 0, minWidth: 0 }}
+    >
       <Visible when={showDevtools} keepAlive={true} load={loadDevtools}>
         <div className={styles.container}>
           <FrameBox

--- a/packages/devtools/client/src/components/Devtools/Capsule.tsx
+++ b/packages/devtools/client/src/components/Devtools/Capsule.tsx
@@ -12,6 +12,7 @@ import { useStickyDraggable } from '@/utils/draggable';
 import { $client, wallAgent } from '@/entries/mount/state';
 import { pTimeout } from '@/utils/promise';
 import { ReactDevtoolsWallListener } from '@/utils/react-devtools';
+import { useThemeAppearance } from '@/utils/theme';
 
 const parseDeepLink = (url = window.location) => {
   // Expected: #/__devtools/doctor
@@ -34,17 +35,7 @@ export const DevtoolsCapsule: React.FC<SetupClientParams> = props => {
 
   const draggable = useStickyDraggable({ clamp: true });
 
-  const [appearance, setAppearance] = useState<'light' | 'dark'>(() => {
-    const ret =
-      localStorage.getItem('__modern_js_devtools_appearance') ?? 'light';
-    localStorage.setItem('__modern_js_devtools_appearance', ret);
-    return ret as any;
-  });
-  useEvent('storage', (e: StorageEvent) => {
-    if (e.key === '__modern_js_devtools_appearance') {
-      setAppearance((e.newValue as any) || undefined);
-    }
-  });
+  const [appearance] = useThemeAppearance();
 
   useEvent('keydown', (e: KeyboardEvent) => {
     e.shiftKey && e.altKey && e.code === 'KeyD' && toggleDevtools();
@@ -90,7 +81,7 @@ export const DevtoolsCapsule: React.FC<SetupClientParams> = props => {
   }, []);
 
   return (
-    <Theme appearance={appearance} className={appearance}>
+    <Theme appearance={appearance} className={appearance} hasBackground={false}>
       <Visible when={showDevtools} keepAlive={true} load={loadDevtools}>
         <div className={styles.container}>
           <FrameBox

--- a/packages/devtools/client/src/components/Devtools/FrameBox.tsx
+++ b/packages/devtools/client/src/components/Devtools/FrameBox.tsx
@@ -1,5 +1,4 @@
-import { Box } from '@radix-ui/themes';
-import type { BoxProps } from '@radix-ui/themes/dist/cjs/components/box';
+import { Box, BoxProps } from '@radix-ui/themes';
 import React from 'react';
 import { HiMiniXMark } from 'react-icons/hi2';
 import { useSnapshot } from 'valtio';
@@ -7,12 +6,10 @@ import { Loading } from '../Loading';
 import styles from './FrameBox.module.scss';
 import { $inner } from '@/entries/mount/state';
 
-export interface FrameBoxProps
-  extends BoxProps,
-    React.RefAttributes<HTMLDivElement> {
+export type FrameBoxProps = BoxProps & {
   src?: string;
   onClose?: () => void;
-}
+};
 
 export const FrameBox: React.FC<FrameBoxProps> = ({
   src,

--- a/packages/devtools/client/src/components/Error/FeatureDisabled.tsx
+++ b/packages/devtools/client/src/components/Error/FeatureDisabled.tsx
@@ -11,11 +11,11 @@ export const FeatureDisabled: React.FC<FeatureDisabledProps> = props => {
   const { title, children } = props;
   return (
     <Flex className={styles.container} mt="9" mx="auto" gap="2">
-      <Flex height="9" align="center">
+      <Flex height="var(--space-9)" align="center">
         <HiExclamationCircle size="36" />
       </Flex>
       <Box>
-        <Flex height="9" align="center">
+        <Flex height="var(--space-9)" align="center">
           <Heading>{title}</Heading>
         </Flex>
         <Box className={styles.children}>{children}</Box>

--- a/packages/devtools/client/src/components/NavLink.tsx
+++ b/packages/devtools/client/src/components/NavLink.tsx
@@ -3,15 +3,16 @@ import {
   NavLinkProps as RouterNavLinkProps,
 } from '@modern-js/runtime/router';
 import { Link as BaseLink } from '@radix-ui/themes';
-import type { LinkProps as BaseLinkProps } from '@radix-ui/themes/dist/esm/components/link';
+import type { LinkProps as BaseLinkProps } from '@radix-ui/themes';
 import React from 'react';
 
-// @ts-expect-error
-export interface NavLinkProps extends RouterNavLinkProps, BaseLinkProps {}
+export type NavLinkProps = RouterNavLinkProps &
+  BaseLinkProps &
+  React.RefAttributes<HTMLAnchorElement>;
 
 export const NavLink: React.FC<NavLinkProps> = React.forwardRef(
   ({ to, children, ...props }, ref) => (
-    <BaseLink {...(props as any)} asChild>
+    <BaseLink {...props} asChild>
       <RouterNavLink ref={ref} to={to}>
         {children}
       </RouterNavLink>

--- a/packages/devtools/client/src/components/PairsEditor/Editor.tsx
+++ b/packages/devtools/client/src/components/PairsEditor/Editor.tsx
@@ -1,5 +1,4 @@
-import { Box } from '@radix-ui/themes';
-import type { BoxProps } from '@radix-ui/themes/dist/cjs/components/box';
+import { Box, BoxProps } from '@radix-ui/themes';
 import { nanoid } from 'nanoid';
 import React, { useEffect } from 'react';
 import { proxy, useSnapshot } from 'valtio';
@@ -7,11 +6,11 @@ import styles from './Editor.module.scss';
 import { Pair } from './Pair';
 import { PairModel } from './types';
 
-export interface PairsEditorProps extends BoxProps {
+export type PairsEditorProps = BoxProps & {
   $data?: PairModel[];
   disabled?: boolean;
   placeholders?: [string, string];
-}
+};
 
 export const PairsEditor: React.FC<PairsEditorProps> = ({
   $data = proxy([]),

--- a/packages/devtools/client/src/components/PairsEditor/Pair.tsx
+++ b/packages/devtools/client/src/components/PairsEditor/Pair.tsx
@@ -24,23 +24,19 @@ export const Pair: React.FC<PairProps> = ({
 
   return (
     <Box key={data.id} className={styles.inputPair} aria-disabled={disabled}>
-      <TextField.Root>
-        <TextField.Input
-          value={data.key}
+      <TextField.Root
+        value={data.key}
+        disabled={disabled}
+        placeholder={placeholders[0]}
+        onChange={e => ($data.key = e.currentTarget.value)}
+      />
+      <Box asChild flexGrow="1">
+        <TextField.Root
+          value={data.value}
           disabled={disabled}
-          placeholder={placeholders[0]}
-          onChange={e => ($data.key = e.currentTarget.value)}
+          placeholder={placeholders[1]}
+          onChange={e => ($data.value = e.currentTarget.value)}
         />
-      </TextField.Root>
-      <Box asChild grow="1">
-        <TextField.Root>
-          <TextField.Input
-            value={data.value}
-            disabled={disabled}
-            placeholder={placeholders[1]}
-            onChange={e => ($data.value = e.currentTarget.value)}
-          />
-        </TextField.Root>
       </Box>
       <Box className={styles.actions}>
         <IconButton variant="ghost" color="gray" onClick={onDelete}>

--- a/packages/devtools/client/src/components/ServerRoute/Base.tsx
+++ b/packages/devtools/client/src/components/ServerRoute/Base.tsx
@@ -40,7 +40,7 @@ export const BaseRoute: React.FC<BaseRouteProps> = ({
           >
             {title}
           </Text>
-          <Box grow="1" />
+          <Box flexGrow="1" />
           <Box className={styles.mark} data-open={isOpen}>
             <CaretSortIcon />
           </Box>

--- a/packages/devtools/client/src/components/Theme.tsx
+++ b/packages/devtools/client/src/components/Theme.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
-import { Theme as OriginalTheme, useThemeContext } from '@radix-ui/themes';
-import type { ThemeProps } from '@radix-ui/themes/dist/cjs/theme';
+import {
+  Theme as OriginalTheme,
+  ThemeProps,
+  useThemeContext,
+} from '@radix-ui/themes';
 import { getQuery } from 'ufo';
 import _ from 'lodash';
 

--- a/packages/devtools/client/src/components/Theme.tsx
+++ b/packages/devtools/client/src/components/Theme.tsx
@@ -1,41 +1,18 @@
 import React, { useEffect } from 'react';
-import {
-  Theme as OriginalTheme,
-  ThemeProps,
-  useThemeContext,
-} from '@radix-ui/themes';
-import { getQuery } from 'ufo';
-import _ from 'lodash';
-
-const isAppearance = (value: string): value is 'inherit' | 'light' | 'dark' =>
-  ['inherit', 'light', 'dark'].includes(value);
-
-const ThemeGuard: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const { appearance } = useThemeContext();
-  useEffect(() => {
-    localStorage.setItem('__modern_js_devtools_appearance', appearance);
-    if (appearance !== 'inherit') {
-      document.documentElement.classList.remove('dark', 'light');
-      document.documentElement.classList.add(appearance);
-    }
-  }, [appearance]);
-  return <>{children}</>;
-};
+import { Theme as OriginalTheme, ThemeProps } from '@radix-ui/themes';
+import { useThemeAppearance } from '@/utils/theme';
 
 export const Theme: React.FC<
   ThemeProps & React.RefAttributes<HTMLDivElement>
-> = ({ appearance, children, ...props }) => {
-  const initialAppearance =
-    appearance ||
-    _.castArray(getQuery(location.href).appearance)[0] ||
-    localStorage.getItem('__modern_js_devtools_appearance') ||
-    'light';
-  if (!isAppearance(initialAppearance)) {
-    throw new Error('Initial appearance value is invalid.');
-  }
+> = ({ children, ...props }) => {
+  const [appearance] = useThemeAppearance();
+  useEffect(() => {
+    document.documentElement.classList.remove('dark', 'light');
+    document.documentElement.classList.add(appearance);
+  }, [appearance]);
   return (
-    <OriginalTheme {...props} appearance={initialAppearance}>
-      <ThemeGuard>{children}</ThemeGuard>
+    <OriginalTheme {...props} appearance={appearance}>
+      {children}
     </OriginalTheme>
   );
 };

--- a/packages/devtools/client/src/components/Toast.tsx
+++ b/packages/devtools/client/src/components/Toast.tsx
@@ -21,7 +21,7 @@ export const Toast: FC<ToastProps> = props => {
           {children}
         </ToastPrimitive.Action>
       )}
-      <Box grow="1" />
+      <Box flexGrow="1" />
       <ToastPrimitive.Close className={styles.close} aria-label="Close">
         <HiMiniXMark />
       </ToastPrimitive.Close>

--- a/packages/devtools/client/src/entries/client/routes/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/layout.tsx
@@ -2,13 +2,7 @@ import '@/styles/theme.scss';
 import React, { useEffect } from 'react';
 import * as ToastPrimitive from '@radix-ui/react-toast';
 import { NavLink, Outlet } from '@modern-js/runtime/router';
-import {
-  Box,
-  Flex,
-  ThemePanel,
-  Tooltip,
-  useThemeContext,
-} from '@radix-ui/themes';
+import { Box, Flex, Tooltip } from '@radix-ui/themes';
 import { HiOutlineMoon, HiOutlineSun } from 'react-icons/hi2';
 import { Tab } from '@modern-js/devtools-kit/runtime';
 import { useSnapshot } from 'valtio';
@@ -17,6 +11,7 @@ import { $tabs } from './state';
 import { Theme } from '@/components/Theme';
 import { Breadcrumbs } from '@/components/Breadcrumbs';
 import { Puller } from '@/components/Devtools/Puller';
+import { useThemeAppearance } from '@/utils/theme';
 
 const NavigateButton: React.FC<{ tab: Tab }> = ({ tab }) => {
   let to = '';
@@ -53,10 +48,10 @@ const NavigateButton: React.FC<{ tab: Tab }> = ({ tab }) => {
 };
 
 const AppearanceButton = () => {
-  const { appearance } = useThemeContext();
+  const [appearance, setAppearance] = useThemeAppearance();
 
   const handleClick = () => {
-    // updateThemeAppearanceClass(appearance === 'light' ? 'dark' : 'light');
+    setAppearance(appearance === 'light' ? 'dark' : 'light');
   };
 
   return (
@@ -93,7 +88,6 @@ const Navigator: React.FC = () => {
 };
 
 const Layout = () => {
-  const display = process.env.NODE_ENV === 'development' ? undefined : 'none';
   return (
     <Theme
       className={styles.wrapper}
@@ -115,7 +109,6 @@ const Layout = () => {
             right="0"
           />
         </Box>
-        <ThemePanel defaultOpen={false} style={{ display }} />
         <Puller />
       </ToastPrimitive.Provider>
     </Theme>

--- a/packages/devtools/client/src/entries/client/routes/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/layout.tsx
@@ -43,7 +43,7 @@ const NavigateButton: React.FC<{ tab: Tab }> = ({ tab }) => {
           p="1"
           className={styles.tabButtonInner}
         >
-          <Box height="5" width="5" asChild>
+          <Box height="var(--space-5)" width="var(--space-5)" asChild>
             {tab.icon}
           </Box>
         </Flex>
@@ -68,7 +68,7 @@ const AppearanceButton = () => {
           p="1"
           className={styles.tabButtonInner}
         >
-          <Box height="5" width="5" asChild>
+          <Box height="var(--space-5)" width="var(--space-5)" asChild>
             {appearance === 'dark' ? <HiOutlineMoon /> : <HiOutlineSun />}
           </Box>
         </Flex>
@@ -108,7 +108,7 @@ const Layout = () => {
           </Box>
           <Breadcrumbs
             className={styles.breadcrumbs}
-            height="7"
+            height="2.5rem"
             position="absolute"
             top="0"
             left="0"

--- a/packages/devtools/client/src/entries/client/routes/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/layout.tsx
@@ -8,7 +8,6 @@ import {
   ThemePanel,
   Tooltip,
   useThemeContext,
-  updateThemeAppearanceClass,
 } from '@radix-ui/themes';
 import { HiOutlineMoon, HiOutlineSun } from 'react-icons/hi2';
 import { Tab } from '@modern-js/devtools-kit/runtime';
@@ -57,7 +56,7 @@ const AppearanceButton = () => {
   const { appearance } = useThemeContext();
 
   const handleClick = () => {
-    updateThemeAppearanceClass(appearance === 'light' ? 'dark' : 'light');
+    // updateThemeAppearanceClass(appearance === 'light' ? 'dark' : 'light');
   };
 
   return (
@@ -82,12 +81,12 @@ const Navigator: React.FC = () => {
   const tabs = useSnapshot($tabs);
 
   return (
-    <Flex direction="column" shrink="0" className={styles.navigator}>
+    <Flex direction="column" flexShrink="0" className={styles.navigator}>
       {tabs.map(tab => (
         // @ts-expect-error
         <NavigateButton key={tab.name} tab={tab} />
       ))}
-      <Box grow="1" />
+      <Box flexGrow="1" />
       <AppearanceButton />
     </Flex>
   );

--- a/packages/devtools/client/src/entries/client/routes/overview/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/overview/page.tsx
@@ -77,9 +77,7 @@ const Page: React.FC = () => {
                 </Link>
               </Flex>
             </Box>
-            <Box color="gray" asChild>
-              <HiOutlineDocumentText size="50" color="var(--gray-6)" />
-            </Box>
+            <HiOutlineDocumentText size="50" color="var(--gray-6)" />
           </Flex>
         </Card>
         <Card variant="indicate" className={styles.pluginCard}>

--- a/packages/devtools/client/src/entries/client/routes/pages/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/pages/page.tsx
@@ -45,18 +45,17 @@ const Page: React.FC = () => {
       </Flex>
       <Box className={styles.input}>
         <Box mx="auto" style={{ maxWidth: '40rem' }}>
-          <TextField.Root>
+          <TextField.Root
+            placeholder="/foo?bar#baz"
+            onChange={e => handleUrlInput(e.target.value)}
+            type="url"
+            autoComplete="false"
+            autoCapitalize="false"
+            autoCorrect="false"
+          >
             <TextField.Slot>
               <HiOutlineArrowsRightLeft />
             </TextField.Slot>
-            <TextField.Input
-              placeholder="/foo?bar#baz"
-              onChange={e => handleUrlInput(e.target.value)}
-              type="url"
-              autoComplete="false"
-              autoCapitalize="false"
-              autoCorrect="false"
-            />
           </TextField.Root>
         </Box>
       </Box>

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
@@ -47,7 +47,13 @@ const PresetToolbar: FC<PresetToolbarProps> = props => {
     props;
 
   return (
-    <Flex position="relative" gap="3" height="5" align="center" {...rest}>
+    <Flex
+      position="relative"
+      gap="3"
+      height="var(--space-5)"
+      align="center"
+      {...rest}
+    >
       <Tooltip content="Copy as Data URL" delayDuration={200}>
         <IconButton onClick={onCopyAction} variant="ghost" color="gray">
           <HiMiniClipboard />

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/[id]/page.tsx
@@ -6,13 +6,20 @@ import {
   HiMiniFire,
 } from 'react-icons/hi2';
 import { useLoaderData, useRevalidator } from '@modern-js/runtime/router';
-import { Badge, Box, Flex, IconButton, Text, Tooltip } from '@radix-ui/themes';
+import {
+  Badge,
+  Box,
+  Flex,
+  IconButton,
+  Text,
+  Tooltip,
+  FlexProps,
+} from '@radix-ui/themes';
 import {
   StoragePresetContext,
   StoragePresetWithIdent,
 } from '@modern-js/devtools-kit/runtime';
 import { subscribe } from 'valtio';
-import type { FlexProps } from '@radix-ui/themes/dist/cjs/components/flex';
 import type { BadgeProps } from '@radix-ui/themes/dist/cjs/components/badge';
 import {
   applyStorage,
@@ -28,12 +35,12 @@ import { useToast } from '@/components/Toast';
 import { useThrowable } from '@/utils';
 import { Card } from '@/components/Card';
 
-interface PresetToolbarProps extends FlexProps {
+type PresetToolbarProps = FlexProps & {
   onCopyAction?: () => void;
   onPasteAction?: () => void;
   onOpenAction?: () => void;
   onApplyAction?: () => void;
-}
+};
 
 const PresetToolbar: FC<PresetToolbarProps> = props => {
   const { onCopyAction, onOpenAction, onApplyAction, onPasteAction, ...rest } =
@@ -153,21 +160,21 @@ const Page = () => {
   return (
     <Flex direction="column" gap="2">
       <Flex
-        grow="0"
+        flexGrow="0"
         px="2"
         gap="2"
         justify="between"
         align="center"
         width="100%"
       >
-        <Box shrink="0" className={styles.textEllipsis}>
+        <Box flexShrink="0" className={styles.textEllipsis}>
           <Text size="1" weight="bold" color="gray">
             {preset.name}
           </Text>
         </Box>
         <PresetToolbar
-          shrink="0"
-          grow="0"
+          flexShrink="0"
+          flexGrow="0"
           px="2"
           justify="end"
           onCopyAction={handleCopyAction}
@@ -176,7 +183,7 @@ const Page = () => {
           onApplyAction={handleApplyAction}
         />
       </Flex>
-      <Box grow="1" pb="2" pr="2" style={{ overflowY: 'scroll' }}>
+      <Box flexGrow="1" pb="2" pr="2" style={{ overflowY: 'scroll' }}>
         <Flex direction="column" gap="2">
           <PresetRecordsCard
             title="Cookie"

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/layout.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/layout.tsx
@@ -22,10 +22,10 @@ import { Card } from '@/components/Card';
 import { $server, $serverExported } from '@/entries/client/routes/state';
 import { useThrowable } from '@/utils';
 
-interface CardButtonProps extends FlexProps {
+type CardButtonProps = FlexProps & {
   selected?: boolean;
   to?: string;
-}
+};
 
 const CardButton: FC<CardButtonProps> = props => {
   const { selected, to, ...rest } = props;
@@ -46,10 +46,10 @@ const CardButton: FC<CardButtonProps> = props => {
   );
 };
 
-interface PresetCardProps extends CardButtonProps {
+type PresetCardProps = CardButtonProps & {
   preset: UnwindPreset;
   highlight?: boolean;
-}
+};
 
 const PresetCard: FC<PresetCardProps> = props => {
   const { preset, highlight, ...rest } = props;
@@ -170,7 +170,7 @@ const Page: FC = () => {
           </CardButton>
         </Flex>
       </Flex>
-      <Box width="0" grow="1" height="100%" shrink="1" pt="2">
+      <Box width="0" flexGrow="1" height="100%" flexShrink="1" pt="2">
         <Outlet />
       </Box>
     </Flex>

--- a/packages/devtools/client/src/entries/client/routes/storage/preset/page.tsx
+++ b/packages/devtools/client/src/entries/client/routes/storage/preset/page.tsx
@@ -59,22 +59,22 @@ const Page: FC = () => {
     (value, key) => ({ key, value, id: key }),
   );
   return (
-    <Flex direction="column" gap="2" height="100%" shrink="1">
+    <Flex direction="column" gap="2" height="100%" flexShrink="1">
       <Flex
-        grow="0"
+        flexGrow="0"
         px="2"
         gap="2"
         justify="between"
         align="center"
         width="100%"
       >
-        <Box shrink="0" className={styles.textEllipsis}>
+        <Box flexShrink="0" className={styles.textEllipsis}>
           <Text size="1" weight="bold" color="gray">
             Current Storage
           </Text>
         </Box>
       </Flex>
-      <Box grow="1" pb="2" pr="2" className={styles.scrollable}>
+      <Box flexGrow="1" pb="2" pr="2" className={styles.scrollable}>
         <Flex direction="column" gap="2">
           <PresetRecordsCard title="Cookie" records={cookie} color="yellow" />
           <PresetRecordsCard

--- a/packages/devtools/client/src/utils/theme.ts
+++ b/packages/devtools/client/src/utils/theme.ts
@@ -1,0 +1,49 @@
+import { useSyncExternalStore } from 'react';
+
+export const APPEARANCE_STORAGE_KEY = '__modern_js_devtools_appearance';
+
+export type Appearance = 'light' | 'dark';
+
+const parseAppearance = (raw: unknown) => {
+  let ret: Appearance;
+  if (raw === 'light' || raw === 'dark') {
+    ret = raw;
+  } else {
+    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    ret = isDark ? 'dark' : 'light';
+  }
+  return ret;
+};
+
+const subscribed = new Array<() => void>();
+
+const subscribeAppearance = (callback: () => void) => {
+  subscribed.push(callback);
+  const unsubscribe = () => subscribed.splice(subscribed.indexOf(callback), 1);
+  return unsubscribe;
+};
+
+window.addEventListener('storage', ev => {
+  if (ev.key === APPEARANCE_STORAGE_KEY) {
+    subscribed.forEach(cb => cb());
+  }
+});
+
+const getAppearance = (): Appearance => {
+  const raw = localStorage.getItem(APPEARANCE_STORAGE_KEY);
+  const ret = parseAppearance(raw);
+  return ret;
+};
+
+export const useThemeAppearance = () => {
+  const appearance = useSyncExternalStore(subscribeAppearance, getAppearance);
+  const setAppearance = (
+    value: Appearance | ((oldValue: Appearance) => Appearance),
+  ) => {
+    const newValue =
+      typeof value === 'function' ? value(getAppearance()) : value;
+    localStorage.setItem(APPEARANCE_STORAGE_KEY, newValue);
+    subscribed.forEach(cb => cb());
+  };
+  return [appearance, setAppearance] as const;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -873,8 +873,8 @@ importers:
         specifier: ^1.1.5
         version: 1.1.5(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/themes':
-        specifier: ^2.0.0
-        version: 2.0.0(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@rsbuild/core':
         specifier: 0.6.13
         version: 0.6.13
@@ -15714,6 +15714,40 @@ packages:
       react-remove-scroll: 2.5.5(@types/react@18.0.21)(react@18.2.0)
     dev: true
 
+  /@radix-ui/react-navigation-menu@1.1.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Cc+seCS3PmWmjI51ufGG7zp1cAAIRqHVw7C9LOA2TZ+R4hG6rDvHcTqIsEEFLmZO3zNVH72jOOE7kKNy8W+RtA==}
+    peerDependencies:
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
   /@radix-ui/react-popover@1.0.7(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-shtvVnlsxT6faMnK/a7n0wptwBD23xc1Z5mdrtKLwVEfsEMXodS0r5s0/g5P0hX//EKYZS2sxUjqfzlg52ZSnQ==}
     peerDependencies:
@@ -15890,6 +15924,28 @@ packages:
       '@types/react-dom': 18.0.6
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  /@radix-ui/react-progress@1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5G6Om/tYSxjSeEdrb1VfKkfZfn/1IlPWd731h2RfPuSbIfNUgfqAwbKfJCg/PP6nuUCTrYzalwHSpSinoWoCag==}
+    peerDependencies:
+      '@types/react': ^18
+      '@types/react-dom': ^18
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/react-context': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
 
   /@radix-ui/react-radio-group@1.1.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-x+yELayyefNeKeTx4fjK6j99Fs6c4qKm3aY38G3swQVTN6xMpsrbigC0uHs2L//g8q4qR7qOcww8430jJmi2ag==}
@@ -16437,8 +16493,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
 
-  /@radix-ui/themes@2.0.0(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-XIJkXLzIOerrmk24wpyYnPnHC+z4KdH4uFGKBcMqKSSAly9GuBDWpscdxaEja1AvOJJChpmONsD768M/GOVpfg==}
+  /@radix-ui/themes@3.0.5(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-fqIxdxer2tVHtrmuT/Wx793sMKIaJBSZQjFSrkorz6BgOCrijjK6pRRi1qa3Sq78vyjixVXR7kRlieBomUzzzQ==}
     peerDependencies:
       '@types/react': ^18
       '@types/react-dom': ^18
@@ -16457,30 +16513,38 @@ packages:
       '@radix-ui/react-aspect-ratio': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-avatar': 1.0.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-checkbox': 1.0.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.0.21)(react@18.2.0)
       '@radix-ui/react-context-menu': 2.1.5(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-direction': 1.0.1(@types/react@18.0.21)(react@18.2.0)
       '@radix-ui/react-dropdown-menu': 2.0.6(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-form': 0.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-hover-card': 1.0.7(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-navigation-menu': 1.1.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-popover': 1.0.7(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-progress': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-radio-group': 1.1.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-scroll-area': 1.0.5(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-select': 2.0.0(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-separator': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-slider': 1.1.2(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-slot': 1.0.2(@types/react@18.0.21)(react@18.2.0)
       '@radix-ui/react-switch': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-tabs': 1.0.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-toggle-group': 1.0.4(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-tooltip': 1.0.7(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.0.21)(react@18.2.0)
       '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6
       classnames: 2.3.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll-bar: 2.3.4(@types/react@18.0.21)(react@18.2.0)
     dev: true
 
   /@rc-component/context@1.3.0(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
## Summary

- Bump `@radix-ui/themes` to v3 and migrate usage cases.
- Refactor theme management.

Changes mainly affect:

- packages/devtools/client/src/utils/theme.ts
- packages/devtools/client/src/components/Theme.tsx
- packages/devtools/client/src/components/Devtools/Capsule.tsx

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
