### PR TITLE
feat(module-tools): add applyAfterBuiltIn to control custom hook apply before or after built-in hook

### DIFF
--- a/packages/document/module-doc/docs/en/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/en/api/config/build-config.mdx
@@ -753,7 +753,8 @@ Build lifecycle hooks that allow custom logic to be injected at specific stages 
 ```ts
 type HookList = {
   name: string;
-  apply: (compiler: ICompiler) => void.
+  apply: (compiler: ICompiler) => void;
+  applyAfterBuiltIn?: boolean;
 }
 
 ```

--- a/packages/document/module-doc/docs/en/guide/advance/in-depth-about-build.md
+++ b/packages/document/module-doc/docs/en/guide/advance/in-depth-about-build.md
@@ -95,6 +95,10 @@ Serial hooks that stop the execution of other tapped functions if a tapped funct
 
 Serial hooks whose results are passed to the next tapped function.
 
+### Hook Order
+
+The execution order of hooks follows the registration order. You can control whether a hook is registered before or after the built-in hooks using `applyAfterBuiltIn`.
+
 ### Hook API
 
 #### load

--- a/packages/document/module-doc/docs/zh/api/config/build-config.mdx
+++ b/packages/document/module-doc/docs/zh/api/config/build-config.mdx
@@ -744,6 +744,8 @@ export default defineConfig({
 type HookList = {
   name: string;
   apply: (compiler: ICompiler) => void;
+  // 是否在 buildIn 钩子之后执行
+  applyAfterBuiltIn?: boolean;
 };
 ```
 

--- a/packages/document/module-doc/docs/zh/guide/advance/in-depth-about-build.md
+++ b/packages/document/module-doc/docs/zh/guide/advance/in-depth-about-build.md
@@ -95,6 +95,10 @@ Modern.js Module Hook 使用了 [tapable](https://github.com/webpack/tapable) �
 
 串行执行的 hooks，其结果会传递给下一个 tapped function
 
+### Hook 顺序
+
+Hook 的执行顺序和注册顺序保持一致，可以通过 `applyAfterBuiltIn` 来控制在 BuiltIn Hook 前或后注册。
+
 ### Hook API
 
 #### load

--- a/packages/solutions/module-tools/src/builder/esbuild/index.ts
+++ b/packages/solutions/module-tools/src/builder/esbuild/index.ts
@@ -109,8 +109,9 @@ export class EsbuildCompiler implements ICompiler {
       initWatcher(this);
     }
     const internal = await getInternalList(this.context);
-    const user = this.config.hooks;
-    this.hookList = [...user, ...internal];
+    const before = this.config.hooks.filter(hook => !hook.applyAfterBuiltIn);
+    const after = this.config.hooks.filter(hook => hook.applyAfterBuiltIn);
+    this.hookList = [...before, ...internal, ...after];
     await Promise.all(this.hookList.map(item => item.apply(this)));
   }
 

--- a/packages/solutions/module-tools/src/types/config/index.ts
+++ b/packages/solutions/module-tools/src/types/config/index.ts
@@ -19,6 +19,7 @@ export * from './copy';
 export type HookList = {
   name: string;
   apply: (compiler: ICompiler) => void;
+  applyAfterBuiltIn?: boolean;
 }[];
 
 export type EsbuildOptions = (options: BuildOptions) => BuildOptions;

--- a/tests/integration/module/fixtures/build/hook/hook.test.ts
+++ b/tests/integration/module/fixtures/build/hook/hook.test.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+import { fs } from '@modern-js/utils';
+import { runCli, initBeforeTest } from '../../utils';
+
+initBeforeTest();
+
+describe('hook.applyAfterBuiltIn', () => {
+  const fixtureDir = __dirname;
+  it('after', async () => {
+    const ret = await runCli({
+      argv: ['build'],
+      appDirectory: fixtureDir,
+    });
+    console.log(ret);
+
+    expect(ret.success).toBe(true);
+
+    const distFilePath = path.join(fixtureDir, './dist/index.js');
+    expect(fs.existsSync(distFilePath)).toBe(true);
+    const content = fs.readFileSync(distFilePath, 'utf-8');
+    expect(content.includes('after')).toBe(true);
+  });
+});

--- a/tests/integration/module/fixtures/build/hook/modern.config.ts
+++ b/tests/integration/module/fixtures/build/hook/modern.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig } from '@modern-js/module-tools/defineConfig';
+
+export default defineConfig({
+  buildConfig: {
+    hooks: [
+      {
+        name: 'before1',
+        apply: compiler => {
+          compiler.hooks.transform.tapPromise(
+            { name: 'before1' },
+            async args => {
+              const code = "export const name = 'before1';";
+              return {
+                ...args,
+                code,
+              };
+            },
+          );
+        },
+      },
+      {
+        name: 'after',
+        applyAfterBuiltIn: true,
+        apply: compiler => {
+          compiler.hooks.transform.tapPromise({ name: 'after' }, async args => {
+            const code = "export const name = 'after';";
+            return {
+              ...args,
+              code,
+            };
+          });
+        },
+      },
+      {
+        name: 'before2',
+        apply: compiler => {
+          compiler.hooks.transform.tapPromise(
+            { name: 'before2' },
+            async args => {
+              const code = "export const name = 'before2';";
+              return {
+                ...args,
+                code,
+              };
+            },
+          );
+        },
+      },
+    ],
+  },
+});

--- a/tests/integration/module/fixtures/build/hook/package.json
+++ b/tests/integration/module/fixtures/build/hook/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "hook-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/integration/module/fixtures/build/hook/src/index.js
+++ b/tests/integration/module/fixtures/build/hook/src/index.js
@@ -1,0 +1,1 @@
+export const another = 'another';


### PR DESCRIPTION
## Summary
Before this change, our custom hook can only be applied before built-in hook, 
this can let hook apply after the built-in, and tranform or render the last result.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
