### PR TITLE
docs: correct Vue link

### DIFF
--- a/packages/document/main-doc/docs/en/guides/get-started/tech-stack.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/tech-stack.mdx
@@ -12,7 +12,7 @@ In this document, you can learn about the main technology stack involved in the 
 
 Modern.js uses [React 18](https://react.dev/) to build user interfaces and is also compatible with React 17.
 
-Rsbuild supports building Vue applications. If you need to use Vue, you can refer to ["Rsbuild - Vue"](https://rsbuild.dev/guide/framework/vue3).
+Rsbuild supports building Vue applications. If you need to use Vue, you can refer to ["Rsbuild - Vue"](https://rsbuild.dev/guide/framework/vue).
 
 ## Routing
 

--- a/packages/document/main-doc/docs/zh/guides/get-started/tech-stack.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/tech-stack.mdx
@@ -12,7 +12,7 @@ Modern.js 框架默认集成了一些社区中流行的库和开发工具。
 
 Modern.js 使用 [React 18](https://react.dev/) 来构建用户界面，同时也兼容 React 17。
 
-Modern.js 底层的 Rsbuild 支持构建 Vue 应用，如果你需要使用 Vue，可以参考 [Rsbuild - Vue](https://rsbuild.dev/zh/guide/framework/vue3)。
+Modern.js 底层的 Rsbuild 支持构建 Vue 应用，如果你需要使用 Vue，可以参考 [Rsbuild - Vue](https://rsbuild.dev/zh/guide/framework/vue)。
 
 ## 路由
 


### PR DESCRIPTION
## Summary

Correct the Vue link in tech stack docs page.

## Related Links

<!--- Provide links of related issues or pages -->

N/A.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
