### PR TITLE
feat: support loadable with async entry

### DIFF
--- a/packages/server/core/src/plugins/render/ssrRender.ts
+++ b/packages/server/core/src/plugins/render/ssrRender.ts
@@ -150,7 +150,7 @@ class IncomingMessgeProxy {
 function createRequestHandlerConfig(
   userConfig: UserConfig,
 ): RequestHandlerConfig {
-  const { output, server, security, html } = userConfig;
+  const { output, server, security, html, source } = userConfig;
 
   return {
     ssr: server?.ssr,
@@ -161,5 +161,6 @@ function createRequestHandlerConfig(
     crossorigin: html?.crossorigin,
     scriptLoading: html?.scriptLoading,
     useJsonScript: server?.useJsonScript,
+    enableAsyncEntry: source?.enableAsyncEntry,
   };
 }

--- a/packages/server/core/src/types/config/source.ts
+++ b/packages/server/core/src/types/config/source.ts
@@ -3,6 +3,7 @@ import type { ConfigChain } from './share';
 
 export interface SourceUserConfig {
   alias?: ConfigChain<Alias>;
+  enableAsyncEntry?: boolean;
 }
 
 export type SourceNormalizedConfig = SourceUserConfig;

--- a/packages/server/core/src/types/requestHandler.ts
+++ b/packages/server/core/src/types/requestHandler.ts
@@ -1,5 +1,5 @@
 import type { Logger, Metrics, Reporter, ServerRoute } from '@modern-js/types';
-import type { ServerUserConfig } from './config';
+import type { ServerUserConfig, SourceUserConfig } from './config';
 
 export type Resource = {
   loadableStats: Record<string, any>;
@@ -20,6 +20,7 @@ export type RequestHandlerConfig = {
   ssr?: ServerUserConfig['ssr'];
   ssrByEntries?: ServerUserConfig['ssrByEntries'];
   useJsonScript?: ServerUserConfig['useJsonScript'];
+  enableAsyncEntry?: SourceUserConfig['enableAsyncEntry'];
 };
 
 export type LoaderContext = Map<string, any>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7138,6 +7138,34 @@ importers:
         specifier: ^5
         version: 5.3.3
 
+  tests/integration/ssr/fixtures/base-async-entry:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../../packages/solutions/app-tools
+      '@modern-js/tsconfig':
+        specifier: workspace:*
+        version: link:../../../../../packages/tsconfig
+      '@types/react':
+        specifier: ^18.3.11
+        version: 18.3.16
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.5(@types/react@18.3.16)
+      typescript:
+        specifier: ^5
+        version: 5.6.3
+
   tests/integration/ssr/fixtures/base-json:
     dependencies:
       '@modern-js/runtime':

--- a/tests/integration/ssr/fixtures/base-async-entry/modern.config.ts
+++ b/tests/integration/ssr/fixtures/base-async-entry/modern.config.ts
@@ -1,0 +1,15 @@
+import { applyBaseConfig } from '../../../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  runtime: {
+    router: true,
+  },
+  server: {
+    ssr: {
+      disablePrerender: true,
+    },
+  },
+  source: {
+    enableAsyncEntry: true,
+  },
+});

--- a/tests/integration/ssr/fixtures/base-async-entry/package.json
+++ b/tests/integration/ssr/fixtures/base-async-entry/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ssr-base-async-entry-test",
+  "version": "2.9.0",
+  "private": true,
+  "scripts": {
+    "dev": "modern dev"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/tsconfig": "workspace:*",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
+    "typescript": "^5"
+  }
+}

--- a/tests/integration/ssr/fixtures/base-async-entry/src/modern-app-env.d.ts
+++ b/tests/integration/ssr/fixtures/base-async-entry/src/modern-app-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@modern-js/runtime/types' />
+/// <reference types='@modern-js/runtime/types/router' />

--- a/tests/integration/ssr/fixtures/base-async-entry/src/routes/index.css
+++ b/tests/integration/ssr/fixtures/base-async-entry/src/routes/index.css
@@ -1,0 +1,3 @@
+body {
+  background-color: #f0f0f0;
+}

--- a/tests/integration/ssr/fixtures/base-async-entry/src/routes/layout.tsx
+++ b/tests/integration/ssr/fixtures/base-async-entry/src/routes/layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from '@modern-js/runtime/router';
+import './index.css';
+
+export default function Layout() {
+  return (
+    <div>
+      Root layout
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/ssr/fixtures/base-async-entry/src/routes/page.tsx
+++ b/tests/integration/ssr/fixtures/base-async-entry/src/routes/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>hello</div>;
+}

--- a/tests/integration/ssr/fixtures/base-async-entry/tsconfig.json
+++ b/tests/integration/ssr/fixtures/base-async-entry/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"],
+      "@api/*": ["./api/*"]
+    }
+  },
+  "include": ["src", "shared", "config", "modern.config.ts", "api", "server"]
+}

--- a/tests/integration/ssr/tests/base-async-entry.test.ts
+++ b/tests/integration/ssr/tests/base-async-entry.test.ts
@@ -1,0 +1,82 @@
+import dns from 'node:dns';
+import path, { join } from 'path';
+import { fs } from '@modern-js/utils';
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchApp,
+  launchOptions,
+} from '../../../utils/modernTestUtils';
+
+const fixtureDir = path.resolve(__dirname, '../fixtures');
+
+dns.setDefaultResultOrder('ipv4first');
+
+jest.setTimeout(1000 * 20);
+
+describe('init with SSR', () => {
+  let app: any;
+  let appPort: number;
+  let page: Page;
+  let browser: Browser;
+  let appDir: string;
+
+  beforeAll(async () => {
+    appDir = join(fixtureDir, 'base-async-entry');
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort);
+
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    if (browser) {
+      browser.close();
+    }
+    if (app) {
+      await killApp(app);
+    }
+  });
+
+  test('should get assets correctly', async () => {
+    page.setJavaScriptEnabled(false);
+    await page.goto(`http://localhost:${appPort}`, {
+      waitUntil: 'load',
+    });
+    const scriptAry = await page.$$eval('body > script', scripts =>
+      scripts
+        .filter(script => script.src && script.type !== 'application/json')
+        .map(script => {
+          return new URL(script.src).pathname;
+        }),
+    );
+    const cssAry = await page.$$eval('head > link', links =>
+      links
+        .filter(link => link.rel === 'stylesheet')
+        .map(link => {
+          return new URL(link.href).pathname;
+        }),
+    );
+
+    const loadableStats = fs.readJSONSync(
+      path.join(appDir, 'dist/loadable-stats.json'),
+    );
+    const chunks = loadableStats.namedChunkGroups['async-main'].assets;
+    const urls: string[] = chunks.map((chunk: { name: string }) => {
+      return `/${chunk.name}`;
+    });
+    const existAssets = loadableStats.entrypoints.main.assets.map(
+      (asset: { name: string }) => `/${asset.name}`,
+    );
+
+    const allInHTML = urls.every(
+      url =>
+        existAssets.includes(url) ||
+        scriptAry.includes(url) ||
+        cssAry.includes(url),
+    );
+    expect(allInHTML).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

In this PR, we support preload entrypoint's assets when we enable async entry and use loadable.

and it's already support in React 18 Streaming SSR with React Lazy.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
