### PR TITLE
fix: shoud not overrides cache when request has tail slash

### DIFF
--- a/.changeset/purple-parrots-admire.md
+++ b/.changeset/purple-parrots-admire.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: cache should not be overrides when request has tail slash
+fix: 当请求有尾斜杠时，缓存不应该被重写

--- a/packages/server/core/src/plugins/render/ssrCache.ts
+++ b/packages/server/core/src/plugins/render/ssrCache.ts
@@ -6,6 +6,7 @@ import type {
   CacheOptionProvider,
   Container,
 } from '@modern-js/types';
+import { removeTailSlash } from '@modern-js/utils';
 import { X_RENDER_CACHE } from '../../constants';
 import type {
   RequestHandler,
@@ -120,7 +121,7 @@ function computedKey(req: Request, cacheControl: CacheControl): string {
   // examples:
   // pathname1: '/api', pathname2: '/api/'
   // pathname1 as same as pathname2
-  const defaultKey = pathname.replace(/.+\/+$/, '');
+  const defaultKey = pathname === '/' ? pathname : removeTailSlash(pathname);
 
   if (customKey) {
     if (typeof customKey === 'string') {


### PR DESCRIPTION
## Summary

before this PR, any SSR request which url has tail slash will be treat as same cache key.

it will cause page Infinite refresh with the logic in router runtime plugin.

this PR fix it.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
