### PR TITLE
fix(server): handle the cases that res cannot be writable & add an env variable to control log

### DIFF
--- a/.changeset/sweet-feet-warn.md
+++ b/.changeset/sweet-feet-warn.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/server-core': patch
+---
+
+fix(server): handle the cases that res cannot be writable
+fix(server): 处理 res 无法写入的情况

--- a/packages/server/core/src/adapters/node/helper/index.ts
+++ b/packages/server/core/src/adapters/node/helper/index.ts
@@ -2,5 +2,5 @@ export { loadServerEnv } from './loadEnv';
 export { loadServerPlugins } from './loadPlugin';
 export { loadServerRuntimeConfig, loadServerCliConfig } from './loadConfig';
 export { loadCacheConfig } from './loadCache';
-export { isResponseFinalized } from './utils';
+export { isResFinalized } from './utils';
 export type { NodeBindings } from './utils';

--- a/packages/server/core/src/adapters/node/helper/index.ts
+++ b/packages/server/core/src/adapters/node/helper/index.ts
@@ -2,3 +2,5 @@ export { loadServerEnv } from './loadEnv';
 export { loadServerPlugins } from './loadPlugin';
 export { loadServerRuntimeConfig, loadServerCliConfig } from './loadConfig';
 export { loadCacheConfig } from './loadCache';
+export { isResponseFinalized } from './utils';
+export type { NodeBindings } from './utils';

--- a/packages/server/core/src/adapters/node/helper/utils.ts
+++ b/packages/server/core/src/adapters/node/helper/utils.ts
@@ -22,7 +22,7 @@ export type NodeBindings = {
   };
 };
 
-export const isResponseFinalized = (res: ExtendedNodeResponse): boolean => {
+export const isResFinalized = (res: ExtendedNodeResponse): boolean => {
   return (
     res.headersSent ||
     res._modernBodyPiped ||

--- a/packages/server/core/src/adapters/node/helper/utils.ts
+++ b/packages/server/core/src/adapters/node/helper/utils.ts
@@ -1,0 +1,33 @@
+import type {
+  HonoRequest,
+  NodeRequest,
+  NodeResponse,
+  ServerManifest,
+} from '../../../types';
+
+type ExtendedNodeRequest = NodeRequest & {
+  __honoRequest?: HonoRequest;
+  __templates?: Record<string, string>;
+  __serverManifest?: ServerManifest;
+};
+
+type ExtendedNodeResponse = NodeResponse & {
+  _modernBodyPiped?: boolean;
+};
+
+export type NodeBindings = {
+  node: {
+    req: ExtendedNodeRequest;
+    res: ExtendedNodeResponse;
+  };
+};
+
+export const isResponseFinalized = (res: ExtendedNodeResponse): boolean => {
+  return (
+    res.headersSent ||
+    res._modernBodyPiped ||
+    res.writableEnded ||
+    res.finished ||
+    !res.socket?.writable
+  );
+};

--- a/packages/server/core/src/adapters/node/hono.ts
+++ b/packages/server/core/src/adapters/node/hono.ts
@@ -8,7 +8,7 @@ import type {
   ServerEnv,
   ServerManifest,
 } from '../../types';
-import { type NodeBindings, isResponseFinalized } from './helper';
+import { type NodeBindings, isResFinalized } from './helper';
 
 export type ServerNodeEnv = {
   Bindings: NodeBindings;
@@ -43,7 +43,7 @@ export const httpCallBack2HonoMid = (handler: Handler) => {
       res.removeListener('pipe', onPipe);
     }
 
-    if (isResponseFinalized(res)) {
+    if (isResFinalized(res)) {
       context.finalized = true;
     } else {
       await next();

--- a/packages/server/core/src/adapters/node/hono.ts
+++ b/packages/server/core/src/adapters/node/hono.ts
@@ -55,7 +55,14 @@ export const httpCallBack2HonoMid = (handler: Handler) => {
       res.removeListener('pipe', onPipe);
     }
 
-    if (res.headersSent || res._modernBodyPiped) {
+    // @ts-ignore
+    if (
+      res.headersSent ||
+      res._modernBodyPiped ||
+      res.writableEnded ||
+      res.finished ||
+      !res.socket?.writable
+    ) {
       context.finalized = true;
     } else {
       await next();

--- a/packages/server/core/src/adapters/node/hono.ts
+++ b/packages/server/core/src/adapters/node/hono.ts
@@ -8,19 +8,7 @@ import type {
   ServerEnv,
   ServerManifest,
 } from '../../types';
-
-type NodeBindings = {
-  node: {
-    req: NodeRequest & {
-      __honoRequest?: HonoRequest;
-      __templates?: Record<string, string>;
-      __serverManifest?: ServerManifest;
-    };
-    res: NodeResponse & {
-      _modernBodyPiped?: boolean;
-    };
-  };
-};
+import { type NodeBindings, isResponseFinalized } from './helper';
 
 export type ServerNodeEnv = {
   Bindings: NodeBindings;
@@ -55,14 +43,7 @@ export const httpCallBack2HonoMid = (handler: Handler) => {
       res.removeListener('pipe', onPipe);
     }
 
-    // @ts-ignore
-    if (
-      res.headersSent ||
-      res._modernBodyPiped ||
-      res.writableEnded ||
-      res.finished ||
-      !res.socket?.writable
-    ) {
+    if (isResponseFinalized(res)) {
       context.finalized = true;
     } else {
       await next();

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -1,7 +1,7 @@
 import { type Server as NodeServer, ServerResponse } from 'node:http';
 import type { Server as NodeHttpsServer } from 'node:https';
 import type { NodeRequest, NodeResponse, RequestHandler } from '../../types';
-import { isResponseFinalized } from './helper';
+import { isResFinalized } from './helper';
 import { installGlobals } from './polyfills/install';
 import {
   createReadableStreamFromReadable,
@@ -130,7 +130,7 @@ const getRequestListener = (handler: RequestHandler) => {
        * ```
        */
 
-      if (!(response as any).res && !isResponseFinalized(res)) {
+      if (!(response as any).res && !isResFinalized(res)) {
         await sendResponse(response, res);
       }
     } catch (error) {

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -1,6 +1,7 @@
 import { type Server as NodeServer, ServerResponse } from 'node:http';
 import type { Server as NodeHttpsServer } from 'node:https';
 import type { NodeRequest, NodeResponse, RequestHandler } from '../../types';
+import { isResponseFinalized } from './helper';
 import { installGlobals } from './polyfills/install';
 import {
   createReadableStreamFromReadable,
@@ -129,11 +130,7 @@ const getRequestListener = (handler: RequestHandler) => {
        * ```
        */
 
-      if (
-        !res.headersSent &&
-        !(response as any).res &&
-        !(res as any)._modernBodyPiped
-      ) {
+      if (!(response as any).res && !isResponseFinalized(res)) {
         await sendResponse(response, res);
       }
     } catch (error) {

--- a/packages/server/prod-server/src/apply.ts
+++ b/packages/server/prod-server/src/apply.ts
@@ -18,11 +18,10 @@ import { createLogger, isProd } from '@modern-js/utils';
 import type { ProdServerOptions } from './types';
 
 function getLogger() {
-  if (
-    process.env.DEBUG ||
-    (process.env.NODE_ENV === 'production' && !process.env.DISABLE_LOG)
-  ) {
-    return createLogger({ level: 'verbose' });
+  if (process.env.DEBUG || process.env.NODE_ENV === 'production') {
+    return createLogger({
+      level: (process.env.MODERN_SERVER_LOG_LEVEL as any) || 'verbose',
+    });
   } else {
     return createLogger();
   }

--- a/packages/server/prod-server/src/apply.ts
+++ b/packages/server/prod-server/src/apply.ts
@@ -18,7 +18,10 @@ import { createLogger, isProd } from '@modern-js/utils';
 import type { ProdServerOptions } from './types';
 
 function getLogger() {
-  if (process.env.DEBUG || process.env.NODE_ENV === 'production') {
+  if (
+    process.env.DEBUG ||
+    (process.env.NODE_ENV === 'production' && !process.env.DISABLE_LOG)
+  ) {
     return createLogger({ level: 'verbose' });
   } else {
     return createLogger();

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test:rspack": "pnpm test:builder:rspack && pnpm test:framework && pnpm test:garfish:rspack",
-    "test:framework": "jest",
+    "test:framework": "DISABLE_LOG=true jest",
     "test:builder:rspack": "cd e2e/builder && pnpm test:rspack",
     "test:garfish:rspack": "cd e2e/garfish && pnpm test:rspack",
     "test:module-tools": "cd integration && jest --testMatch **/module/**/*.test.ts",

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test:rspack": "pnpm test:builder:rspack && pnpm test:framework && pnpm test:garfish:rspack",
-    "test:framework": "DISABLE_LOG=true jest",
+    "test:framework": "MODERN_SERVER_LOG_LEVEL=info jest",
     "test:builder:rspack": "cd e2e/builder && pnpm test:rspack",
     "test:garfish:rspack": "cd e2e/garfish && pnpm test:rspack",
     "test:module-tools": "cd integration && jest --testMatch **/module/**/*.test.ts",


### PR DESCRIPTION
## Summary

1. handle the cases that res cannot be writable
2. add an env variable to control log

Currently, when using bff with koa.js framework when the socket is closed, it returns 404.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
