### PR TITLE
feat: rename runtime plugin modifyRuntimeConfig hook to config

### DIFF
--- a/.changeset/calm-guests-act.md
+++ b/.changeset/calm-guests-act.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/plugin-v2': patch
+---
+
+feat: rename runtime plugin modifyRuntimeConfig hook to config
+
+feat: 重命名 runtime 插件 modifyRuntimeConfig 钩子为 config

--- a/packages/runtime/plugin-runtime/src/core/compat/hooks.ts
+++ b/packages/runtime/plugin-runtime/src/core/compat/hooks.ts
@@ -51,8 +51,8 @@ export function getHookRunners(
     pickContext: (context: RuntimeContext) => {
       return hooks.pickContext.call(context);
     },
-    modifyRuntimeConfig: (config: RuntimeConfig) => {
-      return hooks.modifyRuntimeConfig.call(config);
+    config: () => {
+      return hooks.config.call();
     },
   };
 }

--- a/packages/runtime/plugin-runtime/src/core/plugin/base.ts
+++ b/packages/runtime/plugin-runtime/src/core/plugin/base.ts
@@ -14,7 +14,7 @@ export type RuntimeHooks = {
   beforeRender: AsyncInterruptWorkflow<RuntimeContext, void>;
   wrapRoot: Waterfall<React.ComponentType<any>>;
   pickContext: Waterfall<TRuntimeContext>;
-  modifyRuntimeConfig: SyncParallelWorkflow<void, Record<string, any>>;
+  config: SyncParallelWorkflow<void, Record<string, any>>;
 };
 
 export type RuntimePluginAPI = { useRuntimeConfigContext: () => RuntimeConfig };

--- a/packages/runtime/plugin-runtime/src/core/plugin/types.ts
+++ b/packages/runtime/plugin-runtime/src/core/plugin/types.ts
@@ -3,6 +3,7 @@ import type {
   RuntimePluginExtends,
 } from '@modern-js/plugin-v2';
 import type { Hooks } from '@modern-js/plugin-v2/runtime';
+import type { AppConfig } from '../../common';
 import type { RuntimeContext } from '../context/runtime';
 import type { Plugin } from './base';
 
@@ -14,6 +15,6 @@ export type RuntimeExtends = Required<
 
 export type RuntimePluginFuture<Extends extends RuntimePluginExtends = {}> =
   BaseRuntimePlugin<RuntimeExtends & Extends>;
-export interface RuntimeConfig {
+export interface RuntimeConfig extends AppConfig {
   plugins?: (Plugin | RuntimePluginFuture)[];
 }

--- a/packages/toolkit/plugin-v2/src/runtime/api.ts
+++ b/packages/toolkit/plugin-v2/src/runtime/api.ts
@@ -85,7 +85,7 @@ export function initPluginAPI<Extends extends RuntimePluginExtends>({
     updateRuntimeContext,
     getHooks,
     getRuntimeConfig,
-    modifyRuntimeConfig: hooks.modifyRuntimeConfig.tap,
+    config: hooks.config.tap,
     onBeforeRender: hooks.onBeforeRender.tap,
     wrapRoot: hooks.wrapRoot.tap,
     pickContext: hooks.pickContext.tap,

--- a/packages/toolkit/plugin-v2/src/runtime/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/runtime/hooks.ts
@@ -4,8 +4,8 @@ import {
   createSyncHook,
 } from '../hooks';
 import type {
+  ConfigFn,
   Hooks,
-  ModifyRuntimeConfigFn,
   OnBeforeRenderFn,
   PickContextFn,
   WrapRootFn,
@@ -20,7 +20,6 @@ export function initHooks<RuntimeConfig, RuntimeContext>(): Hooks<
       createAsyncInterruptHook<OnBeforeRenderFn<RuntimeContext>>(),
     wrapRoot: createSyncHook<WrapRootFn>(),
     pickContext: createSyncHook<PickContextFn<RuntimeContext>>(),
-    modifyRuntimeConfig:
-      createCollectSyncHook<ModifyRuntimeConfigFn<RuntimeConfig>>(),
+    config: createCollectSyncHook<ConfigFn<RuntimeConfig>>(),
   };
 }

--- a/packages/toolkit/plugin-v2/src/runtime/run/create.ts
+++ b/packages/toolkit/plugin-v2/src/runtime/run/create.ts
@@ -50,12 +50,12 @@ export const createRuntime = <Extends extends RuntimePluginExtends>() => {
 
   function run(options: RuntimeRunOptions) {
     const { runtimeContext } = init(options);
-    const configs = runtimeContext.hooks.modifyRuntimeConfig
-      .call(runtimeContext.config)
+    const configs = runtimeContext.hooks.config
+      .call()
       .filter((config): config is NonNullable<typeof config> =>
         Boolean(config),
       );
-    runtimeContext.config = merge({}, ...configs);
+    runtimeContext.config = merge({}, ...configs, runtimeContext.config || {});
     return { runtimeContext };
   }
 

--- a/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/cli/hooks.ts
@@ -89,7 +89,7 @@ export type OnAfterDeployFn = (
   options?: Record<string, any>,
 ) => Promise<void> | void;
 
-export type OnBeforeExitFn = () => void;
+export type OnBeforeExitFn = () => Promise<void> | void;
 
 export type ModifyBundlerChainFn<ExtendsUtils> = (
   chain: RspackChain,

--- a/packages/toolkit/plugin-v2/src/types/runtime/api.ts
+++ b/packages/toolkit/plugin-v2/src/types/runtime/api.ts
@@ -3,7 +3,7 @@ import type { DeepPartial } from '../utils';
 import type { RuntimeContext } from './context';
 import type { Hooks } from './hooks';
 import type {
-  ModifyRuntimeConfigFn,
+  ConfigFn,
   OnBeforeRenderFn,
   PickContextFn,
   WrapRootFn,
@@ -21,9 +21,7 @@ export type RuntimePluginAPI<Extends extends RuntimePluginExtends> = Readonly<
     onBeforeRender: PluginHookTap<OnBeforeRenderFn<Extends['extendContext']>>;
     wrapRoot: PluginHookTap<WrapRootFn>;
     pickContext: PluginHookTap<PickContextFn<RuntimeContext>>;
-    modifyRuntimeConfig: PluginHookTap<
-      ModifyRuntimeConfigFn<Extends['config']>
-    >;
+    config: PluginHookTap<ConfigFn<Extends['config']>>;
   } & RuntimePluginExtendsAPI<Extends>
 >;
 

--- a/packages/toolkit/plugin-v2/src/types/runtime/hooks.ts
+++ b/packages/toolkit/plugin-v2/src/types/runtime/hooks.ts
@@ -14,13 +14,11 @@ export type PickContextFn<RuntimeContext> = (
   context: RuntimeContext,
 ) => RuntimeContext;
 
-export type ModifyRuntimeConfigFn<RuntimeConfig> = (
-  config: RuntimeConfig,
-) => RuntimeConfig;
+export type ConfigFn<RuntimeConfig> = () => RuntimeConfig;
 
 export type Hooks<RuntimeConfig, RuntimeContext> = {
   onBeforeRender: AsyncInterruptHook<OnBeforeRenderFn<RuntimeContext>>;
   wrapRoot: SyncHook<WrapRootFn>;
   pickContext: SyncHook<PickContextFn<RuntimeContext>>;
-  modifyRuntimeConfig: CollectSyncHook<ModifyRuntimeConfigFn<RuntimeConfig>>;
+  config: CollectSyncHook<ConfigFn<RuntimeConfig>>;
 };

--- a/tests/integration/runtime-plugin/fixtures/runtime-custom-config-plugin/src/plugins/config.tsx
+++ b/tests/integration/runtime-plugin/fixtures/runtime-custom-config-plugin/src/plugins/config.tsx
@@ -6,7 +6,7 @@ export const configPlugin = (): Plugin => {
     post: ['@modern-js/plugin-router'],
     setup: _api => {
       return {
-        modifyRuntimeConfig() {
+        config() {
           return {
             router: {
               basename: 'test',

--- a/tests/integration/runtime-plugin/fixtures/runtime-custom-config-plugin/src/plugins/config.tsx
+++ b/tests/integration/runtime-plugin/fixtures/runtime-custom-config-plugin/src/plugins/config.tsx
@@ -1,19 +1,17 @@
-import type { Plugin } from '@modern-js/runtime';
+import type { RuntimePluginFuture } from '@modern-js/runtime';
 
-export const configPlugin = (): Plugin => {
+export const configPlugin = (): RuntimePluginFuture => {
   return {
     name: 'app-custom-config-plugin',
     post: ['@modern-js/plugin-router'],
-    setup: _api => {
-      return {
-        config() {
-          return {
-            router: {
-              basename: 'test',
-            },
-          };
-        },
-      };
+    setup: api => {
+      api.config(() => {
+        return {
+          router: {
+            basename: 'test',
+          },
+        };
+      });
     },
   };
 };


### PR DESCRIPTION
## Summary

The design of the Runtime plugin's `modifyRuntimeConfig` is a collectAsyncHook. Just like the `config` hook of the CLI plugin, it is used to collect the configurations of Runtime plugins and then perform merging. Calling it `modifyRuntimeConfig` is not very appropriate. It should be consistent with the CLI plugin, so it is renamed to `config`. Since this Hook has not been officially released externally, there will be a break change here, but it should not have a significant impact.

```ts
import type { RuntimePluginFuture } from '@modern-js/runtime';

export const configPlugin = (): RuntimePluginFuture => {
  return {
    name: 'app-custom-config-plugin',
    post: ['@modern-js/plugin-router'],
    setup: api => {
      api.config(() => {
        return {
          router: {
            basename: 'test',
          },
        };
      });
    },
  };
};

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
