### PR TITLE
fix: redablestream should not be locked, when stream transfer

### DIFF
--- a/.changeset/spicy-lies-look.md
+++ b/.changeset/spicy-lies-look.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: redablestream should not be locked, when stream transfer
+fix: redablestream 不应该被锁住当 stream 传输时


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
