### PR TITLE
fix: should only run hydrate when ssr

### DIFF
--- a/.changeset/wet-trains-battle.md
+++ b/.changeset/wet-trains-battle.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: 只需要在 SSR 模式下才调用 hydrateRoot 函数，修复必定进入 hydrateRoot 函数的问题
+fix: only call hydrateRoot in ssr mode, fix bug that always call hydrateRoot

--- a/packages/runtime/plugin-runtime/src/core/browser/index.tsx
+++ b/packages/runtime/plugin-runtime/src/core/browser/index.tsx
@@ -91,8 +91,10 @@ export async function render(
   };
 
   if (isClientArgs(id)) {
+    // This field may suitable to be called `requestData`,
+    // because both SSR and CSR can get the context
     const ssrData = getSSRData();
-    const loadersData = ssrData?.data?.loadersData || {};
+    const loadersData = ssrData.data?.loadersData || {};
 
     const initialLoadersState = Object.keys(loadersData).reduce(
       (res: any, key) => {
@@ -114,10 +116,10 @@ export async function render(
       }),
       // garfish plugin params
       _internalRouterBaseName: App.props.basename,
-      ...(ssrData ? { ssrContext: ssrData?.context } : {}),
+      ...{ ssrContext: ssrData.context },
     });
 
-    context.initialData = ssrData?.data?.initialData;
+    context.initialData = ssrData.data?.initialData;
     const initialData = await runBeforeRender(context);
     if (initialData) {
       context.initialData = initialData;
@@ -141,7 +143,7 @@ export async function render(
     }
 
     // we should hydateRoot only when ssr
-    if (ssrData) {
+    if (window._SSR_DATA) {
       return hydrateRoot(App, context, ModernRender, ModernHydrate);
     }
     return ModernRender(wrapRuntimeContextProvider(App, context));


### PR DESCRIPTION
## Summary

now `getSSRData()` always return non-null SSR Data, so the runtime-plugin will always run into `hydrateRoot` logic.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
