### PR TITLE
fix(doc): don't briefly show 404 when navigating

### DIFF
--- a/packages/document/main-doc/src/i18n/index.ts
+++ b/packages/document/main-doc/src/i18n/index.ts
@@ -9,7 +9,7 @@ const translations = {
 
 export function useUrl(url: string) {
   const lang = useLang();
-  return withBase(lang === 'zh' ? url : `/en${url}`);
+  return withBase(lang === 'zh' ? `/zh${url}` : url);
 }
 
 export function useI18n() {


### PR DESCRIPTION

https://github.com/user-attachments/assets/808564b3-2400-49d0-84bc-db20b3c6087b

Summary:
Currently, clicking on links will briefly show a 404 page before being
redirected.  This is because we incorrectly set the default route to be zh
while the default language is en.  This commit fixes the issue by aligning the
default route and language.

Test Plan:
1. Go to homepage
2. Click "Introduction"
Before: Briefly see 404 before being redirected
After: See the correct page
