### PR TITLE
feat: add useRuntimeContext api data structure

### DIFF
--- a/packages/runtime/plugin-runtime/src/core/compatible.tsx
+++ b/packages/runtime/plugin-runtime/src/core/compatible.tsx
@@ -13,6 +13,7 @@ import { createLoaderManager } from './loader/loaderManager';
 import { type Plugin, registerPlugin, type runtime } from './plugin';
 import { getGlobalRunner } from './plugin/runner';
 import { wrapRuntimeContextProvider } from './react/wrapper';
+import type { TSSRContext } from './types';
 
 const IS_REACT18 = process.env.IS_REACT18 === 'true';
 
@@ -226,8 +227,20 @@ export const bootstrap: BootStrap = async (
 export const useRuntimeContext = () => {
   const context = useContext(RuntimeReactContext);
 
+  const baseSSRContext = context.ssrContext;
+  const tSSRContext = baseSSRContext
+    ? {
+        isBrowser: context.isBrowser,
+        request: baseSSRContext.request || ({} as TSSRContext['request']),
+        response: baseSSRContext.response || ({} as TSSRContext['response']),
+        logger: baseSSRContext.logger || ({} as TSSRContext['logger']),
+      }
+    : ({} as TSSRContext);
+
+  // TODO: Here we should not provide all the RuntimeReactContext to the user
   const pickedContext: TRuntimeContext = {
     ...context,
+    context: tSSRContext,
     request: context.ssrContext?.request,
     response: context.ssrContext?.response,
   };

--- a/packages/runtime/plugin-runtime/src/core/context/runtime.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/runtime.ts
@@ -9,11 +9,12 @@ import { createContext } from 'react';
 import type { RouteManifest } from '../../router/runtime/types';
 import { createLoaderManager } from '../loader/loaderManager';
 import type { PluginRunner, runtime } from '../plugin';
-import type { SSRServerContext } from '../types';
+import type { SSRServerContext, TSSRContext } from '../types';
 
-export interface BaseRuntimeContext {
+interface BaseRuntimeContext {
   initialData?: Record<string, unknown>;
   loaderManager: ReturnType<typeof createLoaderManager>;
+  isBrowser: boolean;
   runner: ReturnType<typeof runtime.init>;
   // ssr type
   ssrContext?: SSRServerContext;
@@ -39,10 +40,12 @@ export const RuntimeReactContext = createContext<RuntimeContext>({} as any);
 
 export const ServerRouterContext = createContext({} as any);
 
-export interface BaseTRuntimeContext extends Partial<BaseRuntimeContext> {
+export interface TRuntimeContext extends Partial<BaseRuntimeContext> {
   initialData?: Record<string, unknown>;
-  // ssr type
+  context: TSSRContext;
+  /** @deprecated use context.request field instead */
   request?: SSRServerContext['request'];
+  /** @deprecated use context.response field instead */
   response?: SSRServerContext['response'];
   // store type
   store?: Store;
@@ -50,10 +53,6 @@ export interface BaseTRuntimeContext extends Partial<BaseRuntimeContext> {
     navigate: Router['navigate'];
     location: RouterState['location'];
   };
-}
-
-export interface TRuntimeContext extends BaseTRuntimeContext {
-  [key: string]: any;
 }
 
 export const getInitialContext = (

--- a/packages/runtime/plugin-runtime/src/core/types.ts
+++ b/packages/runtime/plugin-runtime/src/core/types.ts
@@ -46,6 +46,7 @@ export interface SSRContainer {
 
 type BuildHtmlCb = (tempalte: string) => string;
 
+/* 在服务端获取的 SSRContext */
 export type SSRServerContext = Pick<
   BaseSSRServerContext,
   | 'redirection'
@@ -70,3 +71,24 @@ export type SSRServerContext = Pick<
   onError?: (e: unknown) => void;
   onTiming?: (name: string, dur: number) => void;
 };
+
+/* 通过 useRuntimeContext 获取的 SSRContext */
+interface TSSRBaseContext {
+  request: BaseSSRServerContext['request'] & {
+    userAgent: string;
+    cookie: string;
+  };
+  [propName: string]: any;
+}
+
+interface ServerContext extends TSSRBaseContext {
+  isBrowser: false;
+  response: BaseSSRServerContext['response'];
+  logger: BaseSSRServerContext['logger'];
+}
+
+interface ClientContext extends TSSRBaseContext {
+  isBrowser: true;
+}
+
+export declare type TSSRContext = ServerContext | ClientContext;

--- a/packages/runtime/plugin-runtime/src/index.ts
+++ b/packages/runtime/plugin-runtime/src/index.ts
@@ -5,11 +5,7 @@ export type { Plugin } from './core';
 export type { AppConfig, RuntimeConfig } from './common';
 export { isBrowser } from './common';
 
-export type {
-  BaseRuntimeContext,
-  RuntimeContext,
-  BaseTRuntimeContext,
-} from './core/context/runtime';
+export type { RuntimeContext } from './core/context/runtime';
 export type { RuntimeUserConfig } from './config';
 
 export {


### PR DESCRIPTION
## Summary

1. add `context` field in `useRuntimeContext` return value, the same as inhouse framework. 
2. add TSSRBaseContext for the `context` field.
3. remove useless export `BaseRuntimeContext`.
4. pickedContext should not be assigned extra field, so we remove `[key: string]: any` in TRuntimeContext, and use TRuntimeContext instead BaseTRuntimeContext.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
