### PR TITLE
fix(runtime): status code should be controlled by data loader

### DIFF
--- a/.changeset/twenty-dolls-remember.md
+++ b/.changeset/twenty-dolls-remember.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(runtime): status code should be controlled by data loader
+fix(runtime): 状态码应该能被 data loader 控制

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
@@ -217,6 +217,14 @@ export const createRequestHandler: CreateRequestHandler =
 
       const initialData = await runBeforeRender(context);
 
+      // Support data loader to return status code
+      if (
+        context.routerContext?.statusCode &&
+        context.routerContext?.statusCode !== 200
+      ) {
+        context.ssrContext?.response.status(context.routerContext?.statusCode);
+      }
+
       context.initialData = initialData;
 
       const redirectResponse = getRedirectResponse(initialData);

--- a/tests/integration/routes/src/three/routes/layout.tsx
+++ b/tests/integration/routes/src/three/routes/layout.tsx
@@ -20,6 +20,13 @@ export default function Layout() {
       <Link to="error/loader" className="loader-error-btn" prefetch="intent">
         /error/loader
       </Link>
+      <Link
+        to="error/response"
+        className="loader-error-response"
+        prefetch="intent"
+      >
+        /error/response
+      </Link>
       <Link to="redirect" className="redirect-btn" prefetch="intent">
         /redirect
       </Link>

--- a/tests/integration/routes/tests/index.test.ts
+++ b/tests/integration/routes/tests/index.test.ts
@@ -366,9 +366,13 @@ const supportThrowResponse = async (
   errors: string[],
   appPort: number,
 ) => {
-  await page.goto(`http://localhost:${appPort}/three/error/response`, {
-    waitUntil: ['domcontentloaded'],
-  });
+  const response = await page.goto(
+    `http://localhost:${appPort}/three/error/response`,
+    {
+      waitUntil: ['domcontentloaded'],
+    },
+  );
+  expect(response?.status()).toBe(255);
   const errorStatusElm = await page.$('.response-status');
   const text = await page.evaluate(el => el?.textContent, errorStatusElm);
   expect(text?.includes('255')).toBeTruthy();


### PR DESCRIPTION
## Summary

In the previous [PR] (https://github.com/web-infra-dev/modern.js/pull/5782), we supported the data loader return status code. At present, it has been removed here and restored support for this.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
