### PR TITLE
[hotfix]fix: use ts-deepmerge instead of deepermge-ts

### DIFF
--- a/.changeset/eighty-worms-jump.md
+++ b/.changeset/eighty-worms-jump.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: downgrading deepmerge-ts, deepmerge-ts v7 can't run in nodev16.2.0
+fix: 降级 deepmerge-ts, deepmerge-ts v7 在 nodev16.2.0 上跑

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -63,7 +63,7 @@
     "@web-std/stream": "^1.0.3",
     "@web-std/file": "^3.0.3",
     "hono": "^3.12.2",
-    "deepmerge-ts": "6.0.3",
+    "ts-deepmerge": "7.0.0",
     "isbot": "3.8.0"
   },
   "devDependencies": {

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -63,7 +63,7 @@
     "@web-std/stream": "^1.0.3",
     "@web-std/file": "^3.0.3",
     "hono": "^3.12.2",
-    "deepmerge-ts": "7.0.2",
+    "deepmerge-ts": "6.0.3",
     "isbot": "3.8.0"
   },
   "devDependencies": {

--- a/packages/server/core/src/utils/serverConfig.ts
+++ b/packages/server/core/src/utils/serverConfig.ts
@@ -1,4 +1,4 @@
-import { deepmerge } from 'deepmerge-ts';
+import { merge } from 'ts-deepmerge';
 import { CliConfig, ServerConfig } from '../types';
 
 /**
@@ -11,7 +11,7 @@ export const loadConfig = ({
   cliConfig: CliConfig;
   serverConfig: ServerConfig;
 }): ServerConfig => {
-  const config = deepmerge(
+  const config = merge(
     {
       ...cliConfig,
       plugins: [],

--- a/packages/server/core/tests/utils/serverConfig.test.ts
+++ b/packages/server/core/tests/utils/serverConfig.test.ts
@@ -1,4 +1,4 @@
-import { deepmerge } from 'deepmerge-ts';
+import { merge } from 'ts-deepmerge';
 
 describe('test loadConfig', () => {
   test('should merge CliConfig and ServerConfig correctly', () => {
@@ -23,7 +23,7 @@ describe('test loadConfig', () => {
       },
     };
 
-    const config = deepmerge(cliConfig as any, serverConfig);
+    const config = merge(cliConfig as any, serverConfig);
 
     expect(config).toEqual({
       bff: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3266,15 +3266,15 @@ importers:
       '@web-std/stream':
         specifier: ^1.0.3
         version: 1.0.3
-      deepmerge-ts:
-        specifier: 6.0.3
-        version: 6.0.3
       hono:
         specifier: ^3.12.2
         version: 3.12.12
       isbot:
         specifier: 3.8.0
         version: 3.8.0
+      ts-deepmerge:
+        specifier: 7.0.0
+        version: 7.0.0
     devDependencies:
       '@modern-js/types':
         specifier: workspace:*
@@ -23534,11 +23534,6 @@ packages:
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  /deepmerge-ts@6.0.3:
-    resolution: {integrity: sha512-LJuILbt5/f3v/O8/YC/76msd0YDddq0WR/iK7rViHayl9I/t4yKxyUFkSbLpF/JCYOQI+ByQAzYt0KyaNFeASQ==}
-    engines: {node: '>=16.0.0'}
-    dev: false
-
   /deepmerge@1.5.2:
     resolution: {integrity: sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==}
     engines: {node: '>=0.10.0'}
@@ -35667,6 +35662,11 @@ packages:
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  /ts-deepmerge@7.0.0:
+    resolution: {integrity: sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==}
+    engines: {node: '>=14.13.1'}
+    dev: false
 
   /ts-easing@0.2.0:
     resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3267,8 +3267,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       deepmerge-ts:
-        specifier: 7.0.2
-        version: 7.0.2
+        specifier: 6.0.3
+        version: 6.0.3
       hono:
         specifier: ^3.12.2
         version: 3.12.12
@@ -21540,7 +21540,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/compat-data': 7.24.7
+      '@babel/compat-data': 7.24.4
       '@babel/core': 7.24.7
       '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.7)
       semver: 6.3.1
@@ -23534,8 +23534,8 @@ packages:
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  /deepmerge-ts@7.0.2:
-    resolution: {integrity: sha512-kt42SClSQ1DTvAdUtPlZfcCHQxiiLG0nIRu6KJEnhRUc1WJwo1ZQwWcUDRw4ZCHcOUk+HIiTBhohGS/lLtITqQ==}
+  /deepmerge-ts@6.0.3:
+    resolution: {integrity: sha512-LJuILbt5/f3v/O8/YC/76msd0YDddq0WR/iK7rViHayl9I/t4yKxyUFkSbLpF/JCYOQI+ByQAzYt0KyaNFeASQ==}
     engines: {node: '>=16.0.0'}
     dev: false
 


### PR DESCRIPTION
## Summary

- deepmerge-ts can't run in node v16.2.0

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
