### PR TITLE
fix(ssr): avoid the compilation problem with renderToPipeableStream a…

### DIFF
--- a/.changeset/twelve-mirrors-decide.md
+++ b/.changeset/twelve-mirrors-decide.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(ssr): Avoid the compilation problem with renderToPipeableStream and react 17
+fix(ssr): 避免 react 17 下，使用 renderToPipeableStream 的编译问题

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
@@ -1,5 +1,4 @@
 import { Transform } from 'stream';
-import { renderToPipeableStream } from 'react-dom/server';
 import { createReadableStreamFromReadable } from '@modern-js/runtime-utils/node';
 import { ServerStyleSheet } from 'styled-components';
 import checkIsBot from 'isbot';
@@ -13,7 +12,8 @@ import {
 } from './shared';
 
 export const createReadableStreamFromElement: CreateReadableStreamFromElement =
-  (request, rootElement, options) => {
+  async (request, rootElement, options) => {
+    const { renderToPipeableStream } = await import('react-dom/server');
     const { runtimeContext, htmlTemplate, config, ssrConfig } = options;
     let shellChunkStatus = ShellChunkStatus.START;
 


### PR DESCRIPTION
…nd react 17

## Summary

Since `renderToPipeableStream` is not available in React17, the following issue occurs when the user's react version is 17:
![image](https://github.com/user-attachments/assets/03c20ac2-bf02-4b65-92a5-585cbb632be1)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
