### PR TITLE
chore: add process exit after build script

### DIFF
--- a/.changeset/quick-parrots-push.md
+++ b/.changeset/quick-parrots-push.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': patch
+---
+
+chore: add process exit after build script, avoid third-party code from blocking process exit
+chore: 添加构建后退出脚本，避免三方代码阻塞进程退出

--- a/packages/solutions/app-tools/src/commands/index.ts
+++ b/packages/solutions/app-tools/src/commands/index.ts
@@ -67,6 +67,7 @@ export const buildCommand = async (
     .action(async (options: BuildOptions) => {
       const { build } = await import('./build.js');
       await build(api, options);
+      process.exit(0);
     });
 
   for (const platformBuilder of platformBuilders) {


### PR DESCRIPTION
## Summary

Sometimes, third-party dependencies establish net connections but are not destroyed after build, causing the build process to fail to exit.

So we add `process.exit(0)` after build command, the same as deploy command

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
