### PR TITLE
docs: add a noticeable webpack only tag

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/performance/transform-lodash.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/performance/transform-lodash.mdx
@@ -4,9 +4,12 @@ title: transformLodash
 
 # performance.transformLodash
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >Webpack Only</Badge>
+
 - **Type:** `boolean`
 - **Default:** `true`
-- **Bundler:** `only support webpack`
 
 Specifies whether to modularize the import of [lodash](https://www.npmjs.com/package/lodash) and remove unused lodash modules to reduce the code size of lodash.
 

--- a/packages/document/main-doc/docs/en/configure/app/source/module-scopes.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/source/module-scopes.mdx
@@ -4,9 +4,12 @@ title: moduleScopes
 
 # source.moduleScopes
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >Webpack Only</Badge>
+
 - **Type:** `Array<string | Regexp> | Function`
 - **Default:** `undefined`
-- **Bundler:** `only support webpack`
 
 Restrict importing paths. After configuring this option, all source files can only import code from the specific paths, and import code from other paths is not allowed.
 

--- a/packages/document/main-doc/docs/en/configure/app/tools/terser.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/terser.mdx
@@ -4,6 +4,10 @@ title: terser
 
 # tools.terser
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >Webpack Only</Badge>
+
 - **Type:** `Object | Function | undefined`
 - **Default:**
 
@@ -16,8 +20,6 @@ const defaultTerserOptions = {
   },
 };
 ```
-
-- **Bundler:** `only support webpack`
 
 When building for production, Modern.js will minimize the JavaScript code through [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin). The config of [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) can be modified via `tools.terser`.
 

--- a/packages/document/main-doc/docs/en/configure/app/tools/ts-loader.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/ts-loader.mdx
@@ -4,9 +4,12 @@ title: tsLoader
 
 # tools.tsLoader
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >Webpack Only</Badge>
+
 - **Type:** `Object | Function | undefined`
 - **Default:** `undefined`
-- **Bundler:** `only support webpack`
 
 :::warning Deprecated
 

--- a/packages/document/main-doc/docs/en/configure/app/tools/webpack-chain.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/webpack-chain.mdx
@@ -4,9 +4,12 @@ title: webpackChain
 
 # tools.webpackChain
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >Webpack Only</Badge>
+
 - **Type:** `Function | undefined`
 - **Default:** `undefined`
-- **Bundler:** `only support webpack`
 
 You can modify the webpack configuration by configuring `tools.webpackChain` which is type of `Function`. The function receives two parameters, the first is the original webpack chain object, and the second is an object containing some utils.
 

--- a/packages/document/main-doc/docs/en/configure/app/tools/webpack.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/tools/webpack.mdx
@@ -4,9 +4,12 @@ title: webpack
 
 # tools.webpack
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >Webpack Only</Badge>
+
 - **Type:** `Object | Function | undefined`
 - **Default:** `undefined`
-- **Bundler:** `only support webpack`
 
 `tools.webpack` is used to configure [webpack](https://webpack.js.org/).
 

--- a/packages/document/main-doc/docs/zh/configure/app/performance/transform-lodash.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/performance/transform-lodash.mdx
@@ -4,9 +4,12 @@ title: transformLodash
 
 # performance.transformLodash
 
+import { Badge } from '@theme';
+
+<Badge type="danger" ><div>仅支持 Webpack</div></Badge>
+
 - **类型：** `boolean`
 - **默认值：** `true`
-- **打包工具：** `仅支持 webpack`
 
 是否模块化 [lodash](https://www.npmjs.com/package/lodash) 的导入，删除未使用的 lodash 模块，从而减少 lodash 代码体积。
 

--- a/packages/document/main-doc/docs/zh/configure/app/source/module-scopes.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/source/module-scopes.mdx
@@ -4,9 +4,12 @@ title: moduleScopes
 
 # source.moduleScopes
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >仅支持 Webpack</Badge>
+
 - **类型：** `Array<string | Regexp> | Function`
 - **默认值：** `undefined`
-- **打包工具：** `仅支持 webpack`
 
 限制源代码的引用路径。配置该选项后，所有源文件只能从约定的目录下引用代码，从其他目录引用代码会产生对应的报错提示。
 

--- a/packages/document/main-doc/docs/zh/configure/app/tools/terser.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/terser.mdx
@@ -4,6 +4,10 @@ title: terser
 
 # tools.terser
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >仅支持 Webpack</Badge>
+
 - **类型：** `Object | Function | undefined`
 - **默认值：**
 
@@ -16,8 +20,6 @@ const defaultTerserOptions = {
   },
 };
 ```
-
-- **打包工具：** `仅支持 webpack`
 
 在生产环境构建时，Modern.js 会通过 [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) 对 JavaScript 代码进行压缩优化。可以通过 `tools.terser` 修改 [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) 的配置。
 

--- a/packages/document/main-doc/docs/zh/configure/app/tools/ts-loader.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/ts-loader.mdx
@@ -4,9 +4,12 @@ title: tsLoader
 
 # tools.tsLoader
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >仅支持 Webpack</Badge>
+
 - **类型：** `Object | Function | undefined`
 - **默认值：** `undefined`
-- **打包工具：** `仅支持 webpack`
 
 :::warning 废弃提示
 

--- a/packages/document/main-doc/docs/zh/configure/app/tools/webpack-chain.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/webpack-chain.mdx
@@ -4,9 +4,12 @@ title: webpackChain
 
 # tools.webpackChain
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >仅支持 Webpack</Badge>
+
 - **类型：** `Function | undefined`
 - **默认值：** `undefined`
-- **打包工具：** `仅支持 webpack`
 
 你可以通过 `tools.webpackChain` 来修改默认的 webpack 配置，它的值为 `Function` 类型，接收两个参数：
 

--- a/packages/document/main-doc/docs/zh/configure/app/tools/webpack.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/tools/webpack.mdx
@@ -4,9 +4,12 @@ title: webpack
 
 # tools.webpack
 
+import { Badge } from '@theme';
+
+<Badge type="danger" >仅支持 Webpack</Badge>
+
 - **类型：** `Object | Function | undefined`
 - **默认值：** `undefined`
-- **打包工具：** `仅支持 webpack`
 
 `tools.webpack` 选项用于配置原生的 [webpack](https://webpack.js.org/)。
 


### PR DESCRIPTION
## Summary

Now, Modern.js is enabled with rspack by default, to avoid it doesn't work after users use it, this PR adds some more noticeable `webpack only` tags.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
