### PR TITLE
chore(server): add compiler option for createDevServer

### DIFF
--- a/.changeset/great-trains-run.md
+++ b/.changeset/great-trains-run.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/server': patch
+---
+
+chore(server): add compiler option for `createDevServer`.

--- a/.changeset/great-trains-run.md
+++ b/.changeset/great-trains-run.md
@@ -2,4 +2,5 @@
 '@modern-js/server': patch
 ---
 
-chore(server): add compiler option for `createDevServer`.
+chore(server): add `compiler` option for `createDevServer`
+chore(server): 为 `createDevServer` 添加 `compiler` 选项

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -49,6 +49,7 @@ export async function createDevServer(
 
   const builderDevServer = await builder?.createDevServer({
     runCompile: options.runCompile,
+    compiler: options.compilier,
   });
 
   server.addPlugins([

--- a/packages/server/server/src/types.ts
+++ b/packages/server/server/src/types.ts
@@ -1,5 +1,5 @@
 import type { DevServerHttpsOptions, DevServerOptions } from '@modern-js/types';
-import type { UniBuilderInstance } from '@modern-js/uni-builder';
+import type { Rspack, UniBuilderInstance } from '@modern-js/uni-builder';
 
 import type {
   NodeServer,
@@ -16,6 +16,11 @@ export type ExtraOptions = {
   };
 
   runCompile?: boolean;
+
+  /**
+   * The existing compiler can be used here.
+   */
+  compilier?: Rspack.Compiler | Rspack.MultiCompiler;
 
   /** compat, the default value is modern.server-runtime.config.ts  */
   serverConfigFile?: string;


### PR DESCRIPTION
## Summary

In case the compiler is created in advance and the dev server is created later, the compiler option needs to be supported in [createDevServer](https://github.com/web-infra-dev/modern.js/blob/main/packages/server/server/src/createDevServer.ts#L11).

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
