### PR TITLE
fix: ignore warning when use legacy state

### DIFF
--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -113,12 +113,14 @@ export async function run({
     userConfig.autoLoadPlugins,
   );
 
+  // We need exclude warning when use legacy state plugin, it's a inhouse logic.
   if (
     !userConfig.autoLoadPlugins &&
     userConfig.runtime &&
     typeof userConfig.runtime !== 'boolean' &&
     (userConfig.runtime?.state === true ||
-      typeof userConfig.runtime?.state === 'object')
+      (typeof userConfig.runtime?.state === 'object' &&
+        !userConfig.runtime?.state?.legacy))
   ) {
     if (!userConfig.plugins.find(plugin => plugin.name === statePluginName)) {
       console.warn(


### PR DESCRIPTION
## Summary

This PR only for compat, the logic will be removed in next major version.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
