### PR TITLE
fix(uni-builder): no need to set html-webpack-plugin

### DIFF
--- a/packages/cli/uni-builder/src/webpack/index.ts
+++ b/packages/cli/uni-builder/src/webpack/index.ts
@@ -167,15 +167,6 @@ export async function createWebpackBuilder(
   });
 
   const { webpackProvider } = await import('@rsbuild/webpack');
-  const {
-    __internalHelper: { setHTMLPlugin },
-  } = await import('@rsbuild/core');
-
-  const { default: HtmlWebpackPlugin } = await import('html-webpack-plugin');
-
-  // Some third-party plug-ins depend on html-webpack-plugin, like sri
-  // @ts-expect-error compilation type mismatch
-  setHTMLPlugin(HtmlWebpackPlugin);
 
   rsbuildConfig.provider = webpackProvider;
 


### PR DESCRIPTION
## Summary

rsbuild already use html-webpack-plugin by default in webpack mode.

https://github.com/web-infra-dev/rsbuild/pull/4175

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
