### PR TITLE
fix(babel-preset): cjs extension should be js

### DIFF
--- a/.changeset/few-fireants-punch.md
+++ b/.changeset/few-fireants-punch.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/babel-preset': patch
+---
+
+fix(babel-preset): cjs extension should be js

--- a/packages/cli/babel-preset/package.json
+++ b/packages/cli/babel-preset/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/modern.js",
-    "directory": "packages/builder/uni-builder"
+    "directory": "packages/cli/babel-preset"
   },
   "license": "MIT",
   "type": "commonjs",

--- a/packages/cli/babel-preset/src/web.ts
+++ b/packages/cli/babel-preset/src/web.ts
@@ -50,7 +50,7 @@ export const getBabelConfigForWeb = (
     ]);
   }
 
-  config.plugins?.push(join(__dirname, './pluginLockCorejsVersion.cjs'));
+  config.plugins?.push(join(__dirname, './pluginLockCorejsVersion.js'));
 
   return config;
 };

--- a/packages/cli/babel-preset/tests/__snapshots__/web.test.ts.snap
+++ b/packages/cli/babel-preset/tests/__snapshots__/web.test.ts.snap
@@ -24,7 +24,7 @@ exports[`should allow to enable legacy decorator 1`] = `
         "version": "7.24.7",
       },
     ],
-    "<ROOT>/src/pluginLockCorejsVersion.cjs",
+    "<ROOT>/src/pluginLockCorejsVersion.js",
   ],
   "presets": [
     [
@@ -84,7 +84,7 @@ exports[`should allow to enable specific version decorator 1`] = `
         "version": "7.24.7",
       },
     ],
-    "<ROOT>/src/pluginLockCorejsVersion.cjs",
+    "<ROOT>/src/pluginLockCorejsVersion.js",
   ],
   "presets": [
     [
@@ -134,7 +134,7 @@ exports[`should provide web preset as expected 1`] = `
         "version": "7.24.7",
       },
     ],
-    "<ROOT>/src/pluginLockCorejsVersion.cjs",
+    "<ROOT>/src/pluginLockCorejsVersion.js",
   ],
   "presets": [
     [
@@ -225,7 +225,7 @@ exports[`should support inject core-js polyfills by entry 1`] = `
         "version": "7.24.7",
       },
     ],
-    "<ROOT>/src/pluginLockCorejsVersion.cjs",
+    "<ROOT>/src/pluginLockCorejsVersion.js",
   ],
   "presets": [
     [
@@ -278,7 +278,7 @@ exports[`should support inject core-js polyfills by usage 1`] = `
         "version": "7.24.7",
       },
     ],
-    "<ROOT>/src/pluginLockCorejsVersion.cjs",
+    "<ROOT>/src/pluginLockCorejsVersion.js",
   ],
   "presets": [
     [

--- a/packages/cli/uni-builder/package.json
+++ b/packages/cli/uni-builder/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/modern.js",
-    "directory": "packages/builder/uni-builder"
+    "directory": "packages/cli/uni-builder"
   },
   "license": "MIT",
   "type": "commonjs",

--- a/packages/cli/uni-builder/tests/__snapshots__/babel.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/babel.test.ts.snap
@@ -266,7 +266,7 @@ exports[`plugin-babel > should add core-js-entry when output.polyfill is entry 1
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -531,7 +531,7 @@ exports[`plugin-babel > should apply exclude condition when using source.exclude
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -673,7 +673,7 @@ exports[`plugin-babel > should not add core-js-entry when output.polyfill is usa
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -809,7 +809,7 @@ exports[`plugin-babel > should not have any pluginImport in Babel 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<ROOT>/compiled/babel-plugin-lodash/index.js",
               {},
@@ -917,7 +917,7 @@ exports[`plugin-babel > should not have any pluginImport in Babel 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<ROOT>/compiled/babel-plugin-lodash/index.js",
               {},
@@ -1028,7 +1028,7 @@ exports[`plugin-babel > should not set default pluginImport for Babel 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1155,7 +1155,7 @@ exports[`plugin-babel > should not set default pluginImport for Babel 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1290,7 +1290,7 @@ exports[`plugin-babel > should override targets of babel-preset-env when using o
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1430,7 +1430,7 @@ exports[`plugin-babel > should set babel-loader 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1576,7 +1576,7 @@ exports[`plugin-babel > should set include/exclude 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1712,7 +1712,7 @@ exports[`plugin-babel > should set proper pluginImport option in Babel 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -1847,7 +1847,7 @@ exports[`plugin-babel > should set proper pluginImport option in Babel 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {

--- a/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
@@ -3515,7 +3515,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                     "version": "7.24.7",
                   },
                 ],
-                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
@@ -3642,7 +3642,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                     "version": "7.24.7",
                   },
                 ],
-                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
@@ -4030,7 +4030,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                         "version": "7.24.7",
                       },
                     ],
-                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {
@@ -4158,7 +4158,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
                         "version": "7.24.7",
                       },
                     ],
-                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {
@@ -4631,7 +4631,7 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                     "version": "7.24.7",
                   },
                 ],
-                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
@@ -4758,7 +4758,7 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                     "version": "7.24.7",
                   },
                 ],
-                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                 [
                   "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                   {
@@ -5152,7 +5152,7 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                         "version": "7.24.7",
                       },
                     ],
-                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {
@@ -5295,7 +5295,7 @@ exports[`uni-builder webpack > should generator webpack config correctly when pr
                         "version": "7.24.7",
                       },
                     ],
-                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+                    "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
                     [
                       "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
                       {

--- a/packages/cli/uni-builder/tests/__snapshots__/react.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/react.test.ts.snap
@@ -51,7 +51,7 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {

--- a/packages/cli/uni-builder/tests/__snapshots__/styledComponents.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/styledComponents.test.ts.snap
@@ -171,7 +171,7 @@ exports[`plugins/styled-components > should enable ssr when target contain node 
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {
@@ -313,7 +313,7 @@ exports[`plugins/styled-components > should works in webpack babel mode 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/babel-plugin-import/lib/index.js",
               {

--- a/packages/cli/uni-builder/tests/__snapshots__/tsLoader.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/tsLoader.test.ts.snap
@@ -234,7 +234,7 @@ exports[`plugin-ts-loader > should set include/exclude 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/react-refresh/babel.js",
               {
@@ -337,7 +337,7 @@ exports[`plugin-ts-loader > should set ts-loader 1`] = `
                 "version": "7.24.7",
               },
             ],
-            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.cjs",
+            "<WORKSPACE>/packages/cli/babel-preset/src/pluginLockCorejsVersion.js",
             [
               "<WORKSPACE>/node_modules/<PNPM_INNER>/react-refresh/babel.js",
               {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3960,7 +3960,7 @@ importers:
         version: 7.23.6
       '@babel/traverse':
         specifier: ^7.23.2
-        version: 7.23.6
+        version: 7.23.6(supports-color@5.5.0)
       '@babel/types':
         specifier: ^7.24.7
         version: 7.24.7
@@ -8816,7 +8816,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.7
-    dev: false
 
   /@babel/parser@7.24.7:
     resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
@@ -10023,24 +10022,6 @@ packages:
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
 
-  /@babel/traverse@7.23.6:
-    resolution: {integrity: sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.7
-      debug: 4.3.4(supports-color@5.5.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/traverse@7.23.6(supports-color@5.5.0):
     resolution: {integrity: sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==}
     engines: {node: '>=6.9.0'}
@@ -10051,7 +10032,7 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.24.7
+      '@babel/parser': 7.24.5
       '@babel/types': 7.24.7
       debug: 4.3.4(supports-color@5.5.0)
       globals: 11.12.0
@@ -17582,7 +17563,7 @@ packages:
       '@babel/helper-module-imports': 7.22.15
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.7)
       '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.6
+      '@babel/traverse': 7.23.6(supports-color@5.5.0)
       '@babel/types': 7.24.7
       '@vue/babel-helper-vue-transform-on': 1.1.5
       camelcase: 6.3.0


### PR DESCRIPTION
## Summary

Fix the cjs extension should be js.

## Related Links

https://github.com/web-infra-dev/modern.js/pull/5946

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
