### PR TITLE
fix: react router error is not Array but Object constructor

### DIFF
--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -122,7 +122,6 @@ export const routerPlugin = (
           if (routerContext instanceof Response) {
             // React Router would return a Response when redirects occur in loader.
             // Throw the Response to bail out and let the server handle it with an HTTP redirect
-
             return interrupt(routerContext);
           }
 
@@ -131,10 +130,14 @@ export const routerPlugin = (
           if (
             routerContext.statusCode >= 500 &&
             routerContext.statusCode < 600 &&
+            // TODO: if loaderFailureMode is not 'errroBoundary', error log will not be printed.
             loaderFailureMode === 'clientRender'
           ) {
             routerContext.statusCode = 200;
-            throw (routerContext.errors as Error[])[0];
+            const errors = Object.values(
+              routerContext.errors as Record<string, Error>,
+            );
+            throw errors[0];
           }
 
           const router = createStaticRouter(routes, routerContext);


### PR DESCRIPTION
## Summary

before this MR, the error in loader will get 'undefined' error in logs.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
