### PR TITLE
feat(ssr): support server.ssrByRouteIds

### DIFF
--- a/.changeset/afraid-insects-tickle.md
+++ b/.changeset/afraid-insects-tickle.md
@@ -1,0 +1,12 @@
+---
+'@modern-js/plugin-data-loader': patch
+'@modern-js/runtime': patch
+'@modern-js/app-tools': patch
+'@modern-js/plugin-ssg': patch
+'@modern-js/types': patch
+'@modern-js/utils': patch
+'@modern-js/server-core': patch
+---
+
+feat(ssr): support server.ssrByRouteIds
+feat(ssr): 支持 server.ssrByRouteIds

--- a/packages/cli/plugin-data-loader/src/cli/loader.ts
+++ b/packages/cli/plugin-data-loader/src/cli/loader.ts
@@ -10,6 +10,7 @@ type Context = {
   action: boolean;
   inline: boolean;
   routeId: string;
+  retain: boolean;
 };
 
 export default async function loader(
@@ -42,7 +43,7 @@ export default async function loader(
       return pre;
     }, {} as Record<string, any>);
 
-  if (!options.loaderId) {
+  if (!options.loaderId || options.retain) {
     return source;
   }
 

--- a/packages/cli/plugin-ssg/src/index.ts
+++ b/packages/cli/plugin-ssg/src/index.ts
@@ -1,7 +1,8 @@
 import path from 'path';
-import { logger } from '@modern-js/utils';
+import { filterRoutesForServer, logger } from '@modern-js/utils';
 import type { AppTools, CliPlugin } from '@modern-js/app-tools';
 import { generatePath } from 'react-router-dom';
+import type { NestedRouteForCli, PageRoute } from '@modern-js/types';
 import { AgreedRouteMap, SSGConfig, SsgRoute } from './types';
 import {
   flattenRoutes,
@@ -27,7 +28,9 @@ export const ssgPlugin = (): CliPlugin<AppTools> => ({
     return {
       modifyFileSystemRoutes({ entrypoint, routes }) {
         const { entryName } = entrypoint;
-        const flattedRoutes = flattenRoutes(routes);
+        const flattedRoutes = flattenRoutes(
+          filterRoutesForServer(routes as (NestedRouteForCli | PageRoute)[]),
+        );
         agreedRouteMap[entryName] = flattedRoutes;
 
         return { entrypoint, routes };

--- a/packages/runtime/plugin-runtime/tests/router/templates.test.ts
+++ b/packages/runtime/plugin-runtime/tests/router/templates.test.ts
@@ -91,7 +91,7 @@ describe('fileSystemRoutes', () => {
 
 describe('routesForServer', () => {
   test('generate code for server', async () => {
-    const routes = [
+    const routesForServerLoaderMatches = [
       {
         path: '/',
         _component: '@_modern_js_src/routes/layout.tsx',
@@ -127,7 +127,7 @@ describe('routesForServer', () => {
       },
     ];
     const code = routesForServer({
-      routes,
+      routesForServerLoaderMatches,
     });
     expect(code).toMatchSnapshot();
   });

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -4,6 +4,7 @@ import type { Logger, ServerRoute } from '@modern-js/types';
 import {
   LOADABLE_STATS_FILE,
   MAIN_ENTRY_NAME,
+  NESTED_ROUTE_SPEC_FILE,
   ROUTE_MANIFEST_FILE,
   SERVER_BUNDLE_DIRECTORY,
   fs,
@@ -106,11 +107,16 @@ export async function getServerManifest(
 
   const routeManifest = await import(routesManifestUri).catch(_ => ({}));
 
+  const nestedRoutesJsonPath = path.join(pwd, NESTED_ROUTE_SPEC_FILE);
+
+  const nestedRoutesJson = await import(nestedRoutesJsonPath).catch(_ => ({}));
+
   return {
     loaderBundles,
     renderBundles,
     loadableStats,
     routeManifest,
+    nestedRoutesJson,
   };
 }
 

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -4,7 +4,6 @@ import { cutNameByHyphen } from '@modern-js/utils/universal';
 import { TrieRouter } from 'hono/router/trie-router';
 import type { Router } from 'hono/router';
 import { matchRoutes } from '@modern-js/runtime-utils/router';
-import { NESTED_ROUTE_SPEC_FILE } from '@modern-js/utils';
 import type { Params } from '../../types/requestHandler';
 import {
   parseQuery,
@@ -247,15 +246,18 @@ async function renderHandler(
   let response: Response | null = null;
 
   const runtimeEnv = getRuntimeEnv();
+  const { serverManifest } = options;
 
   const ssrByRouteIds = options.config.server?.ssrByRouteIds;
 
-  if (runtimeEnv === 'node' && ssrByRouteIds && ssrByRouteIds?.length > 0) {
-    const path = await import('node:path');
-    const nestedRoutesJson = await import(
-      path.join(options.pwd, NESTED_ROUTE_SPEC_FILE)
-    );
-    const routes = nestedRoutesJson[options.routeInfo.entryName!];
+  if (
+    runtimeEnv === 'node' &&
+    serverManifest.nestedRoutesJson &&
+    ssrByRouteIds &&
+    ssrByRouteIds?.length > 0
+  ) {
+    const { nestedRoutesJson } = serverManifest;
+    const routes = nestedRoutesJson?.[options.routeInfo.entryName!];
     if (routes) {
       // eslint-disable-next-line node/prefer-global/url
       const url = new URL(request.url);

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -14,7 +14,6 @@ import {
   onError as onErrorFn,
   ErrorDigest,
   parseHeaders,
-  getRuntimeEnv,
 } from '../../utils';
 import type { CacheConfig, FallbackReason, UserConfig } from '../../types';
 import { REPLACE_REG, X_MODERNJS_RENDER } from '../../constants';
@@ -245,13 +244,11 @@ async function renderHandler(
 
   let response: Response | null = null;
 
-  const runtimeEnv = getRuntimeEnv();
   const { serverManifest } = options;
 
   const ssrByRouteIds = options.config.server?.ssrByRouteIds;
 
   if (
-    runtimeEnv === 'node' &&
     serverManifest.nestedRoutesJson &&
     ssrByRouteIds &&
     ssrByRouteIds?.length > 0

--- a/packages/server/core/src/types/config/server.ts
+++ b/packages/server/core/src/types/config/server.ts
@@ -50,6 +50,10 @@ export type SSRByEntries = Record<string, SSR>;
 
 export interface ServerUserConfig {
   routes?: Routes;
+  /**
+   * Experimenal, it is not recommended to use it now
+   */
+  ssrByRouteIds?: string[];
   publicRoutes?: Record<string, string>;
   ssr?: SSR;
   ssrByEntries?: SSRByEntries;

--- a/packages/server/core/src/types/server.ts
+++ b/packages/server/core/src/types/server.ts
@@ -51,6 +51,7 @@ export type ServerManifest = {
   renderBundles?: Record<string, ServerRenderBundle>;
   loadableStats?: Record<string, any>;
   routeManifest?: Record<string, any>;
+  nestedRoutesJson?: Record<string, any>;
 };
 
 type ServerVariables = {

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -5,8 +5,6 @@ import {
   emptyDir,
   getCommand,
   getArgv,
-  fs,
-  NESTED_ROUTE_SPEC_FILE,
 } from '@modern-js/utils';
 import { CliPlugin } from '@modern-js/core';
 import { getLocaleLanguage } from '@modern-js/plugin-i18n/language-detector';
@@ -90,7 +88,6 @@ export const appTools = (
       ...appContext,
       toolsType: 'app-tools',
     });
-    const nestedRoutes: Record<string, unknown> = {};
 
     const locale = getLocaleLanguage();
     i18n.changeLanguage({ locale });
@@ -169,29 +166,6 @@ export const appTools = (
 
       async beforeRestart() {
         cleanRequireCache([require.resolve('./plugins/analyze')]);
-      },
-
-      async modifyFileSystemRoutes({ entrypoint, routes }) {
-        nestedRoutes[entrypoint.entryName] = routes;
-
-        return {
-          entrypoint,
-          routes,
-        };
-      },
-
-      async beforeGenerateRoutes({ entrypoint, code }) {
-        const { distDirectory } = api.useAppContext();
-
-        await fs.outputJSON(
-          path.resolve(distDirectory, NESTED_ROUTE_SPEC_FILE),
-          nestedRoutes,
-        );
-
-        return {
-          entrypoint,
-          code,
-        };
       },
     };
   },

--- a/packages/toolkit/types/cli/index.d.ts
+++ b/packages/toolkit/types/cli/index.d.ts
@@ -94,6 +94,7 @@ export interface NestedRoute<T = string | (() => JSX.Element)> extends Route {
   error?: T;
   isRoot?: boolean;
   config?: string | Record<string, any>;
+  inValidSSRRoute?: boolean;
 }
 
 export interface PageRoute extends Route {

--- a/packages/toolkit/utils/src/cli/index.ts
+++ b/packages/toolkit/utils/src/cli/index.ts
@@ -19,3 +19,4 @@ export * from './runtimeExports';
 export * from './watch';
 export * from './config';
 export * from './action';
+export * from './route';

--- a/packages/toolkit/utils/src/cli/route.ts
+++ b/packages/toolkit/utils/src/cli/route.ts
@@ -5,7 +5,7 @@ const { cloneDeep } = lodash;
 
 export function filterRoutesForServer(
   routes: (NestedRouteForCli | PageRoute)[],
-): (NestedRouteForCli | PageRoute)[] {
+) {
   const clonedRoutes = cloneDeep(routes);
   const newRoutes = clonedRoutes
     .map(route => {
@@ -26,12 +26,10 @@ export function filterRoutesForServer(
     })
     .filter(route => route !== null);
 
-  return newRoutes;
+  return newRoutes as (NestedRouteForCli | PageRoute)[];
 }
 
-export function filterRoutesLoader(
-  routes: (NestedRouteForCli | PageRoute)[],
-): (NestedRouteForCli | PageRoute)[] {
+export function filterRoutesLoader(routes: (NestedRouteForCli | PageRoute)[]) {
   const clonedRoutes = cloneDeep(routes);
   const newRoutes = clonedRoutes
     .map(route => {
@@ -46,6 +44,8 @@ export function filterRoutesLoader(
 
       if (route.inValidSSRRoute) {
         delete route.loader;
+        delete route.data;
+        delete route.action;
       }
 
       return route;

--- a/packages/toolkit/utils/src/cli/route.ts
+++ b/packages/toolkit/utils/src/cli/route.ts
@@ -1,0 +1,56 @@
+import type { NestedRouteForCli, PageRoute } from '@modern-js/types';
+import { lodash } from '../compiled';
+
+const { cloneDeep } = lodash;
+
+export function filterRoutesForServer(
+  routes: (NestedRouteForCli | PageRoute)[],
+): (NestedRouteForCli | PageRoute)[] {
+  const clonedRoutes = cloneDeep(routes);
+  const newRoutes = clonedRoutes
+    .map(route => {
+      if (route.type !== 'nested') {
+        return route;
+      }
+      if (route.children && route.children.length > 0) {
+        route.children = filterRoutesForServer(
+          route.children,
+        ) as NestedRouteForCli[];
+      }
+
+      if (route.inValidSSRRoute) {
+        return null;
+      }
+
+      return route;
+    })
+    .filter(route => route !== null);
+
+  return newRoutes;
+}
+
+export function filterRoutesLoader(
+  routes: (NestedRouteForCli | PageRoute)[],
+): (NestedRouteForCli | PageRoute)[] {
+  const clonedRoutes = cloneDeep(routes);
+  const newRoutes = clonedRoutes
+    .map(route => {
+      if (route.type !== 'nested') {
+        return route;
+      }
+      if (route.children && route.children.length > 0) {
+        route.children = filterRoutesLoader(
+          route.children,
+        ) as NestedRouteForCli[];
+      }
+
+      if (route.inValidSSRRoute) {
+        delete route.loader;
+      }
+
+      return route;
+    })
+    .filter(route => route !== null);
+
+  return newRoutes;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7634,6 +7634,34 @@ importers:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
 
+  tests/integration/ssr/fixtures/partial:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^18
+        version: 18.2.0
+      react-dom:
+        specifier: ^18
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/tsconfig':
+        specifier: workspace:*
+        version: link:../../../../../packages/review/tsconfig
+      '@types/react':
+        specifier: ^18
+        version: 18.0.21
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.0.6
+      typescript:
+        specifier: ^5
+        version: 5.4.5
+
   tests/integration/ssr/fixtures/preload:
     dependencies:
       '@modern-js/app-tools':

--- a/tests/integration/ssr/fixtures/partial/modern.config.ts
+++ b/tests/integration/ssr/fixtures/partial/modern.config.ts
@@ -1,0 +1,11 @@
+import { applyBaseConfig } from '../../../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  runtime: {
+    router: true,
+  },
+  server: {
+    ssrByRouteIds: ['one_b/page'],
+    ssr: true,
+  },
+});

--- a/tests/integration/ssr/fixtures/partial/package.json
+++ b/tests/integration/ssr/fixtures/partial/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ssr-partial-test",
+  "version": "2.9.0",
+  "private": true,
+  "scripts": {
+    "dev": "modern dev"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/tsconfig": "workspace:*",
+    "typescript": "^5",
+    "@types/react": "^18",
+    "@types/react-dom": "^18"
+  }
+}

--- a/tests/integration/ssr/fixtures/partial/src/modern-app-env.d.ts
+++ b/tests/integration/ssr/fixtures/partial/src/modern-app-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@modern-js/runtime/types' />
+/// <reference types='@modern-js/runtime/types/router' />

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/a/page.data.ts
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/a/page.data.ts
@@ -1,0 +1,3 @@
+export const loader = () => {
+  return 'PageA Data';
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/a/page.tsx
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/a/page.tsx
@@ -1,0 +1,11 @@
+import { Link, useLoaderData } from '@modern-js/runtime/router';
+
+export default () => {
+  const data = useLoaderData() as string;
+  return (
+    <div>
+      {data}
+      <Link to="/b">jupmp to B</Link>
+    </div>
+  );
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/b/d/page.data.ts
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/b/d/page.data.ts
@@ -1,4 +1,4 @@
 export const loader = () => {
   console.log(document.querySelector);
-  return 'PageA Data';
+  return 'PageD Data';
 };

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/b/d/page.tsx
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/b/d/page.tsx
@@ -1,0 +1,6 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+
+export default () => {
+  const data = useLoaderData() as string;
+  return <div className="page-d">{data}</div>;
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/b/layout.tsx
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/b/layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from '@modern-js/runtime/router';
+
+export default () => {
+  return (
+    <div>
+      B Layout
+      <Outlet></Outlet>;
+    </div>
+  );
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/b/page.data.ts
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/b/page.data.ts
@@ -1,0 +1,7 @@
+import fs from 'fs/promises';
+
+export const loader = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  typeof fs;
+  return 'PageB Data';
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/b/page.tsx
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/b/page.tsx
@@ -1,0 +1,11 @@
+import { Link, useLoaderData } from '@modern-js/runtime/router';
+
+export default () => {
+  const data = useLoaderData() as string;
+  return (
+    <div className="page-b">
+      {data}
+      <Link to="/a">jupmp to A</Link>
+    </div>
+  );
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/layout.data.ts
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/layout.data.ts
@@ -1,0 +1,7 @@
+import fs from 'fs/promises';
+
+export const loader = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  typeof fs;
+  return 'root layout';
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/layout.tsx
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/layout.tsx
@@ -1,0 +1,17 @@
+import { Link, Outlet, useLoaderData } from '@modern-js/runtime/router';
+
+export default () => {
+  const data = useLoaderData() as string;
+  return (
+    <div>
+      {data}
+      <Link to="a" className="a-btn">
+        jupmp to A
+      </Link>
+      <Link to="b" className="b-btn">
+        jupmp to B
+      </Link>
+      <Outlet></Outlet>
+    </div>
+  );
+};

--- a/tests/integration/ssr/fixtures/partial/src/one/routes/page.tsx
+++ b/tests/integration/ssr/fixtures/partial/src/one/routes/page.tsx
@@ -1,0 +1,3 @@
+export default () => {
+  return <div>root page</div>;
+};

--- a/tests/integration/ssr/fixtures/partial/tsconfig.json
+++ b/tests/integration/ssr/fixtures/partial/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"],
+      "@api/*": ["./api/*"]
+    }
+  },
+  "include": ["src", "shared", "config", "modern.config.ts", "api", "server"]
+}

--- a/tests/integration/ssr/tests/partial.test.ts
+++ b/tests/integration/ssr/tests/partial.test.ts
@@ -81,4 +81,16 @@ describe('test partial ssr', () => {
     const text = await page.evaluate(el => el?.textContent, pageBElm);
     expect(text).toContain('PageB Data');
   });
+
+  test('should render nested route with CSR', async () => {
+    const res = await axios.get(`http://localhost:${appPort}/one/b/d`);
+    const content = res.data;
+    expect(content).not.toContain('root layout');
+
+    await page.goto(`http://localhost:${appPort}/one/b/d`);
+    await page.waitForSelector('#root');
+    const pageContent = await page.content();
+    expect(pageContent).toContain('root layout');
+    expect(pageContent).toContain('PageD Data');
+  });
 });

--- a/tests/integration/ssr/tests/partial.test.ts
+++ b/tests/integration/ssr/tests/partial.test.ts
@@ -1,0 +1,84 @@
+import dns from 'node:dns';
+import path, { join } from 'path';
+import puppeteer, { Browser, Page } from 'puppeteer';
+import axios from 'axios';
+import {
+  launchApp,
+  getPort,
+  launchOptions,
+  killApp,
+} from '../../../utils/modernTestUtils';
+
+dns.setDefaultResultOrder('ipv4first');
+const fixtureDir = path.resolve(__dirname, '../fixtures');
+
+describe('test partial ssr', () => {
+  let app: any;
+  let appPort: number;
+  let page: Page;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    const appDir = join(fixtureDir, 'partial');
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort);
+
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    if (browser) {
+      browser.close();
+    }
+    if (app) {
+      await killApp(app);
+    }
+  });
+
+  test('should render / with CSR', async () => {
+    const res = await axios.get(`http://localhost:${appPort}/one`);
+    const content = res.data;
+    expect(content).not.toContain('root layout');
+
+    await page.goto(`http://localhost:${appPort}/one`);
+    await page.waitForSelector('#root');
+    const pageContent = await page.content();
+    expect(pageContent).toContain('root layout');
+  });
+
+  test('should render /a with CSR', async () => {
+    const res = await axios.get(`http://localhost:${appPort}/one/a`);
+    const content = res.data;
+    expect(content).not.toContain('root layout');
+
+    await page.goto(`http://localhost:${appPort}/one/a`);
+    await page.waitForSelector('#root');
+    const pageContent = await page.content();
+    expect(pageContent).toContain('root layout');
+    expect(pageContent).toContain('PageA Data');
+  });
+
+  test('should render /b with SSR', async () => {
+    const res = await axios.get(`http://localhost:${appPort}/one/b`);
+    const content = res.data;
+    expect(content).toContain('root layout');
+
+    await page.goto(`http://localhost:${appPort}/one/b`);
+    await page.waitForSelector('#root');
+    const pageContent = await page.content();
+    expect(pageContent).toContain('root layout');
+    expect(pageContent).toContain('PageB Data');
+  });
+
+  // This test case ensures that the data loader for b is executed on the server side
+  test('should navigate to /b correctly', async () => {
+    await page.goto(`http://localhost:${appPort}/one/a`, {
+      waitUntil: ['networkidle0'],
+    });
+    await Promise.all([page.click('.b-btn'), page.waitForSelector('.page-b')]);
+    const pageBElm = await page.$('.page-b');
+    const text = await page.evaluate(el => el?.textContent, pageBElm);
+    expect(text).toContain('PageB Data');
+  });
+});


### PR DESCRIPTION
## Summary


一些相关的讨论

### 为什么 `server.ssrByRouteIds` 不放在 server.ssr 里？比如说 server.ssr.byRouteIds

1. 这个 feature 和 SSR 本身其实没啥关系，改动也更多的是构建侧，所以没有改动 ssr 的配置。
2. 这里配置其实 routeId 中已经包含 entry 信息了，如果在 ssrByentries 中指定，其实重复指定了，实现也会更复杂。

### 为啥不考虑直接放在路由里，加一个 `export const xxx = true` 这种

1. 这个配置更适合集中式，可以看详细用法，其实有些心智负担的，在 page.tsx 中，会很碎片化，也不利于排查问题，目前通过配置，是可以知道那些路线是走 SSR 渲染，哪些是走 CSR 的，通过 page.tsx 是做不到。
​
2. 在 page.tsx 中，需要构建时做提取，不管是对构建速度，还是我们实现的复杂度都有影响。

### 为什么 renderHandler 和 dataHandler 拿的路由信息是不同的？

假设 `user/xxx` 路由是由 CSR 渲染，`user/profile` 路由是由 SSR 渲染，`/user/layout.data.ts` 只会在服务端执行，直接访问 `/user/xxx` 时，会发请求 `/user/xxx?_loader=user/layout`，data loader 的路由表中没有 /user/xxx 路由的话，就会匹配失败 。

所以目前 renderHandler 拿到的是去掉 CSR 路由部分的路由表，dataHandler 拿到的是去掉 data loader 和 action 后的路由表。

### 为什么上个问题中的 `/user/layout.data.ts` 只会在服务端运行？

因为要支持访问 `user/profile` 路由时，`user/layout.tsx`需要有服务端数据获取的函数，如果期望访问 `/user/xxx` 时，`user/layout.tsx` 对应的数据获取函数在客户端运行，就有三种方式：

1.  约束 `user/layout.data.ts` 中的代码只能写客户端和服务端都能运行的代码。
2. 要求用户必须写 `user/layout.data.client.ts`，服务端数据获取函数写 `user/layout.data.ts`
3. `user/layout.data.ts` 在服务端执行，由框架发起请求触发，并获取数据。

第 3 点和第 2 点其实很像，核心差异是 `user/layout.data.client.ts` 是不是一个必选项，因为我们认为使用 `server.ssrRouteByIds` 配置的项目最终改造为 SSR 项目，这里采用第3点跟目前的 SSR 项目行为一致，且当`user/layout.data.client.ts` 没有的时候，客户端 bundle 的体积会更小。


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
