### PR TITLE
fix: import plugin api from @modern-js/plugin instead @modern-js/core

### DIFF
--- a/.changeset/neat-starfishes-design.md
+++ b/.changeset/neat-starfishes-design.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix: import plugin api from @modern-js/plugin instead @modern-js/core
+fix: 从 @modern-js/plugin 导入插件 api 而不是 @modern-js/core

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -73,6 +73,7 @@
   },
   "peerDependencies": {
     "@modern-js/runtime": "workspace:^2.56.0",
+    "@modern-js/plugin": "workspace:*",
     "react": ">=17",
     "react-dom": ">=17"
   },

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@modern-js/utils": "workspace:*",
+    "@modern-js/plugin": "workspace:*",
     "@types/debug": "4.1.7",
     "@types/react-loadable": "^5.5.6",
     "debug": "4.3.4",
@@ -73,7 +74,6 @@
   },
   "peerDependencies": {
     "@modern-js/runtime": "workspace:^2.56.0",
-    "@modern-js/plugin": "workspace:*",
     "react": ">=17",
     "react-dom": ">=17"
   },

--- a/packages/runtime/plugin-garfish/src/cli/code.ts
+++ b/packages/runtime/plugin-garfish/src/cli/code.ts
@@ -6,7 +6,7 @@ import type {
 } from '@modern-js/app-tools';
 import { fs } from '@modern-js/utils';
 import { Entrypoint } from '@modern-js/types';
-import type { MaybeAsync } from '@modern-js/core';
+import type { MaybeAsync } from '@modern-js/plugin';
 import * as template from './template';
 import { generateAsyncEntryCode } from './utils';
 

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -1,10 +1,6 @@
 import { createRuntimeExportsUtils, getEntryOptions } from '@modern-js/utils';
-import {
-  AsyncWorkflow,
-  createAsyncWorkflow,
-  type CliHookCallbacks,
-  type useConfigContext,
-} from '@modern-js/core';
+import { type CliHookCallbacks, type useConfigContext } from '@modern-js/core';
+import { type AsyncWorkflow, createAsyncWorkflow } from '@modern-js/plugin';
 import type { CliPlugin, AppTools } from '@modern-js/app-tools';
 import { Entrypoint } from '@modern-js/types';
 import { logger } from '../util';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2747,6 +2747,9 @@ importers:
 
   packages/runtime/plugin-garfish:
     dependencies:
+      '@modern-js/plugin':
+        specifier: workspace:*
+        version: link:../../toolkit/plugin
       '@modern-js/utils':
         specifier: workspace:*
         version: link:../../toolkit/utils


### PR DESCRIPTION
## Summary

remove the plugin api import from '@modern-js/core', but import from '@modern-js/plugin'

and add '@modern-js/plugin' to `@modern-js/plugin-garfish` dependencies.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
