### PR TITLE
test: use rspack to replace webpack for the test case

### DIFF
--- a/tests/integration/pure-esm-project/modern.config.js
+++ b/tests/integration/pure-esm-project/modern.config.js
@@ -1,9 +1,10 @@
 import { appTools, defineConfig } from '@modern-js/app-tools';
 import { bffPlugin } from '@modern-js/plugin-bff';
 import { koaPlugin } from '@modern-js/plugin-koa';
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
 
 // https://modernjs.dev/docs/apis/app/config
-export default defineConfig({
+export default applyBaseConfig({
   bff: {
     enableHandleWeb: true,
   },
@@ -21,5 +22,5 @@ export default defineConfig({
   output: {
     disableTsChecker: true,
   },
-  plugins: [appTools({}), bffPlugin(), koaPlugin()],
+  plugins: [bffPlugin(), koaPlugin()],
 });


### PR DESCRIPTION
## Summary

In the webpack@5.99.0 version, there will be a bug that causes esm applications to report errors; here, use rspack to replace webpack.
![image](https://github.com/user-attachments/assets/9b6a6557-a379-43b8-b5b1-5e786c0e9465)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
