### PR TITLE
 fix: remove node_modules in watcher ignored list

### DIFF
--- a/.changeset/flat-tomatoes-hammer.md
+++ b/.changeset/flat-tomatoes-hammer.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/core': patch
+---
+
+fix: remove node_modules in watcher ignored list
+fix: 移除 watcher 忽略列表中的 node_modules

--- a/packages/cli/core/src/utils/createFileWatcher.ts
+++ b/packages/cli/core/src/utils/createFileWatcher.ts
@@ -44,7 +44,6 @@ export const createFileWatcher = async (
       ignoreInitial: true,
       ignorePermissionErrors: true,
       ignored: [
-        /node_modules/,
         '**/__test__/**',
         '**/*.test.(js|jsx|ts|tsx)',
         '**/*.spec.(js|jsx|ts|tsx)',


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
