### PR TITLE
fix(dev-server): apply dev configuration, avoid dev.setupMiddleware not apply.

### DIFF
--- a/.changeset/green-beans-provide.md
+++ b/.changeset/green-beans-provide.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/app-tools': major
+---
+
+fix(dev-server): apply dev configuration, then void dev.setupMiddlewares config lost
+fix(dev-server): 应用 dev 配置防止 dev.setupMiddlewares 丢失

--- a/.changeset/green-beans-provide.md
+++ b/.changeset/green-beans-provide.md
@@ -1,5 +1,5 @@
 ---
-'@modern-js/app-tools': major
+'@modern-js/app-tools': patch
 ---
 
 fix(dev-server): apply dev configuration, then void dev.setupMiddlewares config lost

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -89,20 +89,24 @@ export const dev = async (
 
   const pluginInstances = await loadServerPlugins(api, appDirectory, metaName);
 
+  const toolsDevServerConfig = normalizedConfig.tools.devServer;
+
   const serverOptions = {
     metaName,
     dev: {
       // [`normalizedConfig.tools.devServer`](https://modernjs.dev/en/configure/app/tools/dev-server.html) already deprecated, we should using `normalizedConfig.dev` instead firstly.
       // Oterwise, the `normalizedConfig.dev` can't be apply correctly.
-      ...normalizedConfig.tools?.devServer,
+      ...toolsDevServerConfig,
       devMiddleware: {
         writeToDisk: normalizedConfig.dev.writeToDisk,
       },
       port,
-      host: normalizedConfig.dev.host,
-      https: normalizedConfig.dev.https,
-      hot: normalizedConfig.dev.hmr,
-      setupMiddlewares: normalizedConfig.dev.setupMiddlewares,
+      host: normalizedConfig.dev.host ?? (toolsDevServerConfig as any).host,
+      https: normalizedConfig.dev.https ?? (toolsDevServerConfig as any).https,
+      hot: normalizedConfig.dev.hmr ?? (toolsDevServerConfig as any).hot,
+      setupMiddlewares:
+        normalizedConfig.dev.setupMiddlewares ??
+        (toolsDevServerConfig as any).setupMiddlewares,
     },
     appContext: {
       appDirectory,

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -92,10 +92,17 @@ export const dev = async (
   const serverOptions = {
     metaName,
     dev: {
-      port,
-      https: normalizedConfig.dev.https,
-      host: normalizedConfig.dev.host,
+      // [`normalizedConfig.tools.devServer`](https://modernjs.dev/en/configure/app/tools/dev-server.html) already deprecated, we should using `normalizedConfig.dev` instead firstly.
+      // Oterwise, the `normalizedConfig.dev` can't be apply correctly.
       ...normalizedConfig.tools?.devServer,
+      devMiddleware: {
+        writeToDisk: normalizedConfig.dev.writeToDisk,
+      },
+      port,
+      host: normalizedConfig.dev.host,
+      https: normalizedConfig.dev.https,
+      hot: normalizedConfig.dev.hmr,
+      setupMiddlewares: normalizedConfig.dev.setupMiddlewares,
     },
     appContext: {
       appDirectory,

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -89,7 +89,7 @@ export const dev = async (
 
   const pluginInstances = await loadServerPlugins(api, appDirectory, metaName);
 
-  const toolsDevServerConfig = normalizedConfig.tools.devServer;
+  const toolsDevServerConfig = normalizedConfig.tools?.devServer;
 
   const serverOptions = {
     metaName,
@@ -101,12 +101,12 @@ export const dev = async (
         writeToDisk: normalizedConfig.dev.writeToDisk,
       },
       port,
-      host: normalizedConfig.dev.host ?? (toolsDevServerConfig as any).host,
-      https: normalizedConfig.dev.https ?? (toolsDevServerConfig as any).https,
-      hot: normalizedConfig.dev.hmr ?? (toolsDevServerConfig as any).hot,
+      host: normalizedConfig.dev.host ?? (toolsDevServerConfig as any)?.host,
+      https: normalizedConfig.dev.https ?? (toolsDevServerConfig as any)?.https,
+      hot: normalizedConfig.dev.hmr ?? (toolsDevServerConfig as any)?.hot,
       setupMiddlewares:
         normalizedConfig.dev.setupMiddlewares ??
-        (toolsDevServerConfig as any).setupMiddlewares,
+        (toolsDevServerConfig as any)?.setupMiddlewares,
     },
     appContext: {
       appDirectory,

--- a/tests/integration/dev-server/modern.config.ts
+++ b/tests/integration/dev-server/modern.config.ts
@@ -37,6 +37,21 @@ export default applyBaseConfig({
       ],
     },
   },
+  dev: {
+    setupMiddlewares: [
+      (middlewares, _) => {
+        middlewares.push((req, res, next) => {
+          res.setHeader('x-push-middleware', 'test-middleware');
+          return next();
+        });
+
+        middlewares.unshift((req, res, next) => {
+          res.setHeader('x-unshift-middleware', 'test-middleware');
+          return next();
+        });
+      },
+    ],
+  },
   runtime: {
     router: false,
     state: false,

--- a/tests/integration/dev-server/tests/index.test.ts
+++ b/tests/integration/dev-server/tests/index.test.ts
@@ -30,6 +30,8 @@ describe('dev', () => {
     const headers = response!.headers();
     expect(headers['x-config']).toBe('test-config');
     expect(headers['x-plugin']).toBe('test-plugin');
+    expect(headers['x-push-middleware']).toBe('test-middleware');
+    expect(headers['x-unshift-middleware']).toBe('test-middleware');
   });
 
   test('should provide history api fallback correctly', async () => {


### PR DESCRIPTION
## Summary
Modern.js has `dev` and `tools.devServer` configuration. And `tools.devServer` already deprecated, we should using `dev` config instead firstly.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
