### PR TITLE
chore(devtools): disable devtools's styledComponents build

### DIFF
--- a/.changeset/nine-cups-reply.md
+++ b/.changeset/nine-cups-reply.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/devtools-client': patch
+---
+
+chore(devtools): disable devtools's styledComponents build because it's not used

--- a/packages/devtools/client/modern.config.ts
+++ b/packages/devtools/client/modern.config.ts
@@ -98,6 +98,7 @@ export default defineConfig<'rspack'>({
     },
   },
   tools: {
+    styledComponents: false,
     postcss: (config, { addPlugins }) => {
       addPlugins(require('postcss-custom-media'));
     },


### PR DESCRIPTION
## Summary

disable devtools's styledComponents build because it's not used.

fix rsbuild's eco-ci https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/12650068507/job/35247796431

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
