### PR TITLE
chore(CI): remove release with comment feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,56 +24,6 @@ permissions:
   id-token: write
 
 jobs:
-  issue_commentd:
-    name: Release with commentd
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '!canary')
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-          ref: refs/pull/${{ github.event.issue.number }}/head
-
-      - name: Install Pnpm
-        run: corepack enable
-
-      - name: Setup Node.js 18
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          cache: 'pnpm'
-
-      - name: Install npm v9
-        run: npm install -g npm@9
-
-      - name: Nx Cache
-        id: nx-cache
-        uses: actions/cache@v3
-        with:
-          path: .nx/cache
-          key: nx-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            nx-${{ github.ref_name }}-
-            nx-
-
-      - name: Install Dependencies && Build
-        run: pnpm install
-
-      - name: Release
-        uses: web-infra-dev/actions@v2
-        with:
-          version: 'next'
-          type: 'release'
-          branch: ''
-          tools: 'modern'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
-          COMMENT: ${{ toJson(github.event.comment) }}
   release:
     name: Release
     if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary

release with comment is not security, and we can release canary through [actions - release workflow]

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
