### PR TITLE
fix(devtools): `traversePromises` should not traverse null values

### DIFF
--- a/.changeset/wise-paws-sleep.md
+++ b/.changeset/wise-paws-sleep.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/devtools-kit': minor
+'@modern-js/devtools-client': minor
+'@modern-js/plugin-devtools': minor
+---
+
+feat(devtools): new tab added for managing storage presets
+
+feat(devtools): 新增标签页提供 storage presets 管理

--- a/packages/devtools/kit/src/promise.ts
+++ b/packages/devtools/kit/src/promise.ts
@@ -75,6 +75,7 @@ export const traversePromises = (
   const promises = new Set<[PromiseLike<unknown>, Path]>();
   const memo = new WeakSet();
   const traverse = (value: any, currentPath: Path) => {
+    if (value === null) return;
     if (typeof value === 'object') {
       if (memo.has(value)) {
         return;
@@ -84,7 +85,7 @@ export const traversePromises = (
     }
     if (isPromiseLike(value)) {
       promises.add([value, currentPath]);
-    } else if (typeof value === 'object' && value !== null) {
+    } else if (typeof value === 'object') {
       for (const [k, v] of Object.entries(value)) {
         traverse(v, [...currentPath, k]);
       }


### PR DESCRIPTION
## Summary

- Fix: `traversePromises` should not traverse null values

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
