### PR TITLE
fix: initAppContext should not update metaName

### DIFF
--- a/.changeset/fifty-garlics-occur.md
+++ b/.changeset/fifty-garlics-occur.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: initAppContext should not update metaName
+
+fix: initAppContext 时不应该更新 metaName

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -48,6 +48,9 @@ export const garfishPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
   setup: api => {
     api._internalRuntimePlugins(({ entrypoint, plugins }) => {
       const userConfig = api.getNormalizedConfig();
+      if (userConfig.deploy.microFrontend) {
+        return { entrypoint, plugins };
+      }
       const { packageName, metaName } = api.getAppContext();
       const runtimeConfig = getEntryOptions(
         entrypoint.entryName,

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -52,7 +52,6 @@ export const appTools = (
   options: AppToolsOptions = {
     // default webpack to be compatible with original projects
     bundler: 'webpack',
-    metaName: 'modern-js',
   },
 ): CliPluginFuture<AppTools<'shared'>> => ({
   name: '@modern-js/app-tools',
@@ -105,10 +104,8 @@ export const appTools = (
     i18n.changeLanguage({ locale });
     api.updateAppContext(
       initAppContext({
+        metaName: context.metaName,
         appDirectory: context.appDirectory,
-        options: {
-          metaName: options.metaName,
-        },
         serverConfigFile: DEFAULT_SERVER_CONFIG_FILE,
         runtimeConfigFile: DEFAULT_RUNTIME_CONFIG_FILE,
         tempDir: userConfig.output?.tempDir,

--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -25,7 +25,7 @@ export interface RunOptions {
 export async function run({
   cwd,
   initialLog,
-  metaName = 'MODERN',
+  metaName = 'modern-js',
   version,
   internalPlugins,
   packageJsonConfig = PACKAGE_JSON_CONFIG_NAME,

--- a/packages/solutions/app-tools/src/types/index.ts
+++ b/packages/solutions/app-tools/src/types/index.ts
@@ -89,7 +89,6 @@ export type AppToolsOptions = {
    * @default `webpack`
    * */
   bundler?: 'rspack' | 'webpack' | 'experimental-rspack';
-  metaName?: string;
 };
 
 export type {

--- a/packages/solutions/app-tools/src/utils/getUserConfig.ts
+++ b/packages/solutions/app-tools/src/utils/getUserConfig.ts
@@ -6,7 +6,8 @@ export async function getUserConfig(
   packageJsonConfig: string,
   metaName: string,
 ) {
-  loadEnv(appDirectory, process.env[`${metaName.toUpperCase()}_ENV`]);
+  const envName = metaName === 'modern-js' ? 'MODERN' : metaName;
+  loadEnv(appDirectory, process.env[`${envName.toUpperCase()}_ENV`]);
   const loaded = await createLoadedConfig<{
     autoLoadPlugins: boolean;
     runtime: boolean | Record<string, any>;

--- a/packages/solutions/app-tools/src/utils/initAppContext.ts
+++ b/packages/solutions/app-tools/src/utils/initAppContext.ts
@@ -2,16 +2,17 @@ import path from 'path';
 import { fs, address } from '@modern-js/utils';
 
 export const initAppContext = ({
+  metaName,
   appDirectory,
   runtimeConfigFile,
   options,
   serverConfigFile,
   tempDir,
 }: {
+  metaName: string;
   appDirectory: string;
   runtimeConfigFile: string;
   options?: {
-    metaName?: string;
     srcDir?: string;
     apiDir?: string;
     distDir?: string;
@@ -20,14 +21,9 @@ export const initAppContext = ({
   serverConfigFile: string;
   tempDir?: string;
 }) => {
-  const {
-    metaName = 'modern-js',
-    apiDir = 'api',
-    sharedDir = 'shared',
-  } = options || {};
+  const { apiDir = 'api', sharedDir = 'shared' } = options || {};
   const pkgPath = path.resolve(appDirectory, './package.json');
   return {
-    metaName,
     runtimeConfigFile,
     serverConfigFile,
     ip: address.ip(),

--- a/packages/solutions/app-tools/tests/analyze/getFileSystemEntry.test.ts
+++ b/packages/solutions/app-tools/tests/analyze/getFileSystemEntry.test.ts
@@ -19,6 +19,7 @@ describe('get entrypoints from file system', () => {
     const plugins = pluginManager.getPlugins();
     const context = await createContext<AppTools>({
       appContext: {
+        metaName: 'modern-js',
         appDirectory,
         plugins,
       } as any,
@@ -31,7 +32,7 @@ describe('get entrypoints from file system', () => {
     });
     context.pluginAPI = pluginAPI;
     for (const plugin of plugins) {
-      const setupResult = (await plugin.setup(pluginAPI)) as any;
+      const setupResult = (await plugin.setup!(pluginAPI)) as any;
       if (setupResult) {
         await handleSetupResult(setupResult, pluginAPI);
       }

--- a/packages/toolkit/plugin-v2/src/cli/run/create.ts
+++ b/packages/toolkit/plugin-v2/src/cli/run/create.ts
@@ -71,7 +71,8 @@ export const createCli = <Extends extends CLIPluginExtends>() => {
 
     setProgramVersion(version);
 
-    loadEnv(appDirectory, process.env[`${metaName.toUpperCase()}_ENV`]);
+    const envName = metaName === 'modern-js' ? 'MODERN' : metaName;
+    loadEnv(appDirectory, process.env[`${envName.toUpperCase()}_ENV`]);
 
     const loaded = await createLoadedConfig<Extends['config']>(
       appDirectory,

--- a/packages/toolkit/plugin-v2/src/cli/run/create.ts
+++ b/packages/toolkit/plugin-v2/src/cli/run/create.ts
@@ -55,7 +55,7 @@ export const createCli = <Extends extends CLIPluginExtends>() => {
     pluginManager.clear();
     initOptions = options;
     const {
-      metaName = 'MODERN',
+      metaName = 'modern-js',
       configFile,
       config,
       command,


### PR DESCRIPTION
## Summary

The CLI plugin updates the metaName when it starts running, so there is no need to update the metaName information again in the app-tools plugin.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
