### PR TITLE
fix: only inline runtimeChunk/script/style in production

### DIFF
--- a/.changeset/kind-bugs-cheer.md
+++ b/.changeset/kind-bugs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix: only inline runtimeChunk/script/style in production

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -11,7 +11,7 @@ import type {
   UniBuilderConfig,
   DisableSourceMapOption,
 } from '../types';
-import { isFunction } from '@modern-js/utils';
+import { isProd, isFunction } from '@modern-js/utils';
 import { pluginToml } from '@rsbuild/plugin-toml';
 import { pluginYaml } from '@rsbuild/plugin-yaml';
 import { pluginReact } from '@rsbuild/plugin-react';
@@ -199,7 +199,7 @@ export async function parseCommonConfig(
   }
 
   if (enableInlineScripts) {
-    output.inlineScripts = enableInlineScripts;
+    output.inlineScripts ??= isProd() && enableInlineScripts;
   }
 
   if (disableCssExtract) {
@@ -207,7 +207,7 @@ export async function parseCommonConfig(
   }
 
   if (enableInlineStyles) {
-    output.inlineStyles = enableInlineStyles;
+    output.inlineStyles ??= isProd() && enableInlineStyles;
   }
 
   if (disableFilenameHash !== undefined) {
@@ -377,7 +377,9 @@ export async function parseCommonConfig(
   }
 
   rsbuildPlugins.push(
-    pluginRuntimeChunk(uniBuilderConfig.output?.disableInlineRuntimeChunk),
+    pluginRuntimeChunk(
+      isProd() ? uniBuilderConfig.output?.disableInlineRuntimeChunk : true,
+    ),
   );
 
   const { sourceBuild } = uniBuilderConfig.experiments || {};


### PR DESCRIPTION
## Summary

Be consistent with documentation. `disableInlineRuntimeChunk` / `enableInlineScripts` / `enableInlineStyles` configurations only worked  in production mode.

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/4a637a69-ced4-4bef-bc4d-5a5e25b784a2">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
