### PR TITLE
feat: move _internalRuntimePlugins and _internalServerPlugins to plugin v2

### DIFF
--- a/.changeset/strong-weeks-exercise.md
+++ b/.changeset/strong-weeks-exercise.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/plugin-router-v5': patch
+'@modern-js/plugin-garfish': patch
+'@modern-js/runtime': patch
+'@modern-js/app-tools': patch
+'@modern-js/plugin-v2': patch
+---
+
+feat: migrate _internalRuntimePlugins and _internalServerPlugins hooks to plugin v2
+
+feat: 迁移 _internalRuntimePlugins 和 _internalServerPlugins hook 函数到 plugin-v2

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -51,7 +51,7 @@ export const garfishPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
       const { packageName, metaName } = api.getAppContext();
       const runtimeConfig = getEntryOptions(
         entrypoint.entryName,
-        entrypoint.isMainEntry,
+        entrypoint.isMainEntry!,
         userConfig.runtime,
         userConfig.runtimeByEntries,
         packageName,

--- a/packages/runtime/plugin-router-v5/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v5/src/cli/index.ts
@@ -19,7 +19,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools> => ({
       if (isV5(userConfig)) {
         const routerConfig = getEntryOptions(
           entrypoint.entryName,
-          entrypoint.isMainEntry,
+          entrypoint.isMainEntry!,
           userConfig.runtime,
           userConfig.runtimeByEntries,
           packageName,

--- a/packages/runtime/plugin-runtime/src/cli/template.ts
+++ b/packages/runtime/plugin-runtime/src/cli/template.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type { RuntimePlugin } from '@modern-js/app-tools';
+import type { RuntimePluginConfig } from '@modern-js/app-tools';
 import { JS_EXTENSIONS, findExists, formatImportPath } from '@modern-js/utils';
 import {
   ENTRY_POINT_RUNTIME_GLOBAL_CONTEXT_FILE_NAME,
@@ -127,7 +127,7 @@ export const runtimeRegister = ({
   internalSrcAlias: string;
   metaName: string;
   runtimeConfigFile: string | false;
-  runtimePlugins: RuntimePlugin[];
+  runtimePlugins: RuntimePluginConfig[];
 }) => `import { registerPlugin, mergeConfig } from '@${metaName}/runtime/plugin';
 import { getGlobalAppConfig, getGlobalLayoutApp } from '@${metaName}/runtime/context';
 ${getImportRuntimeConfigCode(srcDirectory, internalSrcAlias, runtimeConfigFile)}

--- a/packages/runtime/plugin-runtime/src/core/browser/index.tsx
+++ b/packages/runtime/plugin-runtime/src/core/browser/index.tsx
@@ -155,7 +155,7 @@ export async function render(
   );
 }
 
-async function renderWithReact18(
+export async function renderWithReact18(
   App: React.ReactElement,
   rootElement: HTMLElement,
 ) {
@@ -165,7 +165,7 @@ async function renderWithReact18(
   return root;
 }
 
-async function renderWithReact17(
+export async function renderWithReact17(
   App: React.ReactElement,
   rootElement: HTMLElement,
 ) {
@@ -174,7 +174,7 @@ async function renderWithReact17(
   return rootElement;
 }
 
-async function hydrateWithReact18(
+export async function hydrateWithReact18(
   App: React.ReactElement,
   rootElement: HTMLElement,
 ) {
@@ -183,7 +183,7 @@ async function hydrateWithReact18(
   return root;
 }
 
-async function hydrateWithReact17(
+export async function hydrateWithReact17(
   App: React.ReactElement,
   rootElement: HTMLElement,
   callback?: () => void,

--- a/packages/runtime/plugin-runtime/src/router/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/index.ts
@@ -41,7 +41,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
       const userConfig = api.getNormalizedConfig();
       const routerConfig = getEntryOptions(
         entrypoint.entryName,
-        entrypoint.isMainEntry,
+        entrypoint.isMainEntry!,
         userConfig.runtime,
         userConfig.runtimeByEntries,
         packageName,

--- a/packages/runtime/plugin-runtime/src/state/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/state/cli/index.ts
@@ -11,12 +11,12 @@ export const statePlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   setup: api => {
     api._internalRuntimePlugins(({ entrypoint, plugins }) => {
       const { entryName, isMainEntry } = entrypoint;
-      const userConfig = api.useResolvedConfigContext();
-      const { packageName, metaName } = api.useAppContext();
+      const userConfig = api.getNormalizedConfig();
+      const { packageName, metaName } = api.getAppContext();
 
       const stateConfig = getEntryOptions(
         entryName,
-        isMainEntry,
+        isMainEntry!,
         userConfig.runtime,
         userConfig.runtimeByEntries,
         packageName,

--- a/packages/solutions/app-tools/src/compat/hooks.ts
+++ b/packages/solutions/app-tools/src/compat/hooks.ts
@@ -1,16 +1,18 @@
-import type { InternalContext } from '@modern-js/plugin-v2';
+import type {
+  InternalContext,
+  RuntimePluginConfig,
+  ServerPluginConfig,
+} from '@modern-js/plugin-v2';
 import type {
   Entrypoint,
   HtmlPartials,
   NestedRouteForCli,
   PageRoute,
-  ServerPlugin,
   ServerRoute,
 } from '@modern-js/types';
 import type { Command } from '@modern-js/utils';
 import { getModifyHtmlPartials } from '../plugins/analyze/getHtmlTemplate';
 import type { AppTools, AppToolsNormalizedConfig } from '../types';
-import type { RuntimePlugin } from '../types/hooks';
 import {
   transformHookParams,
   transformHookResult,
@@ -36,11 +38,13 @@ export function getHookRunners(
     },
     _internalRuntimePlugins: async (params: {
       entrypoint: Entrypoint;
-      plugins: RuntimePlugin[];
+      plugins: RuntimePluginConfig[];
     }) => {
       return hooks._internalRuntimePlugins.call(params);
     },
-    _internalServerPlugins: async (params: { plugins: ServerPlugin[] }) => {
+    _internalServerPlugins: async (params: {
+      plugins: ServerPluginConfig[];
+    }) => {
       return hooks._internalServerPlugins.call(params);
     },
     checkEntryPoint: async (params: {

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -3,7 +3,6 @@ import { getLocaleLanguage } from '@modern-js/plugin-i18n/language-detector';
 import { createAsyncHook, createCollectAsyncHook } from '@modern-js/plugin-v2';
 import { castArray } from '@modern-js/uni-builder';
 import {
-  fs,
   cleanRequireCache,
   deprecatedCommands,
   emptyDir,
@@ -38,8 +37,6 @@ import type {
   CheckEntryPointFn,
   DeplpoyFn,
   GenerateEntryCodeFn,
-  InternalRuntimePluginsFn,
-  InternalServerPluginsFn,
   ModifyEntrypointsFn,
   ModifyFileSystemRoutesFn,
   ModifyServerRoutesFn,
@@ -91,8 +88,6 @@ export const appTools = (
   registryHooks: {
     onAfterPrepare: createAsyncHook<AfterPrepareFn>(),
     deploy: createAsyncHook<DeplpoyFn>(),
-    _internalRuntimePlugins: createAsyncHook<InternalRuntimePluginsFn>(),
-    _internalServerPlugins: createAsyncHook<InternalServerPluginsFn>(),
     checkEntryPoint: createAsyncHook<CheckEntryPointFn>(),
     modifyEntrypoints: createAsyncHook<ModifyEntrypointsFn>(),
     modifyFileSystemRoutes: createAsyncHook<ModifyFileSystemRoutesFn>(),

--- a/packages/solutions/app-tools/src/types/hooks.ts
+++ b/packages/solutions/app-tools/src/types/hooks.ts
@@ -5,12 +5,15 @@ import type {
   ParallelWorkflow,
 } from '@modern-js/plugin';
 import type {
+  RuntimePluginConfig,
+  ServerPluginConfig,
+} from '@modern-js/plugin-v2';
+import type {
   Entrypoint,
   HtmlPartials,
   NestedRouteForCli,
   PageRoute,
   RouteLegacy,
-  ServerPlugin,
   ServerRoute,
 } from '@modern-js/types';
 import type {
@@ -26,16 +29,10 @@ export interface ImportSpecifier {
   imported?: string;
 }
 
-export interface RuntimePlugin {
-  name: string;
-  path: string;
-  config: Record<string, any>;
-}
-
 export type AppToolsHooks<B extends Bundler = 'webpack'> = {
   _internalRuntimePlugins: AsyncWaterfall<{
     entrypoint: Entrypoint;
-    plugins: RuntimePlugin[];
+    plugins: RuntimePluginConfig[];
   }>;
   modifyFileSystemRoutes: AsyncWaterfall<{
     entrypoint: Entrypoint;
@@ -61,7 +58,7 @@ export type AppToolsHooks<B extends Bundler = 'webpack'> = {
     code: string;
   }>;
 
-  _internalServerPlugins: AsyncWaterfall<{ plugins: ServerPlugin[] }>;
+  _internalServerPlugins: AsyncWaterfall<{ plugins: ServerPluginConfig[] }>;
 
   // beforeCreateBuilder
   beforeDev: AsyncWorkflow<void, unknown>;

--- a/packages/solutions/app-tools/src/types/index.ts
+++ b/packages/solutions/app-tools/src/types/index.ts
@@ -1,5 +1,10 @@
 import type { NormalizedConfig, UserConfig } from '@modern-js/core';
-import type { CLIPlugin, CLIPluginExtends } from '@modern-js/plugin-v2';
+import type {
+  CLIPlugin,
+  CLIPluginExtends,
+  RuntimePluginConfig,
+  ServerPluginConfig,
+} from '@modern-js/plugin-v2';
 import type { AppToolsNormalizedConfig, AppToolsUserConfig } from './config';
 import type { AppToolsHooks } from './hooks';
 import type {
@@ -13,7 +18,7 @@ import type {
 } from './new';
 import type { Bundler } from './utils';
 
-export type { CLIPluginExtends };
+export type { CLIPluginExtends, RuntimePluginConfig, ServerPluginConfig };
 export * from './hooks';
 export * from './config';
 export * from './legacyConfig';

--- a/packages/solutions/app-tools/src/types/new.ts
+++ b/packages/solutions/app-tools/src/types/new.ts
@@ -22,17 +22,9 @@ import type {
 import type { AppTools } from '.';
 import type { getHookRunners } from '../compat/hooks';
 import type { AppToolsNormalizedConfig, AppToolsUserConfig } from './config';
-import type { RuntimePlugin } from './hooks';
 import type { Bundler } from './utils';
 
 export type AfterPrepareFn = () => Promise<void> | void;
-export type InternalRuntimePluginsFn = TransformFunction<{
-  entrypoint: Entrypoint;
-  plugins: RuntimePlugin[];
-}>;
-export type InternalServerPluginsFn = TransformFunction<{
-  plugins: ServerPlugin[];
-}>;
 export type CheckEntryPointFn = TransformFunction<{
   path: string;
   entry: false | string;
@@ -66,8 +58,6 @@ export interface AppToolsExtendAPI<B extends Bundler = 'webpack'> {
   onAfterPrepare: PluginHookTap<AfterPrepareFn>;
   deploy: PluginHookTap<DeplpoyFn>;
 
-  _internalRuntimePlugins: PluginHookTap<InternalRuntimePluginsFn>;
-  _internalServerPlugins: PluginHookTap<InternalServerPluginsFn>;
   checkEntryPoint: PluginHookTap<CheckEntryPointFn>;
   modifyEntrypoints: PluginHookTap<ModifyEntrypointsFn>;
   modifyFileSystemRoutes: PluginHookTap<ModifyFileSystemRoutesFn>;
@@ -116,8 +106,6 @@ export interface AppToolsExtendHooks
   extends Record<string, PluginHook<(...args: any[]) => any>> {
   onAfterPrepare: AsyncHook<AfterPrepareFn>;
   deploy: AsyncHook<DeplpoyFn>;
-  _internalRuntimePlugins: AsyncHook<InternalRuntimePluginsFn>;
-  _internalServerPlugins: AsyncHook<InternalServerPluginsFn>;
   checkEntryPoint: AsyncHook<CheckEntryPointFn>;
   modifyEntrypoints: AsyncHook<ModifyEntrypointsFn>;
   modifyFileSystemRoutes: AsyncHook<ModifyFileSystemRoutesFn>;

--- a/packages/toolkit/plugin-v2/src/cli/api.ts
+++ b/packages/toolkit/plugin-v2/src/cli/api.ts
@@ -114,6 +114,8 @@ export function initPluginAPI<Extends extends CLIPluginExtends>({
     onBeforeDeploy: hooks.onBeforeDeploy.tap,
     onAfterDeploy: hooks.onAfterDeploy.tap,
     onBeforeExit: hooks.onBeforeExit.tap,
+    _internalRuntimePlugins: hooks._internalRuntimePlugins.tap,
+    _internalServerPlugins: hooks._internalServerPlugins.tap,
     ...extendsPluginApi,
   };
 

--- a/packages/toolkit/plugin-v2/src/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/cli/hooks.ts
@@ -10,6 +10,8 @@ import type {
   AddCommandFn,
   AddWatchFilesFn,
   ConfigFn,
+  InternalRuntimePluginsFn,
+  InternalServerPluginsFn,
   ModifyBundlerChainFn,
   ModifyConfigFn,
   ModifyHtmlPartialsFn,
@@ -26,6 +28,8 @@ import type {
   OnBeforeRestartFn,
   OnFileChangedFn,
   OnPrepareFn,
+  RuntimePluginConfig,
+  ServerPluginConfig,
 } from '../types/cli/hooks';
 import type { DeepPartial } from '../types/utils';
 
@@ -54,6 +58,10 @@ export type {
   OnBeforeRestartFn,
   OnFileChangedFn,
   OnPrepareFn,
+  InternalRuntimePluginsFn,
+  InternalServerPluginsFn,
+  RuntimePluginConfig,
+  ServerPluginConfig,
 };
 
 export function initHooks<
@@ -108,6 +116,8 @@ export function initHooks<
     onBeforeDeploy: createAsyncHook<OnBeforeDeployFn>(),
     onAfterDeploy: createAsyncHook<OnAfterDeployFn>(),
     onBeforeExit: createAsyncHook<OnBeforeExitFn>(),
+    _internalRuntimePlugins: createAsyncHook<InternalRuntimePluginsFn>(),
+    _internalServerPlugins: createAsyncHook<InternalServerPluginsFn>(),
   };
 }
 

--- a/packages/toolkit/plugin-v2/src/cli/index.ts
+++ b/packages/toolkit/plugin-v2/src/cli/index.ts
@@ -27,5 +27,9 @@ export {
   type OnBeforeRestartFn,
   type OnFileChangedFn,
   type OnPrepareFn,
+  type InternalRuntimePluginsFn,
+  type InternalServerPluginsFn,
+  type RuntimePluginConfig,
+  type ServerPluginConfig,
 } from './hooks';
 export { cli, createLoadedConfig, initAppDir, createCli, loadEnv } from './run';

--- a/packages/toolkit/plugin-v2/src/index.ts
+++ b/packages/toolkit/plugin-v2/src/index.ts
@@ -19,6 +19,8 @@ export type {
   Entrypoint,
   CLIPlugin,
   CLIPluginExtends,
+  RuntimePluginConfig,
+  ServerPluginConfig,
 } from './types/cli';
 export type {
   RuntimePluginAPI,

--- a/packages/toolkit/plugin-v2/src/types/cli/api.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/api.ts
@@ -13,6 +13,8 @@ import type {
   AddCommandFn,
   AddWatchFilesFn,
   ConfigFn,
+  InternalRuntimePluginsFn,
+  InternalServerPluginsFn,
   ModifyBundlerChainFn,
   ModifyConfigFn,
   ModifyHtmlPartialsFn,
@@ -106,6 +108,8 @@ export type CLIPluginAPI<Extends extends CLIPluginExtends> = Readonly<
     onBeforeDeploy: PluginHookTap<OnBeforeDeployFn>;
     onAfterDeploy: PluginHookTap<OnAfterDeployFn>;
     onBeforeExit: PluginHookTap<OnBeforeExitFn>;
+    _internalRuntimePlugins: PluginHookTap<InternalRuntimePluginsFn>;
+    _internalServerPlugins: PluginHookTap<InternalServerPluginsFn>;
   } & CLIPluginExtendsAPI<Extends>
 >;
 

--- a/packages/toolkit/plugin-v2/src/types/cli/context.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/context.ts
@@ -8,6 +8,7 @@ import type { CLIPluginAPI } from './api';
 import type { CLIPlugin, CLIPluginExtends } from './plugin';
 
 export interface Entrypoint {
+  isMainEntry?: boolean;
   entryName: string;
   entry: string;
 }

--- a/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
@@ -1,3 +1,4 @@
+import type { ServerPlugin as ServerPluginConfig } from '@modern-js/types';
 import type { WebpackConfig } from '@modern-js/uni-builder';
 import type { Command } from '@modern-js/utils/commander';
 import type {
@@ -18,6 +19,15 @@ declare module '@modern-js/utils/commander' {
     commandsMap: Map<string, Command>;
   }
 }
+
+export interface RuntimePluginConfig {
+  name: string;
+  path: string;
+  config: Record<string, any>;
+}
+
+export type { ServerPluginConfig };
+
 export type ConfigFn<Config> = () => Config | Promise<Config>;
 
 export type ModifyConfigFn<Config, ExtendConfigUtils> = (
@@ -107,3 +117,11 @@ export type ModifyWebpackConfigFn<ExtendsUtils> = (
   config: WebpackConfig,
   utils: ModifyWebpackConfigUtils & ExtendsUtils,
 ) => Promise<WebpackConfig | void> | WebpackConfig | void;
+
+export type InternalRuntimePluginsFn = TransformFunction<{
+  entrypoint: Entrypoint;
+  plugins: RuntimePluginConfig[];
+}>;
+export type InternalServerPluginsFn = TransformFunction<{
+  plugins: ServerPluginConfig[];
+}>;

--- a/packages/toolkit/plugin-v2/src/types/cli/index.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/index.ts
@@ -1,3 +1,4 @@
 export type { CLIPluginAPI } from './api';
 export type { AppContext, InternalContext, Entrypoint } from './context';
 export type { CLIPlugin, CLIPluginExtends } from './plugin';
+export type { RuntimePluginConfig, ServerPluginConfig } from './hooks';


### PR DESCRIPTION
## Summary

feat: move _internalRuntimePlugins and _internalServerPlugins to plugin v2 to support common plugin use this hook

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
