### PR TITLE
fix(server): should sync all headers from req.headers

### DIFF
--- a/.changeset/mean-birds-bake.md
+++ b/.changeset/mean-birds-bake.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix(server): should sync all headers from req.headers
+fix(server): 应该从 req.headers 同步所有的 headers

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -25,11 +25,22 @@ export const createWebRequest = (
   body?: BodyInit,
 ): Request => {
   const headerRecord: [string, string][] = [];
-  const len = req.rawHeaders.length;
-  for (let i = 0; i < len; i += 2) {
-    const key = req.rawHeaders[i];
-    if (!key.startsWith(':')) {
-      headerRecord.push([key, req.rawHeaders[i + 1]]);
+
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (key.startsWith(':')) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item !== undefined) {
+          headerRecord.push([key, item]);
+        }
+      }
+    } else if (value !== undefined) {
+      if (typeof value === 'string') {
+        headerRecord.push([key, value]);
+      }
     }
   }
 

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -381,7 +381,8 @@ async function getRenderMode(
       return 'data';
     }
     const fallbackHeaderValue: string | null =
-      req.headers.get(fallbackHeader) || nodeReq?.headers[fallbackHeader];
+      (req.headers.get(fallbackHeader) as string) ||
+      (nodeReq?.headers[fallbackHeader] as string);
     if (forceCSR && (query.csr || fallbackHeaderValue)) {
       if (query.csr) {
         await onFallback?.('query');

--- a/packages/toolkit/types/server/server.d.ts
+++ b/packages/toolkit/types/server/server.d.ts
@@ -1,2 +1,5 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { Http2ServerRequest, Http2ServerResponse } from 'http2';
+
 export type NodeRequest = IncomingMessage | Http2ServerRequest;
 export type NodeResponse = ServerResponse | Http2ServerResponse;


### PR DESCRIPTION
## Summary

Avoid the problem that rawHeaders can only obtain the original request header. For example, the request header added by the middleware will not be synchronized at present

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
