### PR TITLE
feat: support for security.sri when using Rspack

### DIFF
--- a/.changeset/calm-dancers-mate.md
+++ b/.changeset/calm-dancers-mate.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+feat: support for security.sri when using Rspack

--- a/packages/cli/uni-builder/src/rspack/index.ts
+++ b/packages/cli/uni-builder/src/rspack/index.ts
@@ -31,6 +31,24 @@ export async function parseConfig(
       uniBuilderConfig.experiments.lazyCompilation;
   }
 
+  const { sri } = uniBuilderConfig.security || {};
+  if (sri) {
+    if (sri === true) {
+      rsbuildConfig.security!.sri = {
+        enable: 'auto',
+      };
+    } else {
+      const algorithm = Array.isArray(sri.hashFuncNames)
+        ? (sri.hashFuncNames[0] as 'sha256' | 'sha384' | 'sha512')
+        : undefined;
+
+      rsbuildConfig.security!.sri = {
+        enable: sri.enabled,
+        algorithm,
+      };
+    }
+  }
+
   if (uniBuilderConfig.tools?.babel) {
     const { pluginBabel } = await import('@rsbuild/plugin-babel');
     const { pluginBabelPost } = await import('./plugins/babel-post');

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -446,7 +446,7 @@ export type UniBuilderConfig = {
     distPath?: DistPath;
   };
   performance?: RsbuildConfig['performance'];
-  security?: RsbuildConfig['security'];
+  security?: Omit<RsbuildConfig['security'], 'sri'>;
   tools?: Omit<NonNullable<RsbuildConfig['tools']>, 'htmlPlugin'>;
   source?: Omit<
     NonNullable<RsbuildConfig['source']>,

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -12,11 +12,14 @@ import type {
   RsbuildConfig,
   RsbuildPlugin,
   RsbuildPluginAPI,
+  RsbuildPlugins,
   RsbuildTarget,
   Rspack,
   ScriptInject,
+  SecurityConfig,
   ServerConfig,
   SourceConfig,
+  ToolsConfig,
 } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import type { PluginBabelOptions } from '@rsbuild/plugin-babel';
@@ -437,22 +440,16 @@ export type DistPath = DistPathConfig & {
 
 export type UniBuilderConfig = {
   dev?: RsbuildConfig['dev'];
-  html?: Omit<NonNullable<RsbuildConfig['html']>, 'appIcon'>;
-  output?: Omit<
-    NonNullable<RsbuildConfig['output']>,
-    'polyfill' | 'distPath'
-  > & {
+  html?: Omit<HtmlConfig, 'appIcon'>;
+  output?: Omit<OutputConfig, 'polyfill' | 'distPath'> & {
     polyfill?: Polyfill | 'ua';
     distPath?: DistPath;
   };
   performance?: RsbuildConfig['performance'];
-  security?: Omit<RsbuildConfig['security'], 'sri'>;
-  tools?: Omit<NonNullable<RsbuildConfig['tools']>, 'htmlPlugin'>;
-  source?: Omit<
-    NonNullable<RsbuildConfig['source']>,
-    'alias' | 'transformImport'
-  >;
+  security?: Omit<SecurityConfig, 'sri'>;
+  tools?: Omit<ToolsConfig, 'htmlPlugin'>;
+  source?: Omit<SourceConfig, 'alias' | 'transformImport'>;
   // plugins is a new field, should avoid adding modern plugin by mistake
-  plugins?: RsbuildConfig['plugins'];
+  plugins?: RsbuildPlugins;
   environments?: RsbuildConfig['environments'];
 } & UniBuilderExtraConfig;

--- a/packages/document/builder-doc/docs/en/config/security/sri.md
+++ b/packages/document/builder-doc/docs/en/config/security/sri.md
@@ -5,13 +5,13 @@ type SRIOptions =
   | {
       hashFuncNames?: string[];
       enabled?: 'auto' | boolean;
+      // only works for webpack
       hashLoading?: 'eager' | 'lazy';
     }
   | boolean;
 ```
 
 - **Default:** `undefined`
-- **Bundler:** `only support webpack`
 
 Adding an integrity attribute (`integrity`) to sub-resources introduced by HTML allows the browser to verify the integrity of the introduced resource, thus preventing tampering with the downloaded resource.
 
@@ -27,7 +27,7 @@ For more on subresource integrity, see [Subresource Integrity - MDN](https://dev
 
 #### Example
 
-By default, `SRI` is not turned on, and when it is, its default configuration is as follows:
+By default, `SRI` is not enabled, and when it is, its default configuration is as follows:
 
 ```js
 {

--- a/packages/document/builder-doc/docs/zh/config/security/sri.md
+++ b/packages/document/builder-doc/docs/zh/config/security/sri.md
@@ -5,13 +5,13 @@ type SRIOptions =
   | {
       hashFuncNames?: string[];
       enabled?: 'auto' | boolean;
+      // 仅对 webpack 生效
       hashLoading?: 'eager' | 'lazy';
     }
   | boolean;
 ```
 
 - **默认值：** `undefined`
-- **打包工具：** `仅支持 webpack`
 
 为 HTML 所引入的子资源添加完整性属性 —— `integrity`，使浏览器能够验证引入资源的完整性，以此防止下载的资源被篡改。
 

--- a/tests/e2e/builder/cases/sri/index.test.ts
+++ b/tests/e2e/builder/cases/sri/index.test.ts
@@ -1,9 +1,8 @@
 import path from 'path';
-import { expect } from '@modern-js/e2e/playwright';
-import { webpackOnlyTest } from '@scripts/helper';
+import { expect, test } from '@modern-js/e2e/playwright';
 import { build, getHrefByEntryName } from '@scripts/shared';
 
-webpackOnlyTest('security.sri', async ({ page }) => {
+test('security.sri', async ({ page }) => {
   const builder = await build({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.js') },


### PR DESCRIPTION
## Summary

Support for `security.sri` when using Rspack, Rsbuild now provides partial support for SRI.

## Related Links

See: https://rsbuild.dev/config/security/sri

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
