### PR TITLE
chore: remove remixRouter field context type declare and in browser router plugin

### DIFF
--- a/packages/runtime/plugin-runtime/src/core/context/runtime.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/runtime.ts
@@ -23,10 +23,6 @@ interface BaseRuntimeContext {
   routeManifest: RouteManifest;
   routerContext?: StaticHandlerContext;
   /**
-   * private method
-   */
-  remixRouter?: Router;
-  /**
    * private
    */
   unstable_getBlockNavState?: () => boolean;

--- a/packages/runtime/plugin-runtime/src/router/runtime/hooks.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/hooks.ts
@@ -5,6 +5,7 @@ import {
 import type { RouteObject } from '@modern-js/runtime-utils/router';
 import type { RuntimeContext } from '../../core';
 
+// only for inhouse use
 const modifyRoutes = createWaterfall<RouteObject[]>();
 const beforeCreateRoutes = createAsyncInterruptWorkflow<RuntimeContext, void>();
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -126,6 +126,8 @@ export const routerPlugin = (
             return interrupt(routerContext);
           }
 
+          // requestHandler.ts also has same logic, but handle common status code
+          // maybe we can put the logic in requestHandler.ts in the future
           if (
             routerContext.statusCode >= 500 &&
             routerContext.statusCode < 600 &&
@@ -136,8 +138,17 @@ export const routerPlugin = (
           }
 
           const router = createStaticRouter(routes, routerContext);
-          context.remixRouter = router;
+          // routerContext is used in in css colletor、handle status code、inject loader data in html
           context.routerContext = routerContext;
+
+          // private api, pass to React Component in `wrapRoot`
+          // in the browser, we not need to pass router, cause we create Router in `wrapRoot`
+          // but in node, we need to pass router, cause we need run async function, it can only run in `beforeRender`
+          // when we deprected React 17, we can use Suspense to handle this async function
+          // so the `remixRouter` has no type declare in RuntimeContext
+          context.remixRouter = router;
+
+          // private api, pass to React Component in `wrapRoot`
           context.routes = routes;
         },
         wrapRoot: App => {


### PR DESCRIPTION
## Summary

1. remixRouter in browser router plugin is only for inhouse usage, now we refactor it, so we don't need it anymore.
2. remixRouter is still need in node router plugin, cause we need pass it to anther hook.(we can also use closure)
3. add comments for routes plugin


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
