### PR TITLE
docs(module-tools-docs): correcting the name of the document product added to .gitignore

### DIFF
--- a/.changeset/clean-masks-repair.md
+++ b/.changeset/clean-masks-repair.md
@@ -1,5 +1,5 @@
 ---
-'@modern-js/module-tools-docs': major
+'@modern-js/module-tools-docs': patch
 ---
 
 docs: correcting the name of the document product added to .gitignore

--- a/.changeset/clean-masks-repair.md
+++ b/.changeset/clean-masks-repair.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/module-tools-docs': major
+---
+
+docs: correcting the name of the document product added to .gitignore

--- a/packages/document/module-doc/docs/en/guide/basic/use-module-doc.mdx
+++ b/packages/document/module-doc/docs/en/guide/basic/use-module-doc.mdx
@@ -123,10 +123,10 @@ export default () => {
 }
 ```
 
-3. In the `.gitignore`, add `docs_build/`:
+3. In the `.gitignore`, add `doc_build/`:
 
 ```bash title=".gitignore"
-docs_build/
+doc_build/
 ```
 
 Congratulations, you have finished writing a component document, execute `pnpm run dev` to see the result, remember to build the component library first to make sure the component product exists.

--- a/packages/document/module-doc/docs/zh/guide/basic/use-module-doc.mdx
+++ b/packages/document/module-doc/docs/zh/guide/basic/use-module-doc.mdx
@@ -119,10 +119,10 @@ export default () => {
 }
 ```
 
-3. 在 `.gitignore` 文件下添加 `docs_build/`，文档产物将会生成在此目录下：
+3. 在 `.gitignore` 文件下添加 `doc_build/`，文档产物将会生成在此目录下：
 
 ```bash title=".gitignore"
-docs_build/
+doc_build/
 ```
 
 恭喜你，已经完成了一个组件文档的编写，执行`pnpm run dev`看看效果吧，记得先构建一下组件库，确保组件产物存在。


### PR DESCRIPTION
docs(module-tools-docs): correcting the name of the document product added to .gitignore

## Summary

The name of the packaged product is `doc_build`, not `docs_build`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
