### PR TITLE
docs(bff): Update import path to match current package names

### DIFF
--- a/packages/document/main-doc/docs/en/guides/advanced-features/bff/cross-project.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/bff/cross-project.mdx
@@ -90,7 +90,7 @@ The `configure` function from `${package_name}/runtime` supports domain configur
 
 ```ts title="src/routes/page.tsx"
 import { configure } from '${package_name}/runtime';
-import { configure as innerConfigure } from '@modern-js/runtime/bff';
+import { configure as innerConfigure } from '@modern-js/plugin-bff/runtime/create-request';
 import axios from 'axios';
 
 configure({

--- a/packages/document/main-doc/docs/en/guides/advanced-features/bff/sdk.mdx
+++ b/packages/document/main-doc/docs/en/guides/advanced-features/bff/sdk.mdx
@@ -13,7 +13,7 @@ The `configure` function needs to be called before all BFF requests are sent to 
 :::
 
 ```tsx title="routes/page.tsx"
-import { configure } from '@modern-js/runtime/bff';
+import { configure } from '@modern-js/plugin-bff/runtime/create-request';
 
 configure({
   // ...


### PR DESCRIPTION
## Summary
The Documentation [here](https://modernjs.dev/guides/advanced-features/bff/sdk.html) and [here](https://modernjs.dev/guides/advanced-features/bff/cross-project.html) 
are referencing to an unknown import, since the `@modern-js/runtime/bff` seems not to export it accordingly.

## Related Links

* https://modernjs.dev/guides/advanced-features/bff/sdk.html
* https://modernjs.dev/guides/advanced-features/bff/cross-project.html

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
