### PR TITLE
chore(docs): add module tools to docs deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,12 @@
     "check-dependencies": "check-dependency-version-consistency .",
     "update-codesmith": "cd ./scripts/update-codesmith && pnpm start",
     "update-rspress": "cd ./scripts/update-rspress && pnpm start",
-    "update-rsbuild": "cd ./scripts/update-rsbuild && pnpm start"
+    "update-rsbuild": "cd ./scripts/update-rsbuild && pnpm start",
+    "build:main_docs": "pnpm --filter @modern-js/main-doc... build && pnpm --filter @modern-js/main-doc build:doc",
+    "build:module_docs": "pnpm --filter @modern-js/module-tools-docs... build && pnpm --filter @modern-js/module-tools-docs build:doc",
+    "gen:docs": "rm -rf doc_output && mkdir doc_output && cp -r ./packages/document/main-doc/doc_build/* ./doc_output && cp -r ./packages/document/module-doc/doc_build/ ./doc_output/module-tools",
+    "build:docs": "pnpm run build:main_docs && pnpm run build:module_docs && pnpm run gen:docs"
+
   },
   "engines": {
     "node": ">=14.17.6",


### PR DESCRIPTION
## Summary

now modern.js website is deploy in netlify..

so we add new script for main_doc and module_doc.

after rslib is release, we can remove these scripts.

https://deploy-preview-6005--modernjs-byted.netlify.app/

https://deploy-preview-6005--modernjs-byted.netlify.app/module-tools

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
