### PR TITLE
feat: support dev.watchFiles reload-server option

### DIFF
--- a/.changeset/fluffy-owls-provide.md
+++ b/.changeset/fluffy-owls-provide.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat: support dev.watchFiles reload-server option

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -152,7 +152,21 @@ export const appTools = (
       async watchFiles() {
         const appContext = api.useAppContext();
         const config = api.useResolvedConfigContext();
-        return await generateWatchFiles(appContext, config.source.configDir);
+        const files = await generateWatchFiles(
+          appContext,
+          config.source.configDir,
+        );
+
+        const watchFiles = config.dev.watchFiles;
+        if (watchFiles?.type === 'reload-server') {
+          files.push(
+            ...(Array.isArray(watchFiles.paths)
+              ? watchFiles.paths
+              : [watchFiles.paths]),
+          );
+        }
+
+        return files;
       },
 
       // 这里会被 core/initWatcher 监听的文件变动触发，如果是 src 目录下的文件变动，则不做 restart


### PR DESCRIPTION
## Summary

dev.watchFiles `reload-server` option is provided by Rsbuild CLI in Rsbuild and needs to be implemented separately in modern.js.

<img width="847" alt="image" src="https://github.com/user-attachments/assets/6753b0cc-c860-4ace-8972-21d28b02d96f">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
