### PR TITLE
fix: should detect page route by entryName, not isApi

### DIFF
--- a/.changeset/selfish-spies-serve.md
+++ b/.changeset/selfish-spies-serve.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: should detect page route by entryName, not isApi
+fix: 应该通过 entryName 来判断是否是页面路由，而不是 isApi

--- a/packages/server/core/src/plugins/route.ts
+++ b/packages/server/core/src/plugins/route.ts
@@ -18,7 +18,7 @@ function injectRoute(route: {
 function getPageRoutes(routes: ServerRoute[]): ServerRoute[] {
   return (
     routes
-      .filter(route => !route.isApi)
+      .filter(route => route.entryName)
       // ensure route.urlPath.length diminishing
       .sort(sortRoutes)
   );


### PR DESCRIPTION
## Summary

This PR fix the page detect logic.

We should use `route.entryName`, not `route.isApi`. Because when we config `bff.enableHandleWeb`, all the route `isApi`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
