### PR TITLE
feat: use `jiti` to read config file for supporting esm import

### DIFF
--- a/.changeset/kind-panthers-fail.md
+++ b/.changeset/kind-panthers-fail.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-v2': patch
+---
+
+feat: use `jiti` to read config file for supporting esm import
+
+feat: 使用 `jiti` 读取配置文件，支持 esm 导入

--- a/packages/toolkit/plugin-v2/package.json
+++ b/packages/toolkit/plugin-v2/package.json
@@ -70,7 +70,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@modern-js/node-bundle-require": "workspace:*",
+    "jiti": "1.21.7",
     "@modern-js/utils": "workspace:*",
     "@modern-js/runtime-utils": "workspace:*",
     "@swc/helpers": "0.5.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4012,9 +4012,6 @@ importers:
 
   packages/toolkit/plugin-v2:
     dependencies:
-      '@modern-js/node-bundle-require':
-        specifier: workspace:*
-        version: link:../node-bundle-require
       '@modern-js/runtime-utils':
         specifier: workspace:*
         version: link:../runtime-utils
@@ -4024,6 +4021,9 @@ importers:
       '@swc/helpers':
         specifier: 0.5.13
         version: 0.5.13
+      jiti:
+        specifier: 1.21.7
+        version: 1.21.7
     devDependencies:
       '@modern-js/types':
         specifier: workspace:*
@@ -16705,6 +16705,10 @@ packages:
 
   jiti@1.20.0:
     resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
+    hasBin: true
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
   jju@1.4.0:
@@ -33641,6 +33645,8 @@ snapshots:
       - ts-node
 
   jiti@1.20.0: {}
+
+  jiti@1.21.7: {}
 
   jju@1.4.0: {}
 


### PR DESCRIPTION
## Summary
plugin v2 use `jiti` to read config file for supporting esm import

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
