### PR TITLE
fix: update inspect default output value

### DIFF
--- a/packages/document/main-doc/docs/en/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/commands.mdx
@@ -200,7 +200,7 @@ Usage: modern inspect [options]
 
 Options:
   --env <env>           view the configuration in the target environment (default: "development")
-  --output <output>     Specify the path to output in the dist (default: "/")
+  --output <output>     Specify the path to output in the dist (default: "./")
   --verbose             Show the full function in the result
   -c --config <config>  specify the configuration file, which can be a relative or absolute path
   -h, --help            show command help

--- a/packages/document/main-doc/docs/zh/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/commands.mdx
@@ -200,7 +200,7 @@ Usage: modern inspect [options]
 
 Options:
   --env <env>           查看指定环境下的配置 (default: "development")
-  --output <output>     指定在 dist 目录下输出的路径 (default: "/")
+  --output <output>     指定在 dist 目录下输出的路径 (default: "./")
   --verbose             在结果中展示函数的完整内容
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   -h, --help            显示命令帮助

--- a/packages/solutions/app-tools/src/commands/index.ts
+++ b/packages/solutions/app-tools/src/commands/index.ts
@@ -165,7 +165,11 @@ export const inspectCommand = (
       i18n.t(localeKeys.command.inspect.env),
       'development',
     )
-    .option('--output <output>', i18n.t(localeKeys.command.inspect.output), '/')
+    .option(
+      '--output <output>',
+      i18n.t(localeKeys.command.inspect.output),
+      './',
+    )
     .option('--verbose', i18n.t(localeKeys.command.inspect.verbose))
     .option('-c --config <config>', i18n.t(localeKeys.command.shared.config))
     .action(async (options: InspectOptions) => {


### PR DESCRIPTION
## Summary

update inspect default output value, use relative path `./` instead of absolute output path  `/`
https://github.com/web-infra-dev/rsbuild/pull/3024
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
