### PR TITLE
fix: add server.logger to control internal logger

### DIFF
--- a/.changeset/dry-elephants-promise.md
+++ b/.changeset/dry-elephants-promise.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/server-core': patch
+---
+
+fix: add `server.logger` to control internal server logger
+fix: 添加 `server.logger` 配置来控制 Server 内部日志

--- a/packages/server/core/src/plugins/default.ts
+++ b/packages/server/core/src/plugins/default.ts
@@ -13,8 +13,21 @@ import {
 } from './render';
 
 export type CreateDefaultPluginsOptions = InjectRenderHandlerOptions & {
-  logger?: Logger;
+  logger?: Logger | false;
 };
+
+function createSilenceLogger() {
+  return new Proxy(
+    {},
+    {
+      get: () => {
+        return () => {
+          // do nothing
+        };
+      },
+    },
+  ) as Logger;
+}
 
 export function createDefaultPlugins(
   options: CreateDefaultPluginsOptions = {},
@@ -23,7 +36,9 @@ export function createDefaultPlugins(
     logPlugin(),
     initMonitorsPlugin(),
     injectRenderHandlerPlugin(options),
-    injectloggerPluigin(options.logger),
+    injectloggerPluigin(
+      options.logger ? options.logger : createSilenceLogger(),
+    ),
     injectServerTiming(),
     processedByPlugin(),
   ];

--- a/packages/server/core/src/types/config/server.ts
+++ b/packages/server/core/src/types/config/server.ts
@@ -44,6 +44,7 @@ export interface ServerUserConfig {
    * @default false
    */
   useJsonScript?: boolean;
+  logger?: boolean | Record<string, unknown>;
 }
 
 export type ServerNormalizedConfig = ServerUserConfig;

--- a/packages/server/prod-server/src/types.ts
+++ b/packages/server/prod-server/src/types.ts
@@ -7,8 +7,6 @@ import type { Reporter } from '@modern-js/types';
 import type { Logger } from '@modern-js/utils';
 
 interface ProdServerExtraOptions {
-  logger?: Logger;
-
   /** compat modern.server-runtime.config.ts */
   serverConfigFile?: string;
 


### PR DESCRIPTION
## Summary

This PR add a new config to control internal server logger, and it will add to docs in next major version.

In the past, Modern.js did not provide feature to support user customs log monitor. Currently, Modern.js has initially provided server plugin, so when developers want to customize log monitor, we should also support users to turn off the built-in logging.

The server plugin can use it's own config to control custom logger, may like: 

```ts
export default defineConfig({
  server: {
    logger: false
  },
  plugins: [myMonitors({ logger: true })]
})
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
