### PR TITLE
feat: enable stage3 decorator for swc based on typescript version

### DIFF
--- a/packages/solutions/module-tools/src/builder/feature/index.ts
+++ b/packages/solutions/module-tools/src/builder/feature/index.ts
@@ -1,5 +1,5 @@
 import { HookList, Context } from '../../types';
-import { getProjectTsconfig } from '../../utils/dts';
+import { detectTSVersion, getProjectTsconfig } from '../../utils/dts';
 import { formatCjs } from './format-cjs';
 import { css } from './style';
 import { minify } from './terser';
@@ -29,6 +29,10 @@ export async function getInternalList(context: Context): Promise<HookList> {
   const emitDecoratorMetadata =
     userTsconfig?.compilerOptions?.emitDecoratorMetadata ?? false;
 
+  const tsVersion = await detectTSVersion(
+    context.api.useAppContext().appDirectory,
+  );
+
   const { transformImport, transformLodash, externalHelpers, format, target } =
     context.config;
 
@@ -42,7 +46,7 @@ export async function getInternalList(context: Context): Promise<HookList> {
     : format === 'umd' || target === 'es5';
   if (enbaleSwcTransform) {
     const { swcTransform } = await import('./swc');
-    internal.push(swcTransform(userTsconfig));
+    internal.push(swcTransform(userTsconfig, tsVersion));
   }
 
   if (enableSwcRenderChunk) {

--- a/packages/solutions/module-tools/src/builder/feature/swc.ts
+++ b/packages/solutions/module-tools/src/builder/feature/swc.ts
@@ -40,7 +40,7 @@ const getSwcTarget = (target: string): JscTarget => {
   return 'es2022';
 };
 
-export const swcTransform = (userTsconfig: ITsconfig) => ({
+export const swcTransform = (userTsconfig: ITsconfig, tsVersion: number) => ({
   name,
   apply(compiler: ICompiler) {
     const tsUseDefineForClassFields =
@@ -102,6 +102,10 @@ export const swcTransform = (userTsconfig: ITsconfig) => ({
                 useDefineForClassFields,
                 legacyDecorator: emitDecoratorMetadata ? true : undefined,
                 decoratorMetadata: emitDecoratorMetadata ? true : undefined,
+                decoratorVersion:
+                  !emitDecoratorMetadata && tsVersion >= 5
+                    ? '2022-03'
+                    : undefined,
               },
               externalHelpers,
               target: getSwcTarget(target),


### PR DESCRIPTION
## Summary

This is a draft PR as the API is not designed. I'd like to discuss with the maintenance team if this implementation is fine.

Currently, I can hack it by enabling `transformLodash` to enable swc compiler.

## Related Links

<!--- Provide links of related issues or pages -->

Fixes #5834 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
