### PR TITLE
test: only set no-experimental-require-module in node22 version

### DIFF
--- a/packages/toolkit/utils/src/cli/version.ts
+++ b/packages/toolkit/utils/src/cli/version.ts
@@ -9,3 +9,9 @@ export function isVersionAtLeast18(): boolean {
   const versionArr = nodeVersion.split('.').map(Number);
   return versionArr[0] >= 18;
 }
+
+export function isVersionAtLeast22(): boolean {
+  const nodeVersion = process.versions.node;
+  const versionArr = nodeVersion.split('.').map(Number);
+  return versionArr[0] >= 22;
+}

--- a/tests/integration/pure-esm-project/tests/index.test.ts
+++ b/tests/integration/pure-esm-project/tests/index.test.ts
@@ -10,7 +10,7 @@ import {
   modernServe,
 } from '../../../utils/modernTestUtils';
 import 'isomorphic-fetch';
-import { isVersionAtLeast1819 } from '@modern-js/utils';
+import { isVersionAtLeast22, isVersionAtLeast1819 } from '@modern-js/utils';
 
 const appDir = path.resolve(__dirname, '../');
 dns.setDefaultResultOrder('ipv4first');
@@ -30,9 +30,11 @@ if (isVersionAtLeast1819()) {
         appDir,
         port,
         {},
-        {
-          NODE_OPTIONS: '--no-experimental-require-module',
-        },
+        isVersionAtLeast22()
+          ? {
+              NODE_OPTIONS: '--no-experimental-require-module',
+            }
+          : {},
       );
       browser = await puppeteer.launch(launchOptions as any);
       page = await browser.newPage();


### PR DESCRIPTION


## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
