### PR TITLE
fix(deploy): limit the scope of the find dependencies

### DIFF
--- a/.changeset/friendly-donuts-bake.md
+++ b/.changeset/friendly-donuts-bake.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: handle the case of nft find for error dependencies
+fix: 处理 nft 查找到错误依赖的情况

--- a/packages/solutions/app-tools/src/plugins/deploy/dependencies/index.ts
+++ b/packages/solutions/app-tools/src/plugins/deploy/dependencies/index.ts
@@ -41,8 +41,9 @@ export const handleDependencies = async ({
     serverRootDir,
     base,
   );
-
   const currentProjectModules = path.join(appDir, 'node_modules');
+  // Because vercel/nft may find inaccurately, we limit the range of query of dependencies
+  const dependencySearchRoot = path.resolve(appDir, '../../../../../../');
 
   const tracedFiles: Record<string, TracedFile> = Object.fromEntries(
     (await Promise.all(
@@ -89,7 +90,7 @@ export const handleDependencies = async ({
             ? path.join(match[0], 'package.json')
             : await pkgUp({ cwd: path.dirname(filePath) });
 
-          if (packageJsonPath) {
+          if (packageJsonPath?.startsWith(dependencySearchRoot)) {
             const packageJson: PackageJson = await fse.readJSON(
               packageJsonPath,
             );


### PR DESCRIPTION
## Summary

Limit the scope of the dependency packages to avoid `nft` finding the wrong dependencies.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
