### PR TITLE
docs: link `output.copy` to Rsbuild

### DIFF
--- a/.changeset/angry-bats-own.md
+++ b/.changeset/angry-bats-own.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/main-doc': patch
+---
+
+docs: link `output.copy` to Rsbuild

--- a/packages/document/main-doc/docs/en/configure/app/output/copy.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/output/copy.mdx
@@ -1,5 +1,6 @@
 ---
 title: copy
+configName: output.copy
 ---
 
 # output.copy
@@ -9,4 +10,6 @@ title: copy
 
 Copies the specified file or directory to the dist directory, implemented based on [rspack.CopyRspackPlugin](https://rspack.dev/zh/plugins/rspack/copy-rspack-plugin).
 
-For more detailed configuration, please refer to: [rspack.CopyRspackPlugin](https://rspack.dev/zh/plugins/rspack/copy-rspack-plugin).
+import RsbuildConig from '@site-docs-en/components/rsbuild-config-tooltip';
+
+<RsbuildConig />

--- a/packages/document/main-doc/docs/zh/configure/app/output/copy.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/output/copy.mdx
@@ -1,5 +1,6 @@
 ---
 title: copy
+configName: output.copy
 ---
 
 # output.copy
@@ -7,7 +8,8 @@ title: copy
 - **类型：** `Rspack.CopyRspackPluginOptions | Rspack.CopyRspackPluginOptions['patterns']`
 - **默认值：** `undefined`
 
-
 将指定的文件或目录拷贝到构建输出目录中，基于 [rspack.CopyRspackPlugin](https://rspack.dev/zh/plugins/rspack/copy-rspack-plugin) 实现。
 
-更详细的配置项请参考：[rspack.CopyRspackPlugin](https://rspack.dev/zh/plugins/rspack/copy-rspack-plugin)文档。
+import RsbuildConig from '@site-docs/components/rsbuild-config-tooltip';
+
+<RsbuildConig />


### PR DESCRIPTION
## Summary

Link `output.copy` to Rsbuild instead of Rspack.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
