### PR TITLE
fix: isbot v4.x require nodev18, so we downgrade it into v3.x

### DIFF
--- a/.changeset/brown-cats-wait.md
+++ b/.changeset/brown-cats-wait.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: isbot v4.x require nodev18, so we downgrade it into v3.x
+fix: isbot v4.x 需要 nodev18, 所以我们把他降级为 v3.x

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -185,7 +185,7 @@
     "@babel/core": "^7.23.2",
     "@babel/types": "^7.23.0",
     "cookie": "0.5.0",
-    "isbot": "4",
+    "isbot": "3.7.1",
     "@loadable/babel-plugin": "5.15.3",
     "@loadable/component": "5.15.3",
     "@loadable/server": "5.15.3",

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
@@ -2,7 +2,7 @@ import { Transform } from 'stream';
 import { renderToPipeableStream } from 'react-dom/server';
 import { createReadableStreamFromReadable } from '@modern-js/runtime-utils/node';
 import { ServerStyleSheet } from 'styled-components';
-import { isbot as checkIsBot } from 'isbot';
+import checkIsBot from 'isbot';
 import { ESCAPED_SHELL_STREAM_END_MARK } from '../../../common';
 import { RenderLevel } from '../../constants';
 import { getTemplates } from './template';

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
@@ -1,5 +1,5 @@
 import { renderToReadableStream } from 'react-dom/server';
-import { isbot as checkIsBot } from 'isbot';
+import checkIsBot from 'isbot';
 import { RenderLevel } from '../../constants';
 import { ESCAPED_SHELL_STREAM_END_MARK } from '../../../common';
 import {

--- a/packages/server/core/package.json
+++ b/packages/server/core/package.json
@@ -63,8 +63,7 @@
     "@web-std/stream": "^1.0.3",
     "@web-std/file": "^3.0.3",
     "hono": "^3.12.2",
-    "ts-deepmerge": "7.0.0",
-    "isbot": "4"
+    "ts-deepmerge": "7.0.0"
   },
   "devDependencies": {
     "@modern-js/types": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2908,8 +2908,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       isbot:
-        specifier: '4'
-        version: 4.4.0
+        specifier: 3.7.1
+        version: 3.7.1
       react-helmet:
         specifier: ^6.1.0
         version: 6.1.0(react@18.2.0)
@@ -27537,6 +27537,11 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    dev: false
+
+  /isbot@3.7.1:
+    resolution: {integrity: sha512-JfqOaY3O1lcWt2nc+D6Mq231CNpwZrBboLa59Go0J8hjGH+gY/Sy0CA/YLUSIScINmAVwTdJZIsOTk4PfBtRuw==}
+    engines: {node: '>=12'}
     dev: false
 
   /isbot@4.4.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3263,9 +3263,6 @@ importers:
       hono:
         specifier: ^3.12.2
         version: 3.12.12
-      isbot:
-        specifier: '4'
-        version: 4.4.0
       ts-deepmerge:
         specifier: 7.0.0
         version: 7.0.0
@@ -27542,11 +27539,6 @@ packages:
   /isbot@3.7.1:
     resolution: {integrity: sha512-JfqOaY3O1lcWt2nc+D6Mq231CNpwZrBboLa59Go0J8hjGH+gY/Sy0CA/YLUSIScINmAVwTdJZIsOTk4PfBtRuw==}
     engines: {node: '>=12'}
-    dev: false
-
-  /isbot@4.4.0:
-    resolution: {integrity: sha512-8ZvOWUA68kyJO4hHJdWjyreq7TYNWTS9y15IzeqVdKxR9pPr3P/3r9AHcoIv9M0Rllkao5qWz2v1lmcyKIVCzQ==}
-    engines: {node: '>=18'}
     dev: false
 
   /isexe@2.0.0:


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
