### PR TITLE
test: add no-experimental-require-module for integration test cases

### DIFF
--- a/packages/solutions/app-tools/src/esm/esbuild-loader.mjs
+++ b/packages/solutions/app-tools/src/esm/esbuild-loader.mjs
@@ -1,4 +1,5 @@
 import { pathToFileURL } from 'url';
+import { load as esbuildLoad } from 'esbuild-register/loader';
 import { createMatchPath } from './utils.mjs';
 
 let matchPath;
@@ -17,4 +18,16 @@ export function resolve(specifier, context, defaultResolve) {
     : defaultResolve(specifier, context);
 }
 
-export { load } from 'esbuild-register/loader';
+export function load(url, context, defaultLoad) {
+  const filePath = new URL(url).pathname;
+
+  if (url.startsWith('node:')) {
+    return defaultLoad(url, context);
+  }
+
+  if (filePath.includes('node_modules')) {
+    return defaultLoad(url, context);
+  }
+
+  return esbuildLoad(url, context, defaultLoad);
+}

--- a/packages/solutions/app-tools/src/esm/ts-node-loader.mjs
+++ b/packages/solutions/app-tools/src/esm/ts-node-loader.mjs
@@ -1,5 +1,6 @@
 import { pathToFileURL } from 'url';
 import { resolve as tsNodeResolve } from 'ts-node/esm';
+import { load as tsNodeLoad } from 'ts-node/esm';
 import { createMatchPath } from './utils.mjs';
 
 let matchPath;
@@ -18,4 +19,16 @@ export function resolve(specifier, context, defaultResolve) {
     : tsNodeResolve(specifier, context, defaultResolve);
 }
 
-export { transformSource, load } from 'ts-node/esm';
+export function load(url, context, defaultLoad) {
+  const filePath = new URL(url).pathname;
+
+  if (url.startsWith('node:')) {
+    return defaultLoad(url, context);
+  }
+
+  if (filePath.includes('node_modules')) {
+    return defaultLoad(url, context);
+  }
+
+  return tsNodeLoad(url, context, defaultLoad);
+}

--- a/tests/integration/pure-esm-project/package.json
+++ b/tests/integration/pure-esm-project/package.json
@@ -4,7 +4,7 @@
   "version": "2.64.2",
   "type": "module",
   "scripts": {
-    "dev": "modern dev",
+    "dev": "NODE_OPTIONS='--no-experimental-require-module' modern dev",
     "dev:bff": "modern dev --api-only",
     "build": "modern build",
     "serve": "modern serve",

--- a/tests/integration/pure-esm-project/tests/index.test.ts
+++ b/tests/integration/pure-esm-project/tests/index.test.ts
@@ -26,7 +26,14 @@ if (isVersionAtLeast1819()) {
     beforeAll(async () => {
       jest.setTimeout(1000 * 60 * 2);
       port = await getPort();
-      app = await launchApp(appDir, port, {});
+      app = await launchApp(
+        appDir,
+        port,
+        {},
+        {
+          NODE_OPTIONS: '--no-experimental-require-module',
+        },
+      );
       browser = await puppeteer.launch(launchOptions as any);
       page = await browser.newPage();
     });


### PR DESCRIPTION
## Summary

Starting from the node.js 22.12.0 version, node.js has enabled the `experimental-require-module` by default, which will cause modern.js to fail to handle esm (ts projects will not be affected). Currently, `require` function will not be processed through Customization Hooks registered by Modern.js to handle built-in aliases. In Modern.js 3.0, we will remove all built-in aliases, so we add `no-experimental-require-module` here first to avoid test failures.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
