### PR TITLE
fix: type error when registering Rsbuild plugins

### DIFF
--- a/.changeset/mighty-mails-reply.md
+++ b/.changeset/mighty-mails-reply.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: type error when registering Rsbuild plugins

--- a/packages/cli/uni-builder/src/index.ts
+++ b/packages/cli/uni-builder/src/index.ts
@@ -17,6 +17,7 @@ export type {
 export type {
   UniBuilderConfig,
   UniBuilderPlugin,
+  LooseRsbuildPlugin,
   BundlerType,
   MetaOptions,
   Stats,

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -14,6 +14,7 @@ import type {
   RequestHandler,
   NodeEnv,
   HtmlTagDescriptor,
+  RsbuildPlugin,
 } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import type { PluginStyledComponentsOptions } from '@rsbuild/plugin-styled-components';
@@ -368,7 +369,7 @@ export type SriOptions = {
 
 export type OverridesUniBuilderInstance = {
   addPlugins: (
-    plugins: UniBuilderPlugin[],
+    plugins: Array<UniBuilderPlugin | LooseRsbuildPlugin>,
     options?: {
       before?: string;
     },
@@ -417,6 +418,11 @@ export type UniBuilderPlugin = {
   pre?: string[];
   post?: string[];
   remove?: string[];
+};
+
+// Support for registering any version Rsbuild plugins
+export type LooseRsbuildPlugin = Omit<RsbuildPlugin, 'setup'> & {
+  setup: (api: any) => Promise<void> | void;
 };
 
 export type DistPath = DistPathConfig & {

--- a/packages/solutions/app-tools/src/types/config/index.ts
+++ b/packages/solutions/app-tools/src/types/config/index.ts
@@ -1,6 +1,6 @@
 import type { ServerUserConfig, BffUserConfig } from '@modern-js/server-core';
 import type { UniBuilderPlugin } from '@modern-js/uni-builder';
-import type { RsbuildConfig } from '@rsbuild/core';
+import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
 import type { Bundler } from '../utils';
 import type { OutputUserConfig } from './output';
 import type { SourceUserConfig } from './source';
@@ -22,6 +22,11 @@ export interface RuntimeByEntriesUserConfig {
   [name: string]: RuntimeUserConfig;
 }
 
+// Support for registering any version Rsbuild plugins
+type LooseRsbuildPlugin = Omit<RsbuildPlugin, 'setup'> & {
+  setup: (api: any) => Promise<void> | void;
+};
+
 export interface AppToolsUserConfig<B extends Bundler> {
   server?: ServerUserConfig;
   source?: SourceUserConfig;
@@ -41,7 +46,7 @@ export interface AppToolsUserConfig<B extends Bundler> {
   tools?: ToolsUserConfig<B>;
   security?: SecurityUserConfig;
   testing?: TestingUserConfig;
-  builderPlugins?: UniBuilderPlugin[];
+  builderPlugins?: Array<LooseRsbuildPlugin | UniBuilderPlugin>[];
   performance?: PerformanceUserConfig;
   devtools?: any;
   environments?: RsbuildConfig['environments'];

--- a/packages/solutions/app-tools/src/types/config/index.ts
+++ b/packages/solutions/app-tools/src/types/config/index.ts
@@ -1,6 +1,9 @@
 import type { ServerUserConfig, BffUserConfig } from '@modern-js/server-core';
-import type { UniBuilderPlugin } from '@modern-js/uni-builder';
-import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
+import type {
+  UniBuilderPlugin,
+  LooseRsbuildPlugin,
+} from '@modern-js/uni-builder';
+import type { RsbuildConfig } from '@rsbuild/core';
 import type { Bundler } from '../utils';
 import type { OutputUserConfig } from './output';
 import type { SourceUserConfig } from './source';
@@ -22,11 +25,6 @@ export interface RuntimeByEntriesUserConfig {
   [name: string]: RuntimeUserConfig;
 }
 
-// Support for registering any version Rsbuild plugins
-type LooseRsbuildPlugin = Omit<RsbuildPlugin, 'setup'> & {
-  setup: (api: any) => Promise<void> | void;
-};
-
 export interface AppToolsUserConfig<B extends Bundler> {
   server?: ServerUserConfig;
   source?: SourceUserConfig;
@@ -46,7 +44,7 @@ export interface AppToolsUserConfig<B extends Bundler> {
   tools?: ToolsUserConfig<B>;
   security?: SecurityUserConfig;
   testing?: TestingUserConfig;
-  builderPlugins?: Array<LooseRsbuildPlugin | UniBuilderPlugin>[];
+  builderPlugins?: Array<LooseRsbuildPlugin | UniBuilderPlugin>;
   performance?: PerformanceUserConfig;
   devtools?: any;
   environments?: RsbuildConfig['environments'];


### PR DESCRIPTION
## Summary

Fix type error when registering Rsbuild plugins in `builderPlugins`. We can use a loose type like Rsbuild (see https://github.com/web-infra-dev/rsbuild/pull/2875)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
