### PR TITLE
chore: remove `pnpm-version` in `.nvmrc`

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
 lts/hydrogen
-pnpm-version=8.9.0


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/b4a270c2-8c76-4f10-a141-2fbbfef77057)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
