### PR TITLE
fix: mockHandler should run in dev-server correctly

### DIFF
--- a/.changeset/thirty-dancers-travel.md
+++ b/.changeset/thirty-dancers-travel.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server': patch
+---
+
+fix: mockHandler should run before rsbuild middleware & mockHandler can't hmr correctly
+fix: mockHandler 应该在 rsbuild middleware 之前跑 & mockHandler 不能正确的 hmr

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -72,17 +72,17 @@ export const devPlugin = <O extends ServerBaseOptions>(
             });
           });
 
+        await registerMockHandlers({
+          pwd,
+          server: serverBase!,
+        });
+
         if (rsbuildMiddlewares) {
           middlewares.push({
             name: 'rsbuild-dev',
             handler: connectMid2HonoMid(rsbuildMiddlewares),
           });
         }
-
-        await registerMockHandlers({
-          pwd,
-          server: serverBase!,
-        });
 
         middlewares.push({
           name: 'init-file-reader',

--- a/packages/server/server/src/helpers/mock.ts
+++ b/packages/server/server/src/helpers/mock.ts
@@ -90,10 +90,17 @@ export const registerMockHandlers = async ({
     const { method, path } = parseKey(key);
     const methodName = method.toLowerCase() as keyof ServerBase;
     const handlerId = `${methodName}-${path}`;
-    mockHandlerRegistry.set(handlerId, {
-      handler,
-      isRegistered: false,
-    });
+
+    const mockInfo = mockHandlerRegistry.get(handlerId);
+    if (mockInfo) {
+      mockInfo.handler = handler;
+    } else {
+      mockHandlerRegistry.set(handlerId, {
+        handler,
+        isRegistered: false,
+      });
+    }
+
     if (typeof server[methodName] === 'function') {
       // eslint-disable-next-line consistent-return
       const mockHandler: ServerNodeMiddleware = async (c, next) => {


### PR DESCRIPTION
## Summary
- mockHandler should run before rsbuild middleware
- mockHandler can't hmr correctly


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
