### PR TITLE
docs: improve htmlPlugin configuration docs

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/tools/html-plugin.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/html-plugin.mdx
@@ -33,6 +33,11 @@ const defaultOptions = {
 };
 ```
 
+:::warning
+SSR Application does not enable the `minify.removeComments` configuration, otherwise the SSR rendering will fail.
+:::
+
+
 The configs of [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) or [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) can be modified through `tools.htmlPlugin`.
 
 import RsbuildConfig from '@site-docs-en/components/rsbuild-config-tooltip';

--- a/packages/document/main-doc/docs/zh/configure/app/tools/html-plugin.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/html-plugin.mdx
@@ -33,6 +33,10 @@ const defaultOptions = {
 };
 ```
 
+:::warning
+SSR 应用请勿启用 `minify.removeComments` 配置项，否则会导致 SSR 渲染失败。
+:::
+
 通过 `tools.htmlPlugin` 可以修改 [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) 或 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 的配置项。
 
 import RsbuildConfig from '@site-docs/components/rsbuild-config-tooltip';


### PR DESCRIPTION
## Summary

The HTML template of an SSR application contains placeholders for SSR injection, it cannot be used together with `removeComment`.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
