### PR TITLE
feat: cli plugin support extend build utils

### DIFF
--- a/.changeset/shy-trainers-brush.md
+++ b/.changeset/shy-trainers-brush.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/plugin-v2': patch
+---
+
+feat: cli plugin support extend build utils
+
+feat: cli 插件支持扩展构建工具函数

--- a/packages/solutions/app-tools/src/types/new.ts
+++ b/packages/solutions/app-tools/src/types/new.ts
@@ -186,6 +186,7 @@ export type AppToolsContext<B extends Bundler = 'webpack'> = AppContext<
 
 export type AppToolsHooks<B extends Bundler = 'webpack'> = Hooks<
   AppToolsUserConfig<B>,
-  AppToolsNormalizedConfig
+  AppToolsNormalizedConfig,
+  {}
 > &
   AppToolsExtendHooks;

--- a/packages/toolkit/plugin-v2/src/cli/context.ts
+++ b/packages/toolkit/plugin-v2/src/cli/context.ts
@@ -49,7 +49,11 @@ export async function createContext<Extends extends CLIPluginExtends>({
   return {
     ...appContext,
     hooks: {
-      ...initHooks<Extends['config'], Extends['normalizedConfig']>(),
+      ...initHooks<
+        Extends['config'],
+        Extends['normalizedConfig'],
+        Extends['extendBuildUtils']
+      >(),
       ...extendsHooks,
     },
     extendsHooks,

--- a/packages/toolkit/plugin-v2/src/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/cli/hooks.ts
@@ -1,9 +1,4 @@
 import type {
-  ModifyBundlerChainFn,
-  ModifyRsbuildConfigFn,
-  ModifyRspackConfigFn,
-  ModifyWebpackChainFn,
-  ModifyWebpackConfigFn,
   OnAfterBuildFn,
   OnAfterCreateCompilerFn,
   OnBeforeBuildFn,
@@ -14,9 +9,14 @@ import type {
   AddCommandFn,
   AddWatchFilesFn,
   ConfigFn,
+  ModifyBundlerChainFn,
   ModifyConfigFn,
   ModifyHtmlPartialsFn,
   ModifyResolvedConfigFn,
+  ModifyRsbuildConfigFn,
+  ModifyRspackConfigFn,
+  ModifyWebpackChainFn,
+  ModifyWebpackConfigFn,
   OnAfterDeployFn,
   OnAfterDevFn,
   OnBeforeDeployFn,
@@ -28,7 +28,7 @@ import type {
 } from '../types/cli/hooks';
 import type { DeepPartial } from '../types/utils';
 
-export function initHooks<Config, NormalizedConfig>() {
+export function initHooks<Config, NormalizedConfig, ExtendBuildUtils>() {
   return {
     /**
      * add config for this cli plugin
@@ -45,11 +45,16 @@ export function initHooks<Config, NormalizedConfig>() {
     modifyResolvedConfig:
       createAsyncHook<ModifyResolvedConfigFn<NormalizedConfig>>(),
 
-    modifyRsbuildConfig: createAsyncHook<ModifyRsbuildConfigFn>(),
-    modifyBundlerChain: createAsyncHook<ModifyBundlerChainFn>(),
-    modifyRspackConfig: createAsyncHook<ModifyRspackConfigFn>(),
-    modifyWebpackChain: createAsyncHook<ModifyWebpackChainFn>(),
-    modifyWebpackConfig: createAsyncHook<ModifyWebpackConfigFn>(),
+    modifyRsbuildConfig:
+      createAsyncHook<ModifyRsbuildConfigFn<ExtendBuildUtils>>(),
+    modifyBundlerChain:
+      createAsyncHook<ModifyBundlerChainFn<ExtendBuildUtils>>(),
+    modifyRspackConfig:
+      createAsyncHook<ModifyRspackConfigFn<ExtendBuildUtils>>(),
+    modifyWebpackChain:
+      createAsyncHook<ModifyWebpackChainFn<ExtendBuildUtils>>(),
+    modifyWebpackConfig:
+      createAsyncHook<ModifyWebpackConfigFn<ExtendBuildUtils>>(),
     modifyHtmlPartials: createAsyncHook<ModifyHtmlPartialsFn>(),
 
     addCommand: createAsyncHook<AddCommandFn>(),
@@ -70,6 +75,6 @@ export function initHooks<Config, NormalizedConfig>() {
   };
 }
 
-export type Hooks<Config, NormalizedConfig> = ReturnType<
-  typeof initHooks<Config, NormalizedConfig>
+export type Hooks<Config, NormalizedConfig, ExtendBuildUtils> = ReturnType<
+  typeof initHooks<Config, NormalizedConfig, ExtendBuildUtils>
 >;

--- a/packages/toolkit/plugin-v2/src/cli/run/create.ts
+++ b/packages/toolkit/plugin-v2/src/cli/run/create.ts
@@ -130,7 +130,7 @@ export const createCli = <Extends extends CLIPluginExtends>() => {
     await context.hooks.onPrepare.call();
 
     // compat old modernjs hook
-    await (context.hooks as any)?.onAfterPrepare.call();
+    await (context.hooks as any)?.onAfterPrepare?.call();
 
     return { appContext: context };
   }

--- a/packages/toolkit/plugin-v2/src/types/cli/api.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/api.ts
@@ -1,25 +1,25 @@
 import type {
-  ModifyBundlerChainFn,
-  ModifyRsbuildConfigFn,
-  ModifyRspackConfigFn,
-  ModifyWebpackChainFn,
-  ModifyWebpackConfigFn,
   OnAfterBuildFn,
   OnAfterCreateCompilerFn,
   OnBeforeBuildFn,
   OnBeforeCreateCompilerFn,
 } from '@rsbuild/core';
 import type { Hooks } from '../../cli/hooks';
-import type { PluginHook, PluginHookTap } from '../hooks';
+import type { PluginHookTap } from '../hooks';
 import type { DeepPartial } from '../utils';
 import type { AppContext } from './context';
 import type {
   AddCommandFn,
   AddWatchFilesFn,
   ConfigFn,
+  ModifyBundlerChainFn,
   ModifyConfigFn,
   ModifyHtmlPartialsFn,
   ModifyResolvedConfigFn,
+  ModifyRsbuildConfigFn,
+  ModifyRspackConfigFn,
+  ModifyWebpackChainFn,
+  ModifyWebpackConfigFn,
   OnAfterDeployFn,
   OnAfterDevFn,
   OnBeforeDeployFn,
@@ -40,7 +40,11 @@ export type CLIPluginAPI<Extends extends CLIPluginExtends> = Readonly<{
   getConfig: () => Readonly<Extends['config']>;
   getNormalizedConfig: () => Readonly<Extends['normalizedConfig']>;
   getHooks: () => Readonly<
-    Hooks<Extends['config'], Extends['normalizedConfig']> &
+    Hooks<
+      Extends['config'],
+      Extends['normalizedConfig'],
+      Extends['extendBuildUtils']
+    > &
       Extends['extendHooks']
   >;
 
@@ -56,14 +60,24 @@ export type CLIPluginAPI<Extends extends CLIPluginExtends> = Readonly<{
   >;
 
   // modify rsbuild config hooks
-  modifyRsbuildConfig: PluginHookTap<ModifyRsbuildConfigFn>;
-  modifyBundlerChain: PluginHookTap<ModifyBundlerChainFn>;
+  modifyRsbuildConfig: PluginHookTap<
+    ModifyRsbuildConfigFn<Extends['extendBuildUtils']>
+  >;
+  modifyBundlerChain: PluginHookTap<
+    ModifyBundlerChainFn<Extends['extendBuildUtils']>
+  >;
   /** Only works when bundler is Rspack */
-  modifyRspackConfig: PluginHookTap<ModifyRspackConfigFn>;
+  modifyRspackConfig: PluginHookTap<
+    ModifyRspackConfigFn<Extends['extendBuildUtils']>
+  >;
   /** Only works when bundler is Webpack */
-  modifyWebpackChain: PluginHookTap<ModifyWebpackChainFn>;
+  modifyWebpackChain: PluginHookTap<
+    ModifyWebpackChainFn<Extends['extendBuildUtils']>
+  >;
   /** Only works when bundler is Webpack */
-  modifyWebpackConfig: PluginHookTap<ModifyWebpackConfigFn>;
+  modifyWebpackConfig: PluginHookTap<
+    ModifyWebpackConfigFn<Extends['extendBuildUtils']>
+  >;
   modifyHtmlPartials: PluginHookTap<ModifyHtmlPartialsFn>;
 
   addCommand: PluginHookTap<AddCommandFn>;

--- a/packages/toolkit/plugin-v2/src/types/cli/context.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/context.ts
@@ -50,7 +50,11 @@ export type AppContext<Extends extends CLIPluginExtends> = {
 export type InternalContext<Extends extends CLIPluginExtends> =
   AppContext<Extends> & {
     /** All hooks. */
-    hooks: Hooks<Extends['config'], Extends['normalizedConfig']> &
+    hooks: Hooks<
+      Extends['config'],
+      Extends['normalizedConfig'],
+      Extends['extendBuildUtils']
+    > &
       Extends['extendHooks'];
     /** All plugin registry hooks */
     extendsHooks: Extends['extendHooks'];

--- a/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
@@ -1,5 +1,16 @@
+import type { WebpackConfig } from '@modern-js/uni-builder';
 import type { Command } from '@modern-js/utils/commander';
+import type {
+  ModifyBundlerChainUtils,
+  ModifyRspackConfigUtils,
+  ModifyWebpackChainUtils,
+  ModifyWebpackConfigUtils,
+  RsbuildConfig,
+  Rspack,
+  RspackChain,
+} from '@rsbuild/core';
 import type { TransformFunction } from '../plugin';
+import type { MaybePromise } from '../utils';
 import type { Entrypoint } from './context';
 
 declare module '@modern-js/utils/commander' {
@@ -63,3 +74,33 @@ export type OnAfterDeployFn = (
 ) => Promise<void> | void;
 
 export type OnBeforeExitFn = () => void;
+
+export type ModifyBundlerChainFn<ExtendsUtils> = (
+  chain: RspackChain,
+  utils: ModifyBundlerChainUtils & ExtendsUtils,
+) => MaybePromise<void>;
+
+// todo replace to use rsbuild type after update rsbuild lib version
+export type ModifyRsbuildConfigUtils = {
+  /** Merge multiple Rsbuild config objects into one. */
+  mergeRsbuildConfig: (...configs: RsbuildConfig[]) => RsbuildConfig;
+};
+export type ModifyRsbuildConfigFn<ExtendsUtils> = (
+  config: RsbuildConfig,
+  utils: ModifyRsbuildConfigUtils & ExtendsUtils,
+) => MaybePromise<RsbuildConfig | void>;
+
+export type ModifyRspackConfigFn<ExtendsUtils> = (
+  config: Rspack.Configuration,
+  utils: ModifyRspackConfigUtils & ExtendsUtils,
+) => MaybePromise<Rspack.Configuration | void>;
+
+export type ModifyWebpackChainFn<ExtendsUtils> = (
+  chain: RspackChain,
+  utils: ModifyWebpackChainUtils & ExtendsUtils,
+) => Promise<void> | void;
+
+export type ModifyWebpackConfigFn<ExtendsUtils> = (
+  config: WebpackConfig,
+  utils: ModifyWebpackConfigUtils & ExtendsUtils,
+) => Promise<WebpackConfig | void> | WebpackConfig | void;

--- a/packages/toolkit/plugin-v2/src/types/cli/plugin.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/plugin.ts
@@ -9,12 +9,14 @@ export interface CLIPluginExtends<
   ExtendContext extends Record<string, any> = {},
   ExtendAPI extends Record<string, any> = {},
   ExtendHook extends Record<string, PluginHook<(...args: any[]) => any>> = {},
+  ExtendBuildUtils extends Record<string, any> = {},
 > {
   config?: Config;
   normalizedConfig?: NormalizedConfig;
   extendContext?: ExtendContext;
   extendApi?: ExtendAPI;
   extendHooks?: ExtendHook;
+  extendBuildUtils?: ExtendBuildUtils;
 }
 
 /**


### PR DESCRIPTION
## Summary

add extendBuildUtils type for CLIPluginExtends to support extend rsbuild modify config function

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
