### PR TITLE
fix: use acceptInsecureCerts instead of ignoreHTTPSErrors

### DIFF
--- a/tests/integration/server-hook/router/tests/index.test.ts
+++ b/tests/integration/server-hook/router/tests/index.test.ts
@@ -22,7 +22,7 @@ describe('test status code page', () => {
 
     browser = await puppeteer.launch({
       ...launchOptions,
-      ignoreHTTPSErrors: true, // https://github.com/puppeteer/puppeteer/issues/1137
+      acceptInsecureCerts: true, // https://github.com/puppeteer/puppeteer/issues/1137, Puppeteer 23.0.0 rename ignoreHTTPSErrors to acceptInsecureCerts
     } as any);
     page = await browser.newPage();
   });


### PR DESCRIPTION
## Summary

#7202 upgrade puppeteer version. But in [v23]( https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.0.0), puppeteer rename ignoreHTTPSErrors to acceptInsecureCerts.

This has caused the certificate error, this PR fix it.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
