### PR TITLE
fix: distPath should from output.distPath.root

### DIFF
--- a/.changeset/popular-moose-join.md
+++ b/.changeset/popular-moose-join.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server': patch
+'@modern-js/server-core': patch
+---
+
+fix: distPath should from output.distPath.root
+fix: distPath 应该来自 output.distPath.root

--- a/packages/server/core/src/adapters/node/helper/loadConfig.ts
+++ b/packages/server/core/src/adapters/node/helper/loadConfig.ts
@@ -59,7 +59,10 @@ export function loadServerCliConfig(
 ): CliConfig {
   const cliConfigPath = ensureAbsolutePath(
     pwd,
-    path.join(defaultConfig.output?.path || 'dist', OUTPUT_CONFIG_FILE),
+    path.join(
+      defaultConfig.output?.distPath?.root || 'dist',
+      OUTPUT_CONFIG_FILE,
+    ),
   );
 
   let cliConfig: CliConfig = {

--- a/packages/server/core/src/types/config/output.ts
+++ b/packages/server/core/src/types/config/output.ts
@@ -12,7 +12,6 @@ export interface OutputUserConfig {
   };
   enableInlineRouteManifests?: boolean;
   disableInlineRouteManifests?: boolean;
-  path?: string;
   assetPrefix?: string;
   polyfill?: 'entry' | 'usage' | 'ua' | 'off';
 

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -15,7 +15,7 @@ export async function createDevServer(
   const { config, pwd, serverConfigFile, serverConfigPath, builder } = options;
   const dev = getDevOptions(options);
 
-  const distDir = path.resolve(pwd, config.output.path || 'dist');
+  const distDir = path.resolve(pwd, config.output.distPath?.root || 'dist');
 
   const serverConfig = loadServerRuntimeConfig(
     distDir,


### PR DESCRIPTION
## Summary
- Use `output.distPath.root` instead of output.path in server-core

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
