### PR TITLE
test(e2e): fix Rsbuild logs casing

### DIFF
--- a/tests/e2e/builder/cases/progress/index.test.ts
+++ b/tests/e2e/builder/cases/progress/index.test.ts
@@ -29,9 +29,9 @@ webpackOnlyTest('should emit progress log in non-TTY environment', async () => {
   });
 
   expect(
-    infoMsgs.some(message => message.includes('Build progress')),
+    infoMsgs.some(message => message.includes('build progress')),
   ).toBeTruthy();
-  expect(readyMsgs.some(message => message.includes('Built'))).toBeTruthy();
+  expect(readyMsgs.some(message => message.includes('built'))).toBeTruthy();
 
   process.stdout.isTTY = true;
   logger.info = info;


### PR DESCRIPTION
## Summary

Fix Rsbuild logs casing (now defaults to lowercase)

https://github.com/web-infra-dev/modern.js/actions/runs/14165147338/job/39676946272

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
