### PR TITLE
fix(garfish): @modern-js/runtime should be a dependency

### DIFF
--- a/.changeset/olive-dryers-kick.md
+++ b/.changeset/olive-dryers-kick.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix(garfish): @modern-js/runtime should be a dependency
+fix(garfish): @modern-js/runtime 应该是 dependency

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -69,10 +69,10 @@
     "debug": "4.3.4",
     "garfish": "^1.8.1",
     "react-loadable": "^5.5.0",
+    "@modern-js/runtime": "workspace:*",
     "@swc/helpers": "0.5.3"
   },
   "peerDependencies": {
-    "@modern-js/runtime": "workspace:^2.55.0",
     "react": ">=17",
     "react-dom": ">=17"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2677,6 +2677,9 @@ importers:
 
   packages/runtime/plugin-garfish:
     dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../plugin-runtime
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils
@@ -2708,9 +2711,6 @@ importers:
       '@modern-js/plugin-router-v5':
         specifier: workspace:*
         version: link:../plugin-router-v5
-      '@modern-js/runtime':
-        specifier: workspace:*
-        version: link:../plugin-runtime
       '@modern-js/types':
         specifier: workspace:*
         version: link:../../toolkit/types


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
