### PR TITLE
fix: compat chain.cache true

### DIFF
--- a/.changeset/smart-tigers-breathe.md
+++ b/.changeset/smart-tigers-breathe.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/uni-builder': patch
+---
+
+fix: compat chain.cache true

--- a/packages/cli/uni-builder/src/shared/plugins/frameworkConfig.ts
+++ b/packages/cli/uni-builder/src/shared/plugins/frameworkConfig.ts
@@ -6,7 +6,8 @@ export const pluginFrameworkConfig = (configPath: string): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(chain => {
-      if (!fs.existsSync(configPath)) {
+      // TODO: Support rspack after support `performance.buildCache.buildDependencies` configuration
+      if (!fs.existsSync(configPath) || api.context.bundlerType !== 'webpack') {
         return;
       }
 
@@ -14,6 +15,14 @@ export const pluginFrameworkConfig = (configPath: string): RsbuildPlugin => ({
 
       if (!cache) {
         return;
+      }
+
+      if (cache === true) {
+        chain.cache({
+          buildDependencies: {
+            frameworkConfig: [configPath],
+          },
+        });
       }
 
       cache.buildDependencies = {


### PR DESCRIPTION
## Summary


fix `Cannot create property 'buildDependencies' on boolean 'true'` error.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
