### PR TITLE
fix: new server middleware support get body, if request.method is post

### DIFF
--- a/.changeset/chatty-lies-love.md
+++ b/.changeset/chatty-lies-love.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: new server middleware support get body, if request.method is post
+fix: 如果请求是 post, 新 server middlewares 可以拿到 body 数据

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7121,6 +7121,9 @@ importers:
       '@modern-js/runtime':
         specifier: workspace:*
         version: link:../../../../packages/runtime/plugin-runtime
+      axios:
+        specifier: ^1.6.0
+        version: 1.6.7
       react:
         specifier: ^18
         version: 18.2.0

--- a/tests/integration/server-hook/new-middleware/package.json
+++ b/tests/integration/server-hook/new-middleware/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@modern-js/runtime": "workspace:*",
+    "axios": "^1.6.0",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/tests/integration/server-hook/new-middleware/server/index.ts
+++ b/tests/integration/server-hook/new-middleware/server/index.ts
@@ -76,8 +76,26 @@ function injectMessage(): UnstableMiddleware {
   };
 }
 
+function injectRequestBody(): UnstableMiddleware {
+  return async (c, next) => {
+    await next();
+
+    const { request, response } = c;
+
+    if (request.method.toUpperCase() === 'POST' && request.body) {
+      const requestBody = await request.text();
+
+      c.response = c.body(requestBody, {
+        status: response.status,
+        headers: response.headers,
+      });
+    }
+  };
+}
+
 export const unstableMiddleware: UnstableMiddleware[] = [
   time(),
-  auth() as unknown as UnstableMiddleware,
+  injectRequestBody(),
   injectMessage(),
+  auth() as unknown as UnstableMiddleware,
 ];

--- a/tests/integration/server-hook/new-middleware/tests/index.test.ts
+++ b/tests/integration/server-hook/new-middleware/tests/index.test.ts
@@ -1,11 +1,15 @@
 import path from 'path';
+import dns from 'node:dns';
 import puppeteer, { Browser, Page } from 'puppeteer';
+import axios from 'axios';
 import {
   launchApp,
   getPort,
   killApp,
   launchOptions,
 } from '../../../../utils/modernTestUtils';
+
+dns.setDefaultResultOrder('ipv4first');
 
 const appPath = path.resolve(__dirname, '../');
 
@@ -63,5 +67,19 @@ describe('test new middleware run correctly', () => {
     expect(body).toMatch(/lang="en"/);
 
     expect(headers).toHaveProperty('x-custom-value', 'modern');
+  });
+
+  test('should replace body when request is post', async () => {
+    const url = `http://localhost:${port}/`;
+
+    const message = 'Hello ABC';
+
+    const response = await axios.post(url, message, {
+      responseType: 'text',
+    });
+
+    const body = response.data;
+
+    expect(body).toMatch(message);
   });
 });


### PR DESCRIPTION
## Summary
下个大版本去除旧版 middleware，当请求非 get 和 head 时
1. 不加 bff.enableHandleWeb 时，默认都被 createWebRequest 消费
2. 加 bff.enableHandleWeb 时，__loader 被 createWebRequest 消费，非 loader 不被消费

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
