### PR TITLE
fix: `createDevServer` should not listen port by default

### DIFF
--- a/.changeset/strong-moose-wash.md
+++ b/.changeset/strong-moose-wash.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/server': patch
+---
+
+fix: `createDevServer` should not listen port by default
+fix: `createDevServer` 默认不应该监听端口

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -53,17 +53,5 @@ export async function createDevServer(
 
   await server.init();
 
-  nodeServer.listen(
-    {
-      host: dev.host || '127.0.0.1',
-      port: dev.port || '8080',
-    },
-    (err?: Error) => {
-      if (err) {
-        throw err;
-      }
-    },
-  );
-
   return nodeServer;
 }

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -1,6 +1,11 @@
 import path from 'node:path';
 import { PluginAPI, ResolvedConfigContext } from '@modern-js/core';
-import { DEFAULT_DEV_HOST, SERVER_DIR, getMeta } from '@modern-js/utils';
+import {
+  DEFAULT_DEV_HOST,
+  SERVER_DIR,
+  getMeta,
+  logger,
+} from '@modern-js/utils';
 import { createDevServer } from '@modern-js/server';
 import { applyPlugins } from '@modern-js/prod-server';
 import { loadServerPlugins } from '../utils/loadPlugins';
@@ -97,6 +102,8 @@ export const dev = async (
     ...devServerOptions,
   };
 
+  const host = normalizedConfig.dev?.host || DEFAULT_DEV_HOST;
+
   if (apiOnly) {
     const server = await createDevServer(
       {
@@ -105,8 +112,6 @@ export const dev = async (
       },
       applyPlugins,
     );
-
-    const host = normalizedConfig.dev?.host || DEFAULT_DEV_HOST;
 
     server.listen(
       {
@@ -126,7 +131,18 @@ export const dev = async (
       applyPlugins,
     );
 
-    // TODO: set correct server
+    server.listen(
+      {
+        port,
+        host,
+      },
+      (err?: Error) => {
+        if (err) {
+          logger.error('Occur error %s, when start dev server', err);
+        }
+      },
+    );
+
     setServer(server);
   }
 };


### PR DESCRIPTION
## Summary
- we should listen port outer `createDevServer`
- The listen host should be `0.0.0.0` default


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
