### PR TITLE
feat: support user set x headers in loader

### DIFF
--- a/.changeset/chilled-taxis-help.md
+++ b/.changeset/chilled-taxis-help.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: support set x header in data loader
+feat: 支持在 Data Loader 中设置 x- 响应头

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
@@ -225,6 +225,19 @@ export const createRequestHandler: CreateRequestHandler =
         context.ssrContext?.response.status(context.routerContext?.statusCode);
       }
 
+      // write headers to response
+      if (context.routerContext?.loaderHeaders) {
+        Object.values(context.routerContext?.loaderHeaders).forEach(
+          (headers: Headers) => {
+            headers.forEach((value, key) => {
+              if (key.startsWith('x-')) {
+                context.ssrContext?.response.setHeader(key, value);
+              }
+            });
+          },
+        );
+      }
+
       context.initialData = initialData;
 
       const redirectResponse = getRedirectResponse(initialData);

--- a/tests/integration/ssr/fixtures/base/src/routes/loader-response/error.tsx
+++ b/tests/integration/ssr/fixtures/base/src/routes/loader-response/error.tsx
@@ -1,0 +1,3 @@
+export default function Layout() {
+  return <div>error page</div>;
+}

--- a/tests/integration/ssr/fixtures/base/src/routes/loader-response/layout.tsx
+++ b/tests/integration/ssr/fixtures/base/src/routes/loader-response/layout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from '@modern-js/runtime/router';
+
+export default function Layout() {
+  return (
+    <div>
+      Root layout
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/ssr/fixtures/base/src/routes/loader-response/page.data.ts
+++ b/tests/integration/ssr/fixtures/base/src/routes/loader-response/page.data.ts
@@ -1,0 +1,18 @@
+import type { LoaderFunctionArgs } from '@modern-js/runtime/router';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const error = url.searchParams.get('error');
+
+  if (error) {
+    return new Response('The user was not found', {
+      headers: new Headers({
+        'x-error': 'true',
+      }),
+    });
+  } else {
+    return {
+      name: 'modern.js',
+    };
+  }
+}

--- a/tests/integration/ssr/fixtures/base/src/routes/loader-response/page.tsx
+++ b/tests/integration/ssr/fixtures/base/src/routes/loader-response/page.tsx
@@ -1,0 +1,3 @@
+export default function Layout() {
+  return <div>page</div>;
+}

--- a/tests/integration/ssr/tests/base.test.ts
+++ b/tests/integration/ssr/tests/base.test.ts
@@ -154,4 +154,13 @@ describe('Traditional SSR', () => {
     const content1 = await page.content();
     expect(content1).not.toMatch(result);
   });
+
+  test('loader response headers', async () => {
+    const response = await axios.get(
+      `http://localhost:${appPort}/loader-response?error=true&no-cache=1`,
+    );
+
+    const { headers } = response;
+    expect(Boolean(headers['x-error'])).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

In this PR, we support set headers in Data Loader:

```ts
import type { LoaderFunctionArgs } from '@modern-js/runtime/router';

export async function loader({ request }: LoaderFunctionArgs) {
  const url = new URL(request.url);
  const error = url.searchParams.get('error');

  if (error) {
    return new Response('The user was not found', {
      headers: new Headers({
        'x-error': 'true',
      }),
    });
  } else {
    return {
      name: 'modern.js',
    };
  }
}
```


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
