### PR TITLE
feat(module-tools): add resolve.alias, to support redirect module id

### DIFF
--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -878,6 +878,7 @@ For more information about JSX Transform, you can refer to the following links:
 
 - [React Blog - Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
 - [esbuild - JSX](https://esbuild.github.io/api/#jsx).
+
 :::
 
 ## metafile
@@ -977,6 +978,28 @@ export default {
 ## resolve
 
 Custom module resolution options
+
+### resolve.alias
+
+The basic usage is the same as [alias](#alias).
+
+The issue with [alias](#alias) is that we incorrectly handled Module IDs in a bundleless scenario:
+```js
+import { createElement } from "react";
+```
+When we configure alias: `{ react: 'react-native' }`, the result becomes:
+```js
+import { createElement } from "./react-native";
+```
+A Module ID is incorrectly processed as a relative path, which is not expected.
+
+We want to fix this issue, but it may break existing projects.
+
+Therefore, in **MAJOR_VERSION.58.0**, we provided `resolve.alias` to solve this problem. Additionally, `resolve.alias` removed the default value `{ "@": "./src"}` provided by [alias](#alias).
+
+If you need this feature, please use `resolve.alias` and avoid mixing it with [alias](#alias).
+
+In the next major version, `resolve.alias` will replace [alias](#alias).
 
 ### resolve.mainFields
 

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -968,6 +968,27 @@ export default {
 
 自定义模块解析选项
 
+### resolve.alias
+
+基本用法和 [alias](#alias) 一致。
+
+[alias](#alias) 的问题在于我们在 bundleless 场景下错误的处理了 Module ID 的情况：
+```js
+import { createElement } from "react";
+```
+当我们配置了 `alias: { react: 'react-native' }` 后，结果会变成
+```js
+import { createElement } from "./react-native";
+```
+一个 Module ID 被错误的处理成了相对路径，显然这是不符合预期的。
+
+我们想要修复这个问题，但是这可能会破坏已有的项目，因此我们在 MAJOR_VERSION.58.0 版本提供了 `resolve.alias` 来解决这个问题。
+并且 `resolve.alias` 里移除了 [alias](#alias) 提供的默认值 `{ "@": "./src"}`
+
+如果你需要此功能，请使用 `resolve.alias`, 注意不要与 [alias](#alias) 混用。
+
+在下一个大版本，`resolve.alias` 将会取代 `alias` 。
+
 ### resolve.mainFields
 
 package.json 中，在解析包的入口点时尝试的字段列表。
@@ -1595,4 +1616,6 @@ export default defineConfig({
     },
   },
 });
-```
+```import { aliases } from '../../../../../../toolkit/utils/dist/compiled/browserslist';
+import { createElement } from 'react';
+

--- a/packages/solutions/module-tools/src/config/merge.ts
+++ b/packages/solutions/module-tools/src/config/merge.ts
@@ -25,6 +25,7 @@ export const mergeDefaultBaseConfig = async (
   };
   const mergedAlias = applyOptionsChain(defaultAlias, pConfig.alias);
 
+  const mergedResolveAlias = applyOptionsChain({}, pConfig.resolve?.alias);
   /**
    * Format alias value:
    * - Relative paths need to be turned into absolute paths.
@@ -109,6 +110,7 @@ export const mergeDefaultBaseConfig = async (
     mainFields: pConfig.resolve?.mainFields ?? defaultMainFields,
     jsExtensions:
       pConfig.resolve?.jsExtensions ?? defaultConfig.resolve.jsExtensions,
+    alias: mergedResolveAlias,
   };
 
   const esbuildOptions = pConfig.esbuildOptions ?? defaultConfig.esbuildOptions;

--- a/packages/solutions/module-tools/src/config/valid.ts
+++ b/packages/solutions/module-tools/src/config/valid.ts
@@ -36,4 +36,11 @@ export const validBuildConfig = (
   ) {
     throw new Error(`${config.tsconfig} does not exist in your project`);
   }
+
+  // valid duplicate alias
+  if (config.alias && config.resolve?.alias) {
+    throw new Error(
+      'alias and resolve.alias are not allowed to be used together, alias will be deprecated in the future, please use resolve.alias instead',
+    );
+  }
 };

--- a/packages/solutions/module-tools/src/constants/build.ts
+++ b/packages/solutions/module-tools/src/constants/build.ts
@@ -46,6 +46,7 @@ export const getDefaultBuildConfig = () => {
     resolve: {
       mainFields: ['module', 'main'],
       jsExtensions: ['.jsx', '.tsx', '.js', '.ts', '.json'],
+      alias: {},
     },
     shims: false,
     sideEffects: undefined,

--- a/packages/solutions/module-tools/src/types/config/index.ts
+++ b/packages/solutions/module-tools/src/types/config/index.ts
@@ -140,6 +140,17 @@ export type AliasOption =
 export type Resolve = {
   mainFields?: string[];
   jsExtensions?: string[];
+  /// The same as alias, but support module id as map value,
+  /// which previously unsupported and treat as relative path,
+  /// but now recognized as any path that doesn't start with "./" "../" and "/"
+  /// and this will remove the default alias for "@"
+  alias?: AliasOption;
+};
+
+export type ResolveOptions = {
+  mainFields: string[];
+  jsExtensions: string[];
+  alias: Record<string, string>;
 };
 
 export type BaseBuildConfig = Omit<
@@ -151,7 +162,7 @@ export type BaseBuildConfig = Omit<
   style: Style;
   alias: Record<string, string>;
   asset: Required<Asset>;
-  resolve: Required<Resolve>;
+  resolve: ResolveOptions;
 };
 
 export type PartialBaseBuildConfig = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6686,6 +6686,10 @@ importers:
 
   tests/integration/module/fixtures/build/redirect: {}
 
+  tests/integration/module/fixtures/build/resolve/alias: {}
+
+  tests/integration/module/fixtures/build/resolve/alias-error: {}
+
   tests/integration/module/fixtures/build/resolve/data-url: {}
 
   tests/integration/module/fixtures/build/resolve/false: {}

--- a/tests/integration/module/fixtures/build/alias/alias.test.ts
+++ b/tests/integration/module/fixtures/build/alias/alias.test.ts
@@ -82,3 +82,20 @@ describe('alias in ts project', () => {
     expect(content.includes('hello world')).toBe(true);
   });
 });
+
+describe('resolve alias for module id', () => {
+  const fixtureDir = path.join(__dirname, 'module-id');
+  it('uncorrect module id', async () => {
+    const ret = await runCli({
+      argv: ['build'],
+      appDirectory: fixtureDir,
+    });
+
+    expect(ret.success).toBe(true);
+
+    const distFilePath = path.join(fixtureDir, './dist/index.js');
+    expect(fs.existsSync(distFilePath)).toBe(true);
+    const content = fs.readFileSync(distFilePath, 'utf-8');
+    expect(content.includes('./react-native')).toBe(true);
+  });
+});

--- a/tests/integration/module/fixtures/build/alias/module-id/modern.config.ts
+++ b/tests/integration/module/fixtures/build/alias/module-id/modern.config.ts
@@ -1,0 +1,11 @@
+// import path from 'path';
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    alias: {
+      react: 'react-native',
+    },
+    buildType: 'bundleless',
+  },
+});

--- a/tests/integration/module/fixtures/build/alias/module-id/package.json
+++ b/tests/integration/module/fixtures/build/alias/module-id/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "alias-module-id-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/module/fixtures/build/alias/module-id/src/index.js
+++ b/tests/integration/module/fixtures/build/alias/module-id/src/index.js
@@ -1,0 +1,3 @@
+import { createElement } from 'react';
+
+console.log(createElement);

--- a/tests/integration/module/fixtures/build/resolve/alias-error/alias.test.ts
+++ b/tests/integration/module/fixtures/build/resolve/alias-error/alias.test.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+import { runCli, initBeforeTest } from '../../../utils';
+
+initBeforeTest();
+
+describe('duplicate alias', () => {
+  const fixtureDir = __dirname;
+  it('object usage', async () => {
+    const bundleConfigFile = path.join(fixtureDir, './object.config.ts');
+    const ret = await runCli({
+      argv: ['build'],
+      configFile: bundleConfigFile,
+      appDirectory: fixtureDir,
+    });
+
+    expect(ret.success).toBeFalsy();
+    expect(
+      ret.error?.message.includes(
+        'alias and resolve.alias are not allowed to be used together, alias will be deprecated in the future, please use resolve.alias instead',
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/tests/integration/module/fixtures/build/resolve/alias-error/object.config.ts
+++ b/tests/integration/module/fixtures/build/resolve/alias-error/object.config.ts
@@ -1,0 +1,17 @@
+// import path from 'path';
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    resolve: {
+      alias: {
+        react: 'react-native',
+      },
+    },
+    outDir: './dist/object',
+    buildType: 'bundleless',
+    alias: {
+      react: 'react-native',
+    },
+  },
+});

--- a/tests/integration/module/fixtures/build/resolve/alias-error/package.json
+++ b/tests/integration/module/fixtures/build/resolve/alias-error/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "resolve-alias-error",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/module/fixtures/build/resolve/alias-error/src/index.js
+++ b/tests/integration/module/fixtures/build/resolve/alias-error/src/index.js
@@ -1,0 +1,3 @@
+import { createElement } from 'react';
+
+console.log(createElement);

--- a/tests/integration/module/fixtures/build/resolve/alias/alias.test.ts
+++ b/tests/integration/module/fixtures/build/resolve/alias/alias.test.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+import { fs } from '@modern-js/utils';
+import { runCli, initBeforeTest } from '../../../utils';
+
+initBeforeTest();
+
+describe('resolve alias for module id', () => {
+  const fixtureDir = __dirname;
+  it('object usage', async () => {
+    const bundleConfigFile = path.join(fixtureDir, './object.config.ts');
+    const ret = await runCli({
+      argv: ['build'],
+      configFile: bundleConfigFile,
+      appDirectory: fixtureDir,
+    });
+
+    expect(ret.success).toBe(true);
+
+    const distFilePath = path.join(fixtureDir, './dist/object/index.js');
+    expect(fs.existsSync(distFilePath)).toBe(true);
+    const content = fs.readFileSync(distFilePath, 'utf-8');
+    expect(content.includes('react-native')).toBe(true);
+  });
+
+  it('function usage', async () => {
+    const configFile = path.join(fixtureDir, './function.config.ts');
+    const ret = await runCli({
+      argv: ['build'],
+      configFile,
+      appDirectory: fixtureDir,
+    });
+    expect(ret.success).toBeTruthy();
+    const distFilePath = path.join(fixtureDir, './dist/function/index.js');
+    expect(fs.existsSync(distFilePath)).toBe(true);
+
+    const content = fs.readFileSync(distFilePath, 'utf-8');
+    expect(content.includes('react-native')).toBe(true);
+  });
+});

--- a/tests/integration/module/fixtures/build/resolve/alias/function.config.ts
+++ b/tests/integration/module/fixtures/build/resolve/alias/function.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    resolve: {
+      alias: config => {
+        return {
+          ...config,
+          react: 'react-native',
+        };
+      },
+    },
+    outDir: './dist/function',
+    buildType: 'bundleless',
+  },
+});

--- a/tests/integration/module/fixtures/build/resolve/alias/object.config.ts
+++ b/tests/integration/module/fixtures/build/resolve/alias/object.config.ts
@@ -1,0 +1,14 @@
+// import path from 'path';
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    resolve: {
+      alias: {
+        react: 'react-native',
+      },
+    },
+    outDir: './dist/object',
+    buildType: 'bundleless',
+  },
+});

--- a/tests/integration/module/fixtures/build/resolve/alias/package.json
+++ b/tests/integration/module/fixtures/build/resolve/alias/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "resolve-alias-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/module/fixtures/build/resolve/alias/src/index.js
+++ b/tests/integration/module/fixtures/build/resolve/alias/src/index.js
@@ -1,0 +1,3 @@
+import { createElement } from 'react';
+
+console.log(createElement);


### PR DESCRIPTION
## Summary
When we use `alias: { "react": "react-native"}` and want to redirect the module id, it failed.
We will get a result: "./react-native", but we want "react-native",
Now we use a new config, which names "resolve.alias" to support it.
In this config, we remove the default alias, and make it easier to understand.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
