### PR TITLE
fix: storybook port occupied error

### DIFF
--- a/.changeset/curvy-plants-fold.md
+++ b/.changeset/curvy-plants-fold.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/storybook-builder': patch
+---
+
+fix: storybook port occupied error
+
+fix: 修复 storybook 端口占用报错

--- a/packages/storybook/builder/src/plugin-storybook.ts
+++ b/packages/storybook/builder/src/plugin-storybook.ts
@@ -352,7 +352,6 @@ function applyServerConfig(builderConfig: RsbuildConfig, options: Options) {
     port: options.port,
     host: 'localhost',
     htmlFallback: false,
-    strictPort: true,
     printUrls: false,
   };
 }


### PR DESCRIPTION
## Summary

strictPort is not required and will cause port occupation error.

## Related Links

https://github.com/rspack-contrib/storybook-rsbuild/pull/47

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
