### PR TITLE
fix(cli): correct process exit code

### DIFF
--- a/.changeset/spicy-tools-repair.md
+++ b/.changeset/spicy-tools-repair.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/core': patch
+---
+
+fix(cli): correct process exit code
+
+fix(cli): 修正 process exit code

--- a/packages/cli/core/src/createCli.ts
+++ b/packages/cli/core/src/createCli.ts
@@ -91,10 +91,14 @@ export const createCli = () => {
 
     ['SIGINT', 'SIGTERM', 'unhandledRejection', 'uncaughtException'].forEach(
       event => {
-        process.on(event, async err => {
+        process.on(event, async (err: unknown) => {
           hooksRunner.beforeExit();
+
+          let hasError = false;
+
           if (err instanceof Error) {
             logger.error(err.stack);
+            hasError = true;
           } else if (
             err &&
             (event === 'unhandledRejection' || event === 'uncaughtException')
@@ -102,9 +106,11 @@ export const createCli = () => {
             // We should not pass it, if err is not instanceof Error.
             // We can use `console.trace` to follow it call stack,
             console.trace('Unknown Error', err);
+            hasError = true;
           }
+
           process.nextTick(() => {
-            process.exit(1);
+            process.exit(hasError ? 1 : 0);
           });
         });
       },


### PR DESCRIPTION
## Summary

Correct the CLI process exit code, when executing ctrl + C, the exit code should be `0` instead of `1`.

- before:

<img width="560" alt="Screenshot 2024-09-11 at 11 16 18" src="https://github.com/user-attachments/assets/9145649b-ee41-4408-ab90-27b50ea05de2">

- after:

<img width="620" alt="Screenshot 2024-09-11 at 11 17 36" src="https://github.com/user-attachments/assets/4f97612a-4929-485d-a119-3fba1b930e7f">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
