### PR TITLE
fix: compiler will be changed to client when enable rsc

### DIFF
--- a/packages/server/server/src/helpers/devOptions.ts
+++ b/packages/server/server/src/helpers/devOptions.ts
@@ -19,7 +19,7 @@ export const getDevAssetPrefix = (builder?: UniBuilderInstance) => {
       let webCompiler: typeof params.compiler;
       if ('compilers' in params.compiler) {
         webCompiler = params.compiler.compilers.find(c => {
-          return c.name === 'web';
+          return c.name === 'web' || c.name === 'client';
         })!;
       } else {
         webCompiler = params.compiler;


### PR DESCRIPTION
## Summary

Now if we enable rsc feature, the compiler will be rename to 'client' and 'server'.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
