### PR TITLE
chore: remove server data parse in convention routes

### DIFF
--- a/.changeset/young-trains-judge.md
+++ b/.changeset/young-trains-judge.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-router-v5': patch
+'@modern-js/runtime': patch
+---
+
+chore: remove server data parse when use convention routes
+chore: 移除约定式路由时解析 server data 的逻辑

--- a/packages/runtime/plugin-router-v5/src/runtime/plugin.tsx
+++ b/packages/runtime/plugin-router-v5/src/runtime/plugin.tsx
@@ -23,17 +23,6 @@ import {
 import { modifyRoutesHook } from './hooks';
 import { getLocation, renderRoutes, urlJoin } from './utils';
 
-declare global {
-  interface Window {
-    _SERVER_DATA?: {
-      router: {
-        baseUrl: string;
-        params: Record<string, string>;
-      };
-    };
-  }
-}
-
 export type SingleRouteConfig = RouteProps & {
   redirect?: string;
   routes?: SingleRouteConfig[];
@@ -115,19 +104,12 @@ export const routerPlugin = (userConfig: RouterConfig = {}): Plugin => {
 
           const select = (pathname: string) =>
             serverBase.find(baseUrl => pathname.search(baseUrl) === 0) || '/';
-          if (isBrow) {
-            window._SERVER_DATA = parsedJSONFromElement(
-              '__MODERN_SERVER_DATA__',
-            );
-          }
+
           const getRouteApp = () => {
             if (isBrow) {
               return (props: any) => {
                 const runtimeContext = useContext(RuntimeReactContext);
-                const baseUrl = (
-                  window._SERVER_DATA?.router.baseUrl ||
-                  select(location.pathname)
-                ).replace(/^\/*/, '/');
+                const baseUrl = select(location.pathname).replace(/^\/*/, '/');
                 const basename =
                   baseUrl === '/'
                     ? urlJoin(

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -47,7 +47,6 @@ export const routerPlugin = (
     },
     setup: api => {
       let routes: RouteObject[] = [];
-      window._SERVER_DATA = parsedJSONFromElement('__MODERN_SERVER_DATA__');
       return {
         beforeRender(context) {
           // for garfish plugin to get basename,
@@ -98,9 +97,7 @@ export const routerPlugin = (
                * _internalRouterBaseName: garfish plugin params, priority
                * basename: modern config file config
                */
-              const baseUrl = (
-                window._SERVER_DATA?.router.baseUrl || select(location.pathname)
-              ).replace(/^\/*/, '/');
+              const baseUrl = select(location.pathname).replace(/^\/*/, '/');
               const _basename =
                 baseUrl === '/'
                   ? urlJoin(

--- a/packages/runtime/plugin-runtime/src/router/runtime/types.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/types.ts
@@ -6,17 +6,6 @@ import type {
 } from '@modern-js/runtime-utils/router';
 import type { NestedRoute, PageRoute } from '@modern-js/types';
 
-declare global {
-  interface Window {
-    _SERVER_DATA?: {
-      router: {
-        baseUrl: string;
-        params: Record<string, string>;
-      };
-    };
-  }
-}
-
 export type SingleRouteConfig = RouteProps & {
   redirect?: string;
   routes?: SingleRouteConfig[];

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -80,6 +80,7 @@ function matchRoute(
 
   const result = matched[0][0];
 
+  // here we can parse the dynamic server routes params
   return result || [];
 }
 
@@ -237,14 +238,6 @@ async function renderHandler(
   mode: 'ssr' | 'csr',
   onError: (e: unknown) => Promise<void>,
 ) {
-  // inject server.baseUrl message
-  const serverData = {
-    router: {
-      baseUrl: options.routeInfo.urlPath,
-      params: options.params,
-    },
-  };
-
   let response: Response | null = null;
 
   const { serverManifest } = options;

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -301,12 +301,10 @@ async function renderHandler(
     response = csrRender(options.html);
   }
 
-  const newRes = transformResponse(response, injectServerData(serverData));
-
   const { routeInfo } = options;
-  applyExtendHeaders(newRes, routeInfo);
+  applyExtendHeaders(response, routeInfo);
 
-  return newRes;
+  return response;
 
   function applyExtendHeaders(r: Response, route: ServerRoute) {
     Object.entries(route.responseHeaders || {}).forEach(([k, v]) => {
@@ -356,16 +354,4 @@ function csrRender(html: string): Response {
       [X_MODERNJS_RENDER]: 'client',
     }),
   });
-}
-
-function injectServerData(serverData: Record<string, any>) {
-  const { head } = REPLACE_REG.before;
-  const searchValue = new RegExp(head);
-
-  const replcaeCb = (beforeHead: string) =>
-    `${beforeHead}<script type="application/json" id="__MODERN_SERVER_DATA__">${JSON.stringify(
-      serverData,
-    )}</script>`;
-
-  return (template: string) => template.replace(searchValue, replcaeCb);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3808,10 +3808,10 @@ importers:
         version: link:../../toolkit/utils
       '@storybook/react':
         specifier: ~7.6.1
-        version: 7.6.20(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
+        version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)
       storybook:
         specifier: ~7.6.1
-        version: 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        version: 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     devDependencies:
       '@storybook/types':
         specifier: ~7.6.12
@@ -27381,7 +27381,7 @@ snapshots:
       '@storybook/components': 7.6.20(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 7.6.20
       '@storybook/csf': 0.1.11
-      '@storybook/docs-tools': 7.6.20(encoding@0.1.13)
+      '@storybook/docs-tools': 7.6.20
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/preview-api': 7.6.20
@@ -27407,7 +27407,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-manager@7.6.20(encoding@0.1.13)':
+  '@storybook/builder-manager@7.6.20':
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -27438,7 +27438,7 @@ snapshots:
       telejson: 7.2.0
       tiny-invariant: 1.3.3
 
-  '@storybook/cli@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@storybook/cli@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
@@ -27447,10 +27447,10 @@ snapshots:
       '@storybook/codemod': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-events': 7.6.20
-      '@storybook/core-server': 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@storybook/core-server': 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@storybook/csf-tools': 7.6.20
       '@storybook/node-logger': 7.6.20
-      '@storybook/telemetry': 7.6.20(encoding@0.1.13)
+      '@storybook/telemetry': 7.6.20
       '@storybook/types': 7.6.20
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
@@ -27565,11 +27565,11 @@ snapshots:
     dependencies:
       ts-dedent: 2.2.0
 
-  '@storybook/core-server@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@storybook/core-server@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 7.6.20(encoding@0.1.13)
+      '@storybook/builder-manager': 7.6.20
       '@storybook/channels': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-events': 7.6.20
@@ -27580,7 +27580,7 @@ snapshots:
       '@storybook/manager': 7.6.20
       '@storybook/node-logger': 7.6.20
       '@storybook/preview-api': 7.6.20
-      '@storybook/telemetry': 7.6.20(encoding@0.1.13)
+      '@storybook/telemetry': 7.6.20
       '@storybook/types': 7.6.20
       '@types/detect-port': 1.3.5
       '@types/node': 18.19.64
@@ -27641,7 +27641,7 @@ snapshots:
 
   '@storybook/docs-mdx@0.1.0': {}
 
-  '@storybook/docs-tools@7.6.20(encoding@0.1.13)':
+  '@storybook/docs-tools@7.6.20':
     dependencies:
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/preview-api': 7.6.20
@@ -27730,11 +27730,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react@7.6.20(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
+  '@storybook/react@7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.3.3)':
     dependencies:
       '@storybook/client-logger': 7.6.20
       '@storybook/core-client': 7.6.20
-      '@storybook/docs-tools': 7.6.20(encoding@0.1.13)
+      '@storybook/docs-tools': 7.6.20
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.20
       '@storybook/react-dom-shim': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -27767,7 +27767,7 @@ snapshots:
       memoizerific: 1.11.3
       qs: 6.13.0
 
-  '@storybook/telemetry@7.6.20(encoding@0.1.13)':
+  '@storybook/telemetry@7.6.20':
     dependencies:
       '@storybook/client-logger': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -38351,9 +38351,9 @@ snapshots:
 
   store2@2.14.3: {}
 
-  storybook@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10):
+  storybook@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
-      '@storybook/cli': 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@storybook/cli': 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - encoding


### PR DESCRIPTION
## Summary

In the past, we supported server routing dynamic parameters:

```ts
{
  server: {
    routes: {
      main: "/:id"
    }
  }
}
```

Then user can get the params from `useRuntimeContext().context.params`, and it will inject a script into the HTML

But this feature is not compatible with conventional routing, the script will be parsed in router runtime plugin and cause conventional routing render error. In this PR,  we remove the logic in route runtime plugin.

Now the user can still use this features in self-control route.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
