### PR TITLE
chore: remove reporter.init and use monitors to report request cost

### DIFF
--- a/.changeset/nasty-bananas-join.md
+++ b/.changeset/nasty-bananas-join.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+chore: remove `reporter.init` and use Monitors to report request cost
+chore: 移除 `reporter.init` 并且使用 Monitors 上报请求耗时

--- a/packages/server/core/src/plugins/customServer/index.ts
+++ b/packages/server/core/src/plugins/customServer/index.ts
@@ -313,15 +313,3 @@ async function createMiddlewareContextFromHono(
     redirect: c.redirect.bind(c),
   };
 }
-
-export function injectRoute(route: {
-  entryName: string;
-}): Middleware<ServerEnv> {
-  return async (c, next) => {
-    if (route && !c.get('route')) {
-      c.set('route', route);
-    }
-
-    await next();
-  };
-}

--- a/packages/server/core/src/plugins/default.ts
+++ b/packages/server/core/src/plugins/default.ts
@@ -11,6 +11,7 @@ import {
   type InjectRenderHandlerOptions,
   injectRenderHandlerPlugin,
 } from './render';
+import { injectRoutePlugin } from './route';
 
 export type CreateDefaultPluginsOptions = InjectRenderHandlerOptions & {
   logger?: Logger | false;
@@ -39,6 +40,7 @@ export function createDefaultPlugins(
     injectloggerPlugin(options.logger ? options.logger : createSilenceLogger()),
     injectServerTiming(),
     processedByPlugin(),
+    injectRoutePlugin(),
   ];
 
   return plugins;

--- a/packages/server/core/src/plugins/monitors.ts
+++ b/packages/server/core/src/plugins/monitors.ts
@@ -223,23 +223,21 @@ export const injectServerTiming = (): ServerPlugin => ({
   },
 });
 
-export function initReporter(entryName: string) {
+export function requestLatencyMiddleware(entryName: string) {
   return async (c: Context<ServerEnv>, next: Next) => {
-    const reporter = c.get('reporter');
+    const monitors = c.get('monitors');
 
-    if (!reporter) {
+    if (!monitors) {
       await next();
       return;
     }
 
-    await reporter.init({ entryName });
-
-    // reporter global timeing
+    // record page request timing, should include hook/middleware/render
     const getCost = time();
 
     await next();
 
     const cost = getCost();
-    reporter.reportTiming(ServerTimings.SERVER_HANDLE_REQUEST, cost);
+    monitors.timing(ServerTimings.SERVER_HANDLE_REQUEST, cost);
   };
 }

--- a/packages/server/core/src/plugins/render/index.ts
+++ b/packages/server/core/src/plugins/render/index.ts
@@ -15,7 +15,7 @@ import {
   getServerMidFromUnstableMid,
   injectRoute,
 } from '../customServer';
-import { initReporter } from '../monitors';
+import { requestLatencyMiddleware } from '../monitors';
 
 export * from './inject';
 
@@ -57,8 +57,8 @@ export const renderPlugin = (): ServerPlugin => ({
             : `${originUrlPath}/*`;
 
           middlewares.push({
-            name: 'init-reporter',
-            handler: initReporter(entryName),
+            name: 'page-latency',
+            handler: requestLatencyMiddleware(entryName),
           });
 
           const customServerHookMiddleware = customServer.getHookMiddleware(

--- a/packages/server/core/src/plugins/render/index.ts
+++ b/packages/server/core/src/plugins/render/index.ts
@@ -10,11 +10,7 @@ import type {
   ServerPlugin,
 } from '../../types';
 import { sortRoutes } from '../../utils';
-import {
-  CustomServer,
-  getServerMidFromUnstableMid,
-  injectRoute,
-} from '../customServer';
+import { CustomServer, getServerMidFromUnstableMid } from '../customServer';
 import { requestLatencyMiddleware } from '../monitors';
 
 export * from './inject';
@@ -58,6 +54,7 @@ export const renderPlugin = (): ServerPlugin => ({
 
           middlewares.push({
             name: 'page-latency',
+            path: urlPath,
             handler: requestLatencyMiddleware(entryName),
           });
 
@@ -65,11 +62,6 @@ export const renderPlugin = (): ServerPlugin => ({
             entryName,
             routes,
           );
-
-          middlewares.push({
-            name: 'inject-route-info',
-            handler: injectRoute({ entryName }),
-          });
 
           middlewares.push({
             name: 'custom-server-hook',

--- a/packages/server/core/src/plugins/route.ts
+++ b/packages/server/core/src/plugins/route.ts
@@ -1,0 +1,56 @@
+import type { ServerRoute } from '@modern-js/types';
+import { MAIN_ENTRY_NAME } from '@modern-js/utils/universal/constants';
+import type { Middleware, ServerEnv, ServerPlugin } from '../types';
+import { sortRoutes } from '../utils';
+
+function injectRoute(route: {
+  entryName: string;
+}): Middleware<ServerEnv> {
+  return async (c, next) => {
+    if (route && !c.get('route')) {
+      c.set('route', route);
+    }
+
+    await next();
+  };
+}
+
+function getPageRoutes(routes: ServerRoute[]): ServerRoute[] {
+  return (
+    routes
+      .filter(route => !route.isApi)
+      // ensure route.urlPath.length diminishing
+      .sort(sortRoutes)
+  );
+}
+
+export const injectRoutePlugin = (): ServerPlugin => ({
+  name: '@modern-js/plugin-inject-route',
+
+  setup(api) {
+    return {
+      async prepare() {
+        const { middlewares, routes } = api.useAppContext();
+
+        if (!routes) {
+          return;
+        }
+
+        const pageRoutes = getPageRoutes(routes);
+        // inject current route info into hono context
+        for (const route of pageRoutes) {
+          const { urlPath: originUrlPath, entryName = MAIN_ENTRY_NAME } = route;
+          const urlPath = originUrlPath.endsWith('/')
+            ? `${originUrlPath}*`
+            : `${originUrlPath}/*`;
+
+          middlewares.push({
+            name: 'inject-route-info',
+            path: urlPath,
+            handler: injectRoute({ entryName }),
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Summary

This PR remove `reporter.init` API invoke in `@modern-js/server-core`.

It should implement in the place that create report instance. So we modify the middleware name to `requestLatencyMiddleware`.

And this PR also fix some problem:

1. InjectRoute and requestLatencyMiddleware should add `path`, otherwise it will run multiple times in multi-entry project.
2. Move `injectRoute` to defaultPlugins, so that user can get it before `await next()`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
