### PR TITLE
fix(plugin-data-loader): data loader support async-node target

### DIFF
--- a/.changeset/eighty-actors-try.md
+++ b/.changeset/eighty-actors-try.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-data-loader': patch
+---
+
+fix: data loader support async-node target

--- a/packages/cli/plugin-data-loader/src/cli/loader.ts
+++ b/packages/cli/plugin-data-loader/src/cli/loader.ts
@@ -19,12 +19,18 @@ export default async function loader(
 ) {
   this.cacheable();
   const target = this._compiler?.options.target;
-  if (target === 'node' || (Array.isArray(target) && target.includes('node'))) {
-    return source;
-  }
+
+  const shouldSkip = (compileTarget: string) => {
+    return (
+      target === compileTarget ||
+      (Array.isArray(target) && target.includes(compileTarget))
+    );
+  };
+
   if (
-    target === 'webworker' ||
-    (Array.isArray(target) && target.includes('webworker'))
+    shouldSkip('node') ||
+    shouldSkip('webworker') ||
+    shouldSkip('async-node')
   ) {
     return source;
   }


### PR DESCRIPTION
## Summary

fix: data loader support async-node target

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
