### PR TITLE
feat: support styled-component in streaming ssr

### DIFF
--- a/.changeset/strange-donuts-bake.md
+++ b/.changeset/strange-donuts-bake.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: support styled-component in streaming ssr
+feat: 在流式渲染中支持 styled-component


### PR DESCRIPTION
## Summary

This PR support use styled-component in streaming SSR and the style will be auto added into HTML.

> styled-component docs: https://styled-components.com/docs/advanced#streaming-rendering

The docs only show the example for `renderToNodeStream`, seems not support `renderToPipeableStream`.

In fact, `interleaveWithNodeStream` is only do something like TransformStream.

We create a `new PassThrough` to transform the react PipeableStream to Node.js Readable, and the `interleaveWithNodeStream` work well.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
