### PR TITLE
feat(app-tools): enable Rsbuild CLI shortcuts

### DIFF
--- a/.changeset/afraid-socks-jam.md
+++ b/.changeset/afraid-socks-jam.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/uni-builder': patch
+'@modern-js/utils': patch
+---
+
+feat(app-tools): enable Rsbuild CLI shortcuts

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -316,14 +316,14 @@ export async function parseCommonConfig(
     };
   }
 
-  const { dev: RsbuildDev, server } = transformToRsbuildServerOptions(
+  const { dev: rsbuildDev, server } = transformToRsbuildServerOptions(
     dev || {},
     devServer || {},
   );
 
   rsbuildConfig.server = removeUndefinedKey(server);
 
-  rsbuildConfig.dev = removeUndefinedKey(RsbuildDev);
+  rsbuildConfig.dev = removeUndefinedKey(rsbuildDev);
   rsbuildConfig.html = html;
   rsbuildConfig.output = output;
 

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -11,6 +11,12 @@ export function createDefaultConfig(
     // `dev.port` should not have a default value
     // because we will use `server.port` by default
     port: undefined,
+    cliShortcuts: {
+      help: false,
+      // does not support restart server and print urls yet
+      custom: (shortcuts = []) =>
+        shortcuts.filter(({ key }) => key !== 'r' && key !== 'u'),
+    },
   };
 
   const output: AppUserConfig['output'] = {

--- a/packages/toolkit/utils/src/cli/prettyInstructions.ts
+++ b/packages/toolkit/utils/src/cli/prettyInstructions.ts
@@ -142,5 +142,11 @@ export const prettyInstructions = (appContext: any, config: any) => {
     );
   }
 
+  if (config.dev?.cliShortcuts) {
+    message += `  ${chalk.dim('> press')} ${chalk.bold(
+      'h + enter',
+    )} ${chalk.dim('to show shortcuts')}\n`;
+  }
+
   return message;
 };


### PR DESCRIPTION
## Summary

Enable Rsbuild CLI shortcuts feature:

<img width="694" alt="Screenshot 2024-12-05 at 15 19 10" src="https://github.com/user-attachments/assets/5d620571-a980-43d8-997f-31f54415bcd1">

TODO: Modern.js does not support restart server and print urls yet. We need to:

- Unify the print URL logic of Rsbuild of Modern.js.
- Consider expose a `rsbuild.restartServer` API.

## Related Links

https://rsbuild.dev/config/dev/cli-shortcuts

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
