### PR TITLE
feat(runtime): add new configuration for reload on SSR URL mismatch

### DIFF
--- a/.changeset/four-years-drive.md
+++ b/.changeset/four-years-drive.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: add new configuration for reload on SSR URL mismatch
+feat: 添加新的配置，支持在 SSR URL 不匹配时重新加载页面

--- a/packages/runtime/plugin-runtime/src/core/browser/hydrate.tsx
+++ b/packages/runtime/plugin-runtime/src/core/browser/hydrate.tsx
@@ -26,23 +26,6 @@ export function hydrateRoot(
     _hydration: true,
   };
 
-  const { ssrContext } = hydrateContext;
-
-  const currentPathname = normalizePathname(window.location.pathname);
-  const initialPathname =
-    ssrContext?.request?.pathname &&
-    normalizePathname(ssrContext.request.pathname);
-
-  if (
-    initialPathname &&
-    initialPathname !== currentPathname &&
-    context.router
-  ) {
-    const errorMsg = `The initial URL ${initialPathname} and the URL ${currentPathname} to be hydrated do not match, reload.`;
-    console.error(errorMsg);
-    window.location.reload();
-  }
-
   const callback = () => {
     // won't cause component re-render because context's reference identity doesn't change
     delete hydrateContext._hydration;

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -51,8 +51,7 @@ export const routerPlugin = (
         beforeRender(context) {
           // In some scenarios, the initial pathname and the current pathname do not match.
           // We add a configuration to support the page to reload.
-          if (window._SSR_DATA && userConfig.reloadOnURLMismatch) {
-            console.log('hello world');
+          if (window._SSR_DATA && userConfig.unstable_reloadOnURLMismatch) {
             const { ssrContext } = context;
             const currentPathname = normalizePathname(window.location.pathname);
             const initialPathname =

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -1,5 +1,4 @@
 import { merge } from '@modern-js/runtime-utils/merge';
-import { parsedJSONFromElement } from '@modern-js/runtime-utils/parsed';
 import type { RouterSubscriber } from '@modern-js/runtime-utils/remix-router';
 import {
   type RouteObject,
@@ -11,6 +10,7 @@ import {
   useLocation,
   useMatches,
 } from '@modern-js/runtime-utils/router';
+import { normalizePathname } from '@modern-js/runtime-utils/url';
 import type React from 'react';
 import { useContext, useMemo } from 'react';
 import { type Plugin, RuntimeReactContext } from '../../core';
@@ -49,6 +49,23 @@ export const routerPlugin = (
       let routes: RouteObject[] = [];
       return {
         beforeRender(context) {
+          // In some scenarios, the initial pathname and the current pathname do not match.
+          // We add a configuration to support the page to reload.
+          if (window._SSR_DATA && userConfig.reloadOnURLMismatch) {
+            console.log('hello world');
+            const { ssrContext } = context;
+            const currentPathname = normalizePathname(window.location.pathname);
+            const initialPathname =
+              ssrContext?.request?.pathname &&
+              normalizePathname(ssrContext.request.pathname);
+
+            if (initialPathname && initialPathname !== currentPathname) {
+              const errorMsg = `The initial URL ${initialPathname} and the URL ${currentPathname} to be hydrated do not match, reload.`;
+              console.error(errorMsg);
+              window.location.reload();
+            }
+          }
+
           // for garfish plugin to get basename,
           // why not let garfish plugin just import @modern-js/runtime/router
           // so the `router` has no type declare in RuntimeContext

--- a/packages/runtime/plugin-runtime/src/router/runtime/types.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/types.ts
@@ -44,7 +44,6 @@ export type RouterConfig = {
    */
   unstable_reloadOnURLMismatch?: boolean;
 };
-};
 
 export type Routes = RouterConfig['routesConfig']['routes'];
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/types.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/types.ts
@@ -28,6 +28,7 @@ export type RouterConfig = {
     globalApp?: React.ComponentType<any>;
     routes?: (NestedRoute | PageRoute)[];
   };
+  reloadOnURLMismatch?: boolean;
   /**
    * You should not use it
    */

--- a/packages/runtime/plugin-runtime/src/router/runtime/types.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/types.ts
@@ -28,7 +28,6 @@ export type RouterConfig = {
     globalApp?: React.ComponentType<any>;
     routes?: (NestedRoute | PageRoute)[];
   };
-  reloadOnURLMismatch?: boolean;
   /**
    * You should not use it
    */
@@ -40,6 +39,11 @@ export type RouterConfig = {
   future?: Partial<{
     v7_startTransition: boolean;
   }>;
+  /**
+   * An unstable feature, which will reload the page when the current browser URL and the SSR Context URL do not match.
+   */
+  unstable_reloadOnURLMismatch?: boolean;
+};
 };
 
 export type Routes = RouterConfig['routesConfig']['routes'];


### PR DESCRIPTION
## Summary

This PR move the reload logic when SSR URL mismatch in `hydrateRoot` to `routerPlugin`.

In the past, this feature was designed to ensure that the page could load the current route correctly when using the Browser's native history operation, but default enable would cause many other problems.

1. This features should not enable by default.
2. This features is not entirely certain

So we add a `unstable` configuration to enable it. And this configuration will not display in modern.js document now.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
