### PR TITLE
fix: compat jest plugin hooks

### DIFF
--- a/.changeset/cool-cooks-sell.md
+++ b/.changeset/cool-cooks-sell.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: compat jest plugin hooks
+
+fix: 兼容 jest 插件 hooks 函数

--- a/packages/solutions/app-tools/src/compat/hooks.ts
+++ b/packages/solutions/app-tools/src/compat/hooks.ts
@@ -209,9 +209,9 @@ export function handleSetupResult(
             params,
           );
           if (isMultiple) {
-            transformHookResult(key, await fn(...transformParams));
+            return transformHookResult(key, await fn(...transformParams));
           } else {
-            transformHookResult(key, await fn(transformParams));
+            return transformHookResult(key, await fn(transformParams));
           }
         });
       }

--- a/packages/solutions/app-tools/src/compat/index.ts
+++ b/packages/solutions/app-tools/src/compat/index.ts
@@ -41,7 +41,7 @@ export const compatPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   registryHooks: {
     appendEntryCode: createCollectAsyncHook<AppendEntryCodeFn>(),
     jestConfig: createAsyncHook<JestConfigFn>(),
-    afterHest: createAsyncHook<AfterTestFn>(),
+    afterTest: createAsyncHook<AfterTestFn>(),
   },
   setup: api => {
     api.updateAppContext({

--- a/packages/solutions/app-tools/src/compat/index.ts
+++ b/packages/solutions/app-tools/src/compat/index.ts
@@ -1,4 +1,4 @@
-import { createCollectAsyncHook } from '@modern-js/plugin-v2';
+import { createAsyncHook, createCollectAsyncHook } from '@modern-js/plugin-v2';
 import type { Entrypoint } from '@modern-js/types';
 import type { AppTools, CliPluginFuture } from '../types';
 import { getHookRunners } from './hooks';
@@ -7,6 +7,11 @@ type AppendEntryCodeFn = (params: {
   entrypoint: Entrypoint;
   code: string;
 }) => string | Promise<string>;
+type JestConfigFn = (
+  utils: any,
+  next: (utils: any) => any,
+) => void | Promise<void>;
+type AfterTestFn = () => void | Promise<void>;
 
 export const compatPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   name: '@modern-js/app-tools-compat',
@@ -35,6 +40,8 @@ export const compatPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   },
   registryHooks: {
     appendEntryCode: createCollectAsyncHook<AppendEntryCodeFn>(),
+    jestConfig: createAsyncHook<JestConfigFn>(),
+    afterHest: createAsyncHook<AfterTestFn>(),
   },
   setup: api => {
     api.updateAppContext({

--- a/packages/solutions/app-tools/src/compat/utils.ts
+++ b/packages/solutions/app-tools/src/compat/utils.ts
@@ -48,6 +48,10 @@ export function transformHookRunner(hookRunnerName: string) {
   }
 }
 
+/**
+ * Note:
+ * isMultiple Indicates whether the function parameter represents multiple values.
+ */
 export function transformHookParams(hookRunnerName: string, params: any) {
   switch (hookRunnerName) {
     case 'resolvedConfig':

--- a/packages/solutions/app-tools/src/compat/utils.ts
+++ b/packages/solutions/app-tools/src/compat/utils.ts
@@ -52,19 +52,34 @@ export function transformHookParams(hookRunnerName: string, params: any) {
   switch (hookRunnerName) {
     case 'resolvedConfig':
       return {
-        resolved: params,
+        isMultiple: false,
+        params: {
+          resolved: params[0],
+        },
       };
     case 'htmlPartials':
       return {
-        partials: {
-          top: params.partials.top.current,
-          head: params.partials.head.current,
-          body: params.partials.body.current,
+        isMultiple: false,
+        params: {
+          partials: {
+            top: params.partials.top.current,
+            head: params.partials.head.current,
+            body: params.partials.body.current,
+          },
+          entrypoint: params.entrypoint,
         },
-        entrypoint: params.entrypoint,
       };
+    case 'jestConfig': {
+      return {
+        isMultiple: true,
+        params: params,
+      };
+    }
     default:
-      return params;
+      return {
+        isMultiple: false,
+        params: params[0],
+      };
   }
 }
 


### PR DESCRIPTION
## Summary

Adds compatibility for Jest plugins hooks.

Due to the presence of multiple parameters in the jestConfig hook, the `transformHookParams` function add 
`isMultiple` flag to indicate whether the current parameter is multiple, ensuring correct function execution.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
