### PR TITLE
feat: pass through the body, when query has __pass_body

### DIFF
--- a/.changeset/silver-masks-flash.md
+++ b/.changeset/silver-masks-flash.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+feat: pass through the body, when query is pass_body
+feat: 透传 body，当 query 为 pass_body 时

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -33,11 +33,17 @@ export const createWebRequest = (
   };
   res.on('close', () => controller.abort('res closed'));
 
+  const url = `http://${req.headers.host}${req.url}`;
+  const fullUrl = new URL(url);
+
+  const request = new Request(url, init);
+
   // Since we don't want break changes and now node.req.body will be consumed in bff, custom server, render, so we don't create a stream and consume node.req here by default.
   if (
     body ||
     (!(method === 'GET' || method === 'HEAD') &&
-      req.url?.includes('__loader')) ||
+      fullUrl.searchParams.has('__loader')) ||
+    fullUrl.searchParams.has('__pass_body') ||
     req.headers['x-mf-micro'] ||
     req.headers['x-rsc-action'] ||
     req.headers['x-parse-through-body']
@@ -46,9 +52,6 @@ export const createWebRequest = (
     (init as { duplex: 'half' }).duplex = 'half';
   }
 
-  const url = `http://${req.headers.host}${req.url}`;
-
-  const request = new Request(url, init);
   return request;
 };
 

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -36,8 +36,6 @@ export const createWebRequest = (
   const url = `http://${req.headers.host}${req.url}`;
   const fullUrl = new URL(url);
 
-  const request = new Request(url, init);
-
   // Since we don't want break changes and now node.req.body will be consumed in bff, custom server, render, so we don't create a stream and consume node.req here by default.
   if (
     body ||
@@ -51,6 +49,8 @@ export const createWebRequest = (
     init.body = body ?? createReadableStreamFromReadable(req);
     (init as { duplex: 'half' }).duplex = 'half';
   }
+
+  const request = new Request(url, init);
 
   return request;
 };


### PR DESCRIPTION
## Summary

This PR is for passes through the request body when the query has `__pass_body`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
