### PR TITLE
chore(router): add slash to basename if not exist

### DIFF
--- a/.changeset/light-deers-greet.md
+++ b/.changeset/light-deers-greet.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+chore: add slash to basename if not exist
+chore: 如果 basename 不是 / 开头，则添加 / 前缀

--- a/packages/runtime/plugin-garfish/src/cli/utils.ts
+++ b/packages/runtime/plugin-garfish/src/cli/utils.ts
@@ -55,7 +55,7 @@ function canContinueRender ({ dom, appName }) {
 
 function generateRouterPlugin (basename,routerConfig) {
   if (basename) {
-    routerConfig.originalBaseUrl = basename;
+    routerConfig.originalBaseUrl = basename.replace(/^\\/*/, "/");
     // for compatibility with react router v5
     routerConfig.basename = basename;
     if (routerConfig.supportHtml5History !== false) {


### PR DESCRIPTION
## Summary

- add slash to garfish basename prefix if not exist

if use <Router> Component, the slash will auto add by react-router
![img_v3_02c6_829ef7e9-697d-426a-9639-e9cdf5f75e4g](https://github.com/web-infra-dev/modern.js/assets/68810266/12276caa-5ccd-4aa7-8c4b-fdd45b316dd9)

but in modern.js, we use `createBrowserRouter`, maybe it's a bug in react-router ?

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
