### PR TITLE
chore: rename serviceWorker environment name to workerSSR

### DIFF
--- a/.changeset/hot-jobs-occur.md
+++ b/.changeset/hot-jobs-occur.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/uni-builder': patch
+---
+
+chore: rename serviceWorker environment name to workerSSR

--- a/packages/cli/uni-builder/src/shared/plugins/environmentDefaults.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/environmentDefaults.ts
@@ -58,7 +58,7 @@ export const pluginEnvironmentDefaults = (
     // https://github.com/web-infra-dev/rsbuild/issues/2956
     api.modifyRsbuildConfig({
       handler: config => {
-        const environmentNameOrder = ['web', 'node', 'serviceWorker'];
+        const environmentNameOrder = ['web', 'node', 'workerSSR'];
 
         config.environments = Object.fromEntries(
           Object.entries(config.environments!).sort((a1, a2) =>

--- a/packages/cli/uni-builder/src/shared/utils.ts
+++ b/packages/cli/uni-builder/src/shared/utils.ts
@@ -8,7 +8,7 @@ import browserslist from 'browserslist';
 
 export const RUNTIME_CHUNK_NAME = 'builder-runtime';
 
-export const SERVICE_WORKER_ENVIRONMENT_NAME = 'serviceWorker';
+export const SERVICE_WORKER_ENVIRONMENT_NAME = 'workerSSR';
 
 export const JS_REGEX = /\.(?:js|mjs|cjs|jsx)$/;
 

--- a/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
@@ -3303,7 +3303,7 @@ exports[`uni-builder rspack > should generator rspack config correctly when serv
       },
     ],
   },
-  "name": "serviceWorker",
+  "name": "workerSSR",
   "optimization": {
     "minimize": true,
     "minimizer": [
@@ -3374,7 +3374,7 @@ exports[`uni-builder rspack > should generator rspack config correctly when serv
     ProgressPlugin {
       "_args": [
         {
-          "prefix": "serviceWorker",
+          "prefix": "workerSSR",
         },
       ],
       "affectedHooks": undefined,

--- a/packages/cli/uni-builder/tests/__snapshots__/environment.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/environment.test.ts.snap
@@ -2233,7 +2233,7 @@ exports[`uni-builder environment compat > should generator environment config co
         },
       ],
     },
-    "name": "serviceWorker",
+    "name": "workerSSR",
     "optimization": {
       "minimize": false,
       "splitChunks": false,
@@ -2269,7 +2269,7 @@ exports[`uni-builder environment compat > should generator environment config co
       ProgressPlugin {
         "_args": [
           {
-            "prefix": "serviceWorker",
+            "prefix": "workerSSR",
           },
         ],
         "affectedHooks": undefined,

--- a/packages/cli/uni-builder/tests/default.test.ts
+++ b/packages/cli/uni-builder/tests/default.test.ts
@@ -77,7 +77,7 @@ describe('uni-builder rspack', () => {
       bundlerType: 'rspack',
       config: {
         environments: {
-          serviceWorker: {
+          workerSSR: {
             output: {
               target: 'web-worker',
             },

--- a/packages/cli/uni-builder/tests/environment.test.ts
+++ b/packages/cli/uni-builder/tests/environment.test.ts
@@ -16,7 +16,7 @@ describe('uni-builder environment compat', () => {
               target: 'node',
             },
           },
-          serviceWorker: {
+          workerSSR: {
             output: {
               target: 'web-worker',
             },
@@ -33,7 +33,7 @@ describe('uni-builder environment compat', () => {
     expect(bundlerConfigs.map(c => c.name)).toEqual([
       'web',
       'node',
-      'serviceWorker',
+      'workerSSR',
     ]);
 
     expect(bundlerConfigs).toMatchSnapshot();

--- a/packages/runtime/plugin-runtime/src/cli/ssr/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/ssr/index.ts
@@ -48,7 +48,7 @@ const ssrBuilderPlugin = (modernAPI: PluginAPI<AppTools>): RsbuildPlugin => ({
   setup(api) {
     api.modifyEnvironmentConfig((config, { name, mergeEnvironmentConfig }) => {
       const isServerEnvironment =
-        config.output.target === 'node' || name === 'serviceWorker';
+        config.output.target === 'node' || name === 'workerSSR';
       const userConfig = modernAPI.useResolvedConfigContext();
 
       const useLoadablePlugin =

--- a/packages/solutions/app-tools/tests/builder/__snapshots__/index.test.ts.snap
+++ b/packages/solutions/app-tools/tests/builder/__snapshots__/index.test.ts.snap
@@ -60,9 +60,9 @@ exports[`create builder Options test create builder environments config 2`] = `
 
 exports[`create builder Options test create builder environments config 3`] = `
 {
-  "workerSSR": {
+  "web": {
     "output": {
-      "target": "web-worker",
+      "target": "web",
     },
     "source": {
       "entry": {
@@ -76,9 +76,9 @@ exports[`create builder Options test create builder environments config 3`] = `
       },
     },
   },
-  "web": {
+  "workerSSR": {
     "output": {
-      "target": "web",
+      "target": "web-worker",
     },
     "source": {
       "entry": {

--- a/packages/solutions/app-tools/tests/builder/__snapshots__/index.test.ts.snap
+++ b/packages/solutions/app-tools/tests/builder/__snapshots__/index.test.ts.snap
@@ -60,7 +60,7 @@ exports[`create builder Options test create builder environments config 2`] = `
 
 exports[`create builder Options test create builder environments config 3`] = `
 {
-  "serviceWorker": {
+  "workerSSR": {
     "output": {
       "target": "web-worker",
     },


### PR DESCRIPTION
## Summary

The `serviceWorker` environment is used for worker ssr, which is an inaccurate and misleading name.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
