### PR TITLE
fix: bash highlight should use `#`

### DIFF
--- a/packages/document/main-doc/docs/en/apis/app/hooks/src/routes.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/hooks/src/routes.mdx
@@ -13,8 +13,8 @@ Any `layout.[tj]sx` and `page.[tj]sx` under `src/routes` will be used as the app
 ```bash
 .
 └── routes
-    ├── layout.tsx  // [!code highlight]
-    ├── page.tsx // [!code highlight]
+    ├── layout.tsx  # [!code highlight]
+    ├── page.tsx # [!code highlight]
     └── user
         ├── layout.tsx
         └── page.tsx

--- a/packages/document/main-doc/docs/zh/apis/app/hooks/src/routes.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/hooks/src/routes.mdx
@@ -13,8 +13,8 @@ sidebar_position: 2
 ```bash
 .
 └── routes
-    ├── layout.tsx  // [!code highlight]
-    ├── page.tsx // [!code highlight]
+    ├── layout.tsx  # [!code highlight]
+    ├── page.tsx # [!code highlight]
     └── user
         ├── layout.tsx
         └── page.tsx


### PR DESCRIPTION
## Summary

fix for #7151 

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
