### PR TITLE
fix: support unstable middleware hot reload

### DIFF
--- a/.changeset/pretty-ravens-unite.md
+++ b/.changeset/pretty-ravens-unite.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-server': patch
+---
+
+fix: support unstable middleware hot reload
+fix: 支持 unstable middleware 热更新

--- a/packages/server/plugin-server/src/server.ts
+++ b/packages/server/plugin-server/src/server.ts
@@ -150,7 +150,7 @@ export default (): ServerPlugin => ({
            * In prod mode, we just return unstableMiddlewares directly.
            * In dev mode, we will return a new array with length of maxLen in the first time,
            * The new Array will execute the storage.unstableMiddlewares[index] by index, when the middleware is not exist, we will execute next().
-           * It's the logic for hot reload, when unstableMiddlewares is changed, we will execute the new middleware.
+           * It's the logic for hot reload, when unstableMiddlewares is changed, it will execute the new middleware.
            */
           if (isProd()) {
             return unstableMiddlewares;

--- a/packages/server/plugin-server/src/server.ts
+++ b/packages/server/plugin-server/src/server.ts
@@ -1,5 +1,9 @@
 import type { ServerPlugin } from '@modern-js/server-core';
-import type { MiddlewareContext, NextFunction } from '@modern-js/types';
+import type {
+  MiddlewareContext,
+  NextFunction,
+  UnstableMiddleware,
+} from '@modern-js/types';
 import { isProd, logger } from '@modern-js/utils';
 import {
   type Hook,
@@ -19,7 +23,7 @@ enum HOOKS {
 class Storage {
   public middlewares: Middleware[] = [];
 
-  public unstableMiddlewares: any[] = [];
+  public unstableMiddlewares: UnstableMiddleware[] = [];
 
   public hooks: Record<string, Hook> = {};
 
@@ -142,7 +146,32 @@ export default (): ServerPlugin => ({
         const { unstableMiddlewares } = storage;
 
         if (unstableMiddlewares.length > 0) {
-          return unstableMiddlewares;
+          /**
+           * In prod mode, we just return unstableMiddlewares directly.
+           * In dev mode, we will return a new array with length of maxLen in the first time,
+           * The new Array will execute the storage.unstableMiddlewares[index] by index, when the middleware is not exist, we will execute next().
+           * It's the logic for hot reload, when unstableMiddlewares is changed, we will execute the new middleware.
+           */
+          if (isProd()) {
+            return unstableMiddlewares;
+          } else {
+            const gap = 10;
+            const baseLen =
+              unstableMiddlewares.length < gap
+                ? gap
+                : unstableMiddlewares.length;
+            const maxLen = baseLen + gap;
+            return new Array(maxLen).fill(0).map((_, index) => {
+              return (ctx, next) => {
+                const unstableMiddleware = storage.unstableMiddlewares[index];
+                if (unstableMiddleware) {
+                  return unstableMiddleware(ctx, next);
+                } else {
+                  return next();
+                }
+              };
+            });
+          }
         }
 
         factory = getFactory(storage);


### PR DESCRIPTION
## Summary

In this PR, we support [unstableMiddleware](https://modernjs.dev/apis/app/runtime/web-server/unstable_middleware.html) hot reload.

Here we use a hack way, cause unstable middleware are only collect when the server init.

1. Create a new unstable middleware array in dev mode, the length will be more the original array.
2. Fill the new array, when the middleware is execute, if `storage.unstableMiddleware` has the same index function, it will be execute, otherwise execute `next()`
3. when the `storage.unstableMiddleware` is changed, the new unstable middleware array will execute the new function in `storage.unstableMiddleware`.



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
