### PR TITLE
fix(ssr): we match all asset directly, it can be more faster

### DIFF
--- a/.changeset/twenty-cycles-divide.md
+++ b/.changeset/twenty-cycles-divide.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(ssr): we match all asset directly, it can be more faster
+fix(ssr): 我们一次性匹配出所有资源，这样性能更快

--- a/packages/runtime/plugin-runtime/src/core/server/string/loadable.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/string/loadable.ts
@@ -152,12 +152,22 @@ export class LoadableCollector implements Collector {
       }),
     );
 
+    const jsScriptRegExp = /<script .*?src="([^"]+)".*?>/g;
+
+    const matchs = template.matchAll(jsScriptRegExp);
+
+    // we match all script directly, it can be more faster.
+    const existedScript: string[] = [];
+
+    for (const match of matchs) {
+      existedScript.push(match[1]);
+    }
+
     const scripts = await Promise.all(
       chunks
         .filter(chunk => {
-          const jsChunkReg = new RegExp(`<script .*src="${chunk.url}".*>`);
           return (
-            !jsChunkReg.test(template) &&
+            !existedScript.includes(chunk.url) &&
             !this.existsAssets?.includes(chunk.path)
           );
         })
@@ -188,13 +198,21 @@ export class LoadableCollector implements Collector {
 
     const atrributes = attributesToString(this.generateAttributes());
 
+    const linkRegExp = /<link .*?href="([^"]+)".*?>/g;
+
+    const matchs = template.matchAll(linkRegExp);
+
+    const existedLinks: string[] = [];
+
+    for (const match of matchs) {
+      existedLinks.push(match[1]);
+    }
+
     const css = await Promise.all(
       chunks
         .filter(chunk => {
-          const cssChunkReg = new RegExp(`<link .*href="${chunk.url}".*>`);
-
           return (
-            !cssChunkReg.test(template) &&
+            !existedLinks.includes(chunk.url) &&
             !this.existsAssets?.includes(chunk.path)
           );
         })


### PR DESCRIPTION
## Summary

before, we use for-in to match template many time, it would cost many system assets.
We can match all assets link one time.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
