### PR TITLE
chore: getServerManifest should run first on prepare

### DIFF
--- a/.changeset/tasty-ears-bake.md
+++ b/.changeset/tasty-ears-bake.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+chore: `getServerManifest` should run first on `prepare`
+chore: `getServerManifest` 应该在 `prepare` 时运行

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -9,6 +9,7 @@ import {
   ROUTE_MANIFEST_FILE,
   SERVER_BUNDLE_DIRECTORY,
   compatibleRequire,
+  isProd,
 } from '@modern-js/utils';
 import type {
   Middleware,
@@ -146,6 +147,11 @@ export const injectResourcePlugin = (): ServerPlugin => ({
     return {
       async prepare() {
         const { middlewares, routes, distDirectory: pwd } = api.useAppContext();
+
+        // In Production, should warmup server bundles on prepare.
+        if (isProd()) {
+          getServerManifest(pwd, routes || [], console);
+        }
 
         middlewares.push({
           name: 'inject-server-manifest',


### PR DESCRIPTION
## Summary

Now `getServerManifest` is running at middleware, so that after server inited, the first visit will need load all server bundles.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
