### PR TITLE
fix: add any type to fix qos bff-koa case error

### DIFF
--- a/packages/server/server/src/dev-tools/watcher/statsCache.ts
+++ b/packages/server/server/src/dev-tools/watcher/statsCache.ts
@@ -60,7 +60,7 @@ export class StatsCache {
   private hash(stats: fs.Stats, filename: string) {
     return crypto
       .createHash('md5')
-      .update(fs.readFileSync(filename))
+      .update(fs.readFileSync(filename) as any)
       .digest('hex');
   }
 }


### PR DESCRIPTION
## Summary

After some deps being upgraded yesterday, there exists an error in qos https://github.com/web-infra-dev/web-infra-QoS/actions/runs/11560794413/job/32178422738

![image](https://github.com/user-attachments/assets/2c9d683d-7cc0-4c37-8e91-de69fd77b84d)

simply add `as any` to fix it.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
