### PR TITLE
feat: the runtime path use the meta alias in garfish provider

### DIFF
--- a/.changeset/curvy-mangos-collect.md
+++ b/.changeset/curvy-mangos-collect.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/plugin-router-v5': patch
+'@modern-js/plugin-garfish': patch
+---
+
+feat: the runtime path use the meta alias in garfish provider
+
+feat: 在 garfish provider 函数中使用 runtime 别名路径

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -141,6 +141,8 @@ export const garfishPlugin = (): CliPlugin<
           source: {
             alias: {
               [`@${metaName}/runtime/garfish`]: `@${metaName}/plugin-garfish/runtime`,
+              '@meta/runtime/browser': '@modern-js/runtime/browser',
+              '@meta/runtime/react': '@modern-js/runtime/react',
             },
           },
           tools: {

--- a/packages/runtime/plugin-garfish/src/global.d.ts
+++ b/packages/runtime/plugin-garfish/src/global.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="@modern-js/types" />
+
+declare module '@meta/runtime/react' {
+  export * from '@modern-js/runtime/react';
+}
+
+declare module '@meta/runtime/browser' {
+  export * from '@modern-js/runtime/browser';
+}

--- a/packages/runtime/plugin-garfish/src/runtime/provider.tsx
+++ b/packages/runtime/plugin-garfish/src/runtime/provider.tsx
@@ -1,4 +1,4 @@
-import { createRoot } from '@modern-js/runtime/react';
+import { createRoot } from '@meta/runtime/react';
 import type { Root } from 'react-dom/client';
 import { createPortal, unmountComponentAtNode } from 'react-dom';
 import { garfishRender } from './render';

--- a/packages/runtime/plugin-garfish/src/runtime/render.tsx
+++ b/packages/runtime/plugin-garfish/src/runtime/render.tsx
@@ -1,5 +1,5 @@
-import { render } from '@modern-js/runtime/browser';
-import { createRoot } from '@modern-js/runtime/react';
+import { render } from '@meta/runtime/browser';
+import { createRoot } from '@meta/runtime/react';
 
 declare const __GARFISH_EXPORTS__: string;
 

--- a/packages/runtime/plugin-router-v5/package.json
+++ b/packages/runtime/plugin-router-v5/package.json
@@ -73,7 +73,8 @@
   },
   "peerDependencies": {
     "react": ">=17",
-    "react-dom": ">=17"
+    "react-dom": ">=17",
+    "@modern-js/runtime": "workspace:^2.55.0"
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",

--- a/tests/integration/garfish/app-dashboard/src/index.tsx
+++ b/tests/integration/garfish/app-dashboard/src/index.tsx
@@ -6,7 +6,7 @@ const sleep = () =>
 
 export default (_App: React.ComponentType, bootstrap: () => void) => {
   // do something before bootstrap...
-  sleep().then(() => {
-    bootstrap();
+  return sleep().then(() => {
+    return bootstrap();
   });
 };


### PR DESCRIPTION
## Summary

when in custom framework through custom metaName, @xx/plugin-garfish need use @xx/runtime package to use createRoot and render function, to avoid error when @xx/runtime existing more version.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
