### PR TITLE
feat: add routes into useRuntimeContext

### DIFF
--- a/.changeset/smooth-lions-pay.md
+++ b/.changeset/smooth-lions-pay.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+feat: when use convention routes, useRuntimeContext will return routes field, which is the routes of the current app
+feat: 当前应用为约定式路由时，useRuntimeContext 支持返回 routes 字段，表示当前应用的完整路由表

--- a/packages/runtime/plugin-runtime/src/core/compatible.tsx
+++ b/packages/runtime/plugin-runtime/src/core/compatible.tsx
@@ -231,6 +231,8 @@ export const useRuntimeContext = () => {
   // TODO: Here we should not provide all the RuntimeReactContext to the user
   const pickedContext: TRuntimeContext = {
     ...context,
+    // If using convention routes, we should provide routes to the user
+    routes: context.routes || [],
     context: context.context || ({} as TSSRContext),
     request: context.ssrContext?.request,
     response: context.ssrContext?.response,
@@ -239,9 +241,9 @@ export const useRuntimeContext = () => {
   const internalRuntimeContext = getGlobalInternalRuntimeContext();
   const hooks = internalRuntimeContext.hooks;
   const memoizedContext = useMemo(
-    () => hooks.pickContext.call(pickedContext as RuntimeContext),
+    () => hooks.pickContext.call(pickedContext as unknown as RuntimeContext),
     [context],
   );
 
-  return memoizedContext as TRuntimeContext;
+  return memoizedContext as unknown as TRuntimeContext;
 };

--- a/packages/runtime/plugin-runtime/src/core/compatible.tsx
+++ b/packages/runtime/plugin-runtime/src/core/compatible.tsx
@@ -239,9 +239,9 @@ export const useRuntimeContext = () => {
   const internalRuntimeContext = getGlobalInternalRuntimeContext();
   const hooks = internalRuntimeContext.hooks;
   const memoizedContext = useMemo(
-    () => hooks.pickContext.call(pickedContext as unknown as RuntimeContext),
+    () => hooks.pickContext.call(pickedContext as RuntimeContext),
     [context],
   );
 
-  return memoizedContext as unknown as TRuntimeContext;
+  return memoizedContext as TRuntimeContext;
 };

--- a/packages/runtime/plugin-runtime/src/core/compatible.tsx
+++ b/packages/runtime/plugin-runtime/src/core/compatible.tsx
@@ -232,7 +232,6 @@ export const useRuntimeContext = () => {
   const pickedContext: TRuntimeContext = {
     ...context,
     // If using convention routes, we should provide routes to the user
-    routes: context.routes || [],
     context: context.context || ({} as TSSRContext),
     request: context.ssrContext?.request,
     response: context.ssrContext?.response,

--- a/packages/runtime/plugin-runtime/src/core/compatible.tsx
+++ b/packages/runtime/plugin-runtime/src/core/compatible.tsx
@@ -231,7 +231,6 @@ export const useRuntimeContext = () => {
   // TODO: Here we should not provide all the RuntimeReactContext to the user
   const pickedContext: TRuntimeContext = {
     ...context,
-    // If using convention routes, we should provide routes to the user
     context: context.context || ({} as TSSRContext),
     request: context.ssrContext?.request,
     response: context.ssrContext?.response,

--- a/packages/runtime/plugin-runtime/src/core/context/runtime.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/runtime.ts
@@ -39,7 +39,7 @@ export interface TRuntimeContext {
   request?: SSRServerContext['request'];
   /** @deprecated use context.response field instead */
   response?: SSRServerContext['response'];
-  routes: RouteObject[];
+  routes?: RouteObject[];
   [key: string]: any;
 }
 

--- a/packages/runtime/plugin-runtime/src/core/context/runtime.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/runtime.ts
@@ -1,4 +1,5 @@
 import type { StaticHandlerContext } from '@modern-js/runtime-utils/remix-router';
+import type { RouteObject } from '@modern-js/runtime-utils/router';
 import { ROUTE_MANIFEST } from '@modern-js/utils/universal/constants';
 import { createContext } from 'react';
 import type { RouteManifest } from '../../router/runtime/types';
@@ -30,7 +31,7 @@ export const RuntimeReactContext = createContext<RuntimeContext>({} as any);
 export const ServerRouterContext = createContext({} as any);
 
 // TODO: We should export this context to user as RuntimeContext, use in `init` function
-export interface TRuntimeContext extends Partial<BaseRuntimeContext> {
+export interface TRuntimeContext {
   initialData?: Record<string, unknown>;
   isBrowser: boolean;
   context: TSSRContext;
@@ -38,6 +39,7 @@ export interface TRuntimeContext extends Partial<BaseRuntimeContext> {
   request?: SSRServerContext['request'];
   /** @deprecated use context.response field instead */
   response?: SSRServerContext['response'];
+  routes: RouteObject[];
   [key: string]: any;
 }
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -8,7 +8,10 @@ import {
   createStaticRouter,
 } from '@modern-js/runtime-utils/node/router';
 import { createStaticHandler } from '@modern-js/runtime-utils/remix-router';
-import { createRoutesFromElements } from '@modern-js/runtime-utils/router';
+import {
+  type RouteObject,
+  createRoutesFromElements,
+} from '@modern-js/runtime-utils/router';
 import { time } from '@modern-js/runtime-utils/time';
 import { LOADER_REPORTER_NAME } from '@modern-js/utils/universal/constants';
 import type React from 'react';
@@ -89,7 +92,7 @@ export const routerPlugin = (
 
         await hooks.onBeforeCreateRoutes.call(context);
 
-        let routes = createRoutes
+        let routes: RouteObject[] = createRoutes
           ? createRoutes()
           : createRoutesFromElements(
               renderRoutes({

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -156,7 +156,12 @@ export const routerPlugin = (
         context.remixRouter = router;
 
         // private api, pass to React Component in `wrapRoot`
-        context.routes = routes;
+        Object.defineProperty(context, 'routes', {
+          get() {
+            return routes;
+          },
+          enumerable: true,
+        });
       });
 
       api.wrapRoot(App => {

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -86,6 +86,7 @@ export const routerPlugin = (
           get() {
             return routes;
           },
+          enumerable: true,
         });
       });
       api.wrapRoot(App => {


### PR DESCRIPTION
## Summary

This PR provider routes in `useRuntimeContext` API.

This is mainly to enable developers to get all routing structure in conventional routing and generate the UI they may need.

#6188 

```tsx
import { useRuntimeContext } from '@modern-js/runtime';
import renderSidebar from './sidebar';

const Page = () => {
  const { routes } = useRuntimeContext();

  return (
    <div>{renderSidebar(routes)}</div>
  );
};

export default Page;
```

The routes is an array of `RouteObject`, a routing type definition from React Router v6.

```typescript
export type RouteObject = IndexRouteObject | NonIndexRouteObject;
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
