### PR TITLE
fix: when enable react router v5, tooltip with plugin name is not right

### DIFF
--- a/.changeset/quick-coins-play.md
+++ b/.changeset/quick-coins-play.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/generator-common': patch
+---
+
+fix: when enable react router v5, tooltip with plugin name is not right
+
+fix: 修复当开启 react router v5 时，提示的插件名称不正确

--- a/packages/generator/generator-common/src/newAction/mwa/index.ts
+++ b/packages/generator/generator-common/src/newAction/mwa/index.ts
@@ -187,7 +187,7 @@ export const MWANewActionPluginName: Record<
     [ActionFunction.SWC]: 'swcPlugin',
   },
   [ActionType.Refactor]: {
-    [ActionRefactor.ReactRouter5]: 'reactRouter5Plugin',
+    [ActionRefactor.ReactRouter5]: 'routerPlugin',
   },
 };
 


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
