### PR TITLE
feat(ssr): support customizing fallback reason via x-modern-ssr-fallback header

### DIFF
--- a/.changeset/good-colts-sparkle.md
+++ b/.changeset/good-colts-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server-core': patch
+---
+
+feat(ssr): support customizing fallback reason via `x-modern-ssr-fallback` header
+feat(ssr): 支持在 `x-modern-ssr-fallback` 中自定义降级原因
+

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -357,16 +357,14 @@ async function getRenderMode(
     if (query.__loader) {
       return 'data';
     }
-    if (
-      forceCSR &&
-      (query.csr ||
-        req.headers.get(fallbackHeader) ||
-        nodeReq?.headers[fallbackHeader])
-    ) {
+    const fallbackHeaderValue: string | null =
+      req.headers.get(fallbackHeader) || nodeReq?.headers[fallbackHeader];
+    if (forceCSR && (query.csr || fallbackHeaderValue)) {
       if (query.csr) {
         await onFallback?.('query');
       } else {
-        await onFallback?.('header');
+        const reason = fallbackHeaderValue?.split(';')[1]?.split('=')[1];
+        await onFallback?.(reason ? `header,${reason}` : 'header');
       }
       return 'csr';
     }

--- a/packages/server/core/src/types/plugins/base.ts
+++ b/packages/server/core/src/types/plugins/base.ts
@@ -26,7 +26,7 @@ import type { ServerPlugin } from './new';
 import type { ServerPluginLegacy } from './old';
 
 export type { FileChangeEvent, ResetEvent } from '@modern-js/plugin-v2';
-export type FallbackReason = 'error' | 'header' | 'query';
+export type FallbackReason = 'error' | 'header' | 'query' | `header,${string}`;
 
 export type FallbackInput = {
   reason: FallbackReason;


### PR DESCRIPTION
## Summary

This PR adds support for users to specify the reason when manually falling back to CSR using `x-modern-ssr-fallback` request header, here's how it works:

```ts
// server/index.ts
export const middleware = (ctx, next) => {
  const { req, res } = ctx;
  if (condition) {
    req.headers['x-modern-ssr-fallback'] = '1;reason=some reason';
  }

  next();
};
```
The final `x-modern-ssr-fallback` in the **response** header is as follows:

```ts
x-modern-ssr-fallback: 1;reason=header,some reason
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
