### PR TITLE
fix: remove ssg stdout listener, only stderr

### DIFF
--- a/.changeset/strange-comics-collect.md
+++ b/.changeset/strange-comics-collect.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-ssg': patch
+---
+
+fix: remove ssg stdout listener, only stderr
+fix: 移除 ssg 的 stdout 监听，只保留 stderr

--- a/packages/cli/plugin-ssg/src/server/index.ts
+++ b/packages/cli/plugin-ssg/src/server/index.ts
@@ -87,15 +87,4 @@ export const createServer = (
         logger.info(str.replace(/[^\S\n]+/g, ' '));
       }
     });
-
-    cp.stdout?.on('data', chunk => {
-      const str = chunk.toString();
-      if (str.includes('Error')) {
-        logger.error(str);
-        reject(new Error('ssg render failed'));
-        cp.kill('SIGKILL');
-      } else {
-        logger.info(str.replace(/[^\S\n]+/g, ' '));
-      }
-    });
   });


### PR DESCRIPTION
## Summary

we should not listen `error` message in stdout data event.

This will lead to many misjudgments of normal logs.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
