### PR TITLE
chore(docs): typo in mock.mdx

### DIFF
--- a/packages/document/main-doc/docs/zh/guides/basic-features/mock.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/mock.mdx
@@ -80,7 +80,7 @@ module.exports = {
 
 ## 按需使用 Mock 服务
 
-`config/mock/index.ts` 下还可以到处 `config` 对象，更精细的控制 Mock 服务。
+`config/mock/index.ts` 下还可以导出 `config` 对象，更精细的控制 Mock 服务。
 
 ```ts
 type MockConfig = {


### PR DESCRIPTION
resolve #5975.

correct '到处' to '导出'