### PR TITLE
feat: support some response APIs

### DIFF
--- a/.changeset/two-guests-argue.md
+++ b/.changeset/two-guests-argue.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/runtime-utils': patch
+---
+
+feat: Add response APIs to support setting response headers, status codes, and redirects
+feat: 添加一些响应的 API，可以设置响应头，状态码，及重定向

--- a/packages/runtime/plugin-runtime/src/core/context/response/index.server.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/response/index.server.tsx
@@ -1,0 +1,42 @@
+import { storage } from '@modern-js/runtime-utils/node';
+export const getResponseProxy = () => {
+  const context = storage.useContext();
+  return context?.responseProxy;
+};
+
+export const setHeaders = (headers: Record<string, string>) => {
+  const responseProxy = getResponseProxy();
+  Object.entries(headers).forEach(([key, value]) => {
+    responseProxy!.headers[key] = value;
+  });
+};
+
+export const setStatus = (status: number) => {
+  const responseProxy = getResponseProxy();
+  responseProxy!.status = status;
+};
+
+export const redirect = (url: string, init?: number | ResponseInit) => {
+  const status =
+    init === undefined
+      ? 307
+      : typeof init === 'number'
+        ? init
+        : (init.status ?? 307);
+  const headers =
+    init === undefined
+      ? {}
+      : typeof init === 'number'
+        ? {}
+        : (init.headers ?? {});
+
+  setStatus(status);
+  setHeaders({
+    Location: url,
+    ...(init && typeof init === 'object'
+      ? Object.fromEntries(
+          Object.entries(headers).map(([k, v]) => [k, String(v)]),
+        )
+      : {}),
+  });
+};

--- a/packages/runtime/plugin-runtime/src/core/context/response/index.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/response/index.tsx
@@ -3,4 +3,8 @@ export const getResponseProxy = () => {
 };
 export const setHeaders = (headers: Record<string, string>) => {};
 export const setStatus = (status: number) => {};
-export const redirect = (url: string, init?: number | ResponseInit) => {};
+export const redirect = (url: string, init?: number | ResponseInit) => {
+  console.warn(
+    `You should not use this API in the browser, please use the router's redirect or useNavigate method.`,
+  );
+};

--- a/packages/runtime/plugin-runtime/src/core/context/response/index.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/response/index.tsx
@@ -1,0 +1,6 @@
+export const getResponseProxy = () => {
+  return null;
+};
+export const setHeaders = (headers: Record<string, string>) => {};
+export const setStatus = (status: number) => {};
+export const redirect = (url: string, init?: number | ResponseInit) => {};

--- a/packages/runtime/plugin-runtime/src/index.ts
+++ b/packages/runtime/plugin-runtime/src/index.ts
@@ -10,6 +10,7 @@ export type { RuntimeUserConfig } from './config';
 
 export { getMonitors } from './core/context/monitors';
 export { getRequest } from './core/context/request';
+export { setHeaders, setStatus, redirect } from './core/context/response';
 
 export {
   createApp,

--- a/packages/runtime/plugin-runtime/src/react-server.ts
+++ b/packages/runtime/plugin-runtime/src/react-server.ts
@@ -1,2 +1,3 @@
 export { getRequest } from './core/context/request';
 export { getMonitors } from './core/context/monitors';
+export { setHeaders, setStatus, redirect } from './core/context/response';

--- a/packages/toolkit/runtime-utils/src/universal/async_storage.server.ts
+++ b/packages/toolkit/runtime-utils/src/universal/async_storage.server.ts
@@ -51,6 +51,10 @@ const storage = createStorage<{
   monitors?: Monitors;
   headers?: IncomingHttpHeaders;
   request?: Request;
+  responseProxy?: {
+    headers: Record<string, string>;
+    status: number;
+  };
 }>();
 
 type Storage = typeof storage;

--- a/tests/integration/rsc-ssr-app/src/client-component-root/App.tsx
+++ b/tests/integration/rsc-ssr-app/src/client-component-root/App.tsx
@@ -1,14 +1,51 @@
 'use client';
 import 'client-only';
-import { useRuntimeContext } from '@modern-js/runtime';
+import {
+  getRequest,
+  redirect,
+  setHeaders,
+  setStatus,
+  useRuntimeContext,
+} from '@modern-js/runtime';
 import './App.css';
-import { getRequest } from '@modern-js/runtime';
 import { Counter } from './components/Counter';
+
+const handleResponse = (responseType: string) => {
+  switch (responseType) {
+    case 'headers':
+      setHeaders({ 'x-test': 'test-value' });
+      return { message: 'headers set' };
+
+    case 'status':
+      setStatus(418);
+      return { message: 'status set' };
+
+    case 'redirect':
+      redirect('/server-component-root', 307);
+      return null;
+
+    case 'redirect-with-headers':
+      redirect('/server-component-root', {
+        status: 301,
+        headers: {
+          'x-redirect-test': 'test',
+        },
+      });
+      return null;
+
+    default:
+      return { message: 'invalid type' };
+  }
+};
 
 const App = () => {
   const context = useRuntimeContext();
   const request = getRequest();
-  console.log(typeof request?.url);
+  const url = new URL(request.url);
+  const responseType = url.searchParams.get('type');
+  if (responseType) {
+    handleResponse(responseType);
+  }
   return (
     <>
       <div className="container">

--- a/tests/integration/rsc-ssr-app/src/server-component-root/App.tsx
+++ b/tests/integration/rsc-ssr-app/src/server-component-root/App.tsx
@@ -1,14 +1,48 @@
 import 'server-only';
-import { getRequest } from '@modern-js/runtime';
+import { getRequest, redirect, setHeaders } from '@modern-js/runtime';
+import { setStatus } from '@modern-js/runtime';
 import { Suspense } from 'react';
 import styles from './App.module.less';
 import Suspended from './Suspended';
 import { Counter } from './components/Counter';
 import { getCountState } from './components/ServerState';
 
+const handleResponse = (responseType: string) => {
+  switch (responseType) {
+    case 'headers':
+      setHeaders({ 'x-test': 'test-value' });
+      return { message: 'headers set' };
+
+    case 'status':
+      setStatus(418);
+      return { message: 'status set' };
+
+    case 'redirect':
+      redirect('/client-component-root', 307);
+      return null;
+
+    case 'redirect-with-headers':
+      redirect('/client-component-root', {
+        status: 301,
+        headers: {
+          'x-redirect-test': 'test',
+        },
+      });
+      return null;
+
+    default:
+      return { message: 'invalid type' };
+  }
+};
+
 const App = ({ name }: { name: string }) => {
   const request = getRequest();
-  console.log(typeof request?.url);
+  const url = new URL(request.url);
+  const responseType = url.searchParams.get('type');
+  if (responseType) {
+    handleResponse(responseType);
+  }
+
   const countStateFromServer = getCountState();
   return (
     <div className={styles.root}>

--- a/tests/integration/rsc-ssr-app/tests/index.test.ts
+++ b/tests/integration/rsc-ssr-app/tests/index.test.ts
@@ -54,6 +54,8 @@ describe('dev', () => {
       renderClientRootPageCorrectly({ baseUrl, appPort, page }));
     it('should render page with context correctly', () =>
       renderPageWithContext({ baseUrl, appPort, page }));
+    it('should support response api', () =>
+      supportResponseAPIForClientRoot({ baseUrl, appPort, page }));
   });
 
   describe('server component root', () => {
@@ -62,6 +64,8 @@ describe('dev', () => {
       renderServerRootPageCorrectly({ baseUrl, appPort, page }));
     it('should support client and server actions', () =>
       supportServerAction({ baseUrl, appPort, page }));
+    it('should support response api', () =>
+      supportResponseAPIForServerRoot({ baseUrl, appPort, page }));
   });
 });
 
@@ -110,6 +114,8 @@ describe('build', () => {
       renderClientRootPageCorrectly({ baseUrl, appPort, page }));
     it('should render page with context correctly', () =>
       renderPageWithContext({ baseUrl, appPort, page }));
+    it('should support response api', () =>
+      supportResponseAPIForClientRoot({ baseUrl, appPort, page }));
   });
 
   describe('server component root', () => {
@@ -118,6 +124,8 @@ describe('build', () => {
       renderServerRootPageCorrectly({ baseUrl, appPort, page }));
     it('should support server action', () =>
       supportServerAction({ baseUrl, appPort, page }));
+    it('should support response api', () =>
+      supportResponseAPIForServerRoot({ baseUrl, appPort, page }));
   });
 });
 
@@ -180,4 +188,76 @@ async function supportServerAction({ baseUrl, appPort, page }: TestOptions) {
   );
   serverCount = await page.$eval('.server-count', el => el.textContent);
   expect(serverCount).toBe('1');
+}
+
+async function supportResponseAPIForServerRoot({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  const headersRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=headers`,
+  );
+  expect(headersRes.headers.get('x-test')).toBe('test-value');
+
+  // Test setStatus
+  const statusRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=status`,
+  );
+  expect(statusRes.status).toBe(418);
+
+  // Test redirect with status code
+  const redirectRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=redirect`,
+    { redirect: 'manual' },
+  );
+  expect(redirectRes.status).toBe(307);
+  expect(redirectRes.headers.get('location')).toBe('/client-component-root');
+
+  // Test redirect with init object
+  const redirectWithHeadersRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=redirect-with-headers`,
+    { redirect: 'manual' },
+  );
+  expect(redirectWithHeadersRes.status).toBe(301);
+  expect(redirectWithHeadersRes.headers.get('location')).toBe(
+    '/client-component-root',
+  );
+  expect(redirectWithHeadersRes.headers.get('x-redirect-test')).toBe('test');
+}
+
+async function supportResponseAPIForClientRoot({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  const headersRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=headers`,
+  );
+  expect(headersRes.headers.get('x-test')).toBe('test-value');
+
+  // Test setStatus
+  const statusRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=status`,
+  );
+  expect(statusRes.status).toBe(418);
+
+  // Test redirect with status code
+  const redirectRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=redirect`,
+    { redirect: 'manual' },
+  );
+  expect(redirectRes.status).toBe(307);
+  expect(redirectRes.headers.get('location')).toBe('/server-component-root');
+
+  // Test redirect with init object
+  const redirectWithHeadersRes = await fetch(
+    `http://127.0.0.1:${appPort}/${baseUrl}?type=redirect-with-headers`,
+    { redirect: 'manual' },
+  );
+  expect(redirectWithHeadersRes.status).toBe(301);
+  expect(redirectWithHeadersRes.headers.get('location')).toBe(
+    '/server-component-root',
+  );
+  expect(redirectWithHeadersRes.headers.get('x-redirect-test')).toBe('test');
 }


### PR DESCRIPTION
## Summary

Add some response APIs to support setting response headers, status codes, and redirects

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
