### PR TITLE
fix: should remove extensions for entry file in real entry file

### DIFF
--- a/.changeset/healthy-terms-yell.md
+++ b/.changeset/healthy-terms-yell.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: should remove extensions for entry file in real entry file, cause developer may use [.server] for ssr bundle entry
+fix: 需要移除入口文件的扩展名，因为开发者可能使用 [.server] 作为 ssr 产物的入口文件

--- a/packages/runtime/plugin-runtime/src/cli/template.ts
+++ b/packages/runtime/plugin-runtime/src/cli/template.ts
@@ -165,7 +165,7 @@ import App from '${
     formatImportPath(
       customEntry
         ? entry
-            .replace('entry.tsx', 'App.tsx')
+            .replace('entry.tsx', 'App')
             .replace(srcDirectory, internalSrcAlias)
         : entry.replace(srcDirectory, internalSrcAlias),
     )


### PR DESCRIPTION
## Summary

if use `App.tsx`, when developer add `App.server.tsx`, the file is ignored.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
