### PR TITLE
test: clean up unnecessary build logs

### DIFF
--- a/tests/e2e/builder/cases/check-syntax/index.test.ts
+++ b/tests/e2e/builder/cases/check-syntax/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
 import type { RsbuildConfig } from '@rsbuild/core';
-import { build } from '@scripts/shared';
+import { build, proxyConsole } from '@scripts/shared';
 
 function getCommonBuildConfig(cwd: string): RsbuildConfig {
   return {
@@ -12,6 +12,7 @@ function getCommonBuildConfig(cwd: string): RsbuildConfig {
 }
 
 test('should throw error when exist syntax errors', async () => {
+  const { restore } = proxyConsole();
   const cwd = path.join(__dirname, 'fixtures/basic');
   await expect(
     build({
@@ -25,6 +26,7 @@ test('should throw error when exist syntax errors', async () => {
       },
     }),
   ).rejects.toThrowError('incompatible syntax');
+  restore();
 });
 
 test('should not throw error when the file is excluded', async () => {
@@ -65,6 +67,7 @@ test('should not throw error when the targets are support es6', async () => {
 });
 
 test('should throw error when using optional chaining and target is es6 browsers', async () => {
+  const { restore } = proxyConsole();
   const cwd = path.join(__dirname, 'fixtures/esnext');
 
   await expect(
@@ -81,6 +84,8 @@ test('should throw error when using optional chaining and target is es6 browsers
       },
     }),
   ).rejects.toThrowError('incompatible syntax');
+
+  restore();
 });
 
 test('should not throw error when using optional chaining and ecmaVersion is 2020', async () => {

--- a/tests/e2e/builder/cases/source/source-exclude/index.test.ts
+++ b/tests/e2e/builder/cases/source/source-exclude/index.test.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
-import { build } from '@scripts/shared';
+import { build, proxyConsole } from '@scripts/shared';
 
 test('should not compile specified file when source.exclude', async () => {
+  const { restore } = proxyConsole();
   await expect(
     build({
       cwd: __dirname,
@@ -17,4 +18,6 @@ test('should not compile specified file when source.exclude', async () => {
       },
     }),
   ).rejects.toThrowError('incompatible syntax');
+
+  restore();
 });

--- a/tests/e2e/builder/cases/source/source-include/index.test.ts
+++ b/tests/e2e/builder/cases/source/source-include/index.test.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import { expect, test } from '@modern-js/e2e/playwright';
-import { build } from '@scripts/shared';
+import { build, proxyConsole } from '@scripts/shared';
 
 test('should not compile file which outside of project by default', async () => {
+  const { restore } = proxyConsole();
   await expect(
     build({
       cwd: __dirname,
@@ -14,6 +15,8 @@ test('should not compile file which outside of project by default', async () => 
       },
     }),
   ).rejects.toThrowError('incompatible syntax');
+
+  restore();
 });
 
 test('should compile specified file when source.include', async () => {

--- a/tests/e2e/builder/scripts/shared.ts
+++ b/tests/e2e/builder/scripts/shared.ts
@@ -6,6 +6,9 @@ import type {
   UniBuilderConfig,
 } from '@modern-js/uni-builder';
 import fs from '@modern-js/utils/fs-extra';
+import { type ConsoleType, logger } from '@rsbuild/core';
+
+logger.level = 'error';
 
 type CreateBuilderOptions = Omit<
   CreateUniBuilderOptions,
@@ -183,3 +186,32 @@ export async function build({
     instance: builder,
   };
 }
+
+export const proxyConsole = (
+  types: ConsoleType | ConsoleType[] = ['log', 'warn', 'info', 'error'],
+  keepAnsi = false,
+) => {
+  const logs: string[] = [];
+  const restores: Array<() => void> = [];
+
+  for (const type of Array.isArray(types) ? types : [types]) {
+    const method = console[type];
+
+    restores.push(() => {
+      console[type] = method;
+    });
+
+    console[type] = log => {
+      logs.push(log);
+    };
+  }
+
+  return {
+    logs,
+    restore: () => {
+      for (const restore of restores) {
+        restore();
+      }
+    },
+  };
+};

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -103,7 +103,7 @@ function runModernCommandDev(argv, stdOut, options = {}) {
         options.onStdout(message);
       }
 
-      if (options.stdout !== false) {
+      if (stdOut !== false && options.stdout !== false) {
         process.stdout.write(message);
       }
     }


### PR DESCRIPTION
## Summary

some build logs are unnecessary in CI. such as:

```bash
  ·error   [@rsbuild/plugin-check-syntax] Find some syntax that does not match "ecmaVersion <= 2016":
  
    ERROR 1
    source:  /src/test.js:3:19
    output:  /dist/static/js/index.34a89cf2.js:1:135
    reason:  Unexpected token (1:135)
    code:    
       1 | export const printLog = () => {
       2 |   const arr = [1, 2, 3, 4, [5, 6, [7, 8]]];
     > 3 |   console.log(arr, arr?.flat());
       4 | };
  
  ·success [@rsbuild/plugin-check-syntax] Syntax check passed.
```

```bash
  ready   Built in 0.09 s (web)
  
  ·°ready   Built in 1.51 s (web)
  
  ·start   Building...
  start   Building...
  ready   Built in 0.20 s (web)
  ready   Built in 0.20 s (web)
  ··°°°start   Building...
```

```bash
  PASS integration/swc/tests/transform-fail.test.ts (8.297 s)
  error   Compile error: 
  Failed to compile, check the errors for troubleshooting.
  File: /home/runner/work/rsbuild-ecosystem-ci/rsbuild-ecosystem-ci/workspace/modernjs/modern.js/tests/integration/swc/fixtures/transform-fail/src/App.jsx:1:1
  Module build failed (from ../../../../../node_modules/.pnpm/@rsbuild+plugin-webpack-swc@file+..+..+rsbuild+packages+compat+plugin-webpack-swc_@rsbuild+co_tmpjmojw5u7z3vtbbuot7xgatq/node_modules/@rsbuild/plugin-webpack-swc/dist/loader.mjs):
  Error:   x Expression expected
     ,-[/home/runner/work/rsbuild-ecosystem-ci/rsbuild-ecosystem-ci/workspace/modernjs/modern.js/tests/integration/swc/fixtures/transform-fail/src/App.jsx:6:1]
   3 | // Syntax Error
   4 | const App = () =>
   5 | 
   6 | export default App;
     : ^^^^^^
     `----
  
   @ ./node_modules/.modern-js/main/runtime-global-context.js
   @ ./node_modules/.modern-js/main/register.js
   @ ./node_modules/.modern-js/main/index.jsx
  
  
  
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
