### PR TITLE
test: should reject on compile error

### DIFF
--- a/tests/integration/swc/tests/transform-fail.test.ts
+++ b/tests/integration/swc/tests/transform-fail.test.ts
@@ -15,6 +15,7 @@ describe('swc transform failed minify', () => {
         NODE_ENV: 'development',
         PORT: port,
       },
+      rejectOnCompileError: false,
     });
 
     expect(cp).toBeDefined();

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -48,7 +48,11 @@ function runModernCommand(argv, options = {}) {
 
       const compileErrorMarker = /Compile error/i;
 
-      if (cmd === 'build' && rejectOnCompileError && compileErrorMarker.test(message)) {
+      if (
+        cmd === 'build' &&
+        rejectOnCompileError &&
+        compileErrorMarker.test(message)
+      ) {
         reject(new Error(message));
       }
 


### PR DESCRIPTION
## Summary

When the build fails, the tests have already failed, and continuing execution will make it difficult to pinpoint the correct error message.

like this, compile error but report ` Error: failed to find element matching selector ".mock_file"`
<img width="1516" alt="image" src="https://github.com/user-attachments/assets/e2c0b34b-e8fb-4c2d-885f-c6dd546b2450" />

<img width="1447" alt="image" src="https://github.com/user-attachments/assets/d2cb7f40-bb13-491e-8119-2dd95d8b98e7" />



## Related Links

https://github.com/web-infra-dev/rspack/actions/runs/13515385701/job/37763519692

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
