### PR TITLE
fix(devtools): resolve storage preset config file

### DIFF
--- a/.changeset/poor-rings-breathe.md
+++ b/.changeset/poor-rings-breathe.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-devtools': patch
+---
+
+fix(devtools): resolve storage preset config file
+fix(devtools): 无法正确找到 storage preset 配置文件

--- a/packages/devtools/plugin/src/plugins/watcher.ts
+++ b/packages/devtools/plugin/src/plugins/watcher.ts
@@ -5,8 +5,8 @@ import { updateContext } from '../options';
 
 export const pluginWatcher: Plugin = {
   async setup(api) {
-    const basename = `${api.context.def.name.shortName}.runtime.json`;
     const frameworkApi = await api.setupFramework();
+    const basename = `${api.context.def.name.shortName}.runtime.json`;
     const appCtx = frameworkApi.useAppContext();
     const watcher = chokidar.watch(getConfigFilenames(basename), {
       cwd: appCtx.appDirectory,


### PR DESCRIPTION
## Summary

The client defination property `api.context.def` should be accessed after `api.setupFramework()`. Otherwise, which maybe cause watcher plugin resolving a wrong `modern.runtime.json` filename.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
