### PR TITLE
chore: experiments.lazyCompilation can be used in rspack

### DIFF
--- a/packages/cli/uni-builder/src/rspack/index.ts
+++ b/packages/cli/uni-builder/src/rspack/index.ts
@@ -26,6 +26,11 @@ export async function parseConfig(
     options,
   );
 
+  if (uniBuilderConfig.experiments?.lazyCompilation) {
+    rsbuildConfig.dev!.lazyCompilation =
+      uniBuilderConfig.experiments.lazyCompilation;
+  }
+
   if (uniBuilderConfig.tools?.babel) {
     const { pluginBabel } = await import('@rsbuild/plugin-babel');
     const { pluginBabelPost } = await import('./plugins/babel-post');

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -311,9 +311,6 @@ export type UniBuilderExtraConfig = {
     checkSyntax?: boolean | PluginCheckSyntaxOptions;
   };
   experiments?: {
-    /**
-     * Tips: this configuration is not yet supported in rspack
-     */
     lazyCompilation?: DevConfig['lazyCompilation'];
     /**
      * Enable the ability for source code building

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -19,7 +19,6 @@ import type {
 import type { RsbuildConfig } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import type { PluginStyledComponentsOptions } from '@rsbuild/plugin-styled-components';
-import type { LazyCompilationOptions } from './webpack/plugins/lazyCompilation';
 import type { PluginRemOptions } from '@rsbuild/plugin-rem';
 import type { PluginTsLoaderOptions } from './webpack/plugins/tsLoader';
 import type { SvgDefaultExport } from '@rsbuild/plugin-svgr';
@@ -315,7 +314,7 @@ export type UniBuilderExtraConfig = {
     /**
      * Tips: this configuration is not yet supported in rspack
      */
-    lazyCompilation?: LazyCompilationOptions;
+    lazyCompilation?: DevConfig['lazyCompilation'];
     /**
      * Enable the ability for source code building
      */

--- a/packages/cli/uni-builder/src/webpack/plugins/lazyCompilation.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/lazyCompilation.ts
@@ -1,11 +1,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
+import type { DevConfig } from '@rsbuild/shared';
 
-export type LazyCompilationOptions =
-  | boolean
-  | {
-      entries?: boolean;
-      imports?: boolean;
-    };
+type LazyCompilationOptions = DevConfig['lazyCompilation'];
 
 export const pluginLazyCompilation = (
   options: LazyCompilationOptions,

--- a/packages/document/builder-doc/docs/en/config/experiments/lazyCompilation.md
+++ b/packages/document/builder-doc/docs/en/config/experiments/lazyCompilation.md
@@ -8,11 +8,12 @@ type LazyCompilationOptions =
       entries?: boolean;
       // Whether to enable lazy compilation for dynamic imports
       imports?: boolean;
+      // Specify which imported modules should be lazily compiled.
+      test?: RegExp | ((m: Module) => boolean);
     };
 ```
 
 - **Default:** `false`
-- **Bundler:** `only support webpack`
 
 Used to enable the lazy compilation (i.e. compile on demand). When this config is enabled, Builder will compile entrypoints and dynamic imports only when they are used. It will improve the compilation startup time of the project.
 

--- a/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/en/guide/advanced/rspack-start.mdx
@@ -93,9 +93,7 @@ Unsupported configurations and capabilities include:
 
 > Experimental related configurations in the Builder
 
-Unsupported configurations and capabilities include:
-
-- [experiments.lazyCompilation](/api/config-experiments.html#experimentslazycompilation)
+All configurations and capabilities under experimental are available within rspack.
 
 #### Performance Config
 

--- a/packages/document/builder-doc/docs/zh/config/experiments/lazyCompilation.md
+++ b/packages/document/builder-doc/docs/zh/config/experiments/lazyCompilation.md
@@ -8,11 +8,12 @@ type LazyCompilationOptions =
       imports?: boolean;
       // 是否为入口模块开启延迟编译
       entries?: boolean;
+      // 指定哪些导入的模块应该被延迟编译
+      test?: RegExp | ((m: Module) => boolean);
     };
 ```
 
 - **默认值：** `false`
-- **打包工具：** `仅支持 webpack`
 
 用于开启延迟编译（即按需编译）的能力。当开启此配置项时，Builder 会进行延迟编译，提升项目的编译启动速度。
 

--- a/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
+++ b/packages/document/builder-doc/docs/zh/guide/advanced/rspack-start.mdx
@@ -93,9 +93,7 @@ Builder 旨在消除不同打包工具之间的主要差异，帮助用户以较
 
 > Builder 中的一些实验性配置。
 
-不支持的配置项及能力包括：
-
-- [experiments.lazyCompilation](/api/config-experiments.html#experimentslazycompilation)
+所有 experiments 下的配置项及能力在 Rspack 内均可使用。
 
 #### Performance Config
 


### PR DESCRIPTION
## Summary

modern.js `experiments.lazyCompilation` will map to rsbuild `dev.lazyCompilation` in rspack mode.


## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2454
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
