### PR TITLE
docs: update Rspack precautions

### DIFF
--- a/.changeset/yellow-scissors-happen.md
+++ b/.changeset/yellow-scissors-happen.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/builder-doc': patch
+'@modern-js/main-doc': patch
+---
+
+docs: update Rspack precautions

--- a/packages/document/builder-doc/docs/en/shared/rspack.md
+++ b/packages/document/builder-doc/docs/en/shared/rspack.md
@@ -1,3 +1,3 @@
-[Rspack](https://www.rspack.dev/) is a high performance JavaScript bundler based on Rust, with interoperability with the webpack ecosystem, allowing it to be integrated into webpack projects at a low cost while providing better build performance.
+[Rspack](https://www.rspack.dev/) is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, allowing for seamless replacement of webpack, and provides lightning fast build speeds.
 
 Compared to webpack, Rspack has significantly improved build performance, thanks not only to the language advantages brought by Rust, but also to its parallel architecture and incremental compilation features. Benchmarking has shown that Rspack can provide 5-10 times better compilation performance.

--- a/packages/document/builder-doc/docs/en/shared/rspackPrecautions.md
+++ b/packages/document/builder-doc/docs/en/shared/rspackPrecautions.md
@@ -1,9 +1,6 @@
 ## Precautions
 
-Before using Rspack, please be aware that Rspack is currently in the rapid iteration phase. Therefore, you need to be aware of the following:
+Before using Rspack, you need to be aware of the following:
 
-- The API and configuration items of Rspack are not completely stable yet, so non-major versions may introduce some incompatible changes.
-- Rspack currently relies on SWC for code transformation and compression. Due to the lower maturity of SWC compared to Babel and Terser, you may encounter bugs of SWC in edge cases.
-- Rspack is compatible with most plugins and loaders in the webpack ecosystem, but there are still some plugins and loaders that cannot be used temporarily.
-
-Rspack is actively working to resolve the above issues and plans to address them in future updates. We recommend evaluating your project requirements and risk tolerance before deciding whether to use Rspack. If your project requires high stability and high performance, you should choose the more mature tool, Webpack. If you are willing to try new tools and contribute to their development, we encourage you to use Rspack and provide feedback and bug reports to help improve its stability and functionality.
+- Rspack is compatible with most webpack plugins and almost all loaders, but there are still a few webpack plugins that cannot be used for now. For more details, see [Plugin Compatibility](https://rspack.dev/guide/compatibility/plugin).
+- Rspack uses [SWC](https://rspack.dev/guide/features/builtin-swc-loader) by default for code transformation and compression. In rare cases, you may encounter bugs in SWC in edge cases. You can provide feedback via [SWC issues](https://github.com/swc-project/swc/issues).

--- a/packages/document/builder-doc/docs/zh/shared/rspack.md
+++ b/packages/document/builder-doc/docs/zh/shared/rspack.md
@@ -1,3 +1,3 @@
-[Rspack](https://www.rspack.dev/) 是一个基于 Rust 的高性能 Web 构建工具，具备与 webpack 生态系统的互操作性，可以被 webpack 项目低成本集成，并提供更好的构建性能。
+[Rspack](https://www.rspack.dev/) 是一个基于 Rust 编写的高性能 JavaScript 打包工具， 它提供对 webpack 生态良好的兼容性，能够无缝替换 webpack， 并提供闪电般的构建速度。
 
 相较于 webpack，Rspack 的构建性能有明显提升，除了 Rust 带来的语言优势，这也来自于它的并行架构和增量编译等特性。经过 benchmark 验证，Rspack 可以带来 5 ～ 10 倍编译性能的提升。

--- a/packages/document/builder-doc/docs/zh/shared/rspackPrecautions.md
+++ b/packages/document/builder-doc/docs/zh/shared/rspackPrecautions.md
@@ -1,9 +1,6 @@
 ## 注意事项
 
-在使用 Rspack 之前，请留意 Rspack 当前还处于快速迭代阶段。因此，你需要预先了解以下事项：
+在使用 Rspack 前，你需要了解以下事项：
 
-- Rspack 的 API 和配置项尚未完全稳定，因此在后续的非 major 版本中，可能会引入个别不兼容更新。
-- Rspack 目前基于 SWC 进行代码编译和压缩，由于 SWC 的成熟度不及 babel 和 terser，因此你可能会遇到 SWC 在边界场景下的 bug。
-- Rspack 模式兼容了大部分 webpack 生态的插件和 loaders，但仍有少部分插件和 loaders 暂时无法使用。
-
-Rspack 正在积极改善上述问题，并计划在未来的版本中逐步解决它们。在决定是否使用 Rspack 之前，我们建议你评估项目需求和风险承受能力。如果你的项目对稳定性和性能要求较高，可以先选择更成熟的 webpack。如果你愿意尝试新的开发体验并为其发展做出贡献，我们欢迎你使用 Rspack，并提供反馈和报告问题，以帮助改进它的稳定性和功能。
+- Rspack 能够兼容大部分 webpack 插件和几乎所有的 loaders，但仍有少数 webpack 插件暂时无法使用，详见 [Plugin 兼容](https://rspack.dev/zh/guide/compatibility/plugin)。
+- Rspack 默认基于 [SWC](https://rspack.dev/zh/guide/features/builtin-swc-loader) 进行代码编译和压缩，在个别情况下，你可能会遇到 SWC 在边界场景的 bug，可以通过 [SWC 的 issue](https://github.com/swc-project/swc/issues) 反馈。

--- a/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/rspack-start.mdx
@@ -8,7 +8,7 @@ import Rspack from '@modern-js/builder-doc/docs/en/shared/rspackTip.mdx';
 
 <Rspack />
 
-**Modern.js provides out-of-the-box Rspack support**, so you can switch between the stable Webpack and the faster Rspack.
+**Modern.js provides out-of-the-box Rspack support**, so you can switch between the stable webpack and the faster Rspack.
 
 This document will show you how to enable Rspack build mode in Modern.js.
 
@@ -71,7 +71,7 @@ export default {
 ```
 
 :::tip
-After turning on the Rspack build capability, there are currently a small number of configurations that are not supported in Rspack, such as [source.moduleScopes](/configure/app/source/module-scopes), [security.sri](/configure/app/security/sri) etc.
+After using Rspack for build, there are currently a few configs that are not supported in Rspack, such as [source.moduleScopes](/configure/app/source/module-scopes).
 
 For unsupported configurations, we have marked `Bundler: only support webpack` or `Bundler: only support Rspack` in the document. Please refer to the specific configuration introduction.
 :::
@@ -141,9 +141,7 @@ If you need to use the nightly/canary version of Rspack, the package name of the
       "@rspack/plugin-react-refresh": "npm:@rspack/plugin-react-refresh-canary@nightly"
     },
     "peerDependencyRules": {
-      "allowAny": [
-        "@rspack/*"
-      ]
+      "allowAny": ["@rspack/*"]
     }
   }
 }

--- a/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/advanced-features/rspack-start.mdx
@@ -8,7 +8,7 @@ import Rspack from '@modern-js/builder-doc/docs/zh/shared/rspackTip.mdx';
 
 <Rspack />
 
-**Modern.js 提供开箱即用的 Rspack 支持**，你可以在成熟的 Webpack 和更快的 Rspack 之间进行切换。
+**Modern.js 提供开箱即用的 Rspack 支持**，你可以在成熟的 webpack 和更快的 Rspack 之间进行切换。
 
 这篇文档会向你介绍如何在 Modern.js 中开启 Rspack 构建模式。
 
@@ -70,11 +70,10 @@ export default {
 };
 ```
 
-
 :::tip
-开启 Rspack 构建能力后，目前有小部分配置在 Rspack 中还不支持使用，如 [source.moduleScopes](/configure/app/source/module-scopes)、[security.sri](/configure/app/security/sri) 等。
+开启 Rspack 构建后，目前有个别配置暂不支持在 Rspack 中使用，如 [source.moduleScopes](/configure/app/source/module-scopes)。
 
-对于不支持的配置，我们在文档中有标注 `打包工具： 仅支持 webpack` 或 `打包工具： 仅支持 rspack`，可参考具体配置介绍。
+对于不支持的配置，我们在文档中有标注 `打包工具：仅支持 webpack` 或 `打包工具：仅支持 rspack`，可参考具体配置介绍。
 :::
 
 ## 修改转译配置
@@ -105,7 +104,7 @@ export default defineConfig<'rspack'>({
 
 通常情况下，Modern.js 内会集成 Rspack 的最新版本，通过 `npx modern upgrade` 即可将当前项目中的 Modern.js 相关依赖以及内置的 Rspack 更新至最新版本。
 
-但 Modern.js 对于 Rspack 的依赖方式为锁版本方式(非自动升级)，由于发版周期不同步等原因，可能会出现 Modern.js 内集成的 Rspack 版本落后于 Rspack 最新版本的情况。
+但 Modern.js 对于 Rspack 的依赖方式为锁版本方式（非自动升级），由于发版周期不同步等原因，可能会出现 Modern.js 内集成的 Rspack 版本落后于 Rspack 最新版本的情况。
 
 当你执行 dev / build 命令时，Modern.js 会在[开启调试模式时](https://rsbuild.dev/zh/guide/debug/debug-mode)自动打印当前使用的 Rspack 版本：
 
@@ -140,9 +139,7 @@ export default defineConfig<'rspack'>({
       "@rspack/plugin-react-refresh": "npm:@rspack/plugin-react-refresh@nightly"
     },
     "peerDependencyRules": {
-      "allowAny": [
-        "@rspack/*"
-      ]
+      "allowAny": ["@rspack/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Update Rspack precautions. Rspack 1.0 has been released, and we can remove some precautions now.

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
