### PR TITLE
fix: the problem of NoSSR with Suspense

### DIFF
--- a/.changeset/orange-carrots-study.md
+++ b/.changeset/orange-carrots-study.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: the problem of NoSSR with Suspense
+fix: 修复 NoSSR 在 suspense 下 的问题

--- a/packages/runtime/plugin-runtime/src/core/server/react/nossr/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/react/nossr/index.ts
@@ -1,13 +1,18 @@
+import React from 'react';
 import { type ReactElement, useEffect, useState } from 'react';
 
 export const NoSSR = (
   props?: React.PropsWithChildren<{ fallback?: ReactElement | string }>,
-) => {
+): ReactElement | null => {
   const [isMounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);
   }, []);
 
   const { children, fallback = null } = props || {};
-  return isMounted ? children : fallback;
+  return React.createElement(
+    React.Fragment,
+    null,
+    isMounted ? children : fallback,
+  );
 };

--- a/packages/runtime/plugin-runtime/src/core/server/react/nossr/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/react/nossr/index.ts
@@ -1,13 +1,13 @@
 import { type ReactElement, useEffect, useState } from 'react';
 
 export const NoSSR = (
-  props: React.PropsWithChildren<{ fallback?: ReactElement | string }>,
+  props?: React.PropsWithChildren<{ fallback?: ReactElement | string }>,
 ) => {
   const [isMounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const { children, fallback = null } = props;
+  const { children, fallback = null } = props || {};
   return isMounted ? children : fallback;
 };

--- a/packages/runtime/plugin-runtime/src/core/server/react/nossr/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/react/nossr/index.ts
@@ -1,19 +1,13 @@
-import React, { type ReactElement, useEffect, useState } from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 
-let csr = false;
 export const NoSSR = (
   props: React.PropsWithChildren<{ fallback?: ReactElement | string }>,
 ) => {
-  const [isMounted, setMounted] = useState(csr);
+  const [isMounted, setMounted] = useState(false);
   useEffect(() => {
-    csr = true;
     setMounted(true);
-  });
+  }, []);
 
   const { children, fallback = null } = props;
-  return React.createElement(
-    React.Fragment,
-    null,
-    isMounted ? children : fallback,
-  );
+  return isMounted ? children : fallback;
 };


### PR DESCRIPTION
## Summary

1. When there is Streaming SSR + Suspense, React will hydrate in steps, so we remove the dependence on the closure value `csr`.

2. Make sure that the callback function of useEffect is only executed once.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
