### PR TITLE
perf(plugin-tailwind): reduce tailwindcss `hash()` overhead

### DIFF
--- a/.changeset/flat-moles-think.md
+++ b/.changeset/flat-moles-think.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-tailwindcss': patch
+---
+
+perf(plugin-tailwind): reduce tailwindcss `hash()` overhead

--- a/packages/cli/plugin-tailwind/src/config.ts
+++ b/packages/cli/plugin-tailwind/src/config.ts
@@ -44,10 +44,15 @@ export async function loadConfigFile(appDirectory: string) {
 
   if (configFile) {
     const mod = await bundleRequire(configFile);
-    return mod.default || mod;
+    return {
+      path: configFile,
+      content: mod.default || mod,
+    };
   }
 
-  return {};
+  return {
+    content: {},
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Reduce tailwindcss `hash()` overhead by passing config path to `tailwindcss()`.

See https://github.com/tailwindlabs/tailwindcss/issues/14229 for more details.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
