### PR TITLE
feat(ssr): inject fallback reason to html

### DIFF
--- a/.changeset/quick-mayflies-sort.md
+++ b/.changeset/quick-mayflies-sort.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+feat(ssr): inject fallback reason to html
+feat(ssr): 注入降级原因到响应的 html

--- a/packages/server/core/tests/fixtures/render/ssr/bundles/main.js
+++ b/packages/server/core/tests/fixtures/render/ssr/bundles/main.js
@@ -1,4 +1,7 @@
-export function requestHandler() {
+export function requestHandler(request) {
+  if (request.headers.get('x-render-error')) {
+    throw new Error('custom render error');
+  }
   return new Response('SSR Render', {
     headers: {
       'content-type': 'text/html; charset=UTF-8',

--- a/packages/server/core/tests/fixtures/render/ssr/index.html
+++ b/packages/server/core/tests/fixtures/render/ssr/index.html
@@ -1,3 +1,11 @@
-<body>
-  <h3>Hello Modern</h3>
-</body>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <h3>Hello Modern</h3>
+  </body>
+</html>

--- a/packages/server/core/tests/plugins/render.test.ts
+++ b/packages/server/core/tests/plugins/render.test.ts
@@ -121,6 +121,7 @@ describe('should render html correctly', () => {
       },
     );
     expect(html2).toMatch(/Hello Modern/);
+    expect(html2.includes(`window.__ssr_fallback_reason__='query'`)).toBe(true);
     expect(fallbackHeader).toBe('1;reason=query');
 
     const html3 = await Promise.resolve(
@@ -138,6 +139,9 @@ describe('should render html correctly', () => {
       return res.text();
     });
     expect(fallbackHeader).toBe('1;reason=header');
+    expect(html3.includes(`window.__ssr_fallback_reason__='header'`)).toBe(
+      true,
+    );
     expect(html3).toMatch(/Hello Modern/);
 
     // custom fallback reason in header.
@@ -156,6 +160,11 @@ describe('should render html correctly', () => {
       return res.text();
     });
     expect(fallbackHeader).toBe('1;reason=header,custom fallback reason');
+    expect(
+      html4.includes(
+        `window.__ssr_fallback_reason__='header,custom fallback reason'`,
+      ),
+    ).toBe(true);
     expect(html4).toMatch(/Hello Modern/);
   });
 
@@ -172,5 +181,32 @@ describe('should render html correctly', () => {
     const response2 = await server.request('/user?__loader=layout', {}, {});
     const text2 = await response2.text();
     expect(text2).toBe('handle user');
+  });
+
+  it('should fallback to csr when render error', async () => {
+    const ssrPwd = path.join(pwd, 'ssr');
+    const server = await createSSRServer(ssrPwd, {
+      ssr: {
+        forceCSR: true,
+      },
+    });
+    let fallbackHeader;
+    // custom fallback reason in header.
+    const html = await Promise.resolve(
+      server.request(
+        '/',
+        {
+          headers: new Headers({
+            'x-render-error': '1',
+          }),
+        },
+        {},
+      ),
+    ).then(res => {
+      fallbackHeader = res.headers.get('x-modern-ssr-fallback');
+      return res.text();
+    });
+    expect(fallbackHeader).toBe('1;reason=error');
+    expect(html.includes(`window.__ssr_fallback_reason__='error'`)).toBe(true);
   });
 });

--- a/packages/server/core/tests/plugins/render.test.ts
+++ b/packages/server/core/tests/plugins/render.test.ts
@@ -121,7 +121,11 @@ describe('should render html correctly', () => {
       },
     );
     expect(html2).toMatch(/Hello Modern/);
-    expect(html2.includes(`window.__ssr_fallback_reason__='query'`)).toBe(true);
+    expect(
+      html2.includes(
+        `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"query"}</script>`,
+      ),
+    ).toBe(true);
     expect(fallbackHeader).toBe('1;reason=query');
 
     const html3 = await Promise.resolve(
@@ -139,9 +143,11 @@ describe('should render html correctly', () => {
       return res.text();
     });
     expect(fallbackHeader).toBe('1;reason=header');
-    expect(html3.includes(`window.__ssr_fallback_reason__='header'`)).toBe(
-      true,
-    );
+    expect(
+      html3.includes(
+        `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"header"}</script>`,
+      ),
+    ).toBe(true);
     expect(html3).toMatch(/Hello Modern/);
 
     // custom fallback reason in header.
@@ -162,7 +168,7 @@ describe('should render html correctly', () => {
     expect(fallbackHeader).toBe('1;reason=header,custom fallback reason');
     expect(
       html4.includes(
-        `window.__ssr_fallback_reason__='header,custom fallback reason'`,
+        `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"header,custom fallback reason"}</script>`,
       ),
     ).toBe(true);
     expect(html4).toMatch(/Hello Modern/);
@@ -207,6 +213,11 @@ describe('should render html correctly', () => {
       return res.text();
     });
     expect(fallbackHeader).toBe('1;reason=error');
-    expect(html.includes(`window.__ssr_fallback_reason__='error'`)).toBe(true);
+    console.log(`html -->`, html);
+    expect(
+      html.includes(
+        `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"error"}</script>`,
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/server/core/tests/plugins/render.test.ts
+++ b/packages/server/core/tests/plugins/render.test.ts
@@ -213,7 +213,6 @@ describe('should render html correctly', () => {
       return res.text();
     });
     expect(fallbackHeader).toBe('1;reason=error');
-    console.log(`html -->`, html);
     expect(
       html.includes(
         `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"error"}</script>`,


### PR DESCRIPTION
## Summary

When SSR falls back to CSR, inject the fallback reason into the HTML as an inline script—for example, when the request URL contains `?csr=1`, the final response’s HTML `<head>` tag will include the following inline script:

```
<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"query"}</script>
```


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
