### PR TITLE
fix(module-tools): import order in global.js of plugin node polyfill

### DIFF
--- a/.changeset/khaki-ravens-breathe.md
+++ b/.changeset/khaki-ravens-breathe.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-module-node-polyfill': patch
+---
+
+fix: node polyfill globals.js should use correct import order
+fix: node polyfill 插件需要使用正确的引入顺序

--- a/biome.json
+++ b/biome.json
@@ -97,7 +97,8 @@
       "packages/server/server/tests/fixtures/mock/cjs/config/mock/**/*",
       "tests/integration/ssr/fixtures/preload/**/*",
       "tests/integration/swc/fixtures/transform-fail/src/App.jsx",
-      "tests/integration/module/plugins/vue/**/*"
+      "tests/integration/module/plugins/vue/**/*",
+      "packages/module/plugin-module-node-polyfill/src/globals.js"
     ]
   }
 }

--- a/packages/module/plugin-module-node-polyfill/src/globals.js
+++ b/packages/module/plugin-module-node-polyfill/src/globals.js
@@ -1,6 +1,6 @@
 import Buffer from 'buffer';
-import console from 'console-browserify';
 import processBrowser from 'process/browser';
+import console from 'console-browserify';
 
 const buffer = {
   Buffer,


### PR DESCRIPTION
…fill

## Summary

![img_v3_02eb_23c0807e-6324-4306-9445-12e04f4d139g](https://github.com/user-attachments/assets/df2d89c3-5fd0-4dbc-aff3-e6caea68c9f3)

In umd scene, `import_console_browserify` depends on `util` and `util` depends on `import_browser`

![img_v3_02ec_7a2b012b-0151-43fc-9bc7-93215810ec6g](https://github.com/user-attachments/assets/d768422b-0d16-443d-be0b-6ddb1d19d619)
![img_v3_02ec_64301860-a3fe-401a-94c4-d414d1f482cg](https://github.com/user-attachments/assets/929f5f81-9319-4775-8683-8e44b8ea50c0)

so `import processBrowser from 'process/browser';` should import before `import console from 'console-browserify';`


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
