### PR TITLE
fix: unstable_middlwares doesn't exec when render.middlewares not empty

### DIFF
--- a/.changeset/strange-crabs-walk.md
+++ b/.changeset/strange-crabs-walk.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: unstable_middlwares doesn't exec when render.middlewares not empty
+fix: 修复 unstable_middlwares 在 `render.middlewares` 不为空时不执行的问题

--- a/packages/server/core/src/plugins/render/index.ts
+++ b/packages/server/core/src/plugins/render/index.ts
@@ -41,6 +41,9 @@ export const renderPlugin = (): ServerPlugin => ({
 
         const customServer = new CustomServer(runner, serverBase!, pwd);
 
+        // render.middleware can register by server config and prepare hook
+        // render.middleware is the same as unstable_middleware in server/index.ts, but execute before unstable_middleware
+        // TODO：check api and add docs for render.middleware
         const serverMiddleware =
           config.render?.middleware &&
           getServerMidFromUnstableMid(config.render.middleware);
@@ -75,7 +78,7 @@ export const renderPlugin = (): ServerPlugin => ({
           });
 
           const customServerMiddleware =
-            serverMiddleware || (await customServer.getServerMiddleware());
+            await customServer.getServerMiddleware(serverMiddleware);
 
           customServerMiddleware &&
             middlewares.push({

--- a/tests/integration/server-hook/new-middleware/server/modern.server.ts
+++ b/tests/integration/server-hook/new-middleware/server/modern.server.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@modern-js/app-tools/server';
+
+export default defineConfig({
+  render: {
+    middleware: [
+      async (c, next) => {
+        c.response.headers.set('x-render-middleware-config', 'ok');
+
+        await next();
+      },
+    ],
+  },
+  plugins: [
+    {
+      name: 'custom-plugin-in-config',
+      setup: () => {
+        return {
+          config: async config => {
+            if (!config.render) {
+              config.render = {};
+            }
+            config.render.middleware ||= [];
+            config.render.middleware.push(async (c, next) => {
+              c.response.headers.set('x-render-middleware-plugin', 'ok');
+              await next();
+            });
+
+            return config;
+          },
+        };
+      },
+    },
+  ],
+});

--- a/tests/integration/server-hook/new-middleware/tests/index.test.ts
+++ b/tests/integration/server-hook/new-middleware/tests/index.test.ts
@@ -52,6 +52,10 @@ describe('test new middleware run correctly', () => {
     expect(headers).toHaveProperty('x-custom-value', 'modern');
 
     expect(headers).toHaveProperty('x-matched-route', 'main');
+
+    expect(headers).toHaveProperty('x-render-middleware-config', 'ok');
+
+    expect(headers).toHaveProperty('x-render-middleware-plugin', 'ok');
   });
 
   test('should redirect corretly', async () => {


### PR DESCRIPTION
## Summary

This PR fix the issue: 

when `render.middlewares` not empty, unstable middleware is not executed.

`render.middlewares` is a future feature, and is now used in some plugins.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
