### PR TITLE
feat: add middlewares and renderMiddlewares to server plugin context

### DIFF
--- a/.changeset/nine-rabbits-smoke.md
+++ b/.changeset/nine-rabbits-smoke.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/plugin-v2': patch
+'@modern-js/server': patch
+'@modern-js/types': patch
+'@modern-js/server-core': patch
+---
+
+feat: add middlewares and renderMiddlewares to server plugin context
+feat: 添加 middlewares 和 renderMiddlewares 到服务端插件上下文中

--- a/packages/server/core/src/types/plugins/new.ts
+++ b/packages/server/core/src/types/plugins/new.ts
@@ -10,7 +10,6 @@ import type {
   AfterMatchContext,
   AfterRenderContext,
   AfterStreamingRenderContext,
-  ISAppContext,
   UnstableMiddleware,
 } from '@modern-js/types';
 import type { MiddlewareHandler } from 'hono';
@@ -40,11 +39,7 @@ export interface ServerPluginExtends extends BaseServerPluginExtends {
   config: ServerConfig;
   extendContext: {
     middlewares: MiddlewareObj[];
-  };
-  extendApi: {
-    setAppContext: (c: ISAppContext) => void;
-    useAppContext: () => ISAppContext;
-    useConfigContext: () => ServerConfig;
+    renderMiddlewares: MiddlewareObj[];
   };
   extendHooks: {
     prepareWebServer: AsyncPipelineHook<PrepareWebServerFn>;

--- a/packages/server/server/src/helpers/index.ts
+++ b/packages/server/server/src/helpers/index.ts
@@ -47,6 +47,7 @@ async function onServerChange({
         payload: [{ filename: filepath, event }],
       };
 
+      // TODO: should update to new api in next major version, do not use serverBase.hooks
       await hooks.onReset.call({
         event: fileChangeEvent,
       });

--- a/packages/toolkit/plugin-v2/src/server/api.ts
+++ b/packages/toolkit/plugin-v2/src/server/api.ts
@@ -74,10 +74,11 @@ export function initPluginAPI<Extends extends ServerPluginExtends>({
     context = assign(context, updateContext);
   }
 
+  // TODO: Add type in next major version when remove `Proxy`
   const pluginAPI = {
     isPluginExists: pluginManager.isPluginExists,
     getServerContext,
-    getConfig,
+    getServerConfig: getConfig,
     getHooks,
     updateServerContext,
 

--- a/packages/toolkit/plugin-v2/src/server/context.ts
+++ b/packages/toolkit/plugin-v2/src/server/context.ts
@@ -15,7 +15,7 @@ interface ContextParams<Extends extends ServerPluginExtends> {
 export function initServerContext<Extends extends ServerPluginExtends>(params: {
   options: ServerCreateOptions;
   plugins: ServerPlugin<Extends>[];
-}): ServerContext<Extends> {
+}): ServerContext<Extends> & Extends['extendContext'] {
   const { options, plugins } = params;
   return {
     routes: options.routes || [],

--- a/packages/toolkit/plugin-v2/src/types/server/api.ts
+++ b/packages/toolkit/plugin-v2/src/types/server/api.ts
@@ -6,9 +6,13 @@ import type { ServerPluginExtends } from './plugin';
 
 export type ServerPluginAPI<Extends extends ServerPluginExtends> = Readonly<
   {
-    getServerContext: () => Readonly<ServerContext<Extends>>;
+    getServerContext: () => Readonly<
+      ServerContext<Extends> & Extends['extendContext']
+    >;
     updateServerContext: (
-      updateContext: DeepPartial<ServerContext<Extends>>,
+      updateContext: DeepPartial<
+        ServerContext<Extends> & Extends['extendContext']
+      >,
     ) => void;
     getHooks: () => Readonly<Hooks<Extends['config']> & Extends['extendHooks']>;
     getServerConfig: () => Readonly<Extends['config']>;

--- a/packages/toolkit/types/server/context.d.ts
+++ b/packages/toolkit/types/server/context.d.ts
@@ -119,6 +119,10 @@ export interface ServerInitHookContext {
   app?: HttpServer;
 }
 
+/**
+ * This type extends the `serverContext` type and is also compatible with `ServerPluginLegacy`.
+ * Future implementations should consider it as an extension of the `serverContext` type.
+ */
 export interface ISAppContext {
   appDirectory: string;
   internalDirectory: string;


### PR DESCRIPTION
## Summary

In this PR, we enhance the server plugin api:

1. Support for correct usage of `middlewares` and `renderMiddlewares` in server plugins.
2. Remove of compatibility for legacy APIs like `useAppContext` in new server plugins.
3. Fixed issue where the server plugin API expose `getConfig` not `getServerConfig`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
