### PR TITLE
fix: we should not cache ssr result when ssr fall error

### DIFF
--- a/.changeset/nasty-jars-dress.md
+++ b/.changeset/nasty-jars-dress.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/server-core': patch
+---
+
+fix: we should not cache the html, if we can match the html is downgrading.
+fix: 在 ssr 降级时，我们不应该缓存 html

--- a/packages/runtime/plugin-runtime/src/core/server/string/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/string/index.ts
@@ -129,29 +129,28 @@ async function generateHtml(
   let html = '';
   let helmetData;
 
+  const finalApp = collectors.reduce(
+    (pre, creator) => creator.collect?.(pre) || pre,
+    App,
+  );
   try {
-    const finalApp = collectors.reduce(
-      (pre, creator) => creator.collect?.(pre) || pre,
-      App,
-    );
     // react render to string
     if (chunkSet.renderLevel >= RenderLevel.SERVER_PREFETCH) {
       html = ReactDomServer.renderToString(finalApp);
       chunkSet.renderLevel = RenderLevel.SERVER_RENDER;
     }
-
     helmetData = ReactHelmet.renderStatic();
-
-    // collectors do effect
-    await Promise.all(collectors.map(component => component.effect()));
-
-    const cost = end();
-
-    onTiming(SSRTimings.RENDER_HTML, cost);
   } catch (e) {
     chunkSet.renderLevel = RenderLevel.CLIENT_RENDER;
     onError(SSRErrors.RENDER_HTML, e);
   }
+
+  // collectors do effect
+  await Promise.all(collectors.map(component => component.effect()));
+
+  const cost = end();
+
+  onTiming(SSRTimings.RENDER_HTML, cost);
 
   const { ssrScripts, cssChunk, jsChunk } = chunkSet;
 

--- a/packages/runtime/plugin-runtime/tests/ssr/renderString.test.ts
+++ b/packages/runtime/plugin-runtime/tests/ssr/renderString.test.ts
@@ -56,7 +56,6 @@ describe('test render', () => {
     const renderOptions: RenderOptions = {
       runtimeContext,
       resource: {
-        loadableStats: {},
         route: {
           urlPath: '/',
           entryPath: 'main',
@@ -64,7 +63,7 @@ describe('test render', () => {
         htmlTemplate,
         entryName: 'main',
         routeManifest: {} as any,
-      },
+      } as any,
       loaderContext: new Map(),
       logger: createLogger(),
       params: {},

--- a/packages/server/core/src/plugins/render/ssrCache.ts
+++ b/packages/server/core/src/plugins/render/ssrCache.ts
@@ -18,6 +18,8 @@ interface CacheStruct {
   cursor: number;
 }
 
+const ZERO_RENDER_LEVEL = /.*renderLevel.*:.*0/;
+
 export type CacheStatus = 'hit' | 'stale' | 'expired' | 'miss';
 
 async function processCache({
@@ -51,6 +53,12 @@ async function processCache({
     const push = () =>
       reader.read().then(({ done, value }) => {
         if (done) {
+          const match = ZERO_RENDER_LEVEL.test(html);
+          // We should not cache the html, if we can match the html is downgrading.
+          if (match) {
+            writer.close();
+            return;
+          }
           const current = Date.now();
           const cache: CacheStruct = {
             val: html,

--- a/packages/server/core/src/plugins/render/ssrCache.ts
+++ b/packages/server/core/src/plugins/render/ssrCache.ts
@@ -18,7 +18,7 @@ interface CacheStruct {
   cursor: number;
 }
 
-const ZERO_RENDER_LEVEL = /.*renderLevel.*:.*0/;
+const ZERO_RENDER_LEVEL = /"renderLevel":0/;
 
 export type CacheStatus = 'hit' | 'stale' | 'expired' | 'miss';
 


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
