### PR TITLE
fix(plugin-swc): tools.swc function config not works

### DIFF
--- a/.changeset/strong-walls-ring.md
+++ b/.changeset/strong-walls-ring.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-swc': patch
+---
+
+fix(plugin-swc): function config not works

--- a/packages/cli/plugin-swc/src/index.ts
+++ b/packages/cli/plugin-swc/src/index.ts
@@ -31,10 +31,12 @@ export function factory(
         );
 
         context.builder.addPlugins([
-          pluginSwc({
-            ...finalConfig,
-            transformLodash: config.performance.transformLodash ?? true,
-          }),
+          pluginSwc(
+            applyConfig(finalConfig, swcConfig => {
+              swcConfig.transformLodash =
+                config.performance.transformLodash ?? true;
+            }),
+          ),
         ]);
       },
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7728,6 +7728,25 @@ importers:
         specifier: ^14
         version: 14.18.35
 
+  tests/integration/swc/fixtures/config-function:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^18
+        version: 18.2.0
+      react-dom:
+        specifier: ^18
+        version: 18.3.1(react@18.2.0)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/plugin-swc':
+        specifier: workspace:*
+        version: link:../../../../../packages/cli/plugin-swc
+
   tests/integration/swc/fixtures/decorator/legacy:
     devDependencies:
       '@modern-js/app-tools':

--- a/tests/integration/swc/fixtures/config-function/modern.config.ts
+++ b/tests/integration/swc/fixtures/config-function/modern.config.ts
@@ -1,0 +1,20 @@
+import { appTools, defineConfig } from '@modern-js/app-tools';
+import { swcPlugin } from '@modern-js/plugin-swc';
+
+export default defineConfig({
+  tools: {
+    swc: (config, { setConfig }) => {
+      setConfig(config, 'cssMinify', false);
+      return config;
+    },
+  },
+  output: {
+    disableTsChecker: true,
+  },
+  source: {
+    entries: {
+      index: './src/index.js',
+    },
+  },
+  plugins: [appTools(), swcPlugin()],
+});

--- a/tests/integration/swc/fixtures/config-function/package.json
+++ b/tests/integration/swc/fixtures/config-function/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "swc-config-function",
+  "version": "2.9.0",
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/plugin-swc": "workspace:*"
+  }
+}

--- a/tests/integration/swc/fixtures/config-function/src/bootstrap.css
+++ b/tests/integration/swc/fixtures/config-function/src/bootstrap.css
@@ -1,0 +1,6 @@
+@charset "UTF-8";
+
+:root {
+  --bs-blue: #0d6efd;
+  --bs-indigo: #6610f2;
+}

--- a/tests/integration/swc/fixtures/config-function/src/index.js
+++ b/tests/integration/swc/fixtures/config-function/src/index.js
@@ -1,0 +1,1 @@
+import './bootstrap.css';

--- a/tests/integration/swc/tests/config-function.test.ts
+++ b/tests/integration/swc/tests/config-function.test.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import { readdirSync, readFileSync } from 'fs';
+import { modernBuild } from '../../../utils/modernTestUtils';
+
+const fixtures = path.resolve(__dirname, '../fixtures');
+
+const getCssFiles = (appDir: string) =>
+  readdirSync(path.resolve(appDir, 'dist/static/css')).filter(filepath =>
+    /\.css$/.test(filepath),
+  );
+
+describe('should apply swc function config correctly', () => {
+  test('should not minify css', async () => {
+    const appDir = path.resolve(fixtures, 'config-function');
+
+    await modernBuild(appDir);
+
+    const cssFile = getCssFiles(appDir)[0];
+    const content = readFileSync(
+      path.resolve(appDir, `dist/static/css/${cssFile}`),
+      'utf8',
+    );
+    expect(content).toContain('@charset "UTF-8";');
+    expect(content).toContain(':root');
+    expect(content).not.toContain('@charset "UTF-8";:root');
+  });
+});


### PR DESCRIPTION
## Summary

fix `tools.swc` function config not works when use plugin-swc.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
