### PR TITLE
feat: rename server plugin type define

### DIFF
--- a/.changeset/perfect-pears-move.md
+++ b/.changeset/perfect-pears-move.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server-core': patch
+---
+
+feat: rename ServerPlugin to ServerPluginLegacy and ServerPluginFuture to ServerPlugin
+
+feat: 将 ServerPlugin 类型重命名为 ServerPluginLegacy，ServerPluginFuture 类型重命名为 ServerPlugin

--- a/packages/cli/plugin-bff/src/server.ts
+++ b/packages/cli/plugin-bff/src/server.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { ApiRouter } from '@modern-js/bff-core';
-import type { ServerPlugin } from '@modern-js/server-core';
+import type { ServerPluginLegacy } from '@modern-js/server-core';
 import type { ServerNodeMiddleware } from '@modern-js/server-core/node';
 import {
   API_DIR,
@@ -25,7 +25,7 @@ const createTransformAPI = (storage: Storage) => ({
   },
 });
 
-export default (): ServerPlugin => ({
+export default (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-bff',
   setup: api => {
     const storage = new Storage();

--- a/packages/cli/plugin-bff/tests/server.test.ts
+++ b/packages/cli/plugin-bff/tests/server.test.ts
@@ -4,7 +4,7 @@ import { server } from '@modern-js/plugin-v2/server';
 import {
   type ServerConfig,
   type ServerPlugin,
-  type ServerPluginFuture,
+  type ServerPluginLegacy,
   compatPlugin,
   handleSetupResult,
 } from '@modern-js/server-core';
@@ -21,7 +21,7 @@ export async function serverInit({
   plugins,
   serverConfig,
 }: {
-  plugins?: (ServerPlugin | ServerPluginFuture)[];
+  plugins?: (ServerPlugin | ServerPluginLegacy)[];
   serverConfig?: ServerConfig;
 }) {
   const { serverContext } = await server.run({
@@ -53,7 +53,7 @@ describe('bff server plugin', () => {
   describe('prepareApiServer', () => {
     it('should work well', async () => {
       let apiHandlerInfos = null;
-      const mockApiPlugin: ServerPlugin = {
+      const mockApiPlugin: ServerPluginLegacy = {
         name: 'mock-api',
 
         setup(api) {
@@ -82,7 +82,7 @@ describe('bff server plugin', () => {
     it('should work well with prefix', async () => {
       let apiHandlerInfos = null;
 
-      const mockApiPlugin: ServerPlugin = {
+      const mockApiPlugin: ServerPluginLegacy = {
         name: 'mock-api',
 
         setup(api) {

--- a/packages/devtools/plugin/src/types/common.ts
+++ b/packages/devtools/plugin/src/types/common.ts
@@ -5,7 +5,7 @@ import type {
   DevtoolsContext,
   ServerManifest,
 } from '@modern-js/devtools-kit/node';
-import type { ServerPlugin, ToThreads } from '@modern-js/server-core';
+import type { ServerPluginLegacy, ToThreads } from '@modern-js/server-core';
 import type { RsbuildPluginAPI } from '@rsbuild/core';
 import type { Hookable } from 'hookable';
 
@@ -13,7 +13,9 @@ export type CliPluginAPI = Parameters<
   NonNullable<CliPlugin<AppTools>['setup']>
 >[0];
 
-export type ServerPluginAPI = Parameters<NonNullable<ServerPlugin['setup']>>[0];
+export type ServerPluginAPI = Parameters<
+  NonNullable<ServerPluginLegacy['setup']>
+>[0];
 
 export type BufferLike =
   | string

--- a/packages/runtime/plugin-testing/src/cli/bff/index.ts
+++ b/packages/runtime/plugin-testing/src/cli/bff/index.ts
@@ -1,6 +1,6 @@
 import type { CliPlugin, IAppContext } from '@modern-js/core';
 // must import from server-core, due to ts compiler error.
-import type { ServerPlugin } from '@modern-js/server-core';
+import type { ServerPluginLegacy } from '@modern-js/server-core';
 import { isApiOnly } from '@modern-js/utils';
 import {
   DEFAULT_RESOLVER_PATH,
@@ -22,7 +22,7 @@ export const setJestConfigForBFF = async ({
 }: {
   pwd: string;
   userConfig: any;
-  plugins: ServerPlugin[];
+  plugins: ServerPluginLegacy[];
   routes: any[];
   utils: TestConfigOperator;
   appContext: IAppContext;

--- a/packages/server/core/src/adapters/node/plugins/nodeServer.ts
+++ b/packages/server/core/src/adapters/node/plugins/nodeServer.ts
@@ -1,10 +1,10 @@
 import type { Server as NodeServer } from 'node:http';
-import type { ServerPlugin } from '../../../types';
+import type { ServerPluginLegacy } from '../../../types';
 export const injectNodeSeverPlugin = ({
   nodeServer,
 }: {
   nodeServer: NodeServer;
-}): ServerPlugin => ({
+}): ServerPluginLegacy => ({
   name: '@modern-js/plugin-inject-node-server',
 
   setup(api) {

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -15,7 +15,7 @@ import type {
   Middleware,
   ServerEnv,
   ServerManifest,
-  ServerPlugin,
+  ServerPluginLegacy,
 } from '../../../types';
 import { uniqueKeyByRoute } from '../../../utils';
 
@@ -166,7 +166,7 @@ export async function getRscSSRManifest(pwd: string) {
   return rscSSRManifest;
 }
 
-export const injectRscManifestPlugin = (): ServerPlugin => ({
+export const injectRscManifestPlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-inject-rsc-manifest',
   setup(api) {
     return {
@@ -198,7 +198,7 @@ export const injectRscManifestPlugin = (): ServerPlugin => ({
   },
 });
 
-export const injectResourcePlugin = (): ServerPlugin => ({
+export const injectResourcePlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-inject-resource',
 
   setup(api) {

--- a/packages/server/core/src/adapters/node/plugins/static.ts
+++ b/packages/server/core/src/adapters/node/plugins/static.ts
@@ -8,11 +8,11 @@ import type {
   HtmlNormalizedConfig,
   Middleware,
   OutputNormalizedConfig,
-  ServerPlugin,
+  ServerPluginLegacy,
 } from '../../../types';
 import { sortRoutes } from '../../../utils';
 
-export const serverStaticPlugin = (): ServerPlugin => ({
+export const serverStaticPlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-server-static',
 
   setup(api) {

--- a/packages/server/core/src/plugins/compat/index.ts
+++ b/packages/server/core/src/plugins/compat/index.ts
@@ -6,12 +6,12 @@ import type {
   FallbackFn,
   PrepareApiServerFn,
   PrepareWebServerFn,
-  ServerPluginFuture,
+  ServerPlugin,
 } from '../../types';
 import { getHookRunners } from './hooks';
 
 export { handleSetupResult } from './hooks';
-export const compatPlugin = (): ServerPluginFuture => ({
+export const compatPlugin = (): ServerPlugin => ({
   name: '@modern-js/server-compat',
   registryHooks: {
     fallback: createAsyncHook<FallbackFn>(),

--- a/packages/server/core/src/plugins/default.ts
+++ b/packages/server/core/src/plugins/default.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@modern-js/types';
-import type { ServerPlugin, ServerPluginFuture } from '../types';
+import type { ServerPlugin, ServerPluginLegacy } from '../types';
 import { compatPlugin } from './compat';
 import { logPlugin } from './log';
 import {
@@ -34,7 +34,7 @@ function createSilenceLogger() {
 export function createDefaultPlugins(
   options: CreateDefaultPluginsOptions = {},
 ) {
-  const plugins: (ServerPlugin | ServerPluginFuture)[] = [
+  const plugins: (ServerPlugin | ServerPluginLegacy)[] = [
     compatPlugin(),
     logPlugin(),
     initMonitorsPlugin(),

--- a/packages/server/core/src/plugins/favicon.ts
+++ b/packages/server/core/src/plugins/favicon.ts
@@ -1,6 +1,6 @@
-import type { ServerPlugin } from '../types';
+import type { ServerPluginLegacy } from '../types';
 
-export const faviconPlugin = (): ServerPlugin => ({
+export const faviconPlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-favicon',
 
   setup(api) {

--- a/packages/server/core/src/plugins/log.ts
+++ b/packages/server/core/src/plugins/log.ts
@@ -1,4 +1,4 @@
-import type { Middleware, ServerEnv, ServerPlugin } from '../types';
+import type { Middleware, ServerEnv, ServerPluginLegacy } from '../types';
 // The following code is modified based on https://github.com/honojs/hono/blob/main/src/middleware/logger/index.ts
 // license at https://github.com/honojs/hono/blob/main/LICENSE
 import { getPathname } from '../utils';
@@ -84,7 +84,7 @@ function logHandler(): Middleware<ServerEnv> {
   };
 }
 
-export const logPlugin = (): ServerPlugin => ({
+export const logPlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-log',
 
   setup(api) {

--- a/packages/server/core/src/plugins/monitors.ts
+++ b/packages/server/core/src/plugins/monitors.ts
@@ -9,7 +9,7 @@ import type {
   TimingEvent,
 } from '@modern-js/types';
 import { SERVER_TIMING, ServerTimings } from '../constants';
-import type { Context, Next, ServerEnv, ServerPlugin } from '../types';
+import type { Context, Next, ServerEnv, ServerPluginLegacy } from '../types';
 
 function createMonitors(): Monitors {
   const coreMonitors: CoreMonitor[] = [];
@@ -80,7 +80,7 @@ function createMonitors(): Monitors {
   return mointors;
 }
 
-export const initMonitorsPlugin = (): ServerPlugin => ({
+export const initMonitorsPlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/init-mointor',
 
   setup(api) {
@@ -106,7 +106,9 @@ export const initMonitorsPlugin = (): ServerPlugin => ({
   },
 });
 
-export const injectloggerPlugin = (inputLogger?: Logger): ServerPlugin => ({
+export const injectloggerPlugin = (
+  inputLogger?: Logger,
+): ServerPluginLegacy => ({
   name: '@modern-js/inject-logger',
 
   setup(api) {
@@ -169,7 +171,7 @@ export const injectloggerPlugin = (inputLogger?: Logger): ServerPlugin => ({
   },
 });
 
-export const injectServerTiming = (): ServerPlugin => ({
+export const injectServerTiming = (): ServerPluginLegacy => ({
   name: '@modern-js/inject-server-timing',
 
   setup(api) {

--- a/packages/server/core/src/plugins/processedBy.ts
+++ b/packages/server/core/src/plugins/processedBy.ts
@@ -1,6 +1,6 @@
-import type { ServerPlugin } from '../types';
+import type { ServerPluginLegacy } from '../types';
 
-export const processedByPlugin = (): ServerPlugin => ({
+export const processedByPlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-processed',
 
   setup(api) {

--- a/packages/server/core/src/plugins/render/index.ts
+++ b/packages/server/core/src/plugins/render/index.ts
@@ -7,7 +7,7 @@ import type {
   Middleware,
   Render,
   ServerEnv,
-  ServerPlugin,
+  ServerPluginLegacy,
 } from '../../types';
 import { sortRoutes } from '../../utils';
 import { CustomServer, getServerMidFromUnstableMid } from '../customServer';
@@ -15,7 +15,7 @@ import { requestLatencyMiddleware } from '../monitors';
 
 export * from './inject';
 
-export const renderPlugin = (): ServerPlugin => ({
+export const renderPlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-render',
 
   setup(api) {

--- a/packages/server/core/src/plugins/render/inject.ts
+++ b/packages/server/core/src/plugins/render/inject.ts
@@ -3,7 +3,7 @@ import type {
   GetRenderHandlerOptions,
   OnFallback,
   Render,
-  ServerPlugin,
+  ServerPluginLegacy,
 } from '../../types';
 import { createRender } from './render';
 
@@ -15,7 +15,7 @@ export interface InjectRenderHandlerOptions {
 export const injectRenderHandlerPlugin = ({
   staticGenerate,
   cacheConfig,
-}: InjectRenderHandlerOptions): ServerPlugin => ({
+}: InjectRenderHandlerOptions): ServerPluginLegacy => ({
   name: '@modern-js/plugin-inject-render',
   setup(api) {
     return {

--- a/packages/server/core/src/plugins/route.ts
+++ b/packages/server/core/src/plugins/route.ts
@@ -1,6 +1,6 @@
 import type { ServerRoute } from '@modern-js/types';
 import { MAIN_ENTRY_NAME } from '@modern-js/utils/universal/constants';
-import type { Middleware, ServerEnv, ServerPlugin } from '../types';
+import type { Middleware, ServerEnv, ServerPluginLegacy } from '../types';
 import { sortRoutes } from '../utils';
 
 function injectRoute(route: {
@@ -24,7 +24,7 @@ function getPageRoutes(routes: ServerRoute[]): ServerRoute[] {
   );
 }
 
-export const injectRoutePlugin = (): ServerPlugin => ({
+export const injectRoutePlugin = (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-inject-route',
 
   setup(api) {

--- a/packages/server/core/src/serverBase.ts
+++ b/packages/server/core/src/serverBase.ts
@@ -7,8 +7,8 @@ import type {
   ServerConfig,
   ServerContext,
   ServerPlugin,
-  ServerPluginFuture,
   ServerPluginHooks,
+  ServerPluginLegacy,
 } from './types';
 import type { CliConfig } from './types/config';
 import { loadConfig } from './utils';
@@ -31,7 +31,7 @@ export class ServerBase<E extends Env = any> {
 
   private app: Hono<E>;
 
-  private plugins: (ServerPlugin | ServerPluginFuture)[] = [];
+  private plugins: (ServerPlugin | ServerPluginLegacy)[] = [];
 
   private serverContext: ServerContext | null = null;
 
@@ -66,7 +66,7 @@ export class ServerBase<E extends Env = any> {
     return this;
   }
 
-  addPlugins(plugins: (ServerPlugin | ServerPluginFuture)[]) {
+  addPlugins(plugins: (ServerPlugin | ServerPluginLegacy)[]) {
     this.plugins.push(...plugins);
   }
 

--- a/packages/server/core/src/types/plugins/base.ts
+++ b/packages/server/core/src/types/plugins/base.ts
@@ -17,8 +17,8 @@ import type {
 import type { MiddlewareHandler } from 'hono';
 import type { UserConfig } from '../config';
 import type { Render } from '../render';
-import type { ServerPluginFuture } from './new';
-import type { ServerPlugin } from './old';
+import type { ServerPlugin } from './new';
+import type { ServerPluginLegacy } from './old';
 
 export type { FileChangeEvent, ResetEvent } from '@modern-js/plugin-v2';
 export type FallbackReason = 'error' | 'header' | 'query';
@@ -113,5 +113,5 @@ export interface RenderConfig {
 
 export type ServerConfig = {
   render?: RenderConfig;
-  plugins?: (ServerPlugin | ServerPluginFuture)[];
+  plugins?: (ServerPlugin | ServerPluginLegacy)[];
 } & UserConfig;

--- a/packages/server/core/src/types/plugins/new.ts
+++ b/packages/server/core/src/types/plugins/new.ts
@@ -55,7 +55,7 @@ export interface ServerPluginExtends extends BaseServerPluginExtends {
     afterStreamingRender: AsyncPipelineHook<AfterStreamingRenderContextFn>;
   };
 }
-export type ServerPluginFuture = BaseServerPlugin<ServerPluginExtends>;
+export type ServerPlugin = BaseServerPlugin<ServerPluginExtends>;
 
 export type ServerContext = BaseServerContext<ServerPluginExtends> &
   ServerPluginExtends['extendContext'];

--- a/packages/server/core/src/types/plugins/old.ts
+++ b/packages/server/core/src/types/plugins/old.ts
@@ -87,7 +87,7 @@ export type ServerPluginAPI = {
 export type PluginAPI = ServerPluginAPI & CommonAPI<ServerHooks>;
 
 /**old server plugin. */
-export type ServerPlugin = PluginOptions<
+export type ServerPluginLegacy = PluginOptions<
   ServerHooks,
   AsyncSetup<ServerHooks, PluginAPI>
 >;

--- a/packages/server/plugin-express/src/plugin.ts
+++ b/packages/server/plugin-express/src/plugin.ts
@@ -5,7 +5,7 @@ import type {
   InternalRequest,
   Render,
   ServerManifest,
-  ServerPlugin,
+  ServerPluginLegacy,
 } from '@modern-js/server-core';
 import {
   httpCallBack2HonoMid,
@@ -157,7 +157,7 @@ const initApp = (app: express.Express) => {
   return app;
 };
 
-export default (): ServerPlugin => {
+export default (): ServerPluginLegacy => {
   let app: Express;
   let apiDir: string;
   let mode: 'function' | 'framework';

--- a/packages/server/plugin-express/tests/helpers.ts
+++ b/packages/server/plugin-express/tests/helpers.ts
@@ -5,7 +5,7 @@ import { server } from '@modern-js/plugin-v2/server';
 import {
   type ServerConfig,
   type ServerPlugin,
-  type ServerPluginFuture,
+  type ServerPluginLegacy,
   compatPlugin,
   handleSetupResult,
 } from '@modern-js/server-core';
@@ -15,7 +15,7 @@ export async function serverInit({
   plugins,
   serverConfig,
 }: {
-  plugins?: (ServerPlugin | ServerPluginFuture)[];
+  plugins?: (ServerPlugin | ServerPluginLegacy)[];
   serverConfig?: ServerConfig;
 }) {
   const { serverContext } = await server.run({
@@ -44,7 +44,7 @@ export async function serverInit({
   return hooks as any;
 }
 
-export const APIPlugin: ServerPlugin = {
+export const APIPlugin: ServerPluginLegacy = {
   name: 'api-plugin',
 
   setup(api) {

--- a/packages/server/plugin-koa/src/plugin.ts
+++ b/packages/server/plugin-koa/src/plugin.ts
@@ -4,7 +4,7 @@ import type { APIHandlerInfo } from '@modern-js/bff-core';
 import type {
   Render,
   ServerManifest,
-  ServerPlugin,
+  ServerPluginLegacy,
 } from '@modern-js/server-core';
 import type { InternalRequest } from '@modern-js/server-core';
 import {
@@ -154,7 +154,7 @@ const createApp = async ({
   return app;
 };
 
-export default (): ServerPlugin => {
+export default (): ServerPluginLegacy => {
   let app: Application;
   let apiDir: string;
   let mode: 'function' | 'framework';

--- a/packages/server/plugin-koa/tests/helpers.ts
+++ b/packages/server/plugin-koa/tests/helpers.ts
@@ -5,7 +5,7 @@ import { server } from '@modern-js/plugin-v2/server';
 import {
   type ServerConfig,
   type ServerPlugin,
-  type ServerPluginFuture,
+  type ServerPluginLegacy,
   compatPlugin,
   handleSetupResult,
 } from '@modern-js/server-core';
@@ -15,7 +15,7 @@ export async function serverInit({
   plugins,
   serverConfig,
 }: {
-  plugins?: (ServerPlugin | ServerPluginFuture)[];
+  plugins?: (ServerPlugin | ServerPluginLegacy)[];
   serverConfig?: ServerConfig;
 }) {
   const { serverContext } = await server.run({
@@ -43,7 +43,7 @@ export async function serverInit({
   return hooks as any;
 }
 
-export const APIPlugin: ServerPlugin = {
+export const APIPlugin: ServerPluginLegacy = {
   name: 'api-plugin',
 
   setup(api) {

--- a/packages/server/plugin-polyfill/src/index.ts
+++ b/packages/server/plugin-polyfill/src/index.ts
@@ -1,11 +1,11 @@
 import { getPolyfillString } from '@modern-js/polyfill-lib';
-import type { ServerPlugin } from '@modern-js/server-core';
+import type { ServerPluginLegacy } from '@modern-js/server-core';
 import { mime } from '@modern-js/utils';
 import Parser from 'ua-parser-js';
 import { defaultPolyfill, getDefaultFeatures } from './const';
 import PolyfillCache, { generateCacheKey } from './libs/cache';
 
-export default (): ServerPlugin => ({
+export default (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-polyfill',
 
   setup: api => ({

--- a/packages/server/plugin-server/src/server.ts
+++ b/packages/server/plugin-server/src/server.ts
@@ -1,4 +1,4 @@
-import type { ServerPlugin } from '@modern-js/server-core';
+import type { ServerPluginLegacy } from '@modern-js/server-core';
 import type {
   MiddlewareContext,
   NextFunction,
@@ -79,7 +79,7 @@ function getFactory(storage: Storage) {
   return factory;
 }
 
-export default (): ServerPlugin => ({
+export default (): ServerPluginLegacy => ({
   name: '@modern-js/plugin-server',
 
   setup: api => {

--- a/packages/server/prod-server/src/index.ts
+++ b/packages/server/prod-server/src/index.ts
@@ -18,7 +18,7 @@ export {
   loadServerRuntimeConfig,
 } from '@modern-js/server-core/node';
 
-export type { ServerPlugin } from '@modern-js/server-core';
+export type { ServerPluginLegacy, ServerPlugin } from '@modern-js/server-core';
 
 export type { ProdServerOptions, BaseEnv } from './types';
 

--- a/packages/server/prod-server/src/types.ts
+++ b/packages/server/prod-server/src/types.ts
@@ -2,6 +2,7 @@ import type {
   CreateDefaultPluginsOptions,
   ServerBaseOptions,
   ServerPlugin,
+  ServerPluginLegacy,
 } from '@modern-js/server-core';
 import type { Reporter } from '@modern-js/types';
 import type { Logger } from '@modern-js/utils';
@@ -12,7 +13,7 @@ interface ProdServerExtraOptions {
 
   serverConfigPath?: string;
 
-  plugins?: ServerPlugin[];
+  plugins?: (ServerPlugin | ServerPluginLegacy)[];
 }
 
 export type ProdServerOptions = Exclude<ServerBaseOptions, 'serverConfig'> &

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -1,4 +1,7 @@
-import type { ServerBaseOptions, ServerPlugin } from '@modern-js/server-core';
+import type {
+  ServerBaseOptions,
+  ServerPluginLegacy,
+} from '@modern-js/server-core';
 import { connectMid2HonoMid } from '@modern-js/server-core/node';
 import type { RequestHandler } from '@modern-js/types';
 import type { UniBuilderInstance } from '@modern-js/uni-builder';
@@ -20,7 +23,7 @@ export type DevPluginOptions = ModernDevServerOptions<ServerBaseOptions> & {
   builderDevServer?: BuilderDevServer;
 };
 
-export const devPlugin = (options: DevPluginOptions): ServerPlugin => ({
+export const devPlugin = (options: DevPluginOptions): ServerPluginLegacy => ({
   name: '@modern-js/plugin-dev',
 
   setup(api) {

--- a/packages/server/server/tests/mock.test.ts
+++ b/packages/server/server/tests/mock.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import {
-  type ServerPlugin,
+  type ServerPluginLegacy,
   compatPlugin,
   createServerBase,
 } from '@modern-js/server-core';
@@ -27,7 +27,7 @@ function getDefaultAppContext() {
   };
 }
 
-function createMockPlugin(pwd: string): ServerPlugin {
+function createMockPlugin(pwd: string): ServerPluginLegacy {
   return {
     name: 'mock-plugin',
     setup(api) {

--- a/packages/solutions/app-tools/src/exports/server.ts
+++ b/packages/solutions/app-tools/src/exports/server.ts
@@ -4,7 +4,7 @@ import type {
   UnstableNext,
 } from '@modern-js/types';
 
-export type { ServerPlugin } from '@modern-js/server-core';
+export type { ServerPlugin, ServerPluginLegacy } from '@modern-js/server-core';
 
 export type RenderMiddleware = UnstableMiddleware;
 

--- a/tests/integration/server-config-v2/plugins/serverPlugin.ts
+++ b/tests/integration/server-config-v2/plugins/serverPlugin.ts
@@ -1,6 +1,6 @@
-import type { ServerPlugin } from '@modern-js/server-core';
+import type { ServerPluginLegacy } from '@modern-js/server-core';
 
-export default (): ServerPlugin => ({
+export default (): ServerPluginLegacy => ({
   name: 'serverPlugin1',
   setup() {
     return {

--- a/tests/integration/server-config/plugins/serverPlugin.ts
+++ b/tests/integration/server-config/plugins/serverPlugin.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import type { ServerPlugin } from '@modern-js/server-core';
+import type { ServerPluginLegacy } from '@modern-js/server-core';
 import { requireExistModule } from '@modern-js/utils';
 
 export const isDev = (): boolean => process.env.NODE_ENV === 'development';
@@ -16,7 +16,7 @@ export const SHARED_DIR = 'shared';
 
 export const API_APP_NAME = '_app';
 
-export default (): ServerPlugin => ({
+export default (): ServerPluginLegacy => ({
   name: 'serverPlugin1',
   setup: api => {
     return {


### PR DESCRIPTION
## Summary

- Rename current ServerPlugin type to ServerPluginLegacy

- Rename ServerPluginFuture type to ServerPlugin

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
