### PR TITLE
feat: migrate runtime cli plugin to new cli plugin

### DIFF
--- a/.changeset/witty-hotels-collect.md
+++ b/.changeset/witty-hotels-collect.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: migrate runtime cli plugin to new cli plugin
+
+feat: runtime CLI 插件迁移到新的 CLI 插件

--- a/packages/cli/core/src/context.ts
+++ b/packages/cli/core/src/context.ts
@@ -52,7 +52,7 @@ export const initAppContext = ({
   appDirectory: string;
   plugins: CliPlugin[];
   configFile: string | false;
-  runtimeConfigFile: string | false;
+  runtimeConfigFile: string;
   options?: {
     metaName?: string;
     srcDir?: string;

--- a/packages/document/module-doc/docs/en/guide/basic/command-preview.md
+++ b/packages/document/module-doc/docs/en/guide/basic/command-preview.md
@@ -47,7 +47,6 @@ The following features can currently be enabled.
 
 - Storybook V7
 - Tailwind CSS support
-- Modern.js Runtime API
 
 You can learn more about these features in the [Using the micro generator](/guide/basic/use-micro-generator) section.
 

--- a/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/en/guide/basic/use-micro-generator.md
@@ -43,24 +43,3 @@ The **Storybook feature** can be enabled when we want to debug a component or a 
 [Tailwind CSS](https://tailwindcss.com/) is a CSS framework and design system based on Utility Class, which can quickly add common styles to components, and support flexible extension of theme styles.
 
 If you want to use Tailwind CSS for a project, you can refer to ["Using Tailwind CSS"](https://modernjs.dev/module-tools/guide/best-practices/components.html#tailwind-css).
-
-## Modern.js Runtime API
-
-**Modern.js provides Runtime API capabilities that can only be used in the Modern.js application project environment**. If you need to develop a component for use in a Modern.js application environment, then you can turn on this feature and the microgenerator will add the `"@modern-js/runtime"` dependency.
-
-Also, the Storybook debugging tool will determine if the project needs to use the Runtime API by checking the project's dependencies and providing the same Runtime API runtime environment as the Modern.js application project.
-
-:::tip
-
-After successfully enabling it, you will be prompted to manually add a code similar to the one below to the configuration.
-
-```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
-import runtime from '@modern-js/runtime/cli';
-
-export default defineConfig({
-  plugins: [moduleTools(), runtime()],
-});
-```
-
-:::

--- a/packages/document/module-doc/docs/zh/guide/basic/command-preview.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/command-preview.md
@@ -47,7 +47,6 @@ Options:
 
 - Storybook V7
 - Tailwind CSS 支持
-- Modern.js Runtime API
 
 关于这些功能，可以通过[「使用微生成器」](/guide/basic/use-micro-generator) 章节了解更多。
 

--- a/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
+++ b/packages/document/module-doc/docs/zh/guide/basic/use-micro-generator.md
@@ -43,24 +43,3 @@ export default defineConfig({
 [Tailwind CSS](https://tailwindcss.com/) 是一个以 Utility Class 为基础的 CSS 框架和设计系统，可以快速地为组件添加常用样式，同时支持主题样式的灵活扩展。
 
 如果你想要在项目使用 [Tailwind CSS](https://tailwindcss.com/)，可以参考 [「使用 Tailwind CSS」](https://modernjs.dev/module-tools/guide/best-practices/components.html#tailwind-css)。
-
-## Modern.js Runtime API 支持
-
-**Modern.js 提供了 [Runtime API](https://modernjs.dev/configure/app/runtime/intro) 能力，这些 API 只能在 Modern.js 的应用项目环境中使用**。如果你需要开发一个 Modern.js 应用环境中使用的组件，那么你可以开启该特性，微生成器会增加 `"@modern-js/runtime"`依赖。
-
-另外，Storybook 调试工具也会通过检测项目的依赖确定项目是否需要使用 Runtime API，并且提供与 Modern.js 应用项目一样的 Runtime API 运行环境。
-
-:::tip
-
-在成功开启后，会提示需要手动在配置中增加如下类似的代码。
-
-```ts
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
-import runtime from '@modern-js/runtime/cli';
-
-export default defineConfig({
-  plugins: [moduleTools(), runtime()],
-});
-```
-
-:::

--- a/packages/runtime/plugin-garfish/jest.config.js
+++ b/packages/runtime/plugin-garfish/jest.config.js
@@ -6,5 +6,9 @@ module.exports = {
   rootDir: __dirname,
   moduleNameMapper: {
     '^@meta/runtime$': '<rootDir>/node_modules/@modern-js/runtime/src',
+    '^@modern-js/runtime/browser$':
+      '<rootDir>/node_modules/@modern-js/runtime/src/core/browser',
+    '^@modern-js/runtime/react$':
+      '<rootDir>/node_modules/@modern-js/runtime/src/core/react',
   },
 };

--- a/packages/runtime/plugin-garfish/package.json
+++ b/packages/runtime/plugin-garfish/package.json
@@ -71,7 +71,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@modern-js/plugin": "workspace:*",
+    "@modern-js/plugin-v2": "workspace:*",
     "@modern-js/runtime-utils": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "0.5.13",

--- a/packages/runtime/plugin-garfish/src/cli/code.ts
+++ b/packages/runtime/plugin-garfish/src/cli/code.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import type {
   AppTools,
-  IAppContext,
+  AppToolsContext,
+  AppToolsFeatureHooks,
   NormalizedConfig,
 } from '@modern-js/app-tools';
-import type { MaybeAsync } from '@modern-js/plugin';
 import type { Entrypoint } from '@modern-js/types';
 import { fs } from '@modern-js/utils';
 import * as template from './template';
@@ -15,9 +15,9 @@ export const ENTRY_BOOTSTRAP_FILE_NAME = 'bootstrap.jsx';
 
 export const generateCode = async (
   entrypoints: Entrypoint[],
-  appContext: IAppContext,
+  appContext: AppToolsContext<'shared'>,
   config: NormalizedConfig<AppTools>,
-  appendEntryCode: (input: { entrypoint: Entrypoint }) => MaybeAsync<string[]>,
+  hooks: AppToolsFeatureHooks<'shared'>,
 ) => {
   const { mountId } = config.html;
   const { enableAsyncEntry } = config.source;
@@ -27,7 +27,7 @@ export const generateCode = async (
     entrypoints.map(async entrypoint => {
       const { entryName, isAutoMount, entry, customEntry, customBootstrap } =
         entrypoint;
-      const appendCode = await appendEntryCode({ entrypoint });
+      const appendCode = await hooks.appendEntryCode.call({ entrypoint });
 
       if (isAutoMount) {
         // index.jsx

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -1,6 +1,10 @@
-import type { AppTools, CliPlugin } from '@modern-js/app-tools';
+import type {
+  AppNormalizedConfig,
+  AppTools,
+  CliPluginFuture,
+} from '@modern-js/app-tools';
 import type { CliHookCallbacks, useConfigContext } from '@modern-js/core';
-import { type AsyncWorkflow, createAsyncWorkflow } from '@modern-js/plugin';
+import { createCollectAsyncHook } from '@modern-js/plugin-v2';
 import type { Entrypoint } from '@modern-js/types';
 import { createRuntimeExportsUtils, getEntryOptions } from '@modern-js/utils';
 import { logger } from '../util';
@@ -35,211 +39,194 @@ export function getDefaultMicroFrontedConfig(
   };
 }
 
-const appendEntryCode = createAsyncWorkflow<
-  { entrypoint: Entrypoint },
-  string
->();
+type AppendEntryCodeFn = (params: {
+  entrypoint: Entrypoint;
+  code: string;
+}) => string | Promise<string>;
 
-export const garfishPlugin = (): CliPlugin<
-  AppTools & {
-    hooks: {
-      appendEntryCode: AsyncWorkflow<{ entrypoint: Entrypoint }, string>;
-    };
-  }
-> => ({
+export const garfishPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   name: '@modern-js/plugin-garfish',
   pre: ['@modern-js/runtime'],
-  registerHook: {
-    appendEntryCode,
+  registryHooks: {
+    appendEntryCode: createCollectAsyncHook<AppendEntryCodeFn>(),
   },
   setup: api => {
-    return {
-      _internalRuntimePlugins({ entrypoint, plugins }) {
-        const userConfig = api.useResolvedConfigContext();
-        const { packageName, metaName } = api.useAppContext();
-        const runtimeConfig = getEntryOptions(
-          entrypoint.entryName,
-          entrypoint.isMainEntry,
-          userConfig.runtime,
-          userConfig.runtimeByEntries,
-          packageName,
-        );
-        if (runtimeConfig?.masterApp) {
-          plugins.push({
-            name: 'garfish',
-            path: `@${metaName}/plugin-garfish/runtime`,
-            config: runtimeConfig?.masterApp || {},
-          });
-        }
-        return { entrypoint, plugins };
-      },
-      resolvedConfig: async config => {
-        const { resolved } = config;
-        const { masterApp, router } = getRuntimeConfig(resolved);
-        const nConfig = {
-          resolved: {
-            ...resolved,
-          },
-        };
-        if (masterApp) {
-          const useConfig = api.useConfigContext();
-          const baseUrl = useConfig?.server?.baseUrl;
-          if (Array.isArray(baseUrl)) {
-            throw new Error(
-              'Now Micro-Front-End mode dose not support multiple baseUrl, you can set it as a string',
-            );
-          }
-          // basename does not exist use router's basename
-          setRuntimeConfig(
-            nConfig.resolved,
-            'masterApp',
-            Object.assign(
-              typeof masterApp === 'object' ? { ...masterApp } : {},
-              {
-                basename:
-                  baseUrl ||
-                  router?.historyOptions?.basename ||
-                  router?.basename ||
-                  '/',
-              },
-            ),
-          );
-        }
-        logger(`resolvedConfig`, {
-          output: nConfig.resolved.output,
-          runtime: nConfig.resolved.runtime,
-          deploy: nConfig.resolved.deploy,
-          server: nConfig.resolved.server,
+    api._internalRuntimePlugins(({ entrypoint, plugins }) => {
+      const userConfig = api.getNormalizedConfig();
+      const { packageName, metaName } = api.getAppContext();
+      const runtimeConfig = getEntryOptions(
+        entrypoint.entryName,
+        entrypoint.isMainEntry,
+        userConfig.runtime,
+        userConfig.runtimeByEntries,
+        packageName,
+      );
+      if (runtimeConfig?.masterApp) {
+        plugins.push({
+          name: 'garfish',
+          path: `@${metaName}/plugin-garfish/runtime`,
+          config: runtimeConfig?.masterApp || {},
         });
-        return nConfig;
-      },
-      config() {
-        const useConfig = api.useConfigContext();
-        const { metaName, packageName } = api.useAppContext();
-        logger('useConfig', useConfig);
-
-        let disableCssExtract = useConfig.output?.disableCssExtract || false;
-
-        // When the micro-frontend application js entry, there is no need to extract css, close cssExtract
-        if (useConfig.deploy?.microFrontend) {
-          const { enableHtmlEntry } = getDefaultMicroFrontedConfig(
-            useConfig.deploy?.microFrontend,
+      }
+      return { entrypoint, plugins };
+    });
+    api.modifyResolvedConfig(config => {
+      const { masterApp, router } = getRuntimeConfig(config);
+      if (masterApp) {
+        const useConfig = api.getConfig();
+        const baseUrl = useConfig?.server?.baseUrl;
+        if (Array.isArray(baseUrl)) {
+          throw new Error(
+            'Now Micro-Front-End mode dose not support multiple baseUrl, you can set it as a string',
           );
-          if (!enableHtmlEntry) {
-            disableCssExtract = true;
-          }
         }
-
-        return {
-          output: {
-            disableCssExtract,
-          },
-          source: {
-            alias: {
-              [`@${metaName}/runtime/garfish`]: `@${metaName}/plugin-garfish/runtime`,
-            },
-          },
-          tools: {
-            devServer: {
-              headers: {
-                'Access-Control-Allow-Origin': '*',
-              },
-            },
-            bundlerChain: (chain, { env, CHAIN_ID, bundler }) => {
-              // add comments avoid sourcemap abnormal
-              if (bundler.BannerPlugin) {
-                chain
-                  .plugin('garfish-banner')
-                  .use(bundler.BannerPlugin, [{ banner: 'Micro front-end' }]);
-              }
-
-              const resolveOptions = api.useResolvedConfigContext();
-              if (resolveOptions?.deploy?.microFrontend) {
-                chain.output.libraryTarget('umd');
-
-                const DEFAULT_ASSET_PREFIX = '/';
-
-                // Only override assetPrefix when using the default asset prefix,
-                // this allows user or other plugins to set asset prefix.
-                const resolvedAssetPrefix = resolveOptions.dev?.assetPrefix;
-                const isUsingDefaultAssetPrefix =
-                  !useConfig.dev?.assetPrefix &&
-                  (!resolvedAssetPrefix ||
-                    resolvedAssetPrefix === DEFAULT_ASSET_PREFIX);
-
-                if (
-                  isUsingDefaultAssetPrefix &&
-                  resolveOptions?.server?.port &&
-                  env === 'development'
-                ) {
-                  chain.output.publicPath(
-                    `//localhost:${resolveOptions.server.port}/`,
-                  );
-                }
-
-                const { enableHtmlEntry, externalBasicLibrary } =
-                  getDefaultMicroFrontedConfig(
-                    resolveOptions.deploy?.microFrontend,
-                  );
-                // external
-                if (externalBasicLibrary) {
-                  chain.externals(externals);
-                }
-                // use html mode
-                if (!enableHtmlEntry) {
-                  chain.output.filename('index.js');
-                  chain.plugins.delete(`${CHAIN_ID.PLUGIN.HTML}-main`);
-                  chain.optimization.runtimeChunk(false);
-                  chain.optimization.splitChunks({
-                    chunks: 'async',
-                  });
-                }
-              }
-              const uniqueName = chain.output.get('uniqueName');
-              if (!uniqueName) {
-                chain.output.uniqueName(packageName);
-              }
-              const resolveConfig = chain.toConfig();
-              logger('bundlerConfig', {
-                output: resolveConfig.output,
-                externals: resolveConfig.externals,
-                env,
-                alias: resolveConfig.resolve?.alias,
-                plugins: resolveConfig.plugins,
-              });
-            },
-          },
-        };
-      },
-      addRuntimeExports() {
-        const config = api.useResolvedConfigContext();
-        const { masterApp } = getRuntimeConfig(config);
-        const { internalDirectory, metaName } = api.useAppContext();
-        const pluginsExportsUtils = createRuntimeExportsUtils(
-          internalDirectory,
-          'plugins',
+        // basename does not exist use router's basename
+        setRuntimeConfig(
+          config,
+          'masterApp',
+          Object.assign(typeof masterApp === 'object' ? { ...masterApp } : {}, {
+            basename:
+              baseUrl ||
+              router?.historyOptions?.basename ||
+              router?.basename ||
+              '/',
+          }),
         );
-        if (masterApp) {
-          const addExportStatement = `export { default as garfish, default as masterApp } from '@${metaName}/plugin-garfish/runtime'`;
-          logger('exportStatement', addExportStatement);
-          pluginsExportsUtils.addExport(addExportStatement);
+      }
+      logger(`resolvedConfig`, {
+        output: config.output,
+        runtime: config.runtime,
+        deploy: config.deploy,
+        server: config.server,
+      });
+      return config;
+    });
+    api.config(() => {
+      const useConfig = api.getConfig();
+      const { metaName, packageName } = api.getAppContext();
+      logger('useConfig', useConfig);
+
+      let disableCssExtract = useConfig.output?.disableCssExtract || false;
+
+      // When the micro-frontend application js entry, there is no need to extract css, close cssExtract
+      if (useConfig.deploy?.microFrontend) {
+        const { enableHtmlEntry } = getDefaultMicroFrontedConfig(
+          useConfig.deploy?.microFrontend,
+        );
+        if (!enableHtmlEntry) {
+          disableCssExtract = true;
         }
-      },
-      async generateEntryCode({ entrypoints }) {
-        const resolveOptions = api.useResolvedConfigContext();
-        if (resolveOptions?.deploy?.microFrontend) {
-          const appContext = api.useAppContext();
-          const resolvedConfig = api.useResolvedConfigContext();
-          const { appendEntryCode } = api.useHookRunners();
-          await generateCode(
-            entrypoints,
-            appContext,
-            resolvedConfig,
-            appendEntryCode,
-          );
-        }
-      },
-    };
+      }
+
+      return {
+        output: {
+          disableCssExtract,
+        },
+        source: {
+          alias: {
+            [`@${metaName}/runtime/garfish`]: `@${metaName}/plugin-garfish/runtime`,
+          },
+        },
+        tools: {
+          devServer: {
+            headers: {
+              'Access-Control-Allow-Origin': '*',
+            },
+          },
+          bundlerChain: (chain, { env, CHAIN_ID, bundler }) => {
+            // add comments avoid sourcemap abnormal
+            if (bundler.BannerPlugin) {
+              chain
+                .plugin('garfish-banner')
+                .use(bundler.BannerPlugin, [{ banner: 'Micro front-end' }]);
+            }
+
+            const resolveOptions = api.getNormalizedConfig();
+            if (resolveOptions?.deploy?.microFrontend) {
+              chain.output.libraryTarget('umd');
+
+              const DEFAULT_ASSET_PREFIX = '/';
+
+              // Only override assetPrefix when using the default asset prefix,
+              // this allows user or other plugins to set asset prefix.
+              const resolvedAssetPrefix = resolveOptions.dev?.assetPrefix;
+              const isUsingDefaultAssetPrefix =
+                !useConfig.dev?.assetPrefix &&
+                (!resolvedAssetPrefix ||
+                  resolvedAssetPrefix === DEFAULT_ASSET_PREFIX);
+
+              if (
+                isUsingDefaultAssetPrefix &&
+                resolveOptions?.server?.port &&
+                env === 'development'
+              ) {
+                chain.output.publicPath(
+                  `//localhost:${resolveOptions.server.port}/`,
+                );
+              }
+
+              const { enableHtmlEntry, externalBasicLibrary } =
+                getDefaultMicroFrontedConfig(
+                  resolveOptions.deploy?.microFrontend,
+                );
+              // external
+              if (externalBasicLibrary) {
+                chain.externals(externals);
+              }
+              // use html mode
+              if (!enableHtmlEntry) {
+                chain.output.filename('index.js');
+                chain.plugins.delete(`${CHAIN_ID.PLUGIN.HTML}-main`);
+                chain.optimization.runtimeChunk(false);
+                chain.optimization.splitChunks({
+                  chunks: 'async',
+                });
+              }
+            }
+            const uniqueName = chain.output.get('uniqueName');
+            if (!uniqueName) {
+              chain.output.uniqueName(packageName);
+            }
+            const resolveConfig = chain.toConfig();
+            logger('bundlerConfig', {
+              output: resolveConfig.output,
+              externals: resolveConfig.externals,
+              env,
+              alias: resolveConfig.resolve?.alias,
+              plugins: resolveConfig.plugins,
+            });
+          },
+        },
+      };
+    });
+    api.addRuntimeExports(() => {
+      const config = api.getNormalizedConfig();
+      const { masterApp } = getRuntimeConfig(config);
+      const { internalDirectory, metaName } = api.useAppContext();
+      const pluginsExportsUtils = createRuntimeExportsUtils(
+        internalDirectory,
+        'plugins',
+      );
+      if (masterApp) {
+        const addExportStatement = `export { default as garfish, default as masterApp } from '@${metaName}/plugin-garfish/runtime'`;
+        logger('exportStatement', addExportStatement);
+        pluginsExportsUtils.addExport(addExportStatement);
+      }
+    });
+    api.generateEntryCode(async ({ entrypoints }) => {
+      const resolveOptions = api.getNormalizedConfig();
+      if (resolveOptions?.deploy?.microFrontend) {
+        const appContext = api.getAppContext();
+        const resolvedConfig = api.getNormalizedConfig();
+        const hooks = api.getHooks();
+        await generateCode(
+          entrypoints,
+          appContext,
+          resolvedConfig as AppNormalizedConfig,
+          hooks,
+        );
+      }
+    });
   },
 });
 

--- a/packages/runtime/plugin-router-v5/package.json
+++ b/packages/runtime/plugin-router-v5/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@modern-js/plugin": "workspace:*",
+    "@modern-js/plugin-v2": "workspace:*",
     "@modern-js/runtime-utils": "workspace:*",
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",

--- a/packages/runtime/plugin-router-v5/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v5/src/cli/index.ts
@@ -1,4 +1,4 @@
-import type { AppTools, CliPlugin } from '@modern-js/app-tools';
+import type { AppTools, CliPluginFuture } from '@modern-js/app-tools';
 import {
   createRuntimeExportsUtils,
   getEntryOptions,
@@ -7,74 +7,72 @@ import {
 import './types';
 import type { ServerRoute } from '@modern-js/types';
 
-export const routerPlugin = (): CliPlugin<AppTools> => ({
+export const routerPlugin = (): CliPluginFuture<AppTools> => ({
   name: '@modern-js/plugin-router-v5',
   required: ['@modern-js/runtime'],
   setup: api => {
     let routerExportsUtils: any;
 
-    return {
-      _internalRuntimePlugins({ entrypoint, plugins }) {
-        const userConfig = api.useResolvedConfigContext();
-        const { serverRoutes, metaName, packageName } = api.useAppContext();
-        if (isV5(userConfig)) {
-          const routerConfig = getEntryOptions(
-            entrypoint.entryName,
-            entrypoint.isMainEntry,
-            userConfig.runtime,
-            userConfig.runtimeByEntries,
-            packageName,
-          )?.router;
-          const serverBase = serverRoutes
-            .filter(
-              (route: ServerRoute) => route.entryName === entrypoint.entryName,
-            )
-            .map(route => route.urlPath)
-            .sort((a, b) => (a.length - b.length > 0 ? -1 : 1));
-          plugins.push({
-            name: 'router',
-            path: `@${metaName}/plugin-router-v5/runtime`,
-            config:
-              typeof routerConfig === 'boolean'
-                ? { serverBase }
-                : { ...routerConfig, serverBase },
-          });
-        }
-        return { entrypoint, plugins };
-      },
-      config() {
-        const { internalDirectory, metaName } = api.useAppContext();
-        // .modern-js/.runtime-exports/router (legacy)
-        routerExportsUtils = createRuntimeExportsUtils(
-          internalDirectory,
-          'router',
-        );
+    api._internalRuntimePlugins(({ entrypoint, plugins }) => {
+      const userConfig = api.getNormalizedConfig();
+      const { serverRoutes, metaName, packageName } = api.getAppContext();
+      if (isV5(userConfig)) {
+        const routerConfig = getEntryOptions(
+          entrypoint.entryName,
+          entrypoint.isMainEntry,
+          userConfig.runtime,
+          userConfig.runtimeByEntries,
+          packageName,
+        )?.router;
+        const serverBase = serverRoutes
+          .filter(
+            (route: ServerRoute) => route.entryName === entrypoint.entryName,
+          )
+          .map(route => route.urlPath)
+          .sort((a, b) => (a.length - b.length > 0 ? -1 : 1));
+        plugins.push({
+          name: 'router',
+          path: `@${metaName}/plugin-router-v5/runtime`,
+          config:
+            typeof routerConfig === 'boolean'
+              ? { serverBase }
+              : { ...routerConfig, serverBase },
+        });
+      }
+      return { entrypoint, plugins };
+    });
+    api.config(() => {
+      const { internalDirectory, metaName } = api.getAppContext();
+      // .modern-js/.runtime-exports/router (legacy)
+      routerExportsUtils = createRuntimeExportsUtils(
+        internalDirectory,
+        'router',
+      );
 
-        return {
-          source: {
-            alias: {
-              [`@${metaName}/runtime/router-v5`]: routerExportsUtils.getPath(),
-            },
+      return {
+        source: {
+          alias: {
+            [`@${metaName}/runtime/router-v5`]: routerExportsUtils.getPath(),
           },
-        };
-      },
-      addRuntimeExports() {
-        const userConfig = api.useResolvedConfigContext();
-        const { internalDirectory, metaName } = api.useAppContext();
-        const pluginsExportsUtils = createRuntimeExportsUtils(
-          internalDirectory,
-          'plugins',
+        },
+      };
+    });
+    api.addRuntimeExports(() => {
+      const userConfig = api.getNormalizedConfig();
+      const { internalDirectory, metaName } = api.getAppContext();
+      const pluginsExportsUtils = createRuntimeExportsUtils(
+        internalDirectory,
+        'plugins',
+      );
+      if (isV5(userConfig)) {
+        pluginsExportsUtils.addExport(
+          `export { default as router } from '@${metaName}/plugin-router-v5/runtime'`,
         );
-        if (isV5(userConfig)) {
-          pluginsExportsUtils.addExport(
-            `export { default as router } from '@${metaName}/plugin-router-v5/runtime'`,
-          );
-          routerExportsUtils?.addExport(
-            `export * from '@${metaName}/plugin-router-v5/runtime'`,
-          );
-        }
-      },
-    };
+        routerExportsUtils?.addExport(
+          `export * from '@${metaName}/plugin-router-v5/runtime'`,
+        );
+      }
+    });
   },
 });
 

--- a/packages/runtime/plugin-router-v5/tests/index.test.ts
+++ b/packages/runtime/plugin-router-v5/tests/index.test.ts
@@ -1,5 +1,7 @@
-import { AppContext, manager } from '@modern-js/core';
-import RuntimePlugin from '@modern-js/runtime/cli';
+import type { AppTools } from '@modern-js/app-tools';
+import { createPluginManager } from '@modern-js/plugin-v2';
+import { createContext, initPluginAPI } from '@modern-js/plugin-v2/cli';
+import runtimePlugin from '@modern-js/runtime/cli';
 import plugin, { useHistory, useParams } from '../src';
 import cliPlugin from '../src/cli';
 
@@ -12,20 +14,51 @@ describe('plugin-router-legacy', () => {
 });
 
 describe('cli-router-legacy', () => {
-  const main = manager.clone().usePlugin(RuntimePlugin, cliPlugin as any);
-  let runner: any;
-
-  beforeAll(async () => {
-    runner = await main.init();
-  });
+  const setup = async () => {
+    const pluginManager = createPluginManager();
+    pluginManager.addPlugins([runtimePlugin(), cliPlugin() as Plugin]);
+    const plugins = pluginManager.getPlugins();
+    const context = await createContext<AppTools>({
+      appContext: {
+        plugins,
+      } as any,
+      config: {},
+      normalizedConfig: { plugins: [] } as any,
+    });
+    const pluginAPI = {
+      ...initPluginAPI<AppTools>({
+        context,
+        pluginManager,
+      }),
+      checkEntryPoint: ({ path, entry }: any) => {
+        return { path, entry };
+      },
+      modifyEntrypoints: ({ entrypoints }: any) => {
+        return { entrypoints };
+      },
+      generateEntryCode: async ({ entrypoints }: any) => {},
+      _internalRuntimePlugins: ({ entrypoint, plugins }: any) => {
+        return { entrypoint, plugins };
+      },
+      addRuntimeExports: () => {},
+      modifyFileSystemRoutes: () => {},
+      onBeforeGenerateRoutes: () => {},
+    };
+    context.pluginAPI = pluginAPI;
+    for (const plugin of plugins) {
+      await plugin.setup(pluginAPI);
+    }
+    return pluginAPI;
+  };
 
   test('should plugin-router-legacy defined', async () => {
     expect(cliPlugin).toBeDefined();
   });
 
   it('plugin-router-legacy cli config is defined', async () => {
-    AppContext.set({ metaName: 'modern-js' } as any);
-    const config = await runner.config();
+    const api = await setup();
+    api.updateAppContext({ metaName: 'modern-js' } as any);
+    const config = await api.getHooks().config.call();
     expect(
       config.find(
         (item: any) => item.source.alias['@modern-js/runtime/plugins'],

--- a/packages/runtime/plugin-router-v5/tests/index.test.ts
+++ b/packages/runtime/plugin-router-v5/tests/index.test.ts
@@ -16,7 +16,7 @@ describe('plugin-router-legacy', () => {
 describe('cli-router-legacy', () => {
   const setup = async () => {
     const pluginManager = createPluginManager();
-    pluginManager.addPlugins([runtimePlugin(), cliPlugin() as Plugin]);
+    pluginManager.addPlugins([runtimePlugin(), cliPlugin()]);
     const plugins = pluginManager.getPlugins();
     const context = await createContext<AppTools>({
       appContext: {

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -196,6 +196,7 @@
     "@modern-js-reduck/react": "^1.1.10",
     "@modern-js-reduck/store": "^1.1.10",
     "@modern-js/plugin": "workspace:*",
+    "@modern-js/plugin-v2": "workspace:*",
     "@modern-js/plugin-data-loader": "workspace:*",
     "@modern-js/runtime-utils": "workspace:*",
     "@modern-js/types": "workspace:*",

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -221,7 +221,6 @@
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",
-    "@modern-js/core": "workspace:*",
     "@remix-run/web-fetch": "^4.1.3",
     "@rsbuild/core": "1.1.10",
     "@scripts/build": "workspace:*",

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type { AppTools, CliPlugin } from '@modern-js/app-tools';
+import type { AppTools, CliPluginFuture } from '@modern-js/app-tools';
 import {
   isReact18 as checkIsReact18,
   cleanRequireCache,
@@ -17,8 +17,8 @@ import { ssrPlugin } from './ssr';
 export { isRuntimeEntry } from './entry';
 export { statePlugin, ssrPlugin, routerPlugin, documentPlugin };
 export const runtimePlugin = (params?: {
-  plugins?: CliPlugin<AppTools>[];
-}): CliPlugin<AppTools> => ({
+  plugins?: CliPluginFuture<AppTools<'shared'>>[];
+}): CliPluginFuture<AppTools<'shared'>> => ({
   name: '@modern-js/runtime',
   post: [
     '@modern-js/plugin-ssr',
@@ -29,150 +29,144 @@ export const runtimePlugin = (params?: {
   ],
   // the order of runtime plugins is affected by runtime hooks, mainly `init` and `hoc` hooks
   usePlugins: params?.plugins || [
-    ssrPlugin(),
+    ssrPlugin() as any,
     routerPlugin(),
     statePlugin(),
     documentPlugin(),
   ],
   setup: api => {
-    return {
-      checkEntryPoint({ path, entry }) {
-        return { path, entry: entry || isRuntimeEntry(path) };
-      },
-      modifyEntrypoints({ entrypoints }) {
-        const { internalDirectory } = api.useAppContext();
-        const {
-          source: { enableAsyncEntry },
-        } = api.useResolvedConfigContext();
-        const newEntryPoints = entrypoints.map(entrypoint => {
-          if (entrypoint.isAutoMount) {
-            entrypoint.internalEntry = path.resolve(
-              internalDirectory,
-              `./${entrypoint.entryName}/${
-                enableAsyncEntry
-                  ? ENTRY_BOOTSTRAP_FILE_NAME
-                  : ENTRY_POINT_FILE_NAME
-              }`,
-            );
-          }
-          return entrypoint;
-        });
-        return { entrypoints: newEntryPoints };
-      },
-      async generateEntryCode({ entrypoints }) {
-        const appContext = api.useAppContext();
-        const resolvedConfig = api.useResolvedConfigContext();
-        const runners = api.useHookRunners();
-        await generateCode(
-          entrypoints,
-          appContext,
-          resolvedConfig,
-          runners._internalRuntimePlugins,
-        );
-      },
-      /* Note that the execution time of the config hook is before prepare.
+    api.checkEntryPoint(({ path, entry }) => {
+      return { path, entry: entry || isRuntimeEntry(path) };
+    });
+
+    api.modifyEntrypoints(({ entrypoints }) => {
+      const { internalDirectory } = api.getAppContext();
+      const {
+        source: { enableAsyncEntry },
+      } = api.getNormalizedConfig();
+      const newEntryPoints = entrypoints.map(entrypoint => {
+        if (entrypoint.isAutoMount) {
+          entrypoint.internalEntry = path.resolve(
+            internalDirectory,
+            `./${entrypoint.entryName}/${
+              enableAsyncEntry
+                ? ENTRY_BOOTSTRAP_FILE_NAME
+                : ENTRY_POINT_FILE_NAME
+            }`,
+          );
+        }
+        return entrypoint;
+      });
+      return { entrypoints: newEntryPoints };
+    });
+    api.generateEntryCode(async ({ entrypoints }) => {
+      const appContext = api.getAppContext();
+      const resolvedConfig = api.getNormalizedConfig();
+      const hooks = api.getHooks();
+      await generateCode(entrypoints, appContext, resolvedConfig, hooks);
+    });
+
+    /* Note that the execution time of the config hook is before prepare.
       /* This means that the entry information cannot be obtained in the config hook.
       /* Therefore, aliases cannot be set directly in the config.
       */
-      prepare() {
-        const { builder, entrypoints, internalDirectory, metaName } =
-          api.useAppContext();
-        builder?.addPlugins([
-          builderPluginAlias({ entrypoints, internalDirectory, metaName }),
-        ]);
-      },
-      config() {
-        const { appDirectory, metaName, internalDirectory } =
-          api.useAppContext();
+    api.onPrepare(() => {
+      const { builder, entrypoints, internalDirectory, metaName } =
+        api.getAppContext();
+      builder?.addPlugins([
+        builderPluginAlias({ entrypoints, internalDirectory, metaName }),
+      ]);
+    });
 
-        const isReact18 = checkIsReact18(appDirectory);
+    api.config(() => {
+      const { appDirectory, metaName, internalDirectory } = api.getAppContext();
 
-        process.env.IS_REACT18 = isReact18.toString();
+      const isReact18 = checkIsReact18(appDirectory);
 
-        const pluginsExportsUtils = createRuntimeExportsUtils(
-          internalDirectory,
-          'plugins',
-        );
+      process.env.IS_REACT18 = isReact18.toString();
 
-        return {
-          runtime: {},
-          runtimeByEntries: {},
-          source: {
-            alias: {
-              /**
-               * twin.macro inserts styled-components into the code during the compilation process
-               * But it will not be installed under the user project.
-               * So need to add alias
-               */
-              'styled-components': require.resolve('styled-components'),
-              /**
-               * Compatible with the reference path of the old version of the plugin.
-               */
-              [`@${metaName}/runtime/plugins`]: pluginsExportsUtils.getPath(),
-              '@meta/runtime/browser$': require.resolve(
-                '@modern-js/runtime/browser',
-              ),
-              '@meta/runtime/react$': require.resolve(
-                '@modern-js/runtime/react',
-              ),
-              '@meta/runtime/context$': require.resolve(
-                '@modern-js/runtime/context',
-              ),
-              '@meta/runtime$': require.resolve('@modern-js/runtime'),
-            },
-            globalVars: {
-              'process.env.IS_REACT18': process.env.IS_REACT18,
-            },
-          },
-          tools: {
-            styledComponents: {
-              // https://github.com/styled-components/babel-plugin-styled-components/issues/287
-              topLevelImportPaths: ['@modern-js/runtime/styled'],
-            },
-            bundlerChain: chain => {
-              chain.module
-                .rule('modern-entry')
-                .test(/\.jsx?$/)
-                .include.add(
-                  path.resolve(appDirectory, 'node_modules', `.${metaName}`),
-                )
-                .end()
-                .sideEffects(true);
-            },
+      const pluginsExportsUtils = createRuntimeExportsUtils(
+        internalDirectory,
+        'plugins',
+      );
+
+      return {
+        runtime: {},
+        runtimeByEntries: {},
+        source: {
+          alias: {
             /**
-             * Add IgnorePlugin to fix react-dom/client import error when use react17
+             * twin.macro inserts styled-components into the code during the compilation process
+             * But it will not be installed under the user project.
+             * So need to add alias
              */
-            webpackChain: (chain, { webpack }) => {
-              if (!isReact18) {
-                chain.plugin('ignore-plugin').use(webpack.IgnorePlugin, [
-                  {
-                    resourceRegExp: /^react-dom\/client$/,
-                    contextRegExp: /./,
-                  },
-                ]);
-              }
-            },
-            rspack: (_config, { appendPlugins, rspack }) => {
-              if (!isReact18) {
-                appendPlugins([
-                  new rspack.IgnorePlugin({
-                    resourceRegExp: /^react-dom\/client$/,
-                    contextRegExp: /./,
-                  }),
-                ]);
-              }
-            },
+            'styled-components': require.resolve('styled-components'),
+            /**
+             * Compatible with the reference path of the old version of the plugin.
+             */
+            [`@${metaName}/runtime/plugins`]: pluginsExportsUtils.getPath(),
+            '@meta/runtime/browser$': require.resolve(
+              '@modern-js/runtime/browser',
+            ),
+            '@meta/runtime/react$': require.resolve('@modern-js/runtime/react'),
+            '@meta/runtime/context$': require.resolve(
+              '@modern-js/runtime/context',
+            ),
+            '@meta/runtime$': require.resolve('@modern-js/runtime'),
           },
-        };
-      },
-      async beforeRestart() {
-        cleanRequireCache([
-          require.resolve('../state/cli'),
-          require.resolve('../router/cli'),
-          require.resolve('./ssr'),
-        ]);
-      },
-    };
+          globalVars: {
+            'process.env.IS_REACT18': process.env.IS_REACT18,
+          },
+        },
+        tools: {
+          styledComponents: {
+            // https://github.com/styled-components/babel-plugin-styled-components/issues/287
+            topLevelImportPaths: ['@modern-js/runtime/styled'],
+          },
+          bundlerChain: chain => {
+            chain.module
+              .rule('modern-entry')
+              .test(/\.jsx?$/)
+              .include.add(
+                path.resolve(appDirectory, 'node_modules', `.${metaName}`),
+              )
+              .end()
+              .sideEffects(true);
+          },
+          /**
+           * Add IgnorePlugin to fix react-dom/client import error when use react17
+           */
+          webpackChain: (chain, { webpack }) => {
+            if (!isReact18) {
+              chain.plugin('ignore-plugin').use(webpack.IgnorePlugin, [
+                {
+                  resourceRegExp: /^react-dom\/client$/,
+                  contextRegExp: /./,
+                },
+              ]);
+            }
+          },
+          rspack: (_config, { appendPlugins, rspack }) => {
+            if (!isReact18) {
+              appendPlugins([
+                new rspack.IgnorePlugin({
+                  resourceRegExp: /^react-dom\/client$/,
+                  contextRegExp: /./,
+                }),
+              ]);
+            }
+          },
+        },
+      };
+    });
+
+    api.onBeforeRestart(() => {
+      cleanRequireCache([
+        require.resolve('../state/cli'),
+        require.resolve('../router/cli'),
+        require.resolve('./ssr'),
+      ]);
+    });
   },
 });
 

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -31,8 +31,8 @@ export const runtimePlugin = (params?: {
   usePlugins: params?.plugins || [
     ssrPlugin(),
     routerPlugin(),
-    statePlugin() as any,
-    documentPlugin(),
+    statePlugin(),
+    documentPlugin() as any,
   ],
   setup: api => {
     api.checkEntryPoint(({ path, entry }) => {

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -32,7 +32,7 @@ export const runtimePlugin = (params?: {
     ssrPlugin(),
     routerPlugin(),
     statePlugin(),
-    documentPlugin() as any,
+    documentPlugin(),
   ],
   setup: api => {
     api.checkEntryPoint(({ path, entry }) => {

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -29,8 +29,8 @@ export const runtimePlugin = (params?: {
   ],
   // the order of runtime plugins is affected by runtime hooks, mainly `init` and `hoc` hooks
   usePlugins: params?.plugins || [
-    ssrPlugin() as any,
-    routerPlugin(),
+    ssrPlugin(),
+    routerPlugin() as any,
     statePlugin(),
     documentPlugin(),
   ],

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -30,8 +30,8 @@ export const runtimePlugin = (params?: {
   // the order of runtime plugins is affected by runtime hooks, mainly `init` and `hoc` hooks
   usePlugins: params?.plugins || [
     ssrPlugin(),
-    routerPlugin() as any,
-    statePlugin(),
+    routerPlugin(),
+    statePlugin() as any,
     documentPlugin(),
   ],
   setup: api => {
@@ -67,9 +67,9 @@ export const runtimePlugin = (params?: {
     });
 
     /* Note that the execution time of the config hook is before prepare.
-      /* This means that the entry information cannot be obtained in the config hook.
-      /* Therefore, aliases cannot be set directly in the config.
-      */
+    /* This means that the entry information cannot be obtained in the config hook.
+    /* Therefore, aliases cannot be set directly in the config.
+    */
     api.onPrepare(() => {
       const { builder, entrypoints, internalDirectory, metaName } =
         api.getAppContext();

--- a/packages/runtime/plugin-runtime/src/router/cli/code/templates.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/code/templates.ts
@@ -1,5 +1,8 @@
 import path from 'path';
-import type { AppNormalizedConfig, IAppContext } from '@modern-js/app-tools';
+import type {
+  AppNormalizedConfig,
+  AppToolsContext,
+} from '@modern-js/app-tools';
 import type {
   Entrypoint,
   NestedRouteForCli,
@@ -452,7 +455,7 @@ export function ssrLoaderCombinedModule(
   entrypoints: Entrypoint[],
   entrypoint: Entrypoint,
   config: AppNormalizedConfig<'shared'>,
-  appContext: IAppContext,
+  appContext: AppToolsContext<'shared'>,
 ) {
   const { entryName, isMainEntry } = entrypoint;
   const { packageName, internalDirectory } = appContext;

--- a/packages/runtime/plugin-runtime/src/router/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/index.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { AppTools, CliPlugin } from '@modern-js/app-tools';
+import type { AppTools, CliPluginFuture } from '@modern-js/app-tools';
 import type {
   NestedRouteForCli,
   PageRoute,
@@ -23,110 +23,109 @@ import {
 export { isRouteEntry } from './entry';
 export { handleFileChange, handleModifyEntrypoints } from './handler';
 
-export const routerPlugin = (): CliPlugin<AppTools<'shared'>> => ({
+export const routerPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   name: '@modern-js/plugin-router',
   required: ['@modern-js/runtime'],
   setup: api => {
     const nestedRoutes: Record<string, unknown> = {};
     const nestedRoutesForServer: Record<string, unknown> = {};
-    return {
-      _internalRuntimePlugins({ entrypoint, plugins }) {
-        const { packageName, serverRoutes, metaName } = api.useAppContext();
-        const serverBase = serverRoutes
-          .filter(
-            (route: ServerRoute) => route.entryName === entrypoint.entryName,
-          )
-          .map(route => route.urlPath)
-          .sort((a, b) => (a.length - b.length > 0 ? -1 : 1));
-        const userConfig = api.useResolvedConfigContext();
-        const routerConfig = getEntryOptions(
-          entrypoint.entryName,
-          entrypoint.isMainEntry,
-          userConfig.runtime,
-          userConfig.runtimeByEntries,
-          packageName,
-        )?.router;
-        if (routerConfig && !isV5(userConfig)) {
-          plugins.push({
-            name: 'router',
-            path: `@${metaName}/runtime/router`,
-            config:
-              typeof routerConfig === 'boolean'
-                ? { serverBase }
-                : { ...routerConfig, serverBase },
-          });
-        }
 
-        return { entrypoint, plugins };
-      },
-      checkEntryPoint({ path, entry }) {
-        return { path, entry: entry || isRouteEntry(path) };
-      },
-      config() {
-        return {
-          source: {
-            include: [
-              // react-router v6 is no longer support ie 11
-              // so we need to compile these packages to ensure the compatibility
-              // https://github.com/remix-run/react-router/commit/f6df0697e1b2064a2b3a12e8b39577326fdd945b
-              /node_modules\/react-router/,
-              /node_modules\/react-router-dom/,
-              /node_modules\/@remix-run\/router/,
-            ],
-          },
-        };
-      },
-      async modifyEntrypoints({ entrypoints }) {
-        const newEntryPoints = await handleModifyEntrypoints(api, entrypoints);
-        return { entrypoints: newEntryPoints };
-      },
-      async generateEntryCode({ entrypoints }) {
-        await handleGeneratorEntryCode(api, entrypoints);
-      },
-      addRuntimeExports() {
-        const userConfig = api.useResolvedConfigContext();
-        const { internalDirectory, metaName } = api.useAppContext();
+    api._internalRuntimePlugins(({ entrypoint, plugins }) => {
+      const { packageName, serverRoutes, metaName } = api.getAppContext();
+      const serverBase = serverRoutes
+        .filter(
+          (route: ServerRoute) => route.entryName === entrypoint.entryName,
+        )
+        .map(route => route.urlPath)
+        .sort((a, b) => (a.length - b.length > 0 ? -1 : 1));
+      const userConfig = api.getNormalizedConfig();
+      const routerConfig = getEntryOptions(
+        entrypoint.entryName,
+        entrypoint.isMainEntry,
+        userConfig.runtime,
+        userConfig.runtimeByEntries,
+        packageName,
+      )?.router;
+      if (routerConfig && !isV5(userConfig)) {
+        plugins.push({
+          name: 'router',
+          path: `@${metaName}/runtime/router`,
+          config:
+            typeof routerConfig === 'boolean'
+              ? { serverBase }
+              : { ...routerConfig, serverBase },
+        });
+      }
 
-        const pluginsExportsUtils = createRuntimeExportsUtils(
-          internalDirectory,
-          'plugins',
+      return { entrypoint, plugins };
+    });
+    api.checkEntryPoint(({ path, entry }) => {
+      return { path, entry: entry || isRouteEntry(path) };
+    });
+    api.config(() => {
+      return {
+        source: {
+          include: [
+            // react-router v6 is no longer support ie 11
+            // so we need to compile these packages to ensure the compatibility
+            // https://github.com/remix-run/react-router/commit/f6df0697e1b2064a2b3a12e8b39577326fdd945b
+            /node_modules\/react-router/,
+            /node_modules\/react-router-dom/,
+            /node_modules\/@remix-run\/router/,
+          ],
+        },
+      };
+    });
+    api.modifyEntrypoints(async ({ entrypoints }) => {
+      const newEntryPoints = await handleModifyEntrypoints(api, entrypoints);
+      return { entrypoints: newEntryPoints };
+    });
+    api.generateEntryCode(async ({ entrypoints }) => {
+      await handleGeneratorEntryCode(api, entrypoints);
+    });
+    api.addRuntimeExports(() => {
+      const userConfig = api.useResolvedConfigContext();
+      const { internalDirectory, metaName } = api.useAppContext();
+
+      const pluginsExportsUtils = createRuntimeExportsUtils(
+        internalDirectory,
+        'plugins',
+      );
+      if (!isV5(userConfig)) {
+        pluginsExportsUtils.addExport(
+          `export { default as router } from '@${metaName}/runtime/router'`,
         );
-        if (!isV5(userConfig)) {
-          pluginsExportsUtils.addExport(
-            `export { default as router } from '@${metaName}/runtime/router'`,
-          );
-        }
-      },
-      async fileChange(e) {
-        await handleFileChange(api, e);
-      },
+      }
+    });
+    api.onFileChanged(async e => {
+      await handleFileChange(api, e);
+    });
 
-      async modifyFileSystemRoutes({ entrypoint, routes }) {
-        nestedRoutes[entrypoint.entryName] = routes;
-        nestedRoutesForServer[entrypoint.entryName] = filterRoutesForServer(
-          routes as (NestedRouteForCli | PageRoute)[],
-        );
+    api.modifyFileSystemRoutes(({ entrypoint, routes }) => {
+      nestedRoutes[entrypoint.entryName] = routes;
+      nestedRoutesForServer[entrypoint.entryName] = filterRoutesForServer(
+        routes as (NestedRouteForCli | PageRoute)[],
+      );
 
-        return {
-          entrypoint,
-          routes,
-        };
-      },
+      return {
+        entrypoint,
+        routes,
+      };
+    });
 
-      async beforeGenerateRoutes({ entrypoint, code }) {
-        const { distDirectory } = api.useAppContext();
+    api.onBeforeGenerateRoutes(async ({ entrypoint, code }) => {
+      const { distDirectory } = api.getAppContext();
 
-        await fs.outputJSON(
-          path.resolve(distDirectory, NESTED_ROUTE_SPEC_FILE),
-          nestedRoutesForServer,
-        );
+      await fs.outputJSON(
+        path.resolve(distDirectory, NESTED_ROUTE_SPEC_FILE),
+        nestedRoutesForServer,
+      );
 
-        return {
-          entrypoint,
-          code,
-        };
-      },
-    };
+      return {
+        entrypoint,
+        code,
+      };
+    });
   },
 });
 

--- a/packages/runtime/plugin-runtime/src/state/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/state/cli/index.ts
@@ -3,7 +3,7 @@ import { createRuntimeExportsUtils, getEntryOptions } from '@modern-js/utils';
 
 const PLUGIN_IDENTIFIER = 'state';
 
-export const statePlugin = (): CliPluginFuture<AppTools> => ({
+export const statePlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   name: '@modern-js/plugin-state',
 
   required: ['@modern-js/runtime'],

--- a/packages/runtime/plugin-runtime/src/state/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/state/cli/index.ts
@@ -1,48 +1,46 @@
-import type { AppTools, CliPlugin } from '@modern-js/app-tools';
+import type { AppTools, CliPluginFuture } from '@modern-js/app-tools';
 import { createRuntimeExportsUtils, getEntryOptions } from '@modern-js/utils';
 
 const PLUGIN_IDENTIFIER = 'state';
 
-export const statePlugin = (): CliPlugin<AppTools> => ({
+export const statePlugin = (): CliPluginFuture<AppTools> => ({
   name: '@modern-js/plugin-state',
 
   required: ['@modern-js/runtime'],
 
   setup: api => {
-    return {
-      _internalRuntimePlugins({ entrypoint, plugins }) {
-        const { entryName, isMainEntry } = entrypoint;
-        const userConfig = api.useResolvedConfigContext();
-        const { packageName, metaName } = api.useAppContext();
+    api._internalRuntimePlugins(({ entrypoint, plugins }) => {
+      const { entryName, isMainEntry } = entrypoint;
+      const userConfig = api.useResolvedConfigContext();
+      const { packageName, metaName } = api.useAppContext();
 
-        const stateConfig = getEntryOptions(
-          entryName,
-          isMainEntry,
-          userConfig.runtime,
-          userConfig.runtimeByEntries,
-          packageName,
-        )?.state;
-        if (stateConfig) {
-          plugins.push({
-            name: PLUGIN_IDENTIFIER,
-            path: `@${metaName}/runtime/model`,
-            config: typeof stateConfig === 'boolean' ? {} : stateConfig,
-          });
-        }
-        return { entrypoint, plugins };
-      },
-      addRuntimeExports() {
-        const { internalDirectory, metaName } = api.useAppContext();
+      const stateConfig = getEntryOptions(
+        entryName,
+        isMainEntry,
+        userConfig.runtime,
+        userConfig.runtimeByEntries,
+        packageName,
+      )?.state;
+      if (stateConfig) {
+        plugins.push({
+          name: PLUGIN_IDENTIFIER,
+          path: `@${metaName}/runtime/model`,
+          config: typeof stateConfig === 'boolean' ? {} : stateConfig,
+        });
+      }
+      return { entrypoint, plugins };
+    });
+    api.addRuntimeExports(() => {
+      const { internalDirectory, metaName } = api.useAppContext();
 
-        const pluginsExportsUtils = createRuntimeExportsUtils(
-          internalDirectory,
-          'plugins',
-        );
-        pluginsExportsUtils.addExport(
-          `export { default as state } from '@${metaName}/runtime/model'`,
-        );
-      },
-    };
+      const pluginsExportsUtils = createRuntimeExportsUtils(
+        internalDirectory,
+        'plugins',
+      );
+      pluginsExportsUtils.addExport(
+        `export { default as state } from '@${metaName}/runtime/model'`,
+      );
+    });
   },
 });
 

--- a/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
@@ -7,11 +7,7 @@ import {
 } from '@modern-js/plugin-v2';
 import { createContext, initPluginAPI } from '@modern-js/plugin-v2/cli';
 
-import type {
-  AppTools,
-  AppToolsContext,
-  AppToolsHooks,
-} from '@modern-js/app-tools';
+import type { AppTools, AppToolsContext } from '@modern-js/app-tools';
 import { getBundleEntry } from '../../../../solutions/app-tools/src/plugins/analyze/getBundleEntry';
 import { documentPlugin, getDocumenByEntryName } from '../../src/document/cli';
 

--- a/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
@@ -1,46 +1,70 @@
 import { existsSync } from 'fs';
 import path from 'path';
-import { type CliPlugin, type IAppContext, manager } from '@modern-js/core';
+import {
+  type CLIPluginAPI,
+  type Plugin,
+  createPluginManager,
+} from '@modern-js/plugin-v2';
+import { createContext, initPluginAPI } from '@modern-js/plugin-v2/cli';
 
+import type {
+  AppTools,
+  AppToolsContext,
+  AppToolsHooks,
+} from '@modern-js/app-tools';
 import { getBundleEntry } from '../../../../solutions/app-tools/src/plugins/analyze/getBundleEntry';
 import { documentPlugin, getDocumenByEntryName } from '../../src/document/cli';
 
 describe('plugin runtime cli', () => {
-  const main = manager.clone().usePlugin(documentPlugin as CliPlugin);
-  let runner: any;
-
+  let pluginAPI: CLIPluginAPI<AppTools>;
+  const setup = async ({ appDirectory }: { appDirectory: string }) => {
+    const pluginManager = createPluginManager();
+    pluginManager.addPlugins([documentPlugin() as Plugin]);
+    const plugins = pluginManager.getPlugins();
+    const context = await createContext<AppTools>({
+      appContext: {
+        appDirectory,
+        plugins,
+      } as any,
+      config: {},
+      normalizedConfig: { plugins: [] } as any,
+    });
+    pluginAPI = initPluginAPI<AppTools>({
+      context,
+      pluginManager,
+    });
+    context.pluginAPI = pluginAPI;
+    for (const plugin of plugins) {
+      await plugin.setup(pluginAPI);
+    }
+  };
   beforeAll(async () => {
-    runner = await main.init();
+    await setup({ appDirectory: path.join(__dirname, './feature') });
   });
-
   it('plugin is defined', () => {
     expect(documentPlugin).toBeDefined();
   });
 
   it('plugin-document cli config is defined', async () => {
-    const config = await runner.config();
+    const hooks = pluginAPI.getHooks();
+    const config = await hooks.config.call();
     expect(config.find((item: any) => item.tools)).toBeTruthy();
     expect(config.find((item: any) => item.tools.htmlPlugin)).toBeTruthy();
   });
 
   it('plugin-document htmlPlugin can return the right', async () => {
-    const mockAPI = {
-      useAppContext: jest.fn((): any => ({
-        internalDirectory: path.join(__dirname, './feature'),
-        appDirectory: path.join(__dirname, './feature'),
-        entrypoints: [
-          {
-            entryName: 'main',
-            absoluteEntryDir: path.join(__dirname, './feature'),
-          },
-        ],
-      })),
-    };
-    const cloned = manager.clone(mockAPI);
-    cloned.usePlugin(documentPlugin as CliPlugin);
-    const runner2 = await cloned.init();
-    const config = await runner2.config();
-
+    pluginAPI.updateAppContext({
+      internalDirectory: path.join(__dirname, './feature'),
+      appDirectory: path.join(__dirname, './feature'),
+      entrypoints: [
+        {
+          entryName: 'main',
+          absoluteEntryDir: path.join(__dirname, './feature'),
+        },
+      ],
+    });
+    const hooks = pluginAPI.getHooks();
+    const config = await hooks.config.call();
     const { htmlPlugin } = (
       config.find((item: any) => item.tools.htmlPlugin)! as any
     ).tools;
@@ -77,12 +101,13 @@ describe('plugin runtime cli', () => {
     ).toBeTruthy();
   });
   it('when user config set empty entries and disableDefaultEntries true, should get the ', async () => {
+    const hooks: any = pluginAPI.getHooks();
     const entries = await getBundleEntry(
-      runner,
+      hooks,
       {
         internalDirectory: path.join(__dirname, './feature'),
         appDirectory: path.join(__dirname, './feature'),
-      } as IAppContext,
+      } as AppToolsContext<'shared'>,
       {
         source: {
           disableDefaultEntries: true,

--- a/packages/solutions/app-tools/src/compat/index.ts
+++ b/packages/solutions/app-tools/src/compat/index.ts
@@ -1,12 +1,7 @@
-import { createAsyncHook, createCollectAsyncHook } from '@modern-js/plugin-v2';
-import type { Entrypoint } from '@modern-js/types';
+import { createAsyncHook } from '@modern-js/plugin-v2';
 import type { AppTools, CliPluginFuture } from '../types';
 import { getHookRunners } from './hooks';
 
-type AppendEntryCodeFn = (params: {
-  entrypoint: Entrypoint;
-  code: string;
-}) => string | Promise<string>;
 type JestConfigFn = (
   utils: any,
   next: (utils: any) => any,
@@ -39,7 +34,6 @@ export const compatPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
     };
   },
   registryHooks: {
-    appendEntryCode: createCollectAsyncHook<AppendEntryCodeFn>(),
     jestConfig: createAsyncHook<JestConfigFn>(),
     afterTest: createAsyncHook<AfterTestFn>(),
   },

--- a/packages/solutions/app-tools/src/types/new.ts
+++ b/packages/solutions/app-tools/src/types/new.ts
@@ -154,6 +154,7 @@ export type AppToolsExtendContext<B extends Bundler = 'webpack'> = {
   apiDirectory: string;
   lambdaDirectory: string;
   serverConfigFile: string;
+  runtimeConfigFile: string;
   serverPlugins: ServerPlugin[];
   moduleType: 'module' | 'commonjs';
   /** Information for entry points */

--- a/packages/solutions/app-tools/src/utils/initAppContext.ts
+++ b/packages/solutions/app-tools/src/utils/initAppContext.ts
@@ -9,7 +9,7 @@ export const initAppContext = ({
   tempDir,
 }: {
   appDirectory: string;
-  runtimeConfigFile: string | false;
+  runtimeConfigFile: string;
   options?: {
     metaName?: string;
     srcDir?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2213,9 +2213,9 @@ importers:
 
   packages/runtime/plugin-garfish:
     dependencies:
-      '@modern-js/plugin':
+      '@modern-js/plugin-v2':
         specifier: workspace:*
-        version: link:../../toolkit/plugin
+        version: link:../../toolkit/plugin-v2
       '@modern-js/runtime-utils':
         specifier: workspace:*
         version: link:../../toolkit/runtime-utils
@@ -2310,6 +2310,9 @@ importers:
       '@modern-js/plugin':
         specifier: workspace:*
         version: link:../../toolkit/plugin
+      '@modern-js/plugin-v2':
+        specifier: workspace:*
+        version: link:../../toolkit/plugin-v2
       '@modern-js/runtime-utils':
         specifier: workspace:*
         version: link:../../toolkit/runtime-utils
@@ -2419,6 +2422,9 @@ importers:
       '@modern-js/plugin-data-loader':
         specifier: workspace:*
         version: link:../../cli/plugin-data-loader
+      '@modern-js/plugin-v2':
+        specifier: workspace:*
+        version: link:../../toolkit/plugin-v2
       '@modern-js/runtime-utils':
         specifier: workspace:*
         version: link:../../toolkit/runtime-utils
@@ -2471,9 +2477,6 @@ importers:
       '@modern-js/app-tools':
         specifier: workspace:*
         version: link:../../solutions/app-tools
-      '@modern-js/core':
-        specifier: workspace:*
-        version: link:../../cli/core
       '@remix-run/web-fetch':
         specifier: ^4.1.3
         version: 4.4.2
@@ -3808,10 +3811,10 @@ importers:
         version: link:../../toolkit/utils
       '@storybook/react':
         specifier: ~7.6.1
-        version: 7.6.20(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+        version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       storybook:
         specifier: ~7.6.1
-        version: 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        version: 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     devDependencies:
       '@storybook/types':
         specifier: ~7.6.12
@@ -27381,7 +27384,7 @@ snapshots:
       '@storybook/components': 7.6.20(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 7.6.20
       '@storybook/csf': 0.1.11
-      '@storybook/docs-tools': 7.6.20(encoding@0.1.13)
+      '@storybook/docs-tools': 7.6.20
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/preview-api': 7.6.20
@@ -27407,7 +27410,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-manager@7.6.20(encoding@0.1.13)':
+  '@storybook/builder-manager@7.6.20':
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -27438,7 +27441,7 @@ snapshots:
       telejson: 7.2.0
       tiny-invariant: 1.3.3
 
-  '@storybook/cli@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@storybook/cli@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
@@ -27447,10 +27450,10 @@ snapshots:
       '@storybook/codemod': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-events': 7.6.20
-      '@storybook/core-server': 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@storybook/core-server': 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@storybook/csf-tools': 7.6.20
       '@storybook/node-logger': 7.6.20
-      '@storybook/telemetry': 7.6.20(encoding@0.1.13)
+      '@storybook/telemetry': 7.6.20
       '@storybook/types': 7.6.20
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
@@ -27565,11 +27568,11 @@ snapshots:
     dependencies:
       ts-dedent: 2.2.0
 
-  '@storybook/core-server@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@storybook/core-server@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 7.6.20(encoding@0.1.13)
+      '@storybook/builder-manager': 7.6.20
       '@storybook/channels': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-events': 7.6.20
@@ -27580,7 +27583,7 @@ snapshots:
       '@storybook/manager': 7.6.20
       '@storybook/node-logger': 7.6.20
       '@storybook/preview-api': 7.6.20
-      '@storybook/telemetry': 7.6.20(encoding@0.1.13)
+      '@storybook/telemetry': 7.6.20
       '@storybook/types': 7.6.20
       '@types/detect-port': 1.3.5
       '@types/node': 18.19.64
@@ -27641,7 +27644,7 @@ snapshots:
 
   '@storybook/docs-mdx@0.1.0': {}
 
-  '@storybook/docs-tools@7.6.20(encoding@0.1.13)':
+  '@storybook/docs-tools@7.6.20':
     dependencies:
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/preview-api': 7.6.20
@@ -27730,11 +27733,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react@7.6.20(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
+  '@storybook/react@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
     dependencies:
       '@storybook/client-logger': 7.6.20
       '@storybook/core-client': 7.6.20
-      '@storybook/docs-tools': 7.6.20(encoding@0.1.13)
+      '@storybook/docs-tools': 7.6.20
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.20
       '@storybook/react-dom-shim': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -27767,7 +27770,7 @@ snapshots:
       memoizerific: 1.11.3
       qs: 6.13.0
 
-  '@storybook/telemetry@7.6.20(encoding@0.1.13)':
+  '@storybook/telemetry@7.6.20':
     dependencies:
       '@storybook/client-logger': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -38351,9 +38354,9 @@ snapshots:
 
   store2@2.14.3: {}
 
-  storybook@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10):
+  storybook@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
-      '@storybook/cli': 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@storybook/cli': 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - encoding


### PR DESCRIPTION
## Summary
migrate runtime cli plugin to new cli plugin
- @modern-js/runtime
- @modern-js/plugin-ssr
- @modern-js/plugin-router
- @modern-js/plugin-state
- @modern-js/plugin-document
- @modern-js/plugin-router-v5
- @modern-js/plugin-garfish

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
