### PR TITLE
fix(data-loader): unify the response logic of the Loader in SSR

### DIFF
--- a/.changeset/tricky-chairs-press.md
+++ b/.changeset/tricky-chairs-press.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-data-loader': patch
+'@modern-js/runtime': patch
+---
+
+feat: unify the response logic of the Loader in SSR
+feat: 统一 SSR 中 Loader 的响应逻辑

--- a/packages/cli/plugin-data-loader/src/cli/createRequest.ts
+++ b/packages/cli/plugin-data-loader/src/cli/createRequest.ts
@@ -112,6 +112,7 @@ export const createRequest = (routeId: string, method = 'get') => {
       return await parseDeferredReadableStream(res.body!);
     }
 
+    // some response error not from modern.js
     if (isOtherErrorResponse(res)) {
       return await handleNetworkErrorResponse(res);
     }

--- a/packages/cli/plugin-data-loader/src/cli/createRequest.ts
+++ b/packages/cli/plugin-data-loader/src/cli/createRequest.ts
@@ -38,28 +38,45 @@ const handleRedirectResponse = (res: Response) => {
   return res;
 };
 
-const handleDeferredResponse = async (res: Response) => {
-  if (
-    res.headers.get('Content-Type')?.match(CONTENT_TYPE_DEFERRED) &&
-    res.body
-  ) {
-    return await parseDeferredReadableStream(res.body);
-  }
-  return res;
+const isDeferredResponse = (res: Response) => {
+  return (
+    res.headers.get('Content-Type')?.match(CONTENT_TYPE_DEFERRED) && res.body
+  );
+};
+
+const isRedirectResponse = (res: Response) => {
+  return res.headers.get('X-Modernjs-Redirect') != null;
 };
 
 const isErrorResponse = (res: Response) => {
   return res.headers.get('X-Modernjs-Error') != null;
 };
 
+function isOtherErrorResponse(res: Response) {
+  return (
+    res.status >= 400 &&
+    res.headers.get('X-Modernjs-Error') == null &&
+    res.headers.get('X-Modernjs-Catch') == null &&
+    res.headers.get('X-Modernjs-Response') == null
+  );
+}
+
+const isCatchResponse = (res: Response) => {
+  return res.headers.get('X-Modernjs-Catch') != null;
+};
+
 const handleErrorResponse = async (res: Response) => {
-  if (isErrorResponse(res)) {
-    const data = await res.json();
-    const error = new Error(data.message);
-    error.stack = data.stack;
-    throw error;
-  }
-  return res;
+  const data = await res.json();
+  const error = new Error(data.message);
+  error.stack = data.stack;
+  throw error;
+};
+
+const handleNetworkErrorResponse = async (res: Response) => {
+  const text = await res.text();
+  const error = new Error(text);
+  error.stack = undefined;
+  throw error;
 };
 
 export const createRequest = (routeId: string, method = 'get') => {
@@ -75,11 +92,29 @@ export const createRequest = (routeId: string, method = 'get') => {
     res = await fetch(url, {
       method,
       signal: request.signal,
+    }).catch(error => {
+      throw error;
     });
 
-    res = handleRedirectResponse(res);
-    res = await handleErrorResponse(res);
-    res = await handleDeferredResponse(res);
+    if (isRedirectResponse(res)) {
+      return handleRedirectResponse(res);
+    }
+
+    if (isErrorResponse(res)) {
+      return await handleErrorResponse(res);
+    }
+
+    if (isCatchResponse(res)) {
+      throw res;
+    }
+
+    if (isDeferredResponse(res)) {
+      return await parseDeferredReadableStream(res.body!);
+    }
+
+    if (isOtherErrorResponse(res)) {
+      return await handleNetworkErrorResponse(res);
+    }
 
     return res;
   };

--- a/packages/cli/plugin-data-loader/src/runtime/errors.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/errors.ts
@@ -65,7 +65,7 @@ export function sanitizeError<T = unknown>(error: T) {
     process.env.NODE_ENV !== 'development' &&
     process.env.NODE_ENV !== 'test'
   ) {
-    const sanitized = new Error('Unexpected Server Error');
+    const sanitized = new Error(error.message || 'Unexpected Server Error');
     sanitized.stack = undefined;
     return sanitized;
   }

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -130,7 +130,7 @@ export const handleRequest = async ({
           });
     }
     const cost = end();
-
+    response.headers.set('X-Modernjs-Response', 'yes');
     onTiming?.(`${LOADER_REPORTER_NAME}-navigation`, cost);
   } catch (error) {
     if (isResponse(error)) {

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -130,6 +130,7 @@ export const handleRequest = async ({
           });
     }
     const cost = end();
+    // add response header for client know if the response is from modern server
     response.headers.set('X-Modernjs-Response', 'yes');
     onTiming?.(`${LOADER_REPORTER_NAME}-navigation`, cost);
   } catch (error) {

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
@@ -217,7 +217,7 @@ export const createRequestHandler: CreateRequestHandler =
 
       const initialData = await runBeforeRender(context);
 
-      // Support data loader to return status code
+      // Support data loader to return `new Response` and set status code
       if (
         context.routerContext?.statusCode &&
         context.routerContext?.statusCode !== 200

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -127,16 +127,15 @@ export const routerPlugin = (
 
           // requestHandler.ts also has same logic, but handle common status code
           // maybe we can put the logic in requestHandler.ts in the future
+          const errors = Object.values(
+            (routerContext.errors || {}) as Record<string, Error>,
+          );
           if (
-            routerContext.statusCode >= 500 &&
-            routerContext.statusCode < 600 &&
             // TODO: if loaderFailureMode is not 'errroBoundary', error log will not be printed.
+            errors.length > 0 &&
             loaderFailureMode === 'clientRender'
           ) {
             routerContext.statusCode = 200;
-            const errors = Object.values(
-              routerContext.errors as Record<string, Error>,
-            );
             throw errors[0];
           }
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -125,8 +125,8 @@ export const routerPlugin = (
             return interrupt(routerContext);
           }
 
-          // requestHandler.ts also has same logic, but handle common status code
-          // maybe we can put the logic in requestHandler.ts in the future
+          // Now `throw new Response` or `throw new Error` is same, both will be caught by errorBoundary by default
+          // If loaderFailureMode is 'clientRender', we will downgrade to csr, and the loader will be request in client again
           const errors = Object.values(
             (routerContext.errors || {}) as Record<string, Error>,
           );

--- a/tests/integration/routes/src/three/routes/error/response/page.data.ts
+++ b/tests/integration/routes/src/three/routes/error/response/page.data.ts
@@ -1,10 +1,35 @@
-export const loader = () => {
-  throw new Response(
-    JSON.stringify({
-      message: "can't found the user",
-    }),
-    {
-      status: 255,
-    },
-  );
+import type { LoaderFunctionArgs } from '@modern-js/runtime/router';
+
+export const loader = ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const responseType = url.searchParams.get('type') as string;
+  const statusCode = url.searchParams.get('code') as string;
+
+  if (responseType === 'throw_error') {
+    throw new Error("can't found the user");
+  }
+
+  if (responseType === 'throw_response') {
+    throw new Response(
+      JSON.stringify({
+        message: "can't found the user",
+      }),
+      {
+        status: Number(statusCode),
+      },
+    );
+  }
+
+  if (responseType === 'return_response') {
+    return new Response(
+      JSON.stringify({
+        message: 'user modern.js',
+      }),
+      {
+        status: Number(statusCode),
+      },
+    );
+  }
+
+  return null;
 };

--- a/tests/integration/routes/src/three/routes/error/response/page.tsx
+++ b/tests/integration/routes/src/three/routes/error/response/page.tsx
@@ -1,10 +1,6 @@
-import { Outlet, useLoaderData } from '@modern-js/runtime/router';
+import { useLoaderData } from '@modern-js/runtime/router';
 
 export default function Page() {
   const data = useLoaderData();
-  return (
-    <div>
-      <Outlet />
-    </div>
-  );
+  return <div className="response-content">Response Page</div>;
 }

--- a/tests/integration/routes/tests/index.test.ts
+++ b/tests/integration/routes/tests/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { fs, ROUTE_MANIFEST_FILE, wait } from '@modern-js/utils';
+import { fs, ROUTE_MANIFEST_FILE } from '@modern-js/utils';
 import { ROUTE_MANIFEST } from '@modern-js/utils/universal/constants';
 import puppeteer, { type Browser } from 'puppeteer';
 
@@ -11,7 +11,6 @@ import {
   launchOptions,
   modernBuild,
   modernServe,
-  sleep,
 } from '../../../utils/modernTestUtils';
 
 const appDir = path.resolve(__dirname, '../');


### PR DESCRIPTION
## Summary

This PR is to unify the response logic of the Loader in SSR.

1. By default, `throw Error` or `throw new Response` in Data Loader, will catch by error boundary. 
2. Throw new Response can set the http code, Error will return 500 code, include uncaught error.
3. If `ssr.loaderFailureMode` is `clientRender`, both of `throw xxx` will be ignore in ssr render, and modern.js will request Data Loader in client again.
4. Return Response will not catch by error boundary, even if the http code is 5xx.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
