### PR TITLE
docs: fix nginx typo

### DIFF
--- a/packages/document/main-doc/docs/en/guides/basic-features/deploy.mdx
+++ b/packages/document/main-doc/docs/en/guides/basic-features/deploy.mdx
@@ -348,7 +348,7 @@ In Modern.js, the default `baseURL` is `'/'`. You can configure it by modifying 
 For projects with client-side routing, you can never access HTML files through the `/index.html` path.
 :::
 
-## Nignx
+## Nginx
 
 Nginx is a high-performance HTTP and reverse proxy server that can handle static files, reverse proxy, load balancing, and other functions. Deploying on Nginx typically requires configuring the `nginx.conf` file.
 

--- a/packages/document/main-doc/docs/zh/guides/basic-features/deploy.mdx
+++ b/packages/document/main-doc/docs/zh/guides/basic-features/deploy.mdx
@@ -339,7 +339,7 @@ app.listen(3000);
 存在浏览器路由的项目，永远无法通过 `/index.html` 路径来访问到 HTML 文件。
 :::
 
-## Nignx
+## Nginx
 
 Nginx 是一个高性能的 HTTP 和反向代理服务器，它可以处理静态文件、反向代理、负载均衡等功能。在 Nginx 上部署，通常需要配置 `nginx.conf` 文件。
 


### PR DESCRIPTION
## Summary
Fixes typo in docs: `Nignx` => `Nginx`


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
