### PR TITLE
docs: recommend using Rslib to reuse webpack plugins

### DIFF
--- a/.changeset/selfish-seahorses-care.md
+++ b/.changeset/selfish-seahorses-care.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/module-tools-docs': patch
+---
+
+docs: recommend using Rslib to reuse webpack plugins

--- a/packages/document/module-doc/docs/en/guide/faq/basic.mdx
+++ b/packages/document/module-doc/docs/en/guide/faq/basic.mdx
@@ -7,7 +7,5 @@ Modern.js Module uses esbuild to build toolkits and component libraries, and Rsb
 ## Can Modern.js Module use webpack plugins or loaders?
 
 Modern.js Module is based on esbuild for building and cannot use tools from the webpack-related ecosystem.
-You can find more community plugins for esbuild [here](https://github.com/esbuild/community-plugins)
 
-If the UMD product produced by Modern.js Module does not meet your requirements, you can use Rsbuild and add [UMD Plugin](https://github.com/rspack-contrib/rsbuild-plugin-umd) to build UMD products.
-
+To allow reuse of the webpack and Rspack ecosystems, we have developed Rslib, which is the next generation library development tools that will provide better build performance and plugin ecosystem. You can refer to the [Rslib repository](https://github.com/web-infra-dev/rslib) for more information.

--- a/packages/document/module-doc/docs/zh/guide/faq/basic.mdx
+++ b/packages/document/module-doc/docs/zh/guide/faq/basic.mdx
@@ -4,9 +4,8 @@
 
 Modern.js Module 使用 esbuild 构建工具库和组件库，Rsbuild 专注于解决 Web 应用构建场景。
 
-## Modern.js Module 是否可以使用 webpack plugin 或者 loader?
+## Modern.js Module 是否可以使用 webpack 插件或者 loader?
 
 Modern.js Module 基于 esbuild 构建，无法使用 webpack 相关生态的工具。
-[这里](https://github.com/esbuild/community-plugins)可以发现更多 esbuild 社区插件
 
-如果 Modern.js Module 生产的 UMD 产物达不到你的要求，可以使用 Rsbuild 并添加 [UMD Plugin](https://github.com/rspack-contrib/rsbuild-plugin-umd) 构建 UMD 产物。
+为了允许复用 webpack 和 Rspack 的生态，我们已经基于 Rsbuild 开发了 Rslib，它是下一代的 library 开发工具，将提供更好的构建性能和插件生态，你可以参考 [Rslib 仓库](https://github.com/web-infra-dev/rslib) 了解更多信息。


### PR DESCRIPTION
## Summary

Recommend using Rslib to reuse webpack plugins in the Modern.js Module FAQ.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
