### PR TITLE
fix: custom server hook context request.path should carry query str

### DIFF
--- a/.changeset/hot-stingrays-sing.md
+++ b/.changeset/hot-stingrays-sing.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: custom server hook context request.path should carray query str
+fix: custom server hook context request.path 应该带上 query 字符串

--- a/packages/server/core/src/plugins/customServer/base.ts
+++ b/packages/server/core/src/plugins/customServer/base.ts
@@ -61,7 +61,12 @@ class BaseHookRequest implements ModernRequest {
 
   get url(): string {
     // compat old middlwares,
-    return this.#req.path;
+
+    const query = this.#c.req.query();
+    const q = Object.entries(query)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&');
+    return q ? `${this.#c.req.path}?${q}` : this.#c.req.path;
   }
 
   // TODO: remove next major version


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
