### PR TITLE
fix(ssg): ssg should concat buffer first

### DIFF
--- a/.changeset/violet-fireants-arrive.md
+++ b/.changeset/violet-fireants-arrive.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-ssg': patch
+---
+
+fix: ssg should concat buffer first, then stringify buffer
+fix: ssg 应该先拼接 buffer, 再将 buffer 处理成字符串

--- a/packages/cli/plugin-ssg/src/server/process.ts
+++ b/packages/cli/plugin-ssg/src/server/process.ts
@@ -102,17 +102,18 @@ function getHtml(url: string, port: number): Promise<string> {
         headers,
       },
       res => {
-        let html = '';
+        const chunks: Uint8Array[] = [];
 
         res.on('error', error => {
           reject(error);
         });
 
         res.on('data', chunk => {
-          html += chunk.toString();
+          chunks.push(chunk);
         });
 
         res.on('end', () => {
+          const html = Buffer.concat(chunks).toString();
           resolve(html);
         });
       },


### PR DESCRIPTION
## Summary

This PR fixes the issue of garbled HTML in SSG when dealing with large amounts of data.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
