### PR TITLE
fix: ssrContext should get protocol from x-forwarded-proto first

### DIFF
--- a/.changeset/slimy-emus-clean.md
+++ b/.changeset/slimy-emus-clean.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/server-core': patch
+---
+
+fix: ssrContext get protocal from x-forwarded-proto first, then new server middleware support rewrite request
+fix: ssrContext 优先从 x-forwarded-proto 取协议, 另外新 server middleware 支持重写 request

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
@@ -63,7 +63,9 @@ function createSSRContext(
 
   const { entryName, route } = resource;
 
-  const cookie = request.headers.get('cookie');
+  const { headers } = request;
+
+  const cookie = headers.get('cookie') || '';
 
   const cookieMap = parseCookie(request);
 
@@ -76,9 +78,13 @@ function createSSRContext(
   const url = new URL(request.url);
 
   const host =
-    request.headers.get('X-Forwarded-Host') ||
-    request.headers.get('host') ||
-    url.host;
+    headers.get('X-Forwarded-Host') || headers.get('host') || url.host;
+
+  // The protocal including the final `:`.
+  // Follow: https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol
+  const protocal = `${
+    headers.get('X-Forwarded-Proto') || url.protocol || 'http'
+  }:`;
 
   const ssrConfig = getSSRConfigByEntry(
     entryName,
@@ -99,10 +105,10 @@ function createSSRContext(
     logger,
     metrics,
     request: {
-      url: request.url.replace(url.host, host),
+      url: request.url.replace(url.host, host).replace(url.protocol, protocal),
       baseUrl: route.urlPath,
-      userAgent: request.headers.get('user-agent')!,
-      cookie: cookie!,
+      userAgent: headers.get('user-agent')!,
+      cookie,
       cookieMap,
       pathname,
       query,

--- a/packages/server/core/src/plugins/customServer/index.ts
+++ b/packages/server/core/src/plugins/customServer/index.ts
@@ -233,7 +233,7 @@ async function createMiddlewareContextFromHono(
 ): Promise<UnstableMiddlewareContext> {
   const loaderContext = getLoaderCtx(c as Context);
 
-  let rawRequest = c.req.raw;
+  const rawRequest = c.req.raw;
 
   const method = rawRequest.method.toUpperCase();
 
@@ -253,12 +253,16 @@ async function createMiddlewareContextFromHono(
 
     (init as { duplex: 'half' }).duplex = 'half';
 
-    rawRequest = new Request(rawRequest.url, init);
+    c.req.raw = new Request(rawRequest.url, init);
   }
 
   return {
     get request() {
-      return rawRequest;
+      return c.req.raw;
+    },
+
+    set request(request: Request) {
+      c.req.raw = request;
     },
 
     get response() {

--- a/tests/integration/server-hook/new-middleware/server/index.ts
+++ b/tests/integration/server-hook/new-middleware/server/index.ts
@@ -93,8 +93,23 @@ function injectRequestBody(): UnstableMiddleware {
   };
 }
 
+function modifyRequest(): UnstableMiddleware {
+  return async (c, next) => {
+    const { request } = c;
+
+    if (request.url.includes('modify=1')) {
+      c.request = new Request(
+        request.url.replace('http', 'https').replace('modify=1', 'modify=222'),
+      );
+    }
+
+    await next();
+  };
+}
+
 export const unstableMiddleware: UnstableMiddleware[] = [
   time(),
+  modifyRequest(),
   injectRequestBody(),
   injectMessage(),
   auth() as unknown as UnstableMiddleware,

--- a/tests/integration/server-hook/new-middleware/tests/index.test.ts
+++ b/tests/integration/server-hook/new-middleware/tests/index.test.ts
@@ -82,4 +82,18 @@ describe('test new middleware run correctly', () => {
 
     expect(body).toMatch(message);
   });
+
+  test('should replace request url when request url contains modify=1', async () => {
+    const url = `http://localhost:${port}/?modify=1`;
+
+    const message = '?modify=222';
+
+    const response = await axios.get(url, {
+      responseType: 'text',
+    });
+
+    const body = response.data;
+
+    expect(body).toMatch(message);
+  });
 });


### PR DESCRIPTION
## Summary

- ssrContext get protocol from x-forwarded-proto first
- new server middleware support rewrite request


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
