### PR TITLE
refactor(app-tools): decouple with @rsbuild/shared

### DIFF
--- a/packages/cli/plugin-bff/package.json
+++ b/packages/cli/plugin-bff/package.json
@@ -71,7 +71,6 @@
     "@swc/helpers": "0.5.3"
   },
   "devDependencies": {
-    "@rsbuild/shared": "0.7.10",
     "@modern-js/runtime": "workspace:*",
     "@modern-js/core": "workspace:*",
     "@modern-js/bff-runtime": "workspace:*",

--- a/packages/cli/plugin-bff/tests/cli.test.ts
+++ b/packages/cli/plugin-bff/tests/cli.test.ts
@@ -8,10 +8,15 @@ import {
   ResolvedConfigContext,
 } from '@modern-js/core';
 import Chain from '@modern-js/utils/webpack-chain';
-import { CHAIN_ID } from '@rsbuild/shared';
 import type { AppToolsHooks } from '@modern-js/app-tools';
 import plugin from '../src/cli';
 import './helper';
+
+const CHAIN_ID = {
+  RULE: {
+    JS: 'js',
+  },
+};
 
 describe('bff cli plugin', () => {
   it('routes', async () => {

--- a/packages/cli/rsbuild-plugin-esbuild/package.json
+++ b/packages/cli/rsbuild-plugin-esbuild/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@swc/helpers": "0.5.3",
-    "@rsbuild/shared": "0.7.10",
     "esbuild": "0.17.19",
     "webpack": "^5.92.0"
   },

--- a/packages/cli/uni-builder/src/index.ts
+++ b/packages/cli/uni-builder/src/index.ts
@@ -19,7 +19,14 @@ export type {
   RspackConfig,
   CacheGroup,
 } from '@rsbuild/shared';
-export type { UniBuilderConfig, UniBuilderPlugin } from './types';
+export type {
+  UniBuilderConfig,
+  UniBuilderPlugin,
+  BundlerType,
+  MetaOptions,
+  Stats,
+  MultiStats,
+} from './types';
 export type { StartDevServerOptions } from './shared/devServer';
 
 export async function createUniBuilder(options: CreateUniBuilderOptions) {
@@ -37,6 +44,7 @@ export {
   type Rspack,
   type RsbuildContext,
   type RsbuildConfig,
+  type RsbuildTarget,
 } from '@rsbuild/core';
 export type { webpack, WebpackConfig } from '@rsbuild/webpack';
-export { RUNTIME_CHUNK_NAME } from './shared/utils';
+export { RUNTIME_CHUNK_NAME, isHtmlDisabled, castArray } from './shared/utils';

--- a/packages/cli/uni-builder/src/index.ts
+++ b/packages/cli/uni-builder/src/index.ts
@@ -13,12 +13,7 @@ export type {
   UniBuilderInstance,
   UniBuilderWebpackInstance,
 };
-export type {
-  CopyPluginOptions,
-  NormalizedConfig,
-  RspackConfig,
-  CacheGroup,
-} from '@rsbuild/shared';
+export type { CopyPluginOptions, CacheGroup } from '@rsbuild/shared';
 export type {
   UniBuilderConfig,
   UniBuilderPlugin,
@@ -26,6 +21,7 @@ export type {
   MetaOptions,
   Stats,
   MultiStats,
+  RspackConfig,
 } from './types';
 export type { StartDevServerOptions } from './shared/devServer';
 
@@ -45,6 +41,7 @@ export {
   type RsbuildContext,
   type RsbuildConfig,
   type RsbuildTarget,
+  type NormalizedConfig,
 } from '@rsbuild/core';
 export type { webpack, WebpackConfig } from '@rsbuild/webpack';
 export { RUNTIME_CHUNK_NAME, isHtmlDisabled, castArray } from './shared/utils';

--- a/packages/cli/uni-builder/src/rspack/plugins/babel-post.ts
+++ b/packages/cli/uni-builder/src/rspack/plugins/babel-post.ts
@@ -1,5 +1,5 @@
 import lodash from 'lodash';
-import { type RsbuildPlugin } from '@rsbuild/shared';
+import { type RsbuildPlugin } from '@rsbuild/core';
 import { getDefaultBabelOptions } from '@rsbuild/plugin-babel';
 
 /**

--- a/packages/cli/uni-builder/src/shared/manifest.ts
+++ b/packages/cli/uni-builder/src/shared/manifest.ts
@@ -1,4 +1,4 @@
-import type { Rspack } from '@rsbuild/shared';
+import type { Rspack } from '@rsbuild/core';
 
 export const generateManifest = (
   seed: Record<string, any>,

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -6,13 +6,13 @@ import {
   getBrowserslist,
   isFunction,
   type HtmlTagHandler,
-  type SourceConfig,
 } from '@rsbuild/shared';
 import {
   mergeRsbuildConfig,
   type RsbuildTarget,
   type RsbuildPlugin,
   type RsbuildConfig,
+  type SourceConfig,
 } from '@rsbuild/core';
 import type {
   CreateBuilderCommonOptions,

--- a/packages/cli/uni-builder/src/shared/plugins/antd.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/antd.ts
@@ -1,4 +1,4 @@
-import { type RsbuildPlugin } from '@rsbuild/shared';
+import { type RsbuildPlugin } from '@rsbuild/core';
 import { isServerTarget } from '../utils';
 
 const getAntdMajorVersion = (appDirectory: string) => {

--- a/packages/cli/uni-builder/src/shared/plugins/arco.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/arco.ts
@@ -1,4 +1,4 @@
-import { type RsbuildPlugin } from '@rsbuild/shared';
+import { type RsbuildPlugin } from '@rsbuild/core';
 import { isPackageInstalled } from '@modern-js/utils';
 import { isServerTarget } from '../../shared/utils';
 

--- a/packages/cli/uni-builder/src/shared/plugins/devtools.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/devtools.ts
@@ -1,4 +1,4 @@
-import { RsbuildPlugin } from '@rsbuild/shared';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { DisableSourceMapOption } from '../../types';
 
 const isUseJsSourceMap = (disableSourceMap: DisableSourceMapOption = {}) => {

--- a/packages/cli/uni-builder/src/shared/plugins/emitRouteFile.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/emitRouteFile.ts
@@ -1,9 +1,10 @@
-import { join } from 'path';
-import { type RsbuildPlugin, fse } from '@rsbuild/shared';
+import { join } from 'node:path';
+import fs from 'node:fs';
+import { type RsbuildPlugin } from '@rsbuild/core';
 
 export async function isFileExists(file: string) {
-  return fse.promises
-    .access(file, fse.constants.F_OK)
+  return fs.promises
+    .access(file, fs.constants.F_OK)
     .then(() => true)
     .catch(() => false);
 }

--- a/packages/cli/uni-builder/src/shared/plugins/extensionPrefix.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/extensionPrefix.ts
@@ -1,5 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
-import type { RsbuildTarget } from '@rsbuild/shared';
+import type { RsbuildPlugin, RsbuildTarget } from '@rsbuild/core';
 
 export const pluginExtensionPrefix = (
   prefixInfo: string | Partial<Record<RsbuildTarget, string>>,

--- a/packages/cli/uni-builder/src/shared/plugins/frameworkConfig.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/frameworkConfig.ts
@@ -1,4 +1,4 @@
-import { fse } from '@rsbuild/shared';
+import fs from 'node:fs';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 export const pluginFrameworkConfig = (configPath: string): RsbuildPlugin => ({
@@ -6,7 +6,7 @@ export const pluginFrameworkConfig = (configPath: string): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(chain => {
-      if (!fse.existsSync(configPath)) {
+      if (!fs.existsSync(configPath)) {
         return;
       }
 

--- a/packages/cli/uni-builder/src/shared/plugins/mainFields.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/mainFields.ts
@@ -1,6 +1,5 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin, RsbuildTarget } from '@rsbuild/core';
 import type { MainFields } from '../../types';
-import type { RsbuildTarget } from '@rsbuild/shared';
 
 export const pluginMainFields = (
   resolveMainFields: MainFields | Partial<Record<RsbuildTarget, MainFields>>,

--- a/packages/cli/uni-builder/src/shared/utils.ts
+++ b/packages/cli/uni-builder/src/shared/utils.ts
@@ -19,6 +19,20 @@ export const castArray = <T>(arr?: T | T[]): T[] => {
   return Array.isArray(arr) ? arr : [arr];
 };
 
+export const isHtmlDisabled = (
+  config: NormalizedConfig,
+  target: RsbuildTarget,
+) => {
+  const { htmlPlugin } = config.tools as {
+    htmlPlugin: boolean | Array<unknown>;
+  };
+  return (
+    htmlPlugin === false ||
+    (Array.isArray(htmlPlugin) && htmlPlugin.includes(false)) ||
+    target !== 'web'
+  );
+};
+
 export const getHash = (config: NormalizedConfig) => {
   const { filenameHash } = config.output;
 

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -1,6 +1,5 @@
 import type {
   NodeEnv,
-  MetaOptions,
   RequestHandler,
   HtmlTagDescriptor,
 } from '@rsbuild/shared';
@@ -16,6 +15,7 @@ import type {
   RsbuildPluginAPI,
   SourceConfig,
   OutputConfig,
+  Rspack,
 } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import type { PluginStyledComponentsOptions } from '@rsbuild/plugin-styled-components';
@@ -39,6 +39,31 @@ import type TerserPlugin from 'terser-webpack-plugin';
 
 type ArrayOrNot<T> = T | T[];
 
+export type Stats = Omit<Rspack.Stats, '#private' | 'hash'>;
+
+export type RspackConfig = Rspack.Configuration;
+
+export type MultiStats = Omit<
+  Rspack.MultiStats,
+  '#private' | 'hash' | 'stats'
+> & {
+  stats: Stats[];
+};
+
+/**
+ * custom properties
+ * e.g. { name: 'viewport' content: 'width=500, initial-scale=1' }
+ * */
+type MetaAttrs = { [attrName: string]: string | boolean };
+
+export type MetaOptions = {
+  /**
+   * name content pair
+   * e.g. { viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no' }`
+   * */
+  [name: string]: string | false | MetaAttrs;
+};
+
 export type CreateBuilderCommonOptions = {
   entry?: SourceConfig['entry'];
   frameworkConfigPath?: string;
@@ -47,8 +72,10 @@ export type CreateBuilderCommonOptions = {
   cwd: string;
 };
 
+export type BundlerType = 'rspack' | 'webpack';
+
 export type CreateUniBuilderOptions = {
-  bundlerType: 'rspack' | 'webpack';
+  bundlerType: BundlerType;
   config: UniBuilderConfig;
 } & Partial<CreateBuilderCommonOptions>;
 

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -77,7 +77,6 @@
     "react-dom": ">=17"
   },
   "devDependencies": {
-    "@rsbuild/shared": "0.7.10",
     "@modern-js/app-tools": "workspace:*",
     "@modern-js/core": "workspace:*",
     "@modern-js/plugin-router-v5": "workspace:*",

--- a/packages/runtime/plugin-garfish/tests/cli.test.tsx
+++ b/packages/runtime/plugin-garfish/tests/cli.test.tsx
@@ -1,11 +1,16 @@
 import '@testing-library/jest-dom';
 import { manager, CliPlugin } from '@modern-js/core';
 import WebpackChain from '@modern-js/utils/webpack-chain';
-import { CHAIN_ID } from '@rsbuild/shared';
 import type { AppUserConfig } from '@modern-js/app-tools';
 import { garfishPlugin, externals } from '../src/cli';
 import type { UseConfig } from '../src/cli';
 import { getRuntimeConfig, setRuntimeConfig } from '../src/cli/utils';
+
+const CHAIN_ID = {
+  PLUGIN: {
+    HTML: 'html',
+  },
+};
 
 describe('plugin-garfish cli', () => {
   test('cli garfish basename', async () => {

--- a/packages/solutions/app-tools/package.json
+++ b/packages/solutions/app-tools/package.json
@@ -99,7 +99,6 @@
     "@modern-js/uni-builder": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@rsbuild/plugin-node-polyfill": "0.7.10",
-    "@rsbuild/shared": "0.7.10",
     "@rsbuild/core": "0.7.10",
     "@swc/helpers": "0.5.3",
     "@vercel/nft": "^0.26.4",

--- a/packages/solutions/app-tools/src/builder/generator/createBuilderOptions.ts
+++ b/packages/solutions/app-tools/src/builder/generator/createBuilderOptions.ts
@@ -1,5 +1,8 @@
-import type { CreateUniBuilderOptions } from '@modern-js/uni-builder';
-import type { RsbuildTarget } from '@rsbuild/shared';
+import type {
+  RsbuildTarget,
+  CreateUniBuilderOptions,
+} from '@modern-js/uni-builder';
+
 import type { IAppContext } from '@modern-js/core';
 
 export function createBuilderOptions(

--- a/packages/solutions/app-tools/src/builder/generator/getBuilderTargets.ts
+++ b/packages/solutions/app-tools/src/builder/generator/getBuilderTargets.ts
@@ -1,4 +1,4 @@
-import type { RsbuildTarget } from '@rsbuild/shared';
+import type { RsbuildTarget } from '@rsbuild/core';
 import {
   isProd,
   isServiceWorker,

--- a/packages/solutions/app-tools/src/builder/generator/index.ts
+++ b/packages/solutions/app-tools/src/builder/generator/index.ts
@@ -1,5 +1,8 @@
-import { createUniBuilder, UniBuilderInstance } from '@modern-js/uni-builder';
-import { BundlerType } from '@rsbuild/shared';
+import {
+  createUniBuilder,
+  type UniBuilderInstance,
+  type BundlerType,
+} from '@modern-js/uni-builder';
 import { BuilderOptions } from '../shared';
 import { Bundler } from '../../types';
 import { createBuilderProviderConfig } from './createBuilderProviderConfig';

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterBasic.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { RsbuildPlugin, RspackChain } from '@rsbuild/shared';
+import type { RsbuildPlugin, RspackChain } from '@rsbuild/core';
 
 export const builderPluginAdapterBasic = (): RsbuildPlugin => ({
   name: 'builder-plugin-adapter-modern-basic',

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterHtml.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterHtml.ts
@@ -1,10 +1,10 @@
-import {
-  isHtmlDisabled,
+import { isHtmlDisabled } from '@modern-js/uni-builder';
+import type {
   RsbuildPlugin,
   RspackChain,
   ChainIdentifier,
   RsbuildPluginAPI,
-} from '@rsbuild/shared';
+} from '@rsbuild/core';
 import {
   MAIN_ENTRY_NAME,
   getEntryOptions,

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -1,8 +1,7 @@
 import * as path from 'path';
-import { isHtmlDisabled, RsbuildPlugin, RspackChain } from '@rsbuild/shared';
-import { mergeRsbuildConfig } from '@rsbuild/core';
+import { RsbuildPlugin, RspackChain, mergeRsbuildConfig } from '@rsbuild/core';
 import { fs, isUseSSRBundle } from '@modern-js/utils';
-import type { HtmlWebpackPlugin } from '@modern-js/uni-builder';
+import { type HtmlWebpackPlugin, isHtmlDisabled } from '@modern-js/uni-builder';
 import type {
   AppNormalizedConfig,
   Bundler,

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterWorker.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterWorker.ts
@@ -1,10 +1,10 @@
 import { posix } from 'path';
 
-import {
+import type {
   RsbuildPlugin,
   NormalizedConfig,
   DistPathConfig,
-} from '@rsbuild/shared';
+} from '@rsbuild/core';
 
 const getDistPath = (
   outputConfig: NormalizedConfig['output'],

--- a/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
+++ b/packages/solutions/app-tools/src/builder/shared/bundlerPlugins/RouterPlugin.ts
@@ -7,7 +7,7 @@ import type {
   webpack,
   HtmlWebpackPlugin,
 } from '@modern-js/uni-builder';
-import type { ScriptLoading } from '@rsbuild/shared';
+import type { ScriptLoading } from '@rsbuild/core';
 
 const PLUGIN_NAME = 'ModernjsRoutePlugin';
 

--- a/packages/solutions/app-tools/src/commands/index.ts
+++ b/packages/solutions/app-tools/src/commands/index.ts
@@ -1,6 +1,6 @@
 import { PluginAPI } from '@modern-js/core';
 import { Command, newAction, upgradeAction } from '@modern-js/utils';
-import { castArray } from '@rsbuild/shared';
+import { castArray } from '@modern-js/uni-builder';
 import { AppTools } from '../types';
 import { i18n, localeKeys } from '../locale';
 import type {

--- a/packages/solutions/app-tools/src/commands/inspect.ts
+++ b/packages/solutions/app-tools/src/commands/inspect.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import type { RsbuildMode } from '@rsbuild/shared';
+import type { RsbuildMode } from '@rsbuild/core';
 import type { PluginAPI } from '@modern-js/core';
 import type { InspectOptions } from '../utils/types';
 import type { AppTools } from '../types';

--- a/packages/solutions/app-tools/src/types/hooks.ts
+++ b/packages/solutions/app-tools/src/types/hooks.ts
@@ -13,8 +13,12 @@ import type {
   ServerRoute,
 } from '@modern-js/types';
 import type { RegisterBuildPlatformResult, DevToolData } from '@modern-js/core';
-import type { Stats, MultiStats } from '@rsbuild/shared';
-import type { Rspack, webpack } from '@modern-js/uni-builder';
+import type {
+  Rspack,
+  webpack,
+  Stats,
+  MultiStats,
+} from '@modern-js/uni-builder';
 import { Bundler } from './utils';
 
 export interface ImportSpecifier {

--- a/packages/solutions/app-tools/src/types/legacyConfig/output.ts
+++ b/packages/solutions/app-tools/src/types/legacyConfig/output.ts
@@ -1,4 +1,4 @@
-import type { MetaOptions } from '@rsbuild/shared';
+import type { MetaOptions } from '@modern-js/uni-builder';
 import type { SSGConfig } from '../config';
 
 type CrossOrigin = 'anonymous' | 'use-credentials';

--- a/packages/solutions/app-tools/src/utils/register.ts
+++ b/packages/solutions/app-tools/src/utils/register.ts
@@ -5,7 +5,7 @@ import {
   getAliasConfig,
   readTsConfigByFile,
 } from '@modern-js/utils';
-import { ConfigChain } from '@rsbuild/shared';
+import type { ConfigChain } from '@rsbuild/core';
 
 export const registerCompiler = async (
   appDir: string = process.cwd(),

--- a/packages/solutions/app-tools/tests/builder/index.test.ts
+++ b/packages/solutions/app-tools/tests/builder/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type { RsbuildTarget } from '@rsbuild/shared';
+import type { RsbuildTarget } from '@rsbuild/core';
 import { initSnapshotSerializer } from '@scripts/jest-config/utils';
 import { createBuilderProviderConfig } from '../../src/builder/generator/createBuilderProviderConfig';
 import { createBuilderOptions } from '../../src/builder/generator/createBuilderOptions';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,9 +213,6 @@ importers:
       '@modern-js/types':
         specifier: workspace:*
         version: link:../../toolkit/types
-      '@rsbuild/shared':
-        specifier: 0.7.10
-        version: 0.7.10(@swc/helpers@0.5.3)
       '@scripts/build':
         specifier: workspace:*
         version: link:../../../scripts/build
@@ -629,9 +626,6 @@ importers:
 
   packages/cli/rsbuild-plugin-esbuild:
     dependencies:
-      '@rsbuild/shared':
-        specifier: 0.7.10
-        version: 0.7.10(@swc/helpers@0.5.3)
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -2705,9 +2699,6 @@ importers:
       '@modern-js/types':
         specifier: workspace:*
         version: link:../../toolkit/types
-      '@rsbuild/shared':
-        specifier: 0.7.10
-        version: 0.7.10(@swc/helpers@0.5.3)
       '@scripts/build':
         specifier: workspace:*
         version: link:../../../scripts/build
@@ -3936,9 +3927,6 @@ importers:
       '@rsbuild/plugin-node-polyfill':
         specifier: 0.7.10
         version: 0.7.10(@rsbuild/core@0.7.10)
-      '@rsbuild/shared':
-        specifier: 0.7.10
-        version: 0.7.10(@swc/helpers@0.5.3)
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -5149,12 +5137,12 @@ importers:
       '@playwright/test':
         specifier: 1.33.0
         version: 1.33.0
+      '@rsbuild/core':
+        specifier: 0.7.10
+        version: 0.7.10
       '@rsbuild/plugin-swc':
         specifier: 0.7.10
         version: 0.7.10(@rsbuild/core@0.7.10)
-      '@rsbuild/shared':
-        specifier: 0.7.10
-        version: 0.7.10(@swc/helpers@0.5.3)
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.14.202

--- a/tests/e2e/builder/cases/check-syntax/index.test.ts
+++ b/tests/e2e/builder/cases/check-syntax/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { build } from '@scripts/shared';
-import type { RsbuildConfig } from '@rsbuild/shared';
+import type { RsbuildConfig } from '@rsbuild/core';
 
 function getCommonBuildConfig(cwd: string): RsbuildConfig {
   return {

--- a/tests/e2e/builder/cases/source/plugin-import/helper.ts
+++ b/tests/e2e/builder/cases/source/plugin-import/helper.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { build } from '@scripts/shared';
 import { expect, test } from '@modern-js/e2e/playwright';
 import { ensureDirSync, copySync } from 'fs-extra';
-import { RsbuildConfig, SourceConfig } from '@rsbuild/shared';
+import type { RsbuildConfig, SourceConfig } from '@rsbuild/core';
 
 export const cases: Parameters<typeof shareTest>[] = [
   [

--- a/tests/e2e/builder/package.json
+++ b/tests/e2e/builder/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@rsbuild/plugin-swc": "0.7.10",
-    "@rsbuild/shared": "0.7.10",
+    "@rsbuild/core": "0.7.10",
     "@modern-js/uni-builder": "workspace:*",
     "@modern-js/e2e": "workspace:*",
     "@modern-js/utils": "workspace:*",


### PR DESCRIPTION
## Summary

refactor(app-tools): app-tools and some other pkgs decouple  with @rsbuild/shared.

TODO: Completely make  uni-builder decouple with @rsbuild/shared.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
