### PR TITLE
fix: when the enableCustomEntry is set to true, the entry.tsx should be recognized first

### DIFF
--- a/.changeset/nine-turkeys-hope.md
+++ b/.changeset/nine-turkeys-hope.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: when the enableCustomEntry is set to true, the `entry.tsx` should be recognized first.
+
+fix: 开启 enableCustomEntry 后， `entry.tsx` 入口应优先被识别

--- a/packages/solutions/app-tools/src/plugins/analyze/getFileSystemEntry.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/getFileSystemEntry.ts
@@ -67,17 +67,6 @@ const scanDir = async (
       const customEntryFile = hasEntry(dir);
       const customServerEntry = hasServerEntry(dir);
 
-      if (indexFile && !customBootstrap) {
-        return {
-          entryName,
-          isMainEntry: false,
-          entry: indexFile,
-          absoluteEntryDir: path.resolve(dir),
-          isAutoMount: false,
-          customBootstrap,
-        };
-      }
-
       const entryFile = (
         await hookRunners.checkEntryPoint({
           path: dir,
@@ -97,6 +86,7 @@ const scanDir = async (
           customEntry: enableCustomEntry ? Boolean(customEntryFile) : false,
         };
       }
+
       if (enableCustomEntry && customEntryFile) {
         return {
           entryName,
@@ -108,6 +98,18 @@ const scanDir = async (
           customEntry: Boolean(customEntryFile),
         };
       }
+
+      if (indexFile && !customBootstrap) {
+        return {
+          entryName,
+          isMainEntry: false,
+          entry: indexFile,
+          absoluteEntryDir: path.resolve(dir),
+          isAutoMount: false,
+          customBootstrap,
+        };
+      }
+
       return false;
     }),
   ).then(entries => entries.filter(Boolean) as Entrypoint[]);

--- a/packages/solutions/app-tools/src/plugins/analyze/getFileSystemEntry.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/getFileSystemEntry.ts
@@ -67,6 +67,17 @@ const scanDir = async (
       const customEntryFile = hasEntry(dir);
       const customServerEntry = hasServerEntry(dir);
 
+      if (!enableCustomEntry && indexFile && !customBootstrap) {
+        return {
+          entryName,
+          isMainEntry: false,
+          entry: indexFile,
+          absoluteEntryDir: path.resolve(dir),
+          isAutoMount: false,
+          customBootstrap,
+        };
+      }
+
       const entryFile = (
         await hookRunners.checkEntryPoint({
           path: dir,
@@ -96,17 +107,6 @@ const scanDir = async (
           absoluteEntryDir: path.resolve(dir),
           isAutoMount: false,
           customEntry: Boolean(customEntryFile),
-        };
-      }
-
-      if (indexFile && !customBootstrap) {
-        return {
-          entryName,
-          isMainEntry: false,
-          entry: indexFile,
-          absoluteEntryDir: path.resolve(dir),
-          isAutoMount: false,
-          customBootstrap,
         };
       }
 


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
