### PR TITLE
chore: remove x-forwarded-host logic for safety

### DIFF
--- a/.changeset/heavy-icons-give.md
+++ b/.changeset/heavy-icons-give.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/runtime-utils': patch
+'@modern-js/server-core': patch
+---
+
+chore: remove x-forwarded-host logic for safety
+chore: 移除 x-forwarded-host 逻辑，避免某些安全问题

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.ts
@@ -83,14 +83,9 @@ function createSSRContext(
 
   const url = new URL(request.url);
 
-  const host =
-    headers.get('X-Forwarded-Host') || headers.get('host') || url.host;
+  const host = headers.get('host') || url.host;
 
-  let protocol = (
-    headers.get('X-Forwarded-Proto') ||
-    url.protocol ||
-    'http'
-  ).split(/\s*,\s*/, 1)[0];
+  let protocol = (url.protocol || 'http').split(/\s*,\s*/, 1)[0];
 
   // The protocal including the final `:`.
   // Follow: https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol

--- a/packages/server/core/src/utils/request.ts
+++ b/packages/server/core/src/utils/request.ts
@@ -44,10 +44,7 @@ export function getPathname(request: Request): string {
 
 export function getHost(request: Request): string {
   const { headers } = request;
-  let host = headers.get('X-Forwarded-Host');
-  if (!host) {
-    host = headers.get('Host');
-  }
+  let host = headers.get('Host');
   host = host?.split(/\s*,\s*/, 1)[0] || 'undefined';
   // the host = '',if we can't cat Host or X-Forwarded-Host header
   // but the this.href would assign a invalid value:`http[s]://${pathname}`

--- a/packages/server/core/tests/utils/request.test.ts
+++ b/packages/server/core/tests/utils/request.test.ts
@@ -81,6 +81,6 @@ describe('test utils.request', () => {
           'x-forwarded-host': 'localhost:9090',
         }),
       } as Request),
-    ).toBe('localhost:9090');
+    ).toBe('localhost:8080');
   });
 });

--- a/packages/solutions/app-tools/src/esm/register-esm.mjs
+++ b/packages/solutions/app-tools/src/esm/register-esm.mjs
@@ -48,6 +48,7 @@ export const registerEsm = async ({ appDir, distDir, alias }) => {
     if (hasTsconfig) {
       tsConfig = readTsConfigByFile(tsconfigPath);
     }
+
     register('./esbuild-loader.mjs', import.meta.url, {
       data: {
         appDir,

--- a/packages/toolkit/runtime-utils/src/universal/request.ts
+++ b/packages/toolkit/runtime-utils/src/universal/request.ts
@@ -42,19 +42,6 @@ export function getPathname(request: Request): string {
   return match ? match[1] : '/';
 }
 
-export function getHost(request: Request): string {
-  const { headers } = request;
-  let host = headers.get('X-Forwarded-Host');
-  if (!host) {
-    host = headers.get('Host');
-  }
-  host = host?.split(/\s*,\s*/, 1)[0] || 'undefined';
-  // the host = '',if we can't cat Host or X-Forwarded-Host header
-  // but the this.href would assign a invalid value:`http[s]://${pathname}`
-  // so we need assign host a no-empty value.
-  return host;
-}
-
 type Cookie = Record<string, string>;
 
 export function parseCookie(req: Request): Cookie {


### PR DESCRIPTION
## Summary

In the past, if `headers['x-forwarded-host']` existed, Modern.js will use it to instead `headers['host']` in Middleware、Hook and `useRuntimeContext` API.

This PR remove the logic for some safety problem.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
