### PR TITLE
docs: avoid confusing version number

### DIFF
--- a/.changeset/lovely-geese-kneel.md
+++ b/.changeset/lovely-geese-kneel.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/main-doc': patch
+---
+
+docs: avoid confusing version number

--- a/packages/document/main-doc/docs/en/components/debug-app.mdx
+++ b/packages/document/main-doc/docs/en/components/debug-app.mdx
@@ -4,7 +4,7 @@ Run `pnpm run dev` in the project to start the project:
 $ pnpm run dev
 > modern dev
 
-  Modern.js Framework v2.55.0
+  Modern.js Framework
 
 ready   Client compiled in 0.86 s
 

--- a/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
@@ -93,7 +93,7 @@ $ pnpm run build
 
 > modern build
 
-  Modern.js Framework v2.55.0
+  Modern.js Framework va.b.c
 
 info    Starting production build...
 info    Type checker is enabled. It may take some time.
@@ -141,7 +141,7 @@ $ pnpm run serve
 
 > modern serve
 
-  Modern.js Framework v2.55.0
+  Modern.js Framework
 
 info    Starting production server...
 

--- a/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/quick-start.mdx
@@ -93,7 +93,7 @@ $ pnpm run build
 
 > modern build
 
-  Modern.js Framework va.b.c
+  Modern.js Framework
 
 info    Starting production build...
 info    Type checker is enabled. It may take some time.

--- a/packages/document/main-doc/docs/en/guides/get-started/upgrade.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/upgrade.mdx
@@ -18,7 +18,7 @@ import { PackageManagerTabs } from '@theme';
 > modern upgrade
 
 [INFO] [Project Type]: Web App
-[INFO] [Modern.js Latest Version]: 2.0.0
+[INFO] [Modern.js Latest Version]: x.y.z
 [INFO] Upgrade Modern.js package version success!
 ```
 

--- a/packages/document/main-doc/docs/en/guides/troubleshooting/dependencies.mdx
+++ b/packages/document/main-doc/docs/en/guides/troubleshooting/dependencies.mdx
@@ -18,8 +18,8 @@ For example, running `npm ls @modern-js/core` will show the following result:
 
 ```
 project
-└─┬ @modern-js/app-tools@2.0.0
-  └── @modern-js/core@2.0.0
+└─┬ @modern-js/app-tools@x.y.z
+  └── @modern-js/core@x.y.z
 ```
 
 **pnpm**
@@ -30,8 +30,8 @@ For example, running `pnpm ls @modern-js/core --depth Infinity` will show the fo
 
 ```
 devDependencies:
-@modern-js/app-tools 2.0.0
-└── @modern-js/core 2.0.0
+@modern-js/app-tools x.y.z
+└── @modern-js/core x.y.z
 ```
 
 ---

--- a/packages/document/main-doc/docs/zh/components/debug-app.mdx
+++ b/packages/document/main-doc/docs/zh/components/debug-app.mdx
@@ -5,7 +5,7 @@ $ pnpm run dev
 
 > modern dev
 
-  Modern.js Framework v2.55.0
+  Modern.js Framework
 
 ready   Client compiled in 0.86 s
 

--- a/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/quick-start.mdx
@@ -95,7 +95,7 @@ $ pnpm run build
 
 > modern build
 
-  Modern.js Framework v2.55.0
+  Modern.js Framework
 
 info    Starting production build...
 info    Type checker is enabled. It may take some time.
@@ -141,7 +141,7 @@ dist
 ```bash
 $ pnpm run serve
 
-  Modern.js Framework v2.55.0
+  Modern.js Framework
 
 info    Starting production server...
 

--- a/packages/document/main-doc/docs/zh/guides/get-started/upgrade.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/upgrade.mdx
@@ -18,7 +18,7 @@ import { PackageManagerTabs } from '@theme';
 > modern upgrade
 
 [INFO] [项目类型]: Web 应用
-[INFO] [Modern.js 最新版本]: 2.0.0
+[INFO] [Modern.js 最新版本]: x.y.z
 [INFO] 已更新 Modern.js 依赖至最新版本!
 ```
 

--- a/packages/document/main-doc/docs/zh/guides/troubleshooting/dependencies.mdx
+++ b/packages/document/main-doc/docs/zh/guides/troubleshooting/dependencies.mdx
@@ -18,8 +18,8 @@ sidebar_position: 1
 
 ```
 project
-└─┬ @modern-js/app-tools@2.0.0
-  └── @modern-js/core@2.0.0
+└─┬ @modern-js/app-tools@x.y.z
+  └── @modern-js/core@x.y.z
 ```
 
 **pnpm**
@@ -30,8 +30,8 @@ project
 
 ```
 devDependencies:
-@modern-js/app-tools 2.0.0
-└── @modern-js/core 2.0.0
+@modern-js/app-tools x.y.z
+└── @modern-js/core x.y.z
 ```
 
 ---


### PR DESCRIPTION
## Summary

Avoid confusing version number in the documentation. The in-house framework uses different major version.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
