### PR TITLE
feat: garfish provider support add appName props

### DIFF
--- a/.changeset/tame-peas-fix.md
+++ b/.changeset/tame-peas-fix.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-garfish': patch
+---
+
+feat: garfish provider support add appName props
+
+feat: garfish provider 支持添加 appName props

--- a/packages/runtime/plugin-garfish/src/runtime/provider.tsx
+++ b/packages/runtime/plugin-garfish/src/runtime/provider.tsx
@@ -33,6 +33,7 @@ export function createProvider(
         basename,
         dom,
         props,
+        appName,
       }: {
         basename: string;
         dom: HTMLElement;
@@ -43,14 +44,17 @@ export function createProvider(
         const mountNode = generateRootDom(dom, id || 'root');
         if (customBootstrap) {
           root = await customBootstrap(ModernRoot, () =>
-            render(<ModernRoot basename={basename} {...props} />, mountNode),
+            render(
+              <ModernRoot basename={basename} appName={appName} {...props} />,
+              mountNode,
+            ),
           );
         } else {
           if (beforeRender) {
-            await beforeRender(ModernRoot, { basename, ...props });
+            await beforeRender(ModernRoot, { basename, appName, ...props });
           }
           root = await render(
-            <ModernRoot basename={basename} {...props} />,
+            <ModernRoot basename={basename} appName={appName} {...props} />,
             mountNode,
           );
         }


### PR DESCRIPTION
## Summary

garfish `createProvider` function support add `appName` props to `ModernRoot`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
