### PR TITLE
chore: enable lazyCompilation when doc dev

### DIFF
--- a/packages/document/main-doc/rspress.config.ts
+++ b/packages/document/main-doc/rspress.config.ts
@@ -134,12 +134,10 @@ export default defineConfig({
   ],
   builderConfig: {
     output: {
-      disableTsChecker: true,
-      svgDefaultExport: 'component',
       dataUriLimit: 0,
     },
     dev: {
-      startUrl: false,
+      lazyCompilation: true,
     },
     source: {
       alias: {


### PR DESCRIPTION
## Summary

enable lazyCompilation to improve doc dev startup performance. 

https://rsbuild.dev/config/dev/lazy-compilation

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
