### PR TITLE
fix: react's hook useId cause ssr hydrate failed

### DIFF
--- a/.changeset/strong-hounds-attend.md
+++ b/.changeset/strong-hounds-attend.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: react's hook useId cause ssr hydrate failed
+fix: react's hook useId 导致 ssr hydrate 失败

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -168,11 +168,22 @@ export const routerPlugin = (
               ]);
             };
 
+            const Null = () => null;
+
             return (props => {
               beforeCreateRouter = false;
               const router = useCreateRouter(props);
 
-              return <RouterProvider router={router} />;
+              return (
+                // To match the node tree about https://github.com/web-infra-dev/modern.js/blob/v2.59.0/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx#L150-L168
+                // According to react [useId generation algorithm](https://github.com/facebook/react/pull/22644), `useId` will generate id with the react node react struct.
+                // To void hydration failed, we must guarantee that the node tree when browser hydrate must have same struct with node tree when ssr render.
+                <>
+                  <RouterProvider router={router} />
+                  <Null />
+                  <Null />
+                </>
+              );
             }) as React.ComponentType<any>;
           };
 


### PR DESCRIPTION
## Summary

- Add some empty node to sure the browser hydrate has same struct with ssr render.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
