### PR TITLE
fix: add the user-defined `output.assetPrefix` config for the node mode of modern deploy

### DIFF
--- a/.changeset/shy-dingos-crash.md
+++ b/.changeset/shy-dingos-crash.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': major
+---
+
+fix: add a user-defined output.assetPrefix path for the node mode of modern deploy

--- a/packages/solutions/app-tools/src/plugins/deploy/platforms/node.ts
+++ b/packages/solutions/app-tools/src/plugins/deploy/platforms/node.ts
@@ -35,6 +35,7 @@ export const createNodePreset: CreatePreset = (appContext, config) => {
         },
         output: {
           path: '.',
+          assetPrefix: config?.output?.assetPrefix,
         },
       };
 


### PR DESCRIPTION
## Summary

When using `modern deploy`, the project's configured `output.assetPrefix` is ignored, which results in static resource files failing to be accessed in the Node.js deployment mode.

For example, if the user configures `assetPrefix` as `/foo`, the URLs for the generated static resource files will start with `/foo/static`. However, if this configuration is ignored in the generated `.output/index.js`, the production server will continue to expect static resources to be prefixed with `/static`, leading to failures in accessing the static resource files.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
