### PR TITLE
fix: ssg generate htmls should apply regions

### DIFF
--- a/.changeset/smart-boats-fetch.md
+++ b/.changeset/smart-boats-fetch.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-ssg': patch
+---
+
+fix: ssg generate htmls should apply regions
+fix: ssg 生成 html 应该应用于 deploy.regions


### PR DESCRIPTION
## Summary

- Update plugin ssg writeHtmlFiles path.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
