### PR TITLE
feat(module-tools): support custom loader

### DIFF
--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -881,6 +881,24 @@ For more information about JSX Transform, you can refer to the following links:
 
 :::
 
+
+## loader
+
+**Experimental**
+
+This option is used to change the interpretation method of the given input file.
+For example, you need to handle the js file as jsx.
+
+```js title="modern.config.ts"
+export default defineConfig({
+  buildConfig: {
+    loader: {
+      '.js': 'jsx',
+    }
+  },
+});
+```
+
 ## metafile
 
 This option is used for build analysis. When enabled, esbuild will generate metadata about the build in JSON format.

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -870,6 +870,22 @@ export default defineConfig({
 
 :::
 
+## loader
+
+**试验性功能**
+
+此选项用来更改给定输入文件的解释方式。例如你需要将 js 文件当做 jsx 处理
+
+```js title="modern.config.ts"
+export default defineConfig({
+  buildConfig: {
+    loader: {
+      '.js': 'jsx',
+    }
+  },
+});
+```
+
 ## metafile
 
 这个选项用于构建分析，开启该选项后，esbuild 会以 JSON 格式生成有关构建的一些元数据。

--- a/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/adapter.ts
@@ -264,7 +264,10 @@ export const adapterPlugin = (compiler: ICompiler): Plugin => {
 
         const ext = extname(args.path);
 
-        const loader = (transformResult.loader ?? loaderMap[ext]) as Loader;
+        // Priority: transform result > user loader > default loader
+        const loader = (transformResult.loader ??
+          compiler.config.loader[ext] ??
+          loaderMap[ext]) as Loader;
 
         const inlineSourceMap = context.getInlineSourceMap();
 

--- a/packages/solutions/module-tools/src/builder/feature/swc.ts
+++ b/packages/solutions/module-tools/src/builder/feature/swc.ts
@@ -1,6 +1,7 @@
-import { basename } from 'path';
+import { basename, extname } from 'path';
 import type { TransformConfig, JscTarget } from '@modern-js/swc-plugins';
 import { Compiler } from '@modern-js/swc-plugins';
+import { loaderMap } from '../../constants/loader';
 import type { ICompiler, Source, TsTarget, ITsconfig } from '../../types';
 import {
   isJsExt,
@@ -61,8 +62,12 @@ export const swcTransform = (userTsconfig: ITsconfig) => ({
       useDefineForClassFields = true;
     }
 
-    const { transformImport, transformLodash, externalHelpers } =
-      compiler.config;
+    const {
+      transformImport,
+      transformLodash,
+      externalHelpers,
+      loader: userLoader,
+    } = compiler.config;
 
     compiler.hooks.transform.tapPromise(
       { name },
@@ -70,10 +75,9 @@ export const swcTransform = (userTsconfig: ITsconfig) => ({
         const { path } = source;
         // Todo: emitDecoratorMetadata default value
         const isTs = isTsLoader(source.loader) || isTsExt(path);
-        const enableJsx =
-          source.loader === 'tsx' ||
-          source.loader === 'jsx' ||
-          /\.tsx$|\.jsx$/i.test(path);
+        const ext = extname(path);
+        const loader = source.loader ?? userLoader[ext] ?? loaderMap[ext];
+        const enableJsx = loader === 'tsx' || loader === 'jsx';
 
         if (isJsExt(path) || isJsLoader(source.loader)) {
           const { target, jsx } = compiler.config;

--- a/packages/solutions/module-tools/src/config/merge.ts
+++ b/packages/solutions/module-tools/src/config/merge.ts
@@ -115,6 +115,7 @@ export const mergeDefaultBaseConfig = async (
 
   const esbuildOptions = pConfig.esbuildOptions ?? defaultConfig.esbuildOptions;
   return {
+    loader: pConfig.loader ?? defaultConfig.loader,
     shims: pConfig.shims ?? defaultConfig.shims,
     autoExtension: pConfig.autoExtension ?? defaultConfig.autoExtension,
     footer: pConfig.footer ?? defaultConfig.footer,

--- a/packages/solutions/module-tools/src/constants/build.ts
+++ b/packages/solutions/module-tools/src/constants/build.ts
@@ -33,6 +33,7 @@ export const getDefaultBuildConfig = () => {
     hooks: [],
     input: ['src/index.ts'],
     jsx: 'automatic',
+    loader: {},
     metafile: false,
     minify: false,
     outDir: './dist',

--- a/packages/solutions/module-tools/src/types/config/index.ts
+++ b/packages/solutions/module-tools/src/types/config/index.ts
@@ -166,6 +166,10 @@ export type BaseBuildConfig = Omit<
 };
 
 export type PartialBaseBuildConfig = {
+  /**
+   * @experimental
+   */
+  loader?: Record<string, string>;
   shims?: boolean;
   autoExtension?: boolean;
   resolve?: Resolve;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6597,6 +6597,8 @@ importers:
 
   tests/integration/module/fixtures/build/alias/js: {}
 
+  tests/integration/module/fixtures/build/alias/module-id: {}
+
   tests/integration/module/fixtures/build/alias/ts: {}
 
   tests/integration/module/fixtures/build/asset/limit:
@@ -6677,6 +6679,10 @@ importers:
   tests/integration/module/fixtures/build/input: {}
 
   tests/integration/module/fixtures/build/jsx: {}
+
+  tests/integration/module/fixtures/build/loader/esbuild: {}
+
+  tests/integration/module/fixtures/build/loader/swc: {}
 
   tests/integration/module/fixtures/build/metafile: {}
 

--- a/tests/integration/module/fixtures/build/loader/esbuild/modern.config.ts
+++ b/tests/integration/module/fixtures/build/loader/esbuild/modern.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    loader: {
+      '.js': 'jsx',
+    },
+  },
+});

--- a/tests/integration/module/fixtures/build/loader/esbuild/package.json
+++ b/tests/integration/module/fixtures/build/loader/esbuild/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "loader-esbuild-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/module/fixtures/build/loader/esbuild/src/index.js
+++ b/tests/integration/module/fixtures/build/loader/esbuild/src/index.js
@@ -1,0 +1,3 @@
+export default () => {
+  return <div>hello world</div>;
+};

--- a/tests/integration/module/fixtures/build/loader/loader.test.ts
+++ b/tests/integration/module/fixtures/build/loader/loader.test.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+import { runCli, initBeforeTest } from '../../utils';
+
+initBeforeTest();
+
+describe('loader', () => {
+  it('esbuild usage', async () => {
+    const ret = await runCli({
+      argv: ['build'],
+      appDirectory: path.join(__dirname, 'esbuild'),
+    });
+    console.log(ret);
+    expect(ret.success).toBe(true);
+  });
+  it('swc usage', async () => {
+    const ret = await runCli({
+      argv: ['build'],
+      appDirectory: path.join(__dirname, 'swc'),
+    });
+
+    expect(ret.success).toBe(true);
+  });
+});

--- a/tests/integration/module/fixtures/build/loader/swc/modern.config.ts
+++ b/tests/integration/module/fixtures/build/loader/swc/modern.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    loader: {
+      '.js': 'jsx',
+    },
+    // enable swc
+    target: 'es5',
+  },
+});

--- a/tests/integration/module/fixtures/build/loader/swc/package.json
+++ b/tests/integration/module/fixtures/build/loader/swc/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "loader-swc-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/module/fixtures/build/loader/swc/src/index.js
+++ b/tests/integration/module/fixtures/build/loader/swc/src/index.js
@@ -1,0 +1,3 @@
+export default () => {
+  return <div>hello world</div>;
+};


### PR DESCRIPTION
## Summary
In fact, we can not custom loader. we need this ability.
But this is a experimental config, because loader can not overrides all scene, sometimes, we still use file exe to match the loader or config.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
