### PR TITLE
 feat: cli plugin support ExtendConfigUtils

### DIFF
--- a/.changeset/tricky-starfishes-hug.md
+++ b/.changeset/tricky-starfishes-hug.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-v2': patch
+---
+
+feat: cli plugin support ExtendConfigUtils
+
+feat: cli 插件支持扩展 config 工具函数

--- a/packages/solutions/app-tools/src/types/new.ts
+++ b/packages/solutions/app-tools/src/types/new.ts
@@ -187,6 +187,7 @@ export type AppToolsContext<B extends Bundler = 'webpack'> = AppContext<
 export type AppToolsHooks<B extends Bundler = 'webpack'> = Hooks<
   AppToolsUserConfig<B>,
   AppToolsNormalizedConfig,
+  {},
   {}
 > &
   AppToolsExtendHooks;

--- a/packages/toolkit/plugin-v2/src/cli/context.ts
+++ b/packages/toolkit/plugin-v2/src/cli/context.ts
@@ -52,7 +52,8 @@ export async function createContext<Extends extends CLIPluginExtends>({
       ...initHooks<
         Extends['config'],
         Extends['normalizedConfig'],
-        Extends['extendBuildUtils']
+        Extends['extendBuildUtils'],
+        Extends['extendConfigUtils']
       >(),
       ...extendsHooks,
     },

--- a/packages/toolkit/plugin-v2/src/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/cli/hooks.ts
@@ -56,7 +56,12 @@ export type {
   OnPrepareFn,
 };
 
-export function initHooks<Config, NormalizedConfig, ExtendBuildUtils>() {
+export function initHooks<
+  Config,
+  NormalizedConfig,
+  ExtendBuildUtils,
+  ExtendConfigUtils,
+>() {
   return {
     /**
      * add config for this cli plugin
@@ -66,12 +71,14 @@ export function initHooks<Config, NormalizedConfig, ExtendBuildUtils>() {
      * @private
      * modify config for this cli plugin
      */
-    modifyConfig: createAsyncHook<ModifyConfigFn<Config>>(),
+    modifyConfig: createAsyncHook<ModifyConfigFn<Config, ExtendConfigUtils>>(),
     /**
      * modify final config
      */
     modifyResolvedConfig:
-      createAsyncHook<ModifyResolvedConfigFn<NormalizedConfig>>(),
+      createAsyncHook<
+        ModifyResolvedConfigFn<NormalizedConfig, ExtendConfigUtils>
+      >(),
 
     modifyRsbuildConfig:
       createAsyncHook<ModifyRsbuildConfigFn<ExtendBuildUtils>>(),
@@ -104,6 +111,16 @@ export function initHooks<Config, NormalizedConfig, ExtendBuildUtils>() {
   };
 }
 
-export type Hooks<Config, NormalizedConfig, ExtendBuildUtils> = ReturnType<
-  typeof initHooks<Config, NormalizedConfig, ExtendBuildUtils>
+export type Hooks<
+  Config,
+  NormalizedConfig,
+  ExtendBuildUtils,
+  ExtendConfigUtils,
+> = ReturnType<
+  typeof initHooks<
+    Config,
+    NormalizedConfig,
+    ExtendBuildUtils,
+    ExtendConfigUtils
+  >
 >;

--- a/packages/toolkit/plugin-v2/src/types/cli/api.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/api.ts
@@ -47,7 +47,8 @@ export type CLIPluginAPI<Extends extends CLIPluginExtends> = Readonly<
       Hooks<
         Extends['config'],
         Extends['normalizedConfig'],
-        Extends['extendBuildUtils']
+        Extends['extendBuildUtils'],
+        Extends['extendConfigUtils']
       > &
         Extends['extendHooks']
     >;
@@ -58,9 +59,14 @@ export type CLIPluginAPI<Extends extends CLIPluginExtends> = Readonly<
 
     // config hooks
     config: PluginHookTap<ConfigFn<DeepPartial<Extends['config']>>>;
-    modifyConfig: PluginHookTap<ModifyConfigFn<Extends['config']>>;
+    modifyConfig: PluginHookTap<
+      ModifyConfigFn<Extends['config'], Extends['extendConfigUtils']>
+    >;
     modifyResolvedConfig: PluginHookTap<
-      ModifyResolvedConfigFn<Extends['normalizedConfig']>
+      ModifyResolvedConfigFn<
+        Extends['normalizedConfig'],
+        Extends['extendConfigUtils']
+      >
     >;
 
     // modify rsbuild config hooks

--- a/packages/toolkit/plugin-v2/src/types/cli/context.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/context.ts
@@ -53,7 +53,8 @@ export type InternalContext<Extends extends CLIPluginExtends> =
     hooks: Hooks<
       Extends['config'],
       Extends['normalizedConfig'],
-      Extends['extendBuildUtils']
+      Extends['extendBuildUtils'],
+      Extends['extendConfigUtils']
     > &
       Extends['extendHooks'];
     /** All plugin registry hooks */

--- a/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
@@ -20,10 +20,15 @@ declare module '@modern-js/utils/commander' {
 }
 export type ConfigFn<Config> = () => Config;
 
-export type ModifyConfigFn<Config> = TransformFunction<Config>;
+export type ModifyConfigFn<Config, ExtendConfigUtils> = (
+  arg: Config,
+  utils?: ExtendConfigUtils,
+) => Config | Promise<Config>;
 
-export type ModifyResolvedConfigFn<NormalizedConfig> =
-  TransformFunction<NormalizedConfig>;
+export type ModifyResolvedConfigFn<NormalizedConfig, ExtendConfigUtils> = (
+  arg: NormalizedConfig,
+  utils?: ExtendConfigUtils,
+) => NormalizedConfig | Promise<NormalizedConfig>;
 
 type IPartialMethod = (...script: string[]) => void;
 export interface PartialMethod {

--- a/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
@@ -64,11 +64,11 @@ export type OnBeforeDevFn = () => Promise<void> | void;
 export type OnAfterDevFn = (params: { port: number }) => Promise<void> | void;
 
 export type OnBeforeDeployFn = (
-  options: Record<string, any>,
+  options?: Record<string, any>,
 ) => Promise<void> | void;
 
 export type OnAfterDeployFn = (
-  options: Record<string, any>,
+  options?: Record<string, any>,
 ) => Promise<void> | void;
 
 export type OnBeforeExitFn = () => void;

--- a/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
@@ -18,7 +18,7 @@ declare module '@modern-js/utils/commander' {
     commandsMap: Map<string, Command>;
   }
 }
-export type ConfigFn<Config> = () => Config;
+export type ConfigFn<Config> = () => Config | Promise<Config>;
 
 export type ModifyConfigFn<Config, ExtendConfigUtils> = (
   arg: Config,

--- a/packages/toolkit/plugin-v2/src/types/cli/plugin.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/plugin.ts
@@ -10,6 +10,7 @@ export interface CLIPluginExtends<
   ExtendAPI extends Record<string, any> = {},
   ExtendHook extends Record<string, PluginHook<(...args: any[]) => any>> = {},
   ExtendBuildUtils extends Record<string, any> = {},
+  ExtendConfigUtils extends Record<string, any> = {},
 > {
   config?: Config;
   normalizedConfig?: NormalizedConfig;
@@ -17,6 +18,7 @@ export interface CLIPluginExtends<
   extendApi?: ExtendAPI;
   extendHooks?: ExtendHook;
   extendBuildUtils?: ExtendBuildUtils;
+  extendConfigUtils?: ExtendConfigUtils;
 }
 
 /**

--- a/packages/toolkit/plugin-v2/src/types/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/hooks.ts
@@ -7,12 +7,16 @@ export type SyncHook<Callback extends (...args: any[]) => any> = {
 
 export type AsyncHook<Callback extends (...args: any[]) => any> = {
   tap: (cb: Callback) => void;
-  call: (...args: Parameters<Callback>) => Promise<ReturnType<Callback>>;
+  call: (
+    ...args: Parameters<Callback>
+  ) => Promise<UnwrapPromise<ReturnType<Callback>>>;
 };
 
 export type AsyncInterruptHook<Callback extends (...args: any[]) => any> = {
   tap: (cb: Callback) => void;
-  call: (...args: Tail<Parameters<Callback>>) => Promise<ReturnType<Callback>>;
+  call: (
+    ...args: Tail<Parameters<Callback>>
+  ) => Promise<UnwrapPromise<ReturnType<Callback>>>;
 };
 
 export type CollectAsyncHook<Callback extends (...params: any[]) => any> = {


### PR DESCRIPTION
## Summary
- cli extends add ExtendConfigUtils
- process.on exist event support off

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
