### PR TITLE
fix(plugin-garfish): can not import garfish runtime directly which has sideffects

### DIFF
--- a/.changeset/many-apples-attend.md
+++ b/.changeset/many-apples-attend.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+fix(plugin-garfish): can not import garfish runtime directly which has sideffect
+fix(plugin-garfish): 不能直接注入带有副作用的 garfish runtime

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -29,6 +29,9 @@
       "runtime": [
         "./dist/types/runtime/index.d.ts"
       ],
+      "tools": [
+        "./dist/types/runtime/tools.d.ts"
+      ],
       "types": [
         "./type.d.ts"
       ]
@@ -52,6 +55,11 @@
       "types": "./dist/types/runtime/index.d.ts",
       "jsnext:source": "./src/runtime/index.ts",
       "default": "./dist/esm/runtime/index.js"
+    },
+    "./tools": {
+      "types": "./dist/types/runtime/tools.d.ts",
+      "jsnext:source": "./src/runtime/tools.ts",
+      "default": "./dist/esm/runtime/tools.js"
     }
   },
   "scripts": {

--- a/packages/runtime/plugin-garfish/src/cli/template.ts
+++ b/packages/runtime/plugin-garfish/src/cli/template.ts
@@ -22,7 +22,7 @@ const genRenderCode = ({
 export * from '${entry.replace(srcDirectory, internalSrcAlias)}'`
     : `import { createRoot } from '@${metaName}/runtime/react';
 import { render } from '@${metaName}/runtime/browser';
-import { isRenderGarfish, createProvider } from '@${metaName}/plugin-garfish/runtime';
+import { isRenderGarfish, createProvider } from '@${metaName}/plugin-garfish/tools';
 ${
   customBootstrap
     ? `import customBootstrap from '${formatImportPath(

--- a/packages/runtime/plugin-garfish/src/runtime/index.ts
+++ b/packages/runtime/plugin-garfish/src/runtime/index.ts
@@ -2,6 +2,3 @@ export { default, garfishPlugin } from './plugin';
 export { useModuleApps, useModuleApp } from './useModuleApps';
 export type { Manifest, ModuleInfo, Config } from './useModuleApps';
 export { default as Garfish, default as garfish } from 'garfish';
-
-export { isRenderGarfish } from './utils';
-export { createProvider } from './provider';

--- a/packages/runtime/plugin-garfish/src/runtime/tools.ts
+++ b/packages/runtime/plugin-garfish/src/runtime/tools.ts
@@ -1,0 +1,2 @@
+export { isRenderGarfish } from './utils';
+export { createProvider } from './provider';

--- a/tests/e2e/garfish/tests/dashboard.spec.ts
+++ b/tests/e2e/garfish/tests/dashboard.spec.ts
@@ -4,6 +4,9 @@ import { getPublicPath } from '../testUtils';
 import { launchApp, killApp } from '../../../utils/modernTestUtils';
 
 let app: unknown;
+declare global {
+  const __GARFISH__: unknown;
+}
 
 test.beforeAll(async () => {
   test.setTimeout(90 * 1000);
@@ -23,6 +26,12 @@ test('independent access', async ({ page }) => {
   await link?.click();
 
   expect(await page.textContent('body')).toContain('Dashboard detail page');
+
+  // it should not inject window.__GARFISH__ while independent access
+  const garfishExists = await page.evaluate(
+    () => typeof window.__GARFISH__ !== 'undefined',
+  );
+  expect(garfishExists).toBe(false);
 
   await killApp(app);
 });

--- a/tests/e2e/garfish/tests/whole-process.spec.ts
+++ b/tests/e2e/garfish/tests/whole-process.spec.ts
@@ -65,6 +65,12 @@ webpackOnlyTest('render sub app', async ({ page }) => {
   const subLink = await page.$('[data-test=sub-link-dashboard]');
   await subLink?.click();
   expect(await page.textContent('body')).toContain('Dashboard detail page');
+
+  // it should inject window.__GARFISH__ while run in main app
+  const garfishExists = await page.evaluate(
+    () => typeof window.__GARFISH__ !== 'undefined',
+  );
+  expect(garfishExists).toBe(true);
 });
 
 webpackOnlyTest('render module federation component', async ({ page }) => {

--- a/tests/integration/garfish/app-table/src/entry.tsx
+++ b/tests/integration/garfish/app-table/src/entry.tsx
@@ -3,7 +3,7 @@ import { render } from '@modern-js/runtime/browser';
 import {
   createProvider,
   isRenderGarfish,
-} from '@modern-js/plugin-garfish/runtime';
+} from '@modern-js/plugin-garfish/tools';
 
 async function beforeRender() {
   return new Promise<void>(resolve => {


### PR DESCRIPTION
## Summary
`@modern-js/plugin-garfish/runtime` will auto import Garfish runtime , so it can not import directly in subapp . 

Subapp usually will use `Boolean(window.__GARFISH__)` to check if in garfish env , and the prev action will make it not work.



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
