### PR TITLE
fix: not specify externalsType in rspack mode

### DIFF
--- a/.changeset/afraid-clocks-kick.md
+++ b/.changeset/afraid-clocks-kick.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix: not specify externalsType in rspack mode

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -127,18 +127,6 @@ export const garfishPlugin = ({
                 'Access-Control-Allow-Origin': '*',
               },
             },
-            rspack: (config: any) => {
-              config.builtins ??= {};
-
-              // eslint-disable-next-line react-hooks/rules-of-hooks
-              const resolveOptions = useResolvedConfigContext();
-              if (
-                resolveOptions?.deploy?.microFrontend &&
-                !config.externalsType
-              ) {
-                config.externalsType = 'commonjs';
-              }
-            },
             bundlerChain: (chain, { env, CHAIN_ID, bundler }) => {
               // add comments avoid sourcemap abnormal
               if (bundler.BannerPlugin) {


### PR DESCRIPTION
## Summary

It seems that rspack behavior is aligned with webpack, and this configuration should not be added.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
