### PR TITLE
fix: should get server routes from route.json in serve command

### DIFF
--- a/.changeset/soft-spoons-greet.md
+++ b/.changeset/soft-spoons-greet.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/server-core': patch
+---
+
+fix: should get server routes from route.json in serve command
+fix: 在 serve 命令下应该从 route.json 中获取 server routes

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -16,6 +16,7 @@ import type {
   ServerManifest,
   ServerPlugin,
 } from '../../../types';
+import { uniqueKeyByRoute } from '../../../utils';
 
 export async function getHtmlTemplates(pwd: string, routes: ServerRoute[]) {
   const htmls = await Promise.all(
@@ -27,7 +28,7 @@ export async function getHtmlTemplates(pwd: string, routes: ServerRoute[]) {
       } catch (e) {
         // ignore error
       }
-      return [route.entryName!, html];
+      return [uniqueKeyByRoute(route), html];
     }) || [],
   );
 

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -121,7 +121,6 @@ export async function createRender({
     },
   ) => {
     const forMatchpathname = matchPathname ?? getPathname(req);
-
     const [routeInfo, params] = matchRoute(router, forMatchpathname);
     const framework = metaName || 'modern-js';
     const fallbackHeader = `x-${cutNameByHyphen(framework)}-ssr-fallback`;

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../types';
 import type { Render } from '../../types';
 import type { Params } from '../../types/requestHandler';
+import { uniqueKeyByRoute } from '../../utils';
 import {
   ErrorDigest,
   createErrorHtml,
@@ -120,6 +121,7 @@ export async function createRender({
     },
   ) => {
     const forMatchpathname = matchPathname ?? getPathname(req);
+
     const [routeInfo, params] = matchRoute(router, forMatchpathname);
     const framework = metaName || 'modern-js';
     const fallbackHeader = `x-${cutNameByHyphen(framework)}-ssr-fallback`;
@@ -139,8 +141,7 @@ export async function createRender({
       });
     }
 
-    const html = templates[routeInfo.entryName!];
-
+    const html = templates[uniqueKeyByRoute(routeInfo)];
     if (!html) {
       return new Response(createErrorHtml(404), {
         status: 404,

--- a/packages/server/core/src/utils/entry.ts
+++ b/packages/server/core/src/utils/entry.ts
@@ -3,3 +3,8 @@ import type { ServerRoute } from '@modern-js/types';
 export const sortRoutes = (route1: ServerRoute, route2: ServerRoute) => {
   return route2.urlPath.length - route1.urlPath.length;
 };
+
+// Because the same entryName may have different urlPath(ssg), so we need to add urlPath as key
+export const uniqueKeyByRoute = (route: ServerRoute) => {
+  return `${route.entryName!}-${route.urlPath}`;
+};

--- a/packages/solutions/app-tools/src/plugins/analyze/getServerRoutes.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/getServerRoutes.ts
@@ -245,12 +245,10 @@ export const getServerRoutes = (
     appContext: AppToolsContext<'shared'>;
     config: AppNormalizedConfig<'shared'>;
   },
-): ServerRoute[] => {
-  return [
-    ...collectHtmlRoutes(entrypoints, appContext, config),
-    ...collectStaticRoutes(appContext, config),
-  ];
-};
+): ServerRoute[] => [
+  ...collectHtmlRoutes(entrypoints, appContext, config),
+  ...collectStaticRoutes(appContext, config),
+];
 
 const toPosix = (pathStr: string) =>
   pathStr.split(path.sep).join(path.posix.sep);

--- a/packages/solutions/app-tools/src/plugins/analyze/getServerRoutes.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/getServerRoutes.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
 import path from 'path';
-import type { IAppContext } from '@modern-js/core';
 import type { Entrypoint, ServerRoute } from '@modern-js/types';
 import {
+  fs,
+  ROUTE_SPEC_FILE,
   SERVER_BUNDLE_DIRECTORY,
   SERVER_WORKER_BUNDLE_DIRECTORY,
   getEntryOptions,
@@ -245,10 +245,24 @@ export const getServerRoutes = (
     appContext: AppToolsContext<'shared'>;
     config: AppNormalizedConfig<'shared'>;
   },
-): ServerRoute[] => [
-  ...collectHtmlRoutes(entrypoints, appContext, config),
-  ...collectStaticRoutes(appContext, config),
-];
+): ServerRoute[] => {
+  return [
+    ...collectHtmlRoutes(entrypoints, appContext, config),
+    ...collectStaticRoutes(appContext, config),
+  ];
+};
 
 const toPosix = (pathStr: string) =>
   pathStr.split(path.sep).join(path.posix.sep);
+
+export const getServerRoutesServe = (distDirectory: string) => {
+  const routeJSON = path.join(distDirectory, ROUTE_SPEC_FILE);
+  try {
+    const { routes } = fs.readJSONSync(routeJSON);
+    return routes;
+  } catch (e) {
+    throw new Error(
+      `Failed to read routes from ${routeJSON}, please check if the file exists.`,
+    );
+  }
+};

--- a/packages/solutions/app-tools/src/plugins/analyze/getServerRoutes.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/getServerRoutes.ts
@@ -255,7 +255,7 @@ export const getServerRoutes = (
 const toPosix = (pathStr: string) =>
   pathStr.split(path.sep).join(path.posix.sep);
 
-export const getServerRoutesServe = (distDirectory: string) => {
+export const getProdServerRoutes = (distDirectory: string) => {
   const routeJSON = path.join(distDirectory, ROUTE_SPEC_FILE);
   try {
     const { routes } = fs.readJSONSync(routeJSON);

--- a/packages/solutions/app-tools/src/plugins/analyze/index.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/index.ts
@@ -55,14 +55,14 @@ export default ({
       );
       await hooks.addRuntimeExports.call();
 
-      const [{ getServerRoutesServe }] = await Promise.all([
+      const [{ getProdServerRoutes }] = await Promise.all([
         import('./getServerRoutes.js'),
       ]);
 
       if (apiOnly) {
         const routes: ServerRoute[] = [];
         if (checkIsServeCommand()) {
-          routes.push(...getServerRoutesServe(appContext.distDirectory));
+          routes.push(...getProdServerRoutes(appContext.distDirectory));
         } else {
           const { routes: modifiedRoutes } =
             await hooks.modifyServerRoutes.call({
@@ -96,7 +96,7 @@ export default ({
 
       const routes: ServerRoute[] = [];
       if (checkIsServeCommand()) {
-        routes.push(...getServerRoutesServe(appContext.distDirectory));
+        routes.push(...getProdServerRoutes(appContext.distDirectory));
       } else {
         const initialRoutes = getServerRoutes(entrypoints, {
           appContext,

--- a/packages/solutions/app-tools/src/plugins/analyze/index.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/index.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import type { ServerRoute } from '@modern-js/types';
 import {
   fs,
   createDebugger,
@@ -18,7 +19,7 @@ import { emitResolvedConfig } from '../../utils/config';
 import { getSelectedEntries } from '../../utils/getSelectedEntries';
 import { printInstructions } from '../../utils/printInstructions';
 import { generateRoutes } from '../../utils/routes';
-import { checkIsBuildCommands } from './utils';
+import { checkIsBuildCommands, checkIsServeCommand } from './utils';
 
 const debug = createDebugger('plugin-analyze');
 
@@ -54,8 +55,21 @@ export default ({
       );
       await hooks.addRuntimeExports.call();
 
+      const [{ getServerRoutesServe }] = await Promise.all([
+        import('./getServerRoutes.js'),
+      ]);
+
       if (apiOnly) {
-        const { routes } = await hooks.modifyServerRoutes.call({ routes: [] });
+        const routes: ServerRoute[] = [];
+        if (checkIsServeCommand()) {
+          routes.push(...getServerRoutesServe(appContext.distDirectory));
+        } else {
+          const { routes: modifiedRoutes } =
+            await hooks.modifyServerRoutes.call({
+              routes: [],
+            });
+          routes.push(...modifiedRoutes);
+        }
 
         debug(`server routes: %o`, routes);
 
@@ -80,14 +94,20 @@ export default ({
 
       debug(`entrypoints: %o`, entrypoints);
 
-      const initialRoutes = getServerRoutes(entrypoints, {
-        appContext,
-        config: resolvedConfig,
-      });
+      const routes: ServerRoute[] = [];
+      if (checkIsServeCommand()) {
+        routes.push(...getServerRoutesServe(appContext.distDirectory));
+      } else {
+        const initialRoutes = getServerRoutes(entrypoints, {
+          appContext,
+          config: resolvedConfig,
+        });
 
-      const { routes } = await hooks.modifyServerRoutes.call({
-        routes: initialRoutes,
-      });
+        const { routes: modifiedRoutes } = await hooks.modifyServerRoutes.call({
+          routes: initialRoutes,
+        });
+        routes.push(...modifiedRoutes);
+      }
 
       debug(`server routes: %o`, routes);
 

--- a/packages/solutions/app-tools/src/plugins/analyze/utils.ts
+++ b/packages/solutions/app-tools/src/plugins/analyze/utils.ts
@@ -74,6 +74,12 @@ export const checkIsBuildCommands = () => {
   return buildCommands.includes(command);
 };
 
+export const checkIsServeCommand = () => {
+  const command = getCommand();
+
+  return command === 'serve';
+};
+
 export const isSubDirOrEqual = (parent: string, child: string): boolean => {
   if (parent === child) {
     return true;

--- a/tests/integration/ssg/fixtures/nested-routes/package.json
+++ b/tests/integration/ssg/fixtures/nested-routes/package.json
@@ -3,7 +3,8 @@
   "name": "ssg-fixtures-nested-routes",
   "version": "2.9.0",
   "scripts": {
-    "build": "modern build"
+    "build": "modern build",
+    "serve": "modern serve"
   },
   "dependencies": {
     "@modern-js/app-tools": "workspace:*",

--- a/tests/integration/ssg/tests/nested-routes.test.ts
+++ b/tests/integration/ssg/tests/nested-routes.test.ts
@@ -1,17 +1,22 @@
 import path, { join } from 'path';
 import { fs } from '@modern-js/utils';
-import { killApp, modernBuild } from '../../../utils/modernTestUtils';
+import puppeteer from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchOptions,
+  modernBuild,
+  modernServe,
+} from '../../../utils/modernTestUtils';
 
 const fixtureDir = path.resolve(__dirname, '../fixtures');
-
+const appDir = join(fixtureDir, 'nested-routes');
 jest.setTimeout(1000 * 60 * 3);
 
 describe('ssg', () => {
   let app: any;
-  let appDir: string;
   let distDir: string;
   beforeAll(async () => {
-    appDir = join(fixtureDir, 'nested-routes');
     distDir = join(appDir, './dist');
     await modernBuild(appDir);
   });
@@ -29,5 +34,40 @@ describe('ssg', () => {
     const htmlPath = path.join(distDir, 'html/main/user/index.html');
     const html = (await fs.readFile(htmlPath)).toString();
     expect(html.includes('Hello, User')).toBe(true);
+  });
+});
+
+describe('test ssg request', () => {
+  let buildRes: { code: number };
+  let app: any;
+  let port: any;
+  beforeAll(async () => {
+    port = await getPort();
+
+    buildRes = await modernBuild(appDir);
+    app = await modernServe(appDir, port, {
+      cwd: appDir,
+    });
+  });
+
+  afterAll(async () => {
+    await killApp(app);
+  });
+
+  test('should support enableInlineScripts', async () => {
+    const host = `http://localhost`;
+    expect(buildRes.code === 0).toBe(true);
+    const browser = await puppeteer.launch(launchOptions as any);
+    const page = await browser.newPage();
+    await page.goto(`${host}:${port}/user`);
+
+    const description = await page.$('#data');
+    const targetText = await page.evaluate(el => el?.textContent, description);
+    try {
+      expect(targetText?.trim()).toEqual('Hello, User');
+    } finally {
+      await page.close();
+      await browser.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

there is some issue in server routes when use ssg, this PR fix them:

1. should use routes in `route.json` when exec `serve` command instead of analysis filesystem, for ssg plugin will generate external routes.
> ssg plugin should use modifyServerRoutes to add new routes instead of rewrite `route.json`, we should refactor it in the future. But even we do this, we also should use `route.json` as serverRoutes in serve command for simulation the production environment.

2. now we get route templates by `route.entryName`, but ssg will create new page for same entry, so we should use entryName + urlPath as the unique key.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
