### PR TITLE
fix: add new mid connet for mock handler

### DIFF
--- a/.changeset/eleven-suits-behave.md
+++ b/.changeset/eleven-suits-behave.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server': patch
+'@modern-js/server-core': patch
+---
+
+fix: add new mid connet for mock handler

--- a/packages/server/core/src/adapters/node/index.ts
+++ b/packages/server/core/src/adapters/node/index.ts
@@ -1,4 +1,8 @@
-export { httpCallBack2HonoMid, connectMid2HonoMid } from './hono';
+export {
+  httpCallBack2HonoMid,
+  connectMid2HonoMid,
+  connectMockMid2HonoMid,
+} from './hono';
 export type { ServerNodeContext, ServerNodeMiddleware } from './hono';
 
 export {

--- a/packages/server/server/src/helpers/mock.ts
+++ b/packages/server/server/src/helpers/mock.ts
@@ -5,7 +5,7 @@ import {
   type InternalRequest,
   type Middleware,
 } from '@modern-js/server-core';
-import { connectMid2HonoMid } from '@modern-js/server-core/node';
+import { connectMockMid2HonoMid } from '@modern-js/server-core/node';
 import type { NextFunction } from '@modern-js/types';
 import { fs } from '@modern-js/utils';
 import { match } from 'path-to-regexp';
@@ -163,7 +163,7 @@ export async function getMockMiddleware(pwd: string): Promise<Middleware> {
       const { handler } = matchedMockAPI;
 
       if (typeof handler === 'function') {
-        return await connectMid2HonoMid(handler)(c, next);
+        return await connectMockMid2HonoMid(handler)(c, next);
       } else {
         return c.json(handler);
       }


### PR DESCRIPTION
## Summary

This PR add a new middleware connect function for mock handler.

Because we are not sure how developer use `tools.devServer.before` and `tools.devServer.after`, avoid to affecting the other features, so we add a new function.

We expect mock handler will always handle response by itself.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
