### PR TITLE
fix: typo and type for internalDirectory in server appContext

### DIFF
--- a/.changeset/fuzzy-ties-admire.md
+++ b/.changeset/fuzzy-ties-admire.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/types': patch
+'@modern-js/server-core': patch
+---
+
+fix: typo and type for internalDirectory in server appContext
+fix: 修复 internalDirectory 在 server appContext 中的类型错误

--- a/packages/server/core/src/serverBase.ts
+++ b/packages/server/core/src/serverBase.ts
@@ -93,6 +93,7 @@ export class ServerBase<E extends Env = any> {
       middlewares: [],
       appDirectory: context?.appDirectory || '',
       apiDirectory: context?.apiDirectory,
+      internalDirectory: context?.internalDirectory || '',
       lambdaDirectory: context?.lambdaDirectory,
       sharedDirectory: context?.sharedDirectory || '',
       distDirectory: pwd,

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -98,7 +98,7 @@ export const dev = async (
     },
     appContext: {
       appDirectory,
-      internalDirecory: appContext.internalDirectory,
+      internalDirectory: appContext.internalDirectory,
       apiDirectory: appContext.apiDirectory,
       lambdaDirectory: appContext.lambdaDirectory,
       sharedDirectory: appContext.sharedDirectory,

--- a/packages/toolkit/types/server/context.d.ts
+++ b/packages/toolkit/types/server/context.d.ts
@@ -117,6 +117,7 @@ export interface ServerInitHookContext {
 
 export interface ISAppContext {
   appDirectory: string;
+  internalDirectory: string;
   apiDirectory?: string;
   lambdaDirectory?: string;
   distDirectory: string;


### PR DESCRIPTION
## Summary

add type for `internalDirectory`.

fix the typo for `internalDircory` which miss 't'

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
