### PR TITLE
fix: enum const case

### DIFF
--- a/tests/e2e/builder/cases/typescript/src/foo.ts
+++ b/tests/e2e/builder/cases/typescript/src/foo.ts
@@ -1,3 +1,4 @@
-export enum Animals {
+// biome-ignore lint/suspicious/noConstEnum: <explanation>
+export const enum Animals {
   Fish = 0,
 }


### PR DESCRIPTION
## Summary

this case is used to test `const enum should compile correctly` in webpack mode. 

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
