### PR TITLE
fix: html minify error when tools.htmlPlugin false

### DIFF
--- a/.changeset/good-lobsters-glow.md
+++ b/.changeset/good-lobsters-glow.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/uni-builder': patch
+---
+
+fix: html minify error when tools.htmlPlugin false

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -294,21 +294,23 @@ export async function parseCommonConfig(
 
   extraConfig.tools ??= {};
 
-  // compat template title and meta params
-  extraConfig.tools.htmlPlugin = config => {
-    if (typeof config.templateParameters === 'function') {
-      const originFn = config.templateParameters;
+  if (htmlPlugin !== false) {
+    // compat template title and meta params
+    extraConfig.tools.htmlPlugin = config => {
+      if (typeof config.templateParameters === 'function') {
+        const originFn = config.templateParameters;
 
-      config.templateParameters = (...args) => {
-        const res = originFn(...args);
-        return {
-          title: config.title,
-          meta: undefined,
-          ...res,
+        config.templateParameters = (...args) => {
+          const res = originFn(...args);
+          return {
+            title: config.title,
+            meta: undefined,
+            ...res,
+          };
         };
-      };
-    }
-  };
+      }
+    };
+  }
 
   const { dev: RsbuildDev, server } = transformToRsbuildServerOptions(
     dev || {},

--- a/packages/cli/uni-builder/tests/__snapshots__/minimize.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/minimize.test.ts.snap
@@ -97,6 +97,70 @@ exports[`html minify > should not apply html minify in production when disableMi
 ]
 `;
 
+exports[`html minify > should not apply html plugin when htmlPlugin false 1`] = `
+[
+  RsbuildCorePlugin {},
+  MiniCssExtractPlugin {
+    "_sortedModulesCache": WeakMap {},
+    "options": {
+      "chunkFilename": "static/css/async/[name].[contenthash:8].css",
+      "experimentalUseImportModule": undefined,
+      "filename": "static/css/[name].[contenthash:8].css",
+      "ignoreOrder": true,
+      "runtime": true,
+    },
+    "runtimeOptions": {
+      "attributes": undefined,
+      "insert": undefined,
+      "linkType": "text/css",
+    },
+  },
+  DefinePlugin {
+    "definitions": {
+      "import.meta.env.DEV": false,
+      "import.meta.env.MODE": "\\"production\\"",
+      "import.meta.env.PROD": true,
+      "process.env.ASSET_PREFIX": "\\"\\"",
+    },
+  },
+  ProgressPlugin {
+    "compileTime": null,
+    "dependenciesCount": 10000,
+    "handler": [Function],
+    "hasCompileErrors": false,
+    "id": "web",
+    "modulesCount": 5000,
+    "name": "ProgressPlugin",
+    "percentBy": null,
+    "profile": false,
+    "showActiveModules": false,
+    "showDependencies": true,
+    "showEntries": true,
+    "showModules": true,
+  },
+  ForkTsCheckerWebpackPlugin {
+    "options": {
+      "issue": {
+        "exclude": [
+          [Function],
+        ],
+      },
+      "logger": {
+        "error": [Function],
+        "log": [Function],
+      },
+      "typescript": {
+        "build": false,
+        "configFile": "tsconfig.json",
+        "memoryLimit": 8192,
+        "mode": "readonly",
+        "typescriptPath": "<WORKSPACE>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
+      },
+    },
+  },
+]
+`;
+
 exports[`plugin-minimize > Terser and SWC minimizer should not coexist 1`] = `
 [
   SwcMinimizerPlugin {

--- a/packages/cli/uni-builder/tests/minimize.test.ts
+++ b/packages/cli/uni-builder/tests/minimize.test.ts
@@ -149,4 +149,24 @@ describe('html minify', () => {
 
     process.env.NODE_ENV = 'test';
   });
+
+  it('should not apply html plugin when htmlPlugin false', async () => {
+    process.env.NODE_ENV = 'production';
+
+    const rsbuild = await createUniBuilder({
+      bundlerType: 'webpack',
+      cwd: '',
+      config: {
+        tools: {
+          htmlPlugin: false,
+        },
+      },
+    });
+
+    const config = await unwrapConfig(rsbuild);
+
+    expect(config.plugins).toMatchSnapshot();
+
+    process.env.NODE_ENV = 'test';
+  });
 });

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -299,6 +299,12 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
     };
     return {
       config: () => {
+        const userConfig = api.useConfigContext();
+
+        if (userConfig.tools?.htmlPlugin === false) {
+          return {};
+        }
+
         return {
           tools: {
             htmlPlugin: (options, entry) => {


### PR DESCRIPTION
## Summary

Fix html minify error when tools.htmlPlugin false, should not add modern htmlPlugin function options when user tools.htmlPlugin is false.
![img_v3_02em_c1362a94-ada1-4239-815b-2b59e94984fg](https://github.com/user-attachments/assets/ad1e2c4f-2b6b-4c35-bfdd-10442c19e28b)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
