### PR TITLE
WIP: fix(server-core): support cjs async server loader entry

### DIFF
--- a/.changeset/chilly-rules-dress.md
+++ b/.changeset/chilly-rules-dress.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix(server-core): support cjs async server loader entry
+fix(server-core): 支持 cjs 类型的异步 server loader entry

--- a/packages/cli/plugin-data-loader/src/cli/loader.ts
+++ b/packages/cli/plugin-data-loader/src/cli/loader.ts
@@ -35,6 +35,13 @@ export default async function loader(
     return source;
   }
 
+  if (
+    target === 'async-node' ||
+    (Array.isArray(target) && target.includes('async-node'))
+  ) {
+    return source;
+  }
+
   const { resourceQuery } = this;
   // parse options from resouceQuery
   const options = resourceQuery

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -52,6 +52,9 @@ export function injectTemplates(
 const dynamicImport = (filePath: string) => {
   try {
     const module = require(filePath);
+    if (module.default) {
+      return Promise.resolve(module.default);
+    }
     return Promise.resolve(module);
   } catch (e) {
     return Promise.reject(e);

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -55,7 +55,12 @@ const dynamicImport = (filePath: string) => {
     if (module.default) {
       return Promise.resolve(module.default);
     }
-    return Promise.resolve(module);
+    return Promise.resolve(module).then(m => {
+      if (m.default) {
+        return m.default;
+      }
+      return m;
+    });
   } catch (e) {
     return Promise.reject(e);
   }


### PR DESCRIPTION
## Summary
cjs async server loader entry will return follow content if set `source.enableAsyncEntry` as `true`: 
```js
{
default: Promise.resolve({
  handleRequest: ..
})
}
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
