### PR TITLE
fix: @modern-js/utils cause worker ssr fail

### DIFF
--- a/packages/server/core/src/plugins/render/ssrCache.ts
+++ b/packages/server/core/src/plugins/render/ssrCache.ts
@@ -6,7 +6,6 @@ import type {
   CacheOptionProvider,
   Container,
 } from '@modern-js/types';
-import { removeTailSlash } from '@modern-js/utils';
 import { X_RENDER_CACHE } from '../../constants';
 import type {
   RequestHandler,
@@ -19,6 +18,7 @@ interface CacheStruct {
   cursor: number;
 }
 
+const removeTailSlash = (s: string): string => s.replace(/\/+$/, '');
 const ZERO_RENDER_LEVEL = /"renderLevel":0/;
 const NO_SSR_CACHE = /<meta\s+[^>]*name=["']no-ssr-cache["'][^>]*>/i;
 


### PR DESCRIPTION
## Summary

In #6649, we import `@modern-js/utils` in runtime package, it cause worker ssr failed.

So we remove it in this PR.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
