### PR TITLE
feat: support dev.assetPrefix in static middleware

### DIFF
--- a/.changeset/hip-actors-flow.md
+++ b/.changeset/hip-actors-flow.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server': patch
+---
+
+feat: static middleware support dev.assetPrefix
+feat: 静态资源中间件支持 dev.assetPrefix

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -5,7 +5,7 @@ import {
   loadServerRuntimeConfig,
 } from '@modern-js/server-core/node';
 import { devPlugin } from './dev';
-import { getDevOptions } from './helpers';
+import { getDevAssetPrefix, getDevOptions } from './helpers';
 import type { ApplyPlugins, ModernDevServerOptions } from './types';
 
 export async function createDevServer(
@@ -47,6 +47,7 @@ export async function createDevServer(
     nodeServer = await createNodeServer(server.handle.bind(server));
   }
 
+  const promise = getDevAssetPrefix(builder);
   const builderDevServer = await builder?.createDevServer({
     runCompile: options.runCompile,
     compiler: options.compilier,
@@ -58,6 +59,12 @@ export async function createDevServer(
       builderDevServer,
     }),
   ]);
+
+  // run after createDevServer, we can get assetPrefix from builder
+  const assetPrefix = await promise;
+  if (assetPrefix) {
+    prodServerOptions.config.output.assetPrefix = assetPrefix;
+  }
 
   await applyPlugins(server, prodServerOptions, nodeServer);
 

--- a/packages/server/server/src/helpers/devOptions.ts
+++ b/packages/server/server/src/helpers/devOptions.ts
@@ -1,3 +1,4 @@
+import type { UniBuilderInstance } from '@modern-js/uni-builder';
 import { merge } from '@modern-js/utils/lodash';
 import type { ModernDevServerOptions } from '../types';
 import { getDefaultDevOptions } from './constants';
@@ -6,4 +7,28 @@ export const getDevOptions = (options: ModernDevServerOptions) => {
   const devOptions = options.dev;
   const defaultOptions = getDefaultDevOptions();
   return merge(defaultOptions, devOptions);
+};
+
+export const getDevAssetPrefix = (builder?: UniBuilderInstance) => {
+  return new Promise<string>(resolve => {
+    builder?.onAfterCreateCompiler(params => {
+      let webCompiler: typeof params.compiler;
+      if ('compilers' in params.compiler) {
+        webCompiler = params.compiler.compilers.find(c => {
+          return c.name === 'web';
+        })!;
+      } else {
+        webCompiler = params.compiler;
+      }
+
+      const publicPath = webCompiler.options.output.publicPath;
+      if (publicPath && typeof publicPath === 'string') {
+        // remove host and port
+        const formatPublicPath = publicPath.replace(/^https?:\/\/[^/]+/, '');
+        resolve(formatPublicPath);
+      }
+
+      resolve('');
+    });
+  });
 };

--- a/packages/server/server/src/helpers/devOptions.ts
+++ b/packages/server/server/src/helpers/devOptions.ts
@@ -11,6 +11,10 @@ export const getDevOptions = (options: ModernDevServerOptions) => {
 
 export const getDevAssetPrefix = (builder?: UniBuilderInstance) => {
   return new Promise<string>(resolve => {
+    if (!builder) {
+      return resolve('');
+    }
+
     builder?.onAfterCreateCompiler(params => {
       let webCompiler: typeof params.compiler;
       if ('compilers' in params.compiler) {
@@ -25,10 +29,10 @@ export const getDevAssetPrefix = (builder?: UniBuilderInstance) => {
       if (publicPath && typeof publicPath === 'string') {
         // remove host and port
         const formatPublicPath = publicPath.replace(/^https?:\/\/[^/]+/, '');
-        resolve(formatPublicPath);
+        return resolve(formatPublicPath);
       }
 
-      resolve('');
+      return resolve('');
     });
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3891,10 +3891,10 @@ importers:
         version: link:../../toolkit/utils
       '@storybook/react':
         specifier: ~7.6.1
-        version: 7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)
+        version: 7.6.20(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)
       storybook:
         specifier: ~7.6.1
-        version: 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+        version: 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     devDependencies:
       '@storybook/types':
         specifier: ~7.6.12
@@ -27471,7 +27471,7 @@ snapshots:
       '@storybook/components': 7.6.20(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/core-events': 7.6.20
       '@storybook/csf': 0.1.11
-      '@storybook/docs-tools': 7.6.20(encoding@0.1.13)
+      '@storybook/docs-tools': 7.6.20
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/preview-api': 7.6.20
@@ -27497,7 +27497,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-manager@7.6.20(encoding@0.1.13)':
+  '@storybook/builder-manager@7.6.20':
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -27528,7 +27528,7 @@ snapshots:
       telejson: 7.2.0
       tiny-invariant: 1.3.3
 
-  '@storybook/cli@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@storybook/cli@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
@@ -27537,10 +27537,10 @@ snapshots:
       '@storybook/codemod': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-events': 7.6.20
-      '@storybook/core-server': 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@storybook/core-server': 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@storybook/csf-tools': 7.6.20
       '@storybook/node-logger': 7.6.20
-      '@storybook/telemetry': 7.6.20(encoding@0.1.13)
+      '@storybook/telemetry': 7.6.20
       '@storybook/types': 7.6.20
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
@@ -27673,11 +27673,11 @@ snapshots:
     dependencies:
       ts-dedent: 2.2.0
 
-  '@storybook/core-server@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+  '@storybook/core-server@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 7.6.20(encoding@0.1.13)
+      '@storybook/builder-manager': 7.6.20
       '@storybook/channels': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/core-events': 7.6.20
@@ -27688,7 +27688,7 @@ snapshots:
       '@storybook/manager': 7.6.20
       '@storybook/node-logger': 7.6.20
       '@storybook/preview-api': 7.6.20
-      '@storybook/telemetry': 7.6.20(encoding@0.1.13)
+      '@storybook/telemetry': 7.6.20
       '@storybook/types': 7.6.20
       '@types/detect-port': 1.3.5
       '@types/node': 18.19.74
@@ -27749,7 +27749,7 @@ snapshots:
 
   '@storybook/docs-mdx@0.1.0': {}
 
-  '@storybook/docs-tools@7.6.20(encoding@0.1.13)':
+  '@storybook/docs-tools@7.6.20':
     dependencies:
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
       '@storybook/preview-api': 7.6.20
@@ -27843,11 +27843,11 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/react@7.6.20(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)':
+  '@storybook/react@7.6.20(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.3)':
     dependencies:
       '@storybook/client-logger': 7.6.20
       '@storybook/core-client': 7.6.20
-      '@storybook/docs-tools': 7.6.20(encoding@0.1.13)
+      '@storybook/docs-tools': 7.6.20
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 7.6.20
       '@storybook/react-dom-shim': 7.6.20(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -27880,7 +27880,7 @@ snapshots:
       memoizerific: 1.11.3
       qs: 6.13.0
 
-  '@storybook/telemetry@7.6.20(encoding@0.1.13)':
+  '@storybook/telemetry@7.6.20':
     dependencies:
       '@storybook/client-logger': 7.6.20
       '@storybook/core-common': 7.6.20(encoding@0.1.13)
@@ -38775,9 +38775,9 @@ snapshots:
 
   store2@2.14.3: {}
 
-  storybook@7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10):
+  storybook@7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
-      '@storybook/cli': 7.6.20(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@storybook/cli': 7.6.20(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - encoding

--- a/tests/integration/asset-prefix/modern.config.ts
+++ b/tests/integration/asset-prefix/modern.config.ts
@@ -1,8 +1,31 @@
+import { writeFileSync } from 'fs';
+import path from 'path';
 import { applyBaseConfig } from '../../utils/applyBaseConfig';
 
 export default applyBaseConfig({
   dev: {
     assetPrefix: true,
+  },
+  plugins: [
+    {
+      name: 'test-static-file',
+      setup(api) {
+        api.onDevCompileDone(async () => {
+          writeFileSync(
+            path.resolve(
+              __dirname,
+              api.useAppContext().distDirectory,
+              'static',
+              'test.js',
+            ),
+            'console.log("test")',
+          );
+        });
+      },
+    },
+  ],
+  output: {
+    // assetPrefix: '/my-prefix',
   },
   performance: {
     chunkSplit: {

--- a/tests/integration/asset-prefix/package.json
+++ b/tests/integration/asset-prefix/package.json
@@ -2,6 +2,9 @@
   "private": true,
   "name": "integration-asset-prefix",
   "version": "2.65.5",
+  "scripts": {
+    "dev": "modern dev"
+  },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/tests/integration/asset-prefix/src/index.ts
+++ b/tests/integration/asset-prefix/src/index.ts
@@ -1,1 +1,1 @@
-console.log('hello world!');
+console.log('hello world!', process.env.ASSET_PREFIX);

--- a/tests/integration/asset-prefix/tests/index.test.ts
+++ b/tests/integration/asset-prefix/tests/index.test.ts
@@ -64,4 +64,14 @@ describe('asset prefix', () => {
 
     expect(assetPrefix).toEqual(expected);
   });
+
+  test(`should access the file which create by writeFile correctly`, async () => {
+    const url = `http://${DEFAULT_DEV_HOST}:${appPort}/static/test.js`;
+    const resp = await page.goto(url, {
+      waitUntil: ['networkidle0'],
+      timeout: 50000,
+    });
+    const content = await resp?.text();
+    expect(content).toMatch('console.log("test")');
+  });
 });


### PR DESCRIPTION
## Summary

This PR support `dev.assetPrefix` in static middleware.

In the past, this config only support rsbuild dev middleware. But the file not created by build will not be served by rsbuil dev middleware, it is served by modern.js static middleware.

So, we get the assetPrefix from builder instance, and overrides the `output.assetPrefix` in dev server.

relate MR: #6924

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
