### PR TITLE
chore: add internal directory to server plugin context

### DIFF
--- a/.changeset/short-rocks-knock.md
+++ b/.changeset/short-rocks-knock.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/server-core': patch
+---
+
+chore: add internal directory to server plugin context
+chore: 在 server 插件上下文中增加 internal 目录

--- a/packages/server/core/src/serverBase.ts
+++ b/packages/server/core/src/serverBase.ts
@@ -26,6 +26,7 @@ export type ServerBaseOptions = {
   metaName?: string;
   routes?: ServerRoute[];
   appContext: {
+    internalDirectory?: string;
     appDirectory?: string;
     sharedDirectory?: string;
     apiDirectory?: string;

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -98,6 +98,7 @@ export const dev = async (
     },
     appContext: {
       appDirectory,
+      internalDirecory: appContext.internalDirectory,
       apiDirectory: appContext.apiDirectory,
       lambdaDirectory: appContext.lambdaDirectory,
       sharedDirectory: appContext.sharedDirectory,

--- a/packages/solutions/app-tools/src/commands/serve.ts
+++ b/packages/solutions/app-tools/src/commands/serve.ts
@@ -20,6 +20,7 @@ export const start = async (api: PluginAPI<AppTools<'shared'>>) => {
   const {
     distDirectory,
     appDirectory,
+    internalDirectory,
     port,
     metaName,
     serverRoutes,
@@ -65,6 +66,7 @@ export const start = async (api: PluginAPI<AppTools<'shared'>>) => {
     serverConfigPath,
     appContext: {
       appDirectory,
+      internalDirectory,
       sharedDirectory: getTargetDir(
         appContext.sharedDirectory,
         appContext.appDirectory,


### PR DESCRIPTION
## Summary

Now we can get internalDirectory in server plugin context which return by `useAppContext()`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
