### PR TITLE
docs: remove Module from Modern.js introduction

### DIFF
--- a/.changeset/gorgeous-bears-sit.md
+++ b/.changeset/gorgeous-bears-sit.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/main-doc': patch
+---
+
+docs: remove Module from Modern.js introduction

--- a/README.md
+++ b/README.md
@@ -18,15 +18,13 @@ English | [简体中文](./README.zh-CN.md)
 
 ## Introduction
 
-Modern.js is an open source web engineering system from ByteDance, including:
+The Modern.js framework is a progressive web framework based on React. At ByteDance, we use Modern.js to build upper-level frameworks that have supported the development of thousands of web applications.
 
-- 🦄 [Modern.js Framework](https://modernjs.dev/en/): A progressive React framework for web development.
-- 🐧 [Modern.js Module](https://modernjs.dev/module-tools/en/): A powerful solution for npm package development.
+When developing React applications, developers usually need to design implementation plans for certain features or use other libraries and frameworks to solve these problems. Modern.js supports all configurations and tools needed by React applications, and has built-in additional features and optimizations. Developers can use React to build the UI of the application, and then gradually adopt the features of Modern.js to solve common application requirements, such as routing, data acquisition, and state management.
 
 ## Getting Started
 
-- Use [Modern.js Framework](https://modernjs.dev/en/guides/get-started/quick-start) to develop a web application.
-- Use [Modern.js Module](https://modernjs.dev/module-tools/en/guide/intro/getting-started.html) to develop an npm package.
+See [Quick Start](https://modernjs.dev/en/guides/get-started/quick-start).
 
 ## Ecosystem
 
@@ -35,6 +33,7 @@ The following solutions and libraries are available within the Modern.js ecosyst
 - 🦀 [Rspack](https://github.com/web-infra-dev/rspack): A fast Rust-based web bundler.
 - 🐬 [Rsbuild](https://github.com/web-infra-dev/rsbuild): An Rspack-based build tool for the web, rebranded from Modern.js Builder.
 - 🐹 [Rspress](https://github.com/web-infra-dev/rspress): A fast Rspack-based static site generator.
+- 🦄 [Rslib](https://github.com/web-infra-dev/rslib): An Rspack-based library development tool.
 - 🐟 [Garfish](https://github.com/web-infra-dev/garfish): A powerful micro front-end framework.
 - 🦆 [Reduck](https://github.com/web-infra-dev/reduck): An redux-based state management library.
 - 🐴 [SWC Plugins](https://github.com/web-infra-dev/swc-plugins): Built-in SWC plugins for Modern.js.
@@ -45,7 +44,7 @@ We use [Modern.js Benchmark](https://web-infra-qos.netlify.app/) to observe the 
 
 ## Roadmap
 
-Please refer to the [Modern.js Roadmap](https://github.com/web-infra-dev/modern.js/issues/4741). We will update the Roadmap content every quarter. Please stay tuned.
+Please refer to the [Modern.js Roadmap](https://github.com/web-infra-dev/modern.js/issues/4741). We will update the Roadmap content regularly. Please stay tuned.
 
 ## Examples
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,23 +18,22 @@
 
 ## 介绍
 
-Modern.js 是字节跳动 Web 工程体系的开源版本，包含：
+Modern.js 框架是一个基于 React 的渐进式 Web 开发框架。在字节跳动内部，我们将 Modern.js 封装为上层框架，并支撑了数千个 Web 应用的研发。
 
-- 🦄 [Modern.js Framework](https://modernjs.dev/)：基于 React 的渐进式 Web 开发框架。
-- 🐧 [Modern.js Module](https://modernjs.dev/module-tools)：简单、高性能的 npm 包开发方案。
+在开发 React 应用过程中，开发者通常需要去为某些功能去设计实现方案，或是使用其他的库、框架来解决这些问题。Modern.js 支持 React 应用所需要的所有配置和工具，并内置额外的功能和优化。开发者可以使用 React 构建应用的 UI，然后逐步采用 Modern.js 的功能来解决常见的应用需求，如路由、数据获取、状态管理等。
 
 ## 快速上手
 
-- 使用 [Modern.js Framework](https://modernjs.dev/guides/get-started/quick-start) 来开发一个 Web 应用。
-- 使用 [Modern.js Module](https://modernjs.dev/module-tools/guide/intro/getting-started.html) 来开发一个 npm 包。
+参考 [快速上手](https://modernjs.dev/zh/guides/get-started/quick-start)。
 
 ## 生态
 
 Modern.js 生态提供了以下解决方案和底层库：
 
 - 🦀 [Rspack](https://github.com/web-infra-dev/rspack)：基于 Rust 的高性能模块打包工具。
-- 🐬 [Rsbuild](https://github.com/web-infra-dev/rsbuild)：基于 Rspack 的 Web 构建工具，由 Modern.js Builder 演变而来。
+- 🐬 [Rsbuild](https://github.com/web-infra-dev/rsbuild)：基于 Rspack 的 Web 构建工具。
 - 🐹 [Rspress](https://github.com/web-infra-dev/rspress)：基于 Rspack 的静态站点生成器。
+- 🦄 [Rslib](https://github.com/web-infra-dev/rslib)：基于 Rspack 的 Library 开发工具。
 - 🐟 [Garfish](https://github.com/web-infra-dev/garfish)：一站式微前端解决方案。
 - 🦆 [Reduck](https://github.com/web-infra-dev/reduck)：基于 Redux 的状态管理库。
 - 🐴 [SWC Plugins](https://github.com/web-infra-dev/swc-plugins)：Modern.js 的 SWC 插件。
@@ -45,7 +44,7 @@ Modern.js 生态提供了以下解决方案和底层库：
 
 ## Roadmap
 
-请参阅 [Modern.js Roadmap](https://github.com/web-infra-dev/modern.js/issues/4741)。我们将在每个季度更新 Roadmap 的内容。
+请参阅 [Modern.js Roadmap](https://github.com/web-infra-dev/modern.js/issues/4741)。我们将定期更新 Roadmap 的内容。
 
 ## 示例
 

--- a/packages/document/main-doc/docs/en/guides/get-started/introduction.mdx
+++ b/packages/document/main-doc/docs/en/guides/get-started/introduction.mdx
@@ -5,44 +5,7 @@ sidebar_position: 1
 
 # Introduction to Modern.js
 
-**Modern.js is an open source web engineering system from ByteDance**, which provides multiple solutions to help developers solve problems in different development scenarios.
-
-Currently, Modern.js includes two solutions, targeting web application development and npm package development:
-
-import { SolutionCards } from '@site/src/components/SolutionCards';
-
-<SolutionCards
-  cards={[
-    {
-      title: 'Modern.js Framework',
-      description: 'For web application development',
-      link: 'http://modernjs.dev/en/',
-    },
-    {
-      title: 'Modern.js Module',
-      description: 'For npm package development',
-      link: 'http://modernjs.dev/module-tools/en/',
-    },
-  ]}
-/>
-
-As part of the Modern.js engineering system, each of the above solutions can be used separately and has its own independent documentation site. Developers can choose one or more solutions as needed.
-
-## About Documentation
-
-**The current documentation site corresponds to the Modern.js framework**, which is used to developing web applications.
-
-- If you need to develop an npm package, please refer to the [Modern.js Module documentation](https://modernjs.dev/module-tools).
-- If you need a build tool to bundle web applications, [Rsbuild](https://rsbuild.dev/) is recommended.
-- If you need to develop a documentation site, [Rspress](https://rspress.dev/) is recommended.
-
-:::tip
-Since the Modern.js framework is the most widely used, in this documentation site, we will omit "framework" and directly refer to it as Modern.js.
-:::
-
-## Modern.js Framework
-
-**The Modern.js framework is a progressive web framework based on React**. At ByteDance, we use Modern.js to build upper-level frameworks that have supported the development of thousands of web applications.
+**Modern.js is a progressive web framework based on React**. At ByteDance, we use Modern.js to build upper-level frameworks that have supported the development of thousands of web applications.
 
 Modern.js can provide developers with an ultimate **Development Experience** and enable applications to have better **User Experience**.
 

--- a/packages/document/main-doc/docs/zh/guides/get-started/introduction.mdx
+++ b/packages/document/main-doc/docs/zh/guides/get-started/introduction.mdx
@@ -5,42 +5,7 @@ sidebar_position: 1
 
 # Modern.js 介绍
 
-**Modern.js 是字节跳动 Web 工程体系的开源版本**，它提供多个解决方案，来帮助开发者解决不同研发场景下的问题。
-
-目前 Modern.js 包含两个解决方案，分别面向 Web 应用开发场景 和 npm 包开发场景：
-
-import { SolutionCards } from '@site/src/components/SolutionCards';
-
-<SolutionCards
-  cards={[
-    {
-      title: 'Modern.js Framework',
-      description: '基于 React 的渐进式 Web 开发框架',
-      link: 'http://modernjs.dev/',
-    },
-    {
-      title: 'Modern.js Module',
-      description: '易用、高性能的 npm 包开发方案',
-      link: 'http://modernjs.dev/module-tools/',
-    },
-  ]}
-/>
-
-## 关于文档
-
-**当前文档站对应的是 Modern.js 框架**，适用于开发 Web 应用。
-
-- 如果你需要开发一个 npm 包，请移步 [Modern.js Module 文档](https://modernjs.dev/module-tools)。
-- 如果你需要一个构建工具来打包 Web 应用，请移步 [Rsbuild 文档](https://rsbuild.dev/)。
-- 如果你需要开发一个文档站点，推荐使用 [Rspress 文档](https://rspress.dev/)。
-
-:::tip
-由于 Modern.js 框架的使用最为广泛，在本文档站中，我们会省略「框架」，直接称其为 Modern.js。
-:::
-
-## Modern.js 框架
-
-**Modern.js 框架是一个基于 React 的渐进式 Web 开发框架**。在字节跳动内部，我们将 Modern.js 封装为上层框架，并支撑了数千个 Web 应用的研发。
+**Modern.js 是一个基于 React 的渐进式 Web 开发框架**。在字节跳动内部，我们将 Modern.js 封装为上层框架，并支撑了数千个 Web 应用的研发。
 
 Modern.js 能为开发者提供极致的**开发体验（Development Experience）**，让应用拥有更好的**用户体验（User Experience）**。
 


### PR DESCRIPTION
## Summary

Modern.js is now focused on building the world-class full-stack React framework, and Modern.js Module will be deprecated in the future.

Our team has developed [Rslib](https://github.com/web-infra-dev/rslib) as the next-generation library development tool, and will soon provide a migration guide for Modern.js Module users soon.

Please note that the Modern.js Module packages and documentation will continue to be available. No new features are planned for the Modern.js Module, but we will continue to provide necessary bug fixes.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
