### PR TITLE
fix: ssg should overrides the logger.error method to stderr

### DIFF
--- a/.changeset/ten-pigs-fetch.md
+++ b/.changeset/ten-pigs-fetch.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/prod-server': patch
+'@modern-js/plugin-ssg': patch
+---
+
+fix: 修复 SSG 报错时没有中断构建的问题
+fix: fix the issue that the build will not be interrupted when an error occurs in SSG

--- a/packages/cli/plugin-ssg/src/server/process.ts
+++ b/packages/cli/plugin-ssg/src/server/process.ts
@@ -11,9 +11,23 @@ import type {
   ServerRoute as ModernRoute,
   ServerPlugin,
 } from '@modern-js/types';
+import { createLogger } from '@modern-js/utils';
 import portfinder from 'portfinder';
 import { chunkArray } from '../libs/util';
 import { CLOSE_SIGN } from './consts';
+
+// SSG only interrupt when stderror, so we need to override the rslog's error to console.error
+function getLogger() {
+  const logger = createLogger({
+    level: 'verbose',
+  });
+  return {
+    ...logger,
+    error: (...args: any[]) => {
+      console.error(...args);
+    },
+  };
+}
 
 const MAX_CONCURRENT_REQUESTS = 10;
 
@@ -66,6 +80,7 @@ process.on('message', async (chunk: string) => {
         appContext.appDirectory || distDirectory,
       ),
       staticGenerate: true,
+      logger: getLogger(),
     };
 
     assert(process.send, 'process.send is not available');

--- a/packages/server/core/src/plugins/monitors.ts
+++ b/packages/server/core/src/plugins/monitors.ts
@@ -107,12 +107,12 @@ export const initMonitorsPlugin = (): ServerPluginLegacy => ({
 });
 
 export const injectloggerPlugin = (
-  inputLogger?: Logger,
+  inputLogger: Logger,
 ): ServerPluginLegacy => ({
   name: '@modern-js/inject-logger',
 
   setup(api) {
-    const logger = inputLogger || console;
+    const logger = inputLogger;
     return {
       prepare() {
         const { middlewares } = api.useAppContext();

--- a/packages/server/prod-server/src/apply.ts
+++ b/packages/server/prod-server/src/apply.ts
@@ -38,7 +38,7 @@ export async function applyPlugins(
   options: ProdServerOptions,
   nodeServer?: NodeServer | Http2SecureServer,
 ) {
-  const { pwd, appContext, config } = options;
+  const { pwd, appContext, config, logger: optLogger } = options;
 
   const loadCachePwd = isProd() ? pwd : appContext.appDirectory || pwd;
   const cacheConfig = await loadCacheConfig(loadCachePwd);
@@ -63,7 +63,8 @@ export async function applyPlugins(
     ...createDefaultPlugins({
       cacheConfig,
       staticGenerate: options.staticGenerate,
-      logger: loggerOptions === false ? false : getLogger(loggerOptions),
+      logger:
+        loggerOptions === false ? false : optLogger || getLogger(loggerOptions),
     }),
     injectConfigMiddlewarePlugin(middlewares, renderMiddlewares),
     ...(options.plugins || []),


### PR DESCRIPTION
## Summary

In this PR, we have overridden the `logger` passed to the server in the SSG plugin. 

We want the error log to interrupt the SSG build but the default Logger only outputs to stdout, so we have overridden it to output to stderr.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
