### PR TITLE
fix: add getInitData api

### DIFF
--- a/.changeset/afraid-walls-do.md
+++ b/.changeset/afraid-walls-do.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: add missing getInitData api
+fix: 添加缺失的 getInitData 接口

--- a/packages/runtime/plugin-runtime/src/core/compatible.tsx
+++ b/packages/runtime/plugin-runtime/src/core/compatible.tsx
@@ -234,6 +234,9 @@ export const useRuntimeContext = () => {
         request: baseSSRContext.request || ({} as TSSRContext['request']),
         response: baseSSRContext.response || ({} as TSSRContext['response']),
         logger: baseSSRContext.logger || ({} as TSSRContext['logger']),
+        getInitData: () => {
+          return Object.freeze(context.initialData);
+        },
       }
     : ({} as TSSRContext);
 


### PR DESCRIPTION
## Summary

The `getInitData` API is display in website docs. But it's missing on the runtimeContext.

This PR fix it.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
