### PR TITLE
fix: add the "$" character to avoid alias override in nested entries

### DIFF
--- a/.changeset/young-bats-taste.md
+++ b/.changeset/young-bats-taste.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: add the "$" character to avoid alias override in nested entries
+fix: 添加 $ 字符避免嵌套入口时 alias 覆盖

--- a/packages/runtime/plugin-runtime/src/cli/alias.ts
+++ b/packages/runtime/plugin-runtime/src/cli/alias.ts
@@ -20,7 +20,7 @@ export const builderPluginAlias = ({
       const mainEntrypointsAlias: Record<string, string> = {};
       entrypoints.forEach(entrypoint => {
         entrypointsAlias[
-          `@${metaName}/runtime/registry/${entrypoint.entryName}`
+          `@${metaName}/runtime/registry/${entrypoint.entryName}$`
         ] = path.join(
           internalDirectory,
           entrypoint.entryName,


### PR DESCRIPTION
## Summary

This PR fix the issue when project has nested entries.

```json
{
    "entries": {
      "foo": "./src/foo/App.tsx",
      "foo/bar": "./src/foo/bar/App.tsx"
    }
}
```

Modern.js will generate the internal alias for the entries, like:

```json
{
  "@modern-js/runtime/registry/foo": "/root/node_modules/.modern-js/foo/register.js",
  "@modern-js/runtime/registry/foo/bar": "/root/node_modules/.modern-js/foo/bar/register.js",
}
```

But the second alias is not effected, then the compiler throw error `can not found @modern-js/runtime/registry/foo/bar`

So we add `$` to alias key to avoid this.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
