### PR TITLE
fix: should not minify html when disableMinimize in webpack mode

### DIFF
--- a/.changeset/happy-rockets-cough.md
+++ b/.changeset/happy-rockets-cough.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix: should not minify html when disableMinimize in webpack mode
+
+fix: webpack 模式下，当配置 disableMinimize 时不开启 html 压缩

--- a/packages/cli/uni-builder/src/shared/plugins/htmlMinify.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/htmlMinify.ts
@@ -73,10 +73,8 @@ export const pluginHtmlMinifierTerser = (): RsbuildPlugin => ({
         output,
         tools: { htmlPlugin },
       } = environment.config;
-
-      if (!isProd || output.minify === false || htmlPlugin === false) {
-        return;
-      }
+      const disableHtmlMinify =
+        !isProd || output.minify === false || htmlPlugin === false;
 
       const { minify } = await import('html-minifier-terser');
 
@@ -96,7 +94,7 @@ export const pluginHtmlMinifierTerser = (): RsbuildPlugin => ({
           return name === 'HtmlRspackPlugin';
         });
 
-        if (isHtmlRspackPlugin) {
+        if (isHtmlRspackPlugin && !disableHtmlMinify) {
           chain.plugin(id).tap(options => {
             if (!options.length) {
               return options;
@@ -126,6 +124,11 @@ export const pluginHtmlMinifierTerser = (): RsbuildPlugin => ({
         if (isHtmlWebpackPlugin) {
           chain.plugin(id).tap(options => {
             if (!options.length || options[0].minify) {
+              return options;
+            }
+
+            if (disableHtmlMinify) {
+              options[0].minify = false;
               return options;
             }
             const userMinifyOption = options[0].minify;

--- a/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
@@ -4423,6 +4423,7 @@ exports[`uni-builder webpack > should generator webpack config correctly 1`] = `
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
+        "minify": false,
         "scriptLoading": "defer",
         "template": "",
         "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",

--- a/packages/cli/uni-builder/tests/__snapshots__/minimize.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/minimize.test.ts.snap
@@ -1,5 +1,100 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`html minify > should not apply html minify in production when disableMinimize 1`] = `
+[
+  RsbuildCorePlugin {},
+  MiniCssExtractPlugin {
+    "_sortedModulesCache": WeakMap {},
+    "options": {
+      "chunkFilename": "static/css/async/[name].[contenthash:8].css",
+      "experimentalUseImportModule": undefined,
+      "filename": "static/css/[name].[contenthash:8].css",
+      "ignoreOrder": true,
+      "runtime": true,
+    },
+    "runtimeOptions": {
+      "attributes": undefined,
+      "insert": undefined,
+      "linkType": "text/css",
+    },
+  },
+  HtmlWebpackPlugin {
+    "userOptions": {
+      "chunks": [
+        "index",
+      ],
+      "entryName": "index",
+      "filename": "html/index/index.html",
+      "inject": "head",
+      "meta": {
+        "charset": {
+          "charset": "UTF-8",
+        },
+        "viewport": "width=device-width, initial-scale=1.0",
+      },
+      "minify": false,
+      "scriptLoading": "defer",
+      "template": "",
+      "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
+      "templateParameters": [Function],
+      "title": "",
+    },
+    "version": 5,
+  },
+  RsbuildHtmlPlugin {
+    "getEnvironment": [Function],
+    "modifyTagsFn": [Function],
+    "name": "RsbuildHtmlPlugin",
+    "options": {
+      "index": {
+        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
+      },
+    },
+  },
+  DefinePlugin {
+    "definitions": {
+      "process.env.ASSET_PREFIX": "\\"\\"",
+      "process.env.NODE_ENV": "\\"production\\"",
+    },
+  },
+  ProgressPlugin {
+    "compileTime": null,
+    "dependenciesCount": 10000,
+    "handler": [Function],
+    "hasCompileErrors": false,
+    "id": "web",
+    "modulesCount": 5000,
+    "name": "ProgressPlugin",
+    "percentBy": null,
+    "profile": false,
+    "showActiveModules": false,
+    "showDependencies": true,
+    "showEntries": true,
+    "showModules": true,
+  },
+  ForkTsCheckerWebpackPlugin {
+    "options": {
+      "issue": {
+        "exclude": [
+          [Function],
+        ],
+      },
+      "logger": {
+        "error": [Function],
+        "log": [Function],
+      },
+      "typescript": {
+        "build": false,
+        "configFile": "tsconfig.json",
+        "memoryLimit": 8192,
+        "mode": "readonly",
+        "typescriptPath": "<WORKSPACE>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
+      },
+    },
+  },
+]
+`;
+
 exports[`plugin-minimize > Terser and SWC minimizer should not coexist 1`] = `
 [
   SwcMinimizerPlugin {

--- a/packages/cli/uni-builder/tests/minimize.test.ts
+++ b/packages/cli/uni-builder/tests/minimize.test.ts
@@ -128,3 +128,25 @@ describe('plugin-minimize', () => {
     process.env.NODE_ENV = 'test';
   });
 });
+
+describe('html minify', () => {
+  it('should not apply html minify in production when disableMinimize', async () => {
+    process.env.NODE_ENV = 'production';
+
+    const rsbuild = await createUniBuilder({
+      bundlerType: 'webpack',
+      cwd: '',
+      config: {
+        output: {
+          disableMinimize: true,
+        },
+      },
+    });
+
+    const config = await unwrapConfig(rsbuild);
+
+    expect(config.plugins).toMatchSnapshot();
+
+    process.env.NODE_ENV = 'test';
+  });
+});


### PR DESCRIPTION
## Summary

should not apply html minify in production when disableMinimize. The default value of minify in `html-webpack-plugin` is true ('production' mode)

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/e773e36e-4cb6-41a6-8108-e286e0b56b78">

https://github.com/jantimon/html-webpack-plugin?tab=readme-ov-file#options

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
