### PR TITLE
fix(app-tools): error when restart app

### DIFF
--- a/.changeset/friendly-dingos-guess.md
+++ b/.changeset/friendly-dingos-guess.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: module not found error when restart app
+fix: 修复重启应用时找不到模块的报错

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -168,7 +168,7 @@ export const appTools = (
       },
 
       async beforeRestart() {
-        cleanRequireCache([require.resolve('./analyze')]);
+        cleanRequireCache([require.resolve('./plugins/analyze')]);
       },
 
       async modifyFileSystemRoutes({ entrypoint, routes }) {


### PR DESCRIPTION
## Summary

bug in #5861 .

move the `analyze` module to `plugins/analyze` but not modify the path in restart hook.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
