### PR TITLE
fix: uni-builder plugins should be registered earlier than user plugins

### DIFF
--- a/.changeset/clever-rocks-enjoy.md
+++ b/.changeset/clever-rocks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix: uni-builder plugins should be registered earlier than user plugins

--- a/packages/cli/uni-builder/src/rspack/index.ts
+++ b/packages/cli/uni-builder/src/rspack/index.ts
@@ -93,12 +93,13 @@ export async function createRspackBuilder(
     cwd,
   });
 
+  // uni-builder plugins should be registered earlier than user plugins
+  rsbuildConfig.plugins = [...rsbuildPlugins, ...(rsbuildConfig.plugins || [])];
+
   const rsbuild = await createRsbuild({
     cwd,
     rsbuildConfig,
   });
-
-  rsbuild.addPlugins(rsbuildPlugins);
 
   return {
     ...rsbuild,

--- a/packages/cli/uni-builder/src/webpack/index.ts
+++ b/packages/cli/uni-builder/src/webpack/index.ts
@@ -80,6 +80,10 @@ export async function parseConfig(
     rsbuildPlugins.push(pluginStyledComponents(options));
   }
 
+  rsbuildPlugins.push(
+    pluginModuleScopes(uniBuilderConfig.source?.moduleScopes),
+  );
+
   return {
     rsbuildConfig,
     rsbuildPlugins,
@@ -115,15 +119,12 @@ export async function createWebpackBuilder(
 
   rsbuildConfig.provider = webpackProvider;
 
+  rsbuildConfig.plugins = [...rsbuildPlugins, ...(rsbuildConfig.plugins || [])];
+
   const rsbuild = await createRsbuild({
     rsbuildConfig,
     cwd,
   });
-
-  rsbuild.addPlugins([
-    ...rsbuildPlugins,
-    pluginModuleScopes(options.config.source?.moduleScopes),
-  ]);
 
   return {
     ...rsbuild,

--- a/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/default.test.ts.snap
@@ -1030,7 +1030,30 @@ exports[`uni-builder rspack > should generator rspack config correctly 1`] = `
 }
 `;
 
-exports[`uni-builder rspack > should generator rspack config correctly 2`] = `undefined`;
+exports[`uni-builder rspack > should generator rspack config correctly 2`] = `
+[
+  "uni-builder:split-chunks",
+  "uni-builder:global-vars",
+  "uni-builder:devtool",
+  "uni-builder:emit-route-file",
+  "rsbuild:toml",
+  "rsbuild:yaml",
+  "uni-builder:antd",
+  "uni-builder:arco",
+  "rsbuild:sass",
+  "rsbuild:less",
+  "uni-builder:environment-defaults-plugin",
+  "uni-builder:plugin-html-minifier-terser",
+  "rsbuild:type-check",
+  "uni-builder:runtime-chunk",
+  "rsbuild:react",
+  "rsbuild:svgr",
+  "rsbuild:css-minimizer",
+  "uni-builder:postcss-plugins",
+  "rsbuild:styled-components",
+  "user-plugin",
+]
+`;
 
 exports[`uni-builder rspack > should generator rspack config correctly when node 1`] = `
 {

--- a/packages/cli/uni-builder/tests/default.test.ts
+++ b/packages/cli/uni-builder/tests/default.test.ts
@@ -1,3 +1,4 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { describe, expect, it } from 'vitest';
 import { createUniBuilder } from '../src';
 
@@ -8,7 +9,14 @@ describe('uni-builder rspack', () => {
 
     const rsbuild = await createUniBuilder({
       bundlerType: 'rspack',
-      config: {},
+      config: {
+        plugins: [
+          {
+            name: 'user-plugin',
+            setup: () => {},
+          },
+        ],
+      },
       cwd: '',
     });
 
@@ -18,7 +26,9 @@ describe('uni-builder rspack', () => {
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
 
-    expect(rsbuildConfig.pluginNames).toMatchSnapshot();
+    expect(
+      rsbuildConfig.plugins?.map(p => (p as RsbuildPlugin)?.name),
+    ).toMatchSnapshot();
 
     process.env.NODE_ENV = NODE_ENV;
   });


### PR DESCRIPTION
## Summary
Uni-builder plugins should be registered earlier than user plugins.

The current uni-builder plugin is added through `addPlugins` after rsbuild is created. If other plugins are passed in through configuration, they will be registered and executed earlier than the uni-builder plugin.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
