### PR TITLE
fix(server): if res was piped, res should be treated as sent

### DIFF
--- a/.changeset/tricky-countries-live.md
+++ b/.changeset/tricky-countries-live.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix(server): if res was piped, res should be treated as sent
+fix(server): 如果响应被 pipe，响应应该被当作已经发送

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -129,7 +129,11 @@ const getRequestListener = (handler: RequestHandler) => {
        * ```
        */
 
-      if (!res.headersSent && !(response as any).res) {
+      if (
+        !res.headersSent &&
+        !(response as any).res &&
+        !(res as any)._modernBodyPiped
+      ) {
         await sendResponse(response, res);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

When res is piped,  res's headerSent will not be changed immediately, which will lead to error. The PR is to solve this misjudgment problem.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
