### PR TITLE
feat: defineRuntimeConfig supports function parameters

### DIFF
--- a/.changeset/honest-turtles-chew.md
+++ b/.changeset/honest-turtles-chew.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: defineRuntimeConfig supports function parameters and multiple entry configuration
+
+feat: defineRuntimeConfig 支持函数参数及配置多入口

--- a/packages/runtime/plugin-runtime/src/cli/code.ts
+++ b/packages/runtime/plugin-runtime/src/cli/code.ts
@@ -193,6 +193,7 @@ export const generateCode = async (
         let contextCode = '';
         if (!config.server.rsc) {
           contextCode = template.runtimeGlobalContext({
+            entryName,
             srcDirectory,
             internalSrcAlias,
             metaName,

--- a/packages/runtime/plugin-runtime/src/cli/template.ts
+++ b/packages/runtime/plugin-runtime/src/cli/template.ts
@@ -164,7 +164,8 @@ const getImportRuntimeConfigCode = (
       ),
     )
   ) {
-    return `import runtimeConfig from '${internalSrcAlias}/${runtimeConfigFile}';`;
+    return `import modernRuntime from '${internalSrcAlias}/${runtimeConfigFile}';
+const runtimeConfig = typeof modernRuntime === 'function' ? modernRuntime(getCurrentEntryName()) : modernRuntime`;
   }
   return `let runtimeConfig;`;
 };
@@ -195,7 +196,8 @@ export const runtimeRegister = ({
   runtimeConfigFile: string | false;
   runtimePlugins: RuntimePluginConfig[];
 }) => `import { registerPlugin, mergeConfig } from '@${metaName}/runtime/plugin';
-import { getGlobalAppConfig, getGlobalLayoutApp } from '@${metaName}/runtime/context';
+import { getGlobalAppConfig, getGlobalLayoutApp, getCurrentEntryName } from '@${metaName}/runtime/context';
+
 ${getImportRuntimeConfigCode(srcDirectory, internalSrcAlias, runtimeConfigFile)}
 
 const plugins = [];
@@ -212,12 +214,14 @@ registerPlugin(plugins, runtimeConfig);
 `;
 
 export const runtimeGlobalContext = ({
+  entryName,
   srcDirectory,
   internalSrcAlias,
   metaName,
   entry,
   customEntry,
 }: {
+  entryName: string;
   srcDirectory: string;
   internalSrcAlias: string;
   metaName: string;
@@ -237,7 +241,9 @@ import App from '${
     )
   }';
 
+const entryName = '${entryName}';
 setGlobalContext({
+  entryName,
   App,
 });`;
 };

--- a/packages/runtime/plugin-runtime/src/core/config.ts
+++ b/packages/runtime/plugin-runtime/src/core/config.ts
@@ -25,4 +25,6 @@ export const defineConfig = (
  * This function helps you to autocomplete configuration types.
  * It accepts a direct config object, or a function that returns a config.
  */
-export const defineRuntimeConfig = (config: RuntimeConfig) => config;
+export const defineRuntimeConfig = (
+  config: RuntimeConfig | ((entryName: string) => RuntimeConfig),
+) => config;

--- a/packages/runtime/plugin-runtime/src/core/context/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/index.ts
@@ -10,6 +10,7 @@ export {
 } from './runtime';
 
 interface GlobalContext {
+  entryName?: string;
   /**
    * App.tsx export default component
    */
@@ -45,6 +46,7 @@ export function setGlobalContext(
     appConfig?: () => AppConfig;
   },
 ) {
+  globalContext.entryName = context.entryName;
   globalContext.App = context.App;
   globalContext.routes = context.routes;
   globalContext.appInit = context.appInit;
@@ -54,6 +56,10 @@ export function setGlobalContext(
       : context.appConfig;
   globalContext.layoutApp = context.layoutApp;
   globalContext.RSCRoot = context.RSCRoot;
+}
+
+export function getCurrentEntryName() {
+  return globalContext.entryName;
 }
 
 export function getGlobalRSCRoot() {

--- a/packages/runtime/plugin-runtime/src/router/cli/code/templates.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/code/templates.ts
@@ -537,12 +537,14 @@ export function ssrLoaderCombinedModule(
 }
 
 export const runtimeGlobalContext = async ({
+  entryName,
   metaName,
   srcDirectory,
   nestedRoutesEntry,
   internalSrcAlias,
   globalApp,
 }: {
+  entryName: string;
   metaName: string;
   srcDirectory: string;
   nestedRoutesEntry?: string;
@@ -600,7 +602,9 @@ export const runtimeGlobalContext = async ({
 
 import { routes } from './routes';
 
+const entryName = '${entryName}';
 setGlobalContext({
+  entryName,
   layoutApp,
   routes,
   appInit,

--- a/packages/runtime/plugin-runtime/src/router/cli/handler.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/handler.ts
@@ -39,6 +39,7 @@ export async function handleGeneratorEntryCode(
           internalDirectory,
           entrypoint.entryName,
           await templates.runtimeGlobalContext({
+            entryName: entrypoint.entryName,
             metaName: appContext.metaName,
             srcDirectory: appContext.srcDirectory,
             nestedRoutesEntry: entrypoint.nestedRoutesEntry,


### PR DESCRIPTION
## Summary

`src/modern.runtime.ts` defines Runtime config support function and uses entry name params.
```ts title="src/modern.runtime.ts"
import { defineRuntimeConfig } from '@modern-js/runtime';

export default defineRuntimeConfig(entryName => {
  console.log('entryName', entryName);
  return {
    plugins: [],
  };
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
