### PR TITLE
fix(runtime-utils): the normalizePathname should handles multiple slashes correctly

### DIFF
--- a/.changeset/weak-singers-destroy.md
+++ b/.changeset/weak-singers-destroy.md
@@ -2,5 +2,5 @@
 '@modern-js/runtime-utils': patch
 ---
 
-fix: should handle multiple slashes
-fix: 应该处理好多个 / 的情况
+fix(runtime-utils): the normalizePathname should handles multiple slashes
+fix(runtime-utils): normalizePathname 函数应该处理好多个 / 的情况

--- a/.changeset/weak-singers-destroy.md
+++ b/.changeset/weak-singers-destroy.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime-utils': patch
+---
+
+fix: should handle multiple slashes
+fix: 应该处理好多个 / 的情况

--- a/packages/toolkit/runtime-utils/src/url.ts
+++ b/packages/toolkit/runtime-utils/src/url.ts
@@ -8,10 +8,13 @@
  *
  * pathname3: '/', the nomalizeResult also as '/'
  */
-export function normalizePathname(pathname: string) {
-  if (pathname === '/') {
-    return pathname;
-  } else {
-    return pathname.replace(/\/+$/, '');
+export function normalizePathname(pathname: string): string {
+  // biome-ignore lint/style/useTemplate: <explanation>
+  const normalized = '/' + pathname.replace(/^\/+|\/+$/g, '');
+
+  if (normalized === '/') {
+    return normalized;
   }
+
+  return normalized;
 }

--- a/packages/toolkit/runtime-utils/tests/url.test.ts
+++ b/packages/toolkit/runtime-utils/tests/url.test.ts
@@ -17,5 +17,11 @@ describe('test ./src/url.ts', () => {
 
     pathname = '/a/b/c/d/';
     expect(normalizePathname(pathname)).toBe('/a/b/c/d');
+
+    pathname = '//';
+    expect(normalizePathname(pathname)).toBe('/');
+
+    pathname = '/api//';
+    expect(normalizePathname(pathname)).toBe('/api');
   });
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test:rspack": "pnpm test:builder:rspack && pnpm test:framework && pnpm test:garfish:rspack",
-    "test:framework": "MODERN_SERVER_LOG_LEVEL=info jest",
+    "test:framework": "cross-env MODERN_SERVER_LOG_LEVEL=info jest",
     "test:builder:rspack": "cd e2e/builder && pnpm test:rspack",
     "test:garfish:rspack": "cd e2e/garfish && pnpm test:rspack",
     "test:module-tools": "cd integration && jest --testMatch **/module/**/*.test.ts",


### PR DESCRIPTION
## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
