### PR TITLE
refactor(uni-builder): decouple with @rsbuild/shared

### DIFF
--- a/.changeset/happy-cycles-occur.md
+++ b/.changeset/happy-cycles-occur.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/storybook-builder': patch
+'@modern-js/uni-builder': patch
+---
+
+chore: decouple with rsbuild/shared

--- a/packages/cli/uni-builder/src/index.ts
+++ b/packages/cli/uni-builder/src/index.ts
@@ -14,11 +14,7 @@ export type {
   UniBuilderWebpackInstance,
 };
 export type {
-  RspackChain,
-  RsbuildPlugin,
-  ConfigChain,
   CopyPluginOptions,
-  ChainIdentifier,
   NormalizedConfig,
   RspackConfig,
   CacheGroup,
@@ -34,6 +30,10 @@ export async function createUniBuilder(options: CreateUniBuilderOptions) {
 
 export {
   logger,
+  type ConfigChain,
+  type RsbuildPlugin,
+  type ChainIdentifier,
+  type RspackChain,
   type Rspack,
   type RsbuildContext,
   type RsbuildConfig,

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -2,16 +2,15 @@
 /* eslint-disable complexity */
 import {
   NODE_MODULES_REGEX,
-  RsbuildTarget,
   OverrideBrowserslist,
   getBrowserslist,
-  castArray,
   isFunction,
   type HtmlTagHandler,
   type SourceConfig,
 } from '@rsbuild/shared';
 import {
   mergeRsbuildConfig,
+  type RsbuildTarget,
   type RsbuildPlugin,
   type RsbuildConfig,
 } from '@rsbuild/core';
@@ -36,6 +35,7 @@ import { pluginArco } from './plugins/arco';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { transformToRsbuildServerOptions } from './devServer';
+import { castArray } from './utils';
 
 const CSS_MODULES_REGEX = /\.modules?\.\w+$/i;
 const GLOBAL_CSS_REGEX = /\.global\.\w+$/;

--- a/packages/cli/uni-builder/src/shared/plugins/fallback.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/fallback.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
-import { JS_REGEX, type Rspack } from '@rsbuild/shared';
-import type { RsbuildPlugin } from '@rsbuild/core';
-import { TS_REGEX, getHash } from '../../shared/utils';
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+import { JS_REGEX, TS_REGEX, getHash } from '../../shared/utils';
 
 const HTML_REGEX = /\.html$/;
 
@@ -64,19 +63,19 @@ export const pluginFallback = (): RsbuildPlugin => ({
   name: 'uni-builder:fallback',
 
   setup(api) {
-    if (api.context.bundlerType === 'webpack') {
-      api.modifyBundlerChain(chain => {
-        const rsbuildConfig = api.getNormalizedConfig();
-        const { distPath, filename } = rsbuildConfig.output;
-        const distDir = distPath.media;
-        const mediaFilename =
-          filename.media ?? `[name]${getHash(rsbuildConfig)}[ext]`;
+    api.modifyBundlerChain(chain => {
+      const rsbuildConfig = api.getNormalizedConfig();
+      const { distPath, filename } = rsbuildConfig.output;
+      const distDir = distPath.media;
+      const mediaFilename =
+        filename.media ?? `[name]${getHash(rsbuildConfig)}[ext]`;
 
-        chain.output.merge({
-          assetModuleFilename: join(distDir, mediaFilename),
-        });
+      chain.output.merge({
+        assetModuleFilename: join(distDir, mediaFilename),
       });
+    });
 
+    if (api.context.bundlerType === 'webpack') {
       api.modifyWebpackConfig(config => {
         if (!config.module) {
           return;
@@ -87,15 +86,6 @@ export const pluginFallback = (): RsbuildPlugin => ({
       });
     } else {
       api.modifyRspackConfig(config => {
-        const rsbuildConfig = api.getNormalizedConfig();
-        const distDir = rsbuildConfig.output.distPath.media;
-        const filename =
-          rsbuildConfig.output.filename.media ??
-          `[name]${getHash(rsbuildConfig)}[ext]`;
-
-        config.output ||= {};
-        config.output.assetModuleFilename = join(distDir, filename);
-
         if (!config.module) {
           return;
         }

--- a/packages/cli/uni-builder/src/shared/utils.ts
+++ b/packages/cli/uni-builder/src/shared/utils.ts
@@ -2,6 +2,8 @@ import type { RsbuildTarget, NormalizedConfig } from '@rsbuild/core';
 
 export const RUNTIME_CHUNK_NAME = 'builder-runtime';
 
+export const JS_REGEX = /\.(?:js|mjs|cjs|jsx)$/;
+
 export const TS_REGEX = /\.(?:ts|mts|cts|tsx)$/;
 
 export function isServerTarget(target: RsbuildTarget[]) {
@@ -9,6 +11,13 @@ export function isServerTarget(target: RsbuildTarget[]) {
     ['node', 'service-worker'].includes(item),
   );
 }
+
+export const castArray = <T>(arr?: T | T[]): T[] => {
+  if (arr === undefined) {
+    return [];
+  }
+  return Array.isArray(arr) ? arr : [arr];
+};
 
 export const getHash = (config: NormalizedConfig) => {
   const { filenameHash } = config.output;

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -1,14 +1,12 @@
 import type {
   NodeEnv,
   MetaOptions,
-  ConfigChain,
-  ConfigChainWithContext,
-  InlineChunkTest,
   RequestHandler,
-  MaybePromise,
   HtmlTagDescriptor,
 } from '@rsbuild/shared';
 import type {
+  ConfigChainWithContext,
+  ConfigChain,
   DevConfig,
   RsbuildConfig,
   RsbuildTarget,
@@ -17,6 +15,7 @@ import type {
   ServerConfig,
   RsbuildPluginAPI,
   SourceConfig,
+  OutputConfig,
 } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import type { PluginStyledComponentsOptions } from '@rsbuild/plugin-styled-components';
@@ -232,11 +231,11 @@ export type UniBuilderExtraConfig = {
     /**
      * @deprecated use `output.inlineScripts` instead
      */
-    enableInlineScripts?: boolean | InlineChunkTest;
+    enableInlineScripts?: OutputConfig['inlineScripts'];
     /**
      * @deprecated use `output.inlineStyles` instead
      */
-    enableInlineStyles?: boolean | InlineChunkTest;
+    enableInlineStyles?: OutputConfig['injectStyles'];
     /**
      * Configure the default export type of SVG files.
      */
@@ -376,7 +375,7 @@ export type UniBuilderPluginAPI = {
       utils: {
         mergeBuilderConfig: <T>(...configs: T[]) => T;
       },
-    ) => MaybePromise<any | void>,
+    ) => any | Promise<any>,
   ) => void;
 };
 
@@ -385,7 +384,7 @@ export type UniBuilderPluginAPI = {
  */
 export type UniBuilderPlugin = {
   name: string;
-  setup: (api: UniBuilderPluginAPI) => MaybePromise<void>;
+  setup: (api: UniBuilderPluginAPI) => void | Promise<void>;
   pre?: string[];
   post?: string[];
   remove?: string[];

--- a/packages/cli/uni-builder/src/webpack/plugins/babel.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/babel.ts
@@ -3,13 +3,12 @@ import { getBabelConfigForWeb } from '@rsbuild/babel-preset/web';
 import { getBabelConfigForNode } from '@rsbuild/babel-preset/node';
 import type { BabelConfig } from '@rsbuild/babel-preset';
 import { isBeyondReact17, applyOptionsChain } from '@modern-js/utils';
+import { type RsbuildPlugin, type NormalizedConfig } from '@rsbuild/core';
 import {
   SCRIPT_REGEX,
   applyScriptCondition,
   getBrowserslistWithDefault,
-  type RsbuildPlugin,
   type TransformImport,
-  type NormalizedConfig,
 } from '@rsbuild/shared';
 import {
   getBabelUtils,

--- a/packages/cli/uni-builder/src/webpack/plugins/lazyCompilation.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/lazyCompilation.ts
@@ -1,5 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
-import type { DevConfig } from '@rsbuild/shared';
+import type { RsbuildPlugin, DevConfig } from '@rsbuild/core';
 
 type LazyCompilationOptions = DevConfig['lazyCompilation'];
 

--- a/packages/cli/uni-builder/src/webpack/plugins/minimize.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/minimize.ts
@@ -1,9 +1,9 @@
 import {
-  CHAIN_ID,
+  type ChainIdentifier,
   type RspackChain,
   type RsbuildPlugin,
   type NormalizedConfig,
-} from '@rsbuild/shared';
+} from '@rsbuild/core';
 import { applyOptionsChain } from '@modern-js/utils';
 import { TerserPluginOptions, ToolsTerserConfig } from '../../types';
 
@@ -36,6 +36,7 @@ function applyRemoveConsole(
 async function applyJSMinimizer(
   chain: RspackChain,
   config: NormalizedConfig,
+  CHAIN_ID: ChainIdentifier,
   userTerserConfig?: ToolsTerserConfig,
 ) {
   const { default: TerserPlugin } = await import('terser-webpack-plugin');
@@ -86,7 +87,7 @@ export const pluginMinimize = (
   name: 'uni-builder:minimize',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { isProd }) => {
+    api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {
       const config = api.getNormalizedConfig();
       const { minify } = config.output;
 
@@ -95,7 +96,7 @@ export const pluginMinimize = (
       }
 
       if (minify === true || minify?.js !== false) {
-        await applyJSMinimizer(chain, config, userTerserConfig);
+        await applyJSMinimizer(chain, config, CHAIN_ID, userTerserConfig);
       }
     });
   },

--- a/packages/cli/uni-builder/src/webpack/plugins/moduleScopes.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/moduleScopes.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import type { RsbuildPlugin } from '@rsbuild/core';
-import { type ConfigChain } from '@rsbuild/shared';
+import type { RsbuildPlugin, ConfigChain } from '@rsbuild/core';
 import type { ModuleScopes } from '../../types';
 
 const ensureAbsolutePath = (base: string, filePath: string): string =>

--- a/packages/cli/uni-builder/src/webpack/plugins/react.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/react.ts
@@ -1,4 +1,3 @@
-import { isUsingHMR } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 export const pluginReact = (): RsbuildPlugin => ({
@@ -10,7 +9,9 @@ export const pluginReact = (): RsbuildPlugin => ({
     api.modifyBundlerChain(async (chain, utils) => {
       const config = api.getNormalizedConfig();
 
-      if (!isUsingHMR(config, utils)) {
+      const usingHMR =
+        !utils.isProd && config.dev.hmr && utils.target === 'web';
+      if (!usingHMR) {
         return;
       }
 

--- a/packages/cli/uni-builder/src/webpack/plugins/styledComponents.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/styledComponents.ts
@@ -1,6 +1,5 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin, ConfigChain } from '@rsbuild/core';
 import { PLUGIN_SWC_NAME } from '@rsbuild/core';
-import { type ConfigChain } from '@rsbuild/shared';
 import { applyOptionsChain } from '@modern-js/utils';
 import type { PluginStyledComponentsOptions } from '@rsbuild/plugin-styled-components';
 import { isServerTarget } from '../../shared/utils';

--- a/packages/cli/uni-builder/src/webpack/plugins/tsLoader.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/tsLoader.ts
@@ -1,11 +1,9 @@
 import {
-  JS_REGEX,
-  castArray,
   applyScriptCondition,
   getBrowserslistWithDefault,
   type FileFilterUtil,
-  type ConfigChainWithContext,
 } from '@rsbuild/shared';
+import { type ConfigChainWithContext } from '@rsbuild/core';
 import { applyOptionsChain } from '@modern-js/utils';
 import {
   PluginBabelOptions,
@@ -16,7 +14,7 @@ import { getBabelConfigForWeb } from '@rsbuild/babel-preset/web';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { Options as RawTSLoaderOptions } from 'ts-loader';
 import { getPresetReact } from './babel';
-import { TS_REGEX } from '../../shared/utils';
+import { JS_REGEX, TS_REGEX, castArray } from '../../shared/utils';
 
 export type TSLoaderOptions = Partial<RawTSLoaderOptions>;
 

--- a/packages/cli/uni-builder/tests/fallback.test.ts
+++ b/packages/cli/uni-builder/tests/fallback.test.ts
@@ -7,7 +7,7 @@ describe('plugin-fallback', () => {
   const testPlugin: RsbuildPlugin = {
     name: 'test-plugin',
     setup(api) {
-      api.modifyWebpackChain(chain => {
+      api.modifyBundlerChain(chain => {
         chain.module
           .rule('mjs')
           .test(/\.m?js/)
@@ -36,6 +36,28 @@ describe('plugin-fallback', () => {
   it('should convert fallback rule correctly', async () => {
     const rsbuild = await createUniBuilder({
       bundlerType: 'webpack',
+      cwd: '',
+      config: {
+        plugins: [testPlugin],
+        output: {
+          enableAssetFallback: true,
+        },
+      },
+    });
+    const config = await unwrapConfig(rsbuild);
+
+    expect(config.module?.rules?.length).toBe(2);
+    expect(
+      matchRules({
+        config,
+        testFile: 'bar',
+      }),
+    ).toEqual([]);
+  });
+
+  it('should convert fallback rule correctly in rspack', async () => {
+    const rsbuild = await createUniBuilder({
+      bundlerType: 'rspack',
       cwd: '',
       config: {
         plugins: [testPlugin],

--- a/packages/cli/uni-builder/tests/helper.ts
+++ b/packages/cli/uni-builder/tests/helper.ts
@@ -1,11 +1,11 @@
-import type { RspackConfig, RspackRule } from '@rsbuild/shared';
+import type { Rspack, RspackRule } from '@rsbuild/core';
 import type { UniBuilderInstance } from '../src';
 
 export function matchRules({
   config,
   testFile,
 }: {
-  config: RspackConfig;
+  config: Rspack.Configuration;
   testFile: string;
 }): RspackRule[] {
   if (!config.module?.rules) {
@@ -31,7 +31,10 @@ export const unwrapConfig = async (rsbuild: UniBuilderInstance) => {
 };
 
 /** Match plugin by constructor name. */
-export const matchPlugins = (config: RspackConfig, pluginName: string) => {
+export const matchPlugins = (
+  config: Rspack.Configuration,
+  pluginName: string,
+) => {
   const result = config.plugins?.filter(
     item => item?.constructor.name === pluginName,
   );

--- a/packages/storybook/builder/package.json
+++ b/packages/storybook/builder/package.json
@@ -56,7 +56,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@rsbuild/shared": "0.7.10",
     "@rsbuild/core": "0.7.10",
     "@modern-js/uni-builder": "workspace:*",
     "@modern-js/core": "workspace:*",

--- a/packages/storybook/builder/src/docgen/index.ts
+++ b/packages/storybook/builder/src/docgen/index.ts
@@ -1,14 +1,17 @@
 import type { Options } from '@storybook/types';
 import { logger } from '@modern-js/utils';
-import { CHAIN_ID } from '@rsbuild/shared';
-import type { RspackConfig, RspackChain } from '@rsbuild/shared';
+import type { Rspack, RspackChain, ChainIdentifier } from '@rsbuild/core';
 
 export type DocgenOptions = {
   reactDocgen?: 'react-docgen' | 'react-docgen-typescript' | false;
   reactDocgenTypescriptOptions?: any;
 };
 
-export async function applyDocgenWebpack(chain: RspackChain, options: Options) {
+export async function applyDocgenWebpack(
+  chain: RspackChain,
+  CHAIN_ID: ChainIdentifier,
+  options: Options,
+) {
   const typescriptOptions = (await options.presets.apply(
     'typescript',
     {},
@@ -64,7 +67,7 @@ export async function applyDocgenWebpack(chain: RspackChain, options: Options) {
 }
 
 export async function applyDocgenRspack(
-  config: RspackConfig,
+  config: Rspack.Configuration,
   options: Options,
 ) {
   const typescriptOptions = (await options.presets.apply('typescript', {})) as {

--- a/packages/storybook/builder/src/plugin-storybook.ts
+++ b/packages/storybook/builder/src/plugin-storybook.ts
@@ -28,14 +28,13 @@ import {
   type RsbuildPlugin,
   type RsbuildPluginAPI,
   type RsbuildConfig,
-  type WebpackConfig,
-  type RspackConfig,
-} from '@rsbuild/shared';
-import { mergeRsbuildConfig } from '@rsbuild/core';
+  type Rspack,
+  mergeRsbuildConfig,
+} from '@rsbuild/core';
 
 import { unplugin as csfPlugin } from '@storybook/csf-plugin';
 import { minimatch } from 'minimatch';
-import type { UniBuilderConfig } from '@modern-js/uni-builder';
+import type { UniBuilderConfig, WebpackConfig } from '@modern-js/uni-builder';
 import { BuilderConfig, BuilderOptions } from './types';
 import {
   toImportFn,
@@ -44,6 +43,8 @@ import {
   isDev,
 } from './utils';
 import { applyDocgenRspack, applyDocgenWebpack } from './docgen';
+
+type RspackConfig = Rspack.Configuration;
 
 const STORIES_FILENAME = 'storybook-stories.js';
 const STORYBOOK_CONFIG_ENTRY = 'storybook-config-entry.js';
@@ -122,8 +123,8 @@ export const pluginStorybook: (
         addonAdapter(api, options);
 
         api.modifyWebpackConfig(modifyConfig);
-        api.modifyWebpackChain(async chain => {
-          await applyDocgenWebpack(chain, options);
+        api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {
+          await applyDocgenWebpack(chain, CHAIN_ID, options);
         });
       } else {
         api.modifyRspackConfig(async config => {

--- a/packages/storybook/builder/src/types.ts
+++ b/packages/storybook/builder/src/types.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/shared';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { UniBuilderConfig } from '@modern-js/uni-builder';
 
 export type BundlerType = 'webpack' | 'rspack';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4182,9 +4182,6 @@ importers:
       '@rsbuild/core':
         specifier: 0.7.10
         version: 0.7.10
-      '@rsbuild/shared':
-        specifier: 0.7.10
-        version: 0.7.10(@swc/helpers@0.5.3)
       '@storybook/components':
         specifier: ~7.6.12
         version: 7.6.17(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
## Summary

Decouple some code from `@rsbuild/shared`, `@rsbuild/shared` will removed in rsbuild 1.0.0, we should remove all `@rsbuild/shared` deps in modern.js.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
