### PR TITLE
docs: add some deprecated warning in model docs and hidden generator

### DIFF
--- a/.changeset/cyan-taxis-try.md
+++ b/.changeset/cyan-taxis-try.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/main-doc': patch
+---
+
+docs: add some deprecated warning in model docs and hidden generator docs
+docs: 添加 Reduck 文档的废弃警告，隐藏的 generator 文档

--- a/packages/document/main-doc/docs/en/guides/topic-detail/_meta.json
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/_meta.json
@@ -10,11 +10,5 @@
     "name": "model",
     "label": "reduck",
     "collapsed": true
-  },
-  {
-    "type": "dir",
-    "name": "generator",
-    "label": "generator",
-    "collapsed": true
   }
 ]

--- a/packages/document/main-doc/docs/en/guides/topic-detail/model/quick-start.mdx
+++ b/packages/document/main-doc/docs/en/guides/topic-detail/model/quick-start.mdx
@@ -2,6 +2,11 @@
 sidebar_position: 1
 title: Quick Start
 ---
+
+:::caution
+New projects are no longer recommended to use Reduck. You can use state management tools from the community, such as [Jotai](https://jotai.org/), [zustand](https://zustand.docs.pmnd.rs/getting-started/introduction), [valtio](https://valtio.dev/docs/introduction/getting-started), etc.
+:::
+
 # Quick Start
 
 import ReduckMigration from "@site-docs-en/components/reduck-migration"

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/_meta.json
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/_meta.json
@@ -10,11 +10,5 @@
     "name": "model",
     "label": "reduck",
     "collapsed": true
-  },
-  {
-    "type": "dir",
-    "name": "generator",
-    "label": "generator",
-    "collapsed": true
   }
 ]

--- a/packages/document/main-doc/docs/zh/guides/topic-detail/model/quick-start.mdx
+++ b/packages/document/main-doc/docs/zh/guides/topic-detail/model/quick-start.mdx
@@ -2,6 +2,11 @@
 sidebar_position: 1
 title: 快速上手
 ---
+
+:::caution
+新项目不再推荐使用 Reduck，可以使用社区中的状态管理工具，例如 [Jotai](https://jotai.org/)、[zustand](https://zustand.docs.pmnd.rs/getting-started/introduction)、[valtio](https://valtio.dev/docs/introduction/getting-started) 等。
+:::
+
 # 快速上手
 
 import ReduckMigration from "@site-docs/components/reduck-migration"


### PR DESCRIPTION
## Summary

Reduck is no longer under active development.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
