### PR TITLE
fix: ignore domain when detect whether the request is for static asset

### DIFF
--- a/.changeset/happy-bats-attend.md
+++ b/.changeset/happy-bats-attend.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix(server): static middleware should ignore domain name in assetPrefix when hit static asset
+fix(server): 资源中间件在命中静态资源时，应该忽略 assetPrefix 中的域名

--- a/.changeset/happy-bats-attend.md
+++ b/.changeset/happy-bats-attend.md
@@ -2,5 +2,5 @@
 '@modern-js/server-core': patch
 ---
 
-fix(server): static middleware should ignore domain name in assetPrefix when hit static asset
-fix(server): 资源中间件在命中静态资源时，应该忽略 assetPrefix 中的域名
+fix(server): static middleware should ignore domain when detect whether the request is for static asset
+fix(server): 资源中间件在检测请求是否为静态资源时，应该忽略 assetPrefix 中的域名

--- a/packages/server/core/src/adapters/node/plugins/static.ts
+++ b/packages/server/core/src/adapters/node/plugins/static.ts
@@ -161,8 +161,6 @@ export function createStaticMiddleware(
     // exist is path
     const hit = staticPathRegExp.test(pathname);
 
-    console.log('hit', hit, staticPathRegExp, pathname);
-
     // FIXME: shoudn't hit, when cssPath, jsPath, mediaPath as '.'
     if (hit) {
       const filepath = path.join(

--- a/packages/server/core/src/adapters/node/plugins/static.ts
+++ b/packages/server/core/src/adapters/node/plugins/static.ts
@@ -87,6 +87,23 @@ function matchPublicRoute(req: HonoRequest, routes: ServerRoute[]) {
   return undefined;
 }
 
+// Remove domain name from assetPrefix if it exists
+const extractPathname = (url: string): string => {
+  try {
+    // Check if the URL contains a protocol
+    if (url.includes('://')) {
+      return new URL(url).pathname || '/';
+    }
+    // Handle protocol-relative URLs (starting with //)
+    if (url.startsWith('//')) {
+      return new URL(`http:${url}`).pathname || '/';
+    }
+    return url;
+  } catch (e) {
+    return url;
+  }
+};
+
 export interface ServerStaticOptions {
   pwd: string;
   output: OutputNormalizedConfig;
@@ -108,6 +125,7 @@ export function createStaticMiddleware(
 ): Middleware {
   const { pwd, routes } = options;
   const prefix = options.output.assetPrefix || '/';
+  const pathPrefix = extractPathname(prefix);
 
   const {
     distPath: { css: cssPath, js: jsPath, media: mediaPath } = {},
@@ -120,7 +138,7 @@ export function createStaticMiddleware(
   const staticReg = ['static/', 'upload/', ...staticFiles];
   // TODO: Also remove iconReg
   const iconReg = ['favicon.ico', 'icon.png', ...favicons];
-  const regPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  const regPrefix = pathPrefix.endsWith('/') ? pathPrefix : `${pathPrefix}/`;
   const staticPathRegExp = new RegExp(
     `^${regPrefix}(${[...staticReg, ...iconReg].join('|')})`,
   );
@@ -143,11 +161,13 @@ export function createStaticMiddleware(
     // exist is path
     const hit = staticPathRegExp.test(pathname);
 
+    console.log('hit', hit, staticPathRegExp, pathname);
+
     // FIXME: shoudn't hit, when cssPath, jsPath, mediaPath as '.'
     if (hit) {
       const filepath = path.join(
         pwd,
-        pathname.replace(prefix, () => ''),
+        pathname.replace(pathPrefix, () => ''),
       );
       if (!(await fs.pathExists(filepath))) {
         // FIXME: we shoud return a response with status is 404, if we can't found static asset


### PR DESCRIPTION
## Summary

This PR resolves the issue where static assets cannot be accessed when developers configure the current domain name as `assetPrefix`.

```ts
import { appTools, defineConfig } from "@modern-js/app-tools";

export default defineConfig({
  runtime: {
    router: true,
  },
  server: {
    port: 3052,
  },
  output: {
    assetPrefix:"http://localhost:3052"
  },
  plugins: [
    appTools({
      bundler: "rspack",
    }),
  ],
});
```

Because middleware also valida host, which is actually unnecessary since resource requests from non-current hosts cannot enter the server.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
