### PR TITLE
feat: adjust cli plugin type

### DIFF
--- a/.changeset/smart-lamps-shout.md
+++ b/.changeset/smart-lamps-shout.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/plugin-v2': patch
+---
+
+feat: adjust cli plugin type
+
+feat: 调整 CLI 插件类型定义

--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -59,6 +59,17 @@ export async function run({
     customConfigFile = cliParams['config-file'];
   }
 
+  // set NODE_ENV value because configFile may use
+  if (!process.env.NODE_ENV) {
+    if (['build', 'serve', 'deploy', 'analyze'].includes(command)) {
+      process.env.NODE_ENV = 'production';
+    } else if (command === 'test') {
+      process.env.NODE_ENV = 'test';
+    } else {
+      process.env.NODE_ENV = 'development';
+    }
+  }
+
   const appDirectory = await initAppDir(cwd);
   const finalConfigFile = customConfigFile || getConfigFile(configFile);
   const autoLoadPlugins = await isAutoLoadPlugins(

--- a/packages/solutions/app-tools/src/types/new.ts
+++ b/packages/solutions/app-tools/src/types/new.ts
@@ -145,7 +145,7 @@ export interface AppToolsExtendHooks
   addRuntimeExports: AsyncHook<AddRuntimeExportsFn>;
 }
 
-export type AppToolsExtendContext<B extends Bundler = 'webpack'> = {
+export interface AppToolsExtendContext<B extends Bundler = 'webpack'> {
   metaName: string;
   internalDirectory: string;
   sharedDirectory: string;
@@ -180,7 +180,7 @@ export type AppToolsExtendContext<B extends Bundler = 'webpack'> = {
    * @deprecated compat old plugin, default is app tools
    */
   toolsType?: string;
-};
+}
 
 export type AppToolsContext<B extends Bundler = 'webpack'> = AppContext<
   AppTools<B>

--- a/packages/toolkit/plugin-v2/src/types/plugin.ts
+++ b/packages/toolkit/plugin-v2/src/types/plugin.ts
@@ -29,7 +29,7 @@ export type Plugin<PluginAPI = {}, Context = {}> = {
    * This function is called once when the plugin is initialized.
    * @param api provides the context info, utility functions and lifecycle hooks.
    */
-  setup: (api: PluginAPI) => MaybePromise<void>;
+  setup?: (api: PluginAPI) => MaybePromise<void>;
   /**
    * Declare the names of pre-plugins, which will be executed before the current plugin.
    */


### PR DESCRIPTION
## Summary
- CLI plugin setup function allow not define
- app tools AppToolsExtendContext type use interface
- app tools add NODE_ENV value before load config file

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
