### PR TITLE
feat: support resolve.alias

### DIFF
--- a/.changeset/young-coins-bet.md
+++ b/.changeset/young-coins-bet.md
@@ -1,0 +1,15 @@
+---
+'@modern-js/plugin-router-v5': patch
+'@modern-js/plugin-router-v7': patch
+'@modern-js/plugin-garfish': patch
+'@modern-js/runtime': patch
+'@modern-js/plugin-testing': patch
+'@modern-js/plugin-express': patch
+'@modern-js/plugin-state': patch
+'@modern-js/app-tools': patch
+'@modern-js/plugin-koa': patch
+'@modern-js/uni-builder': patch
+---
+
+feat: support resolve configuration in rsbuild.
+feat: 支持 rsbuild 的 resolve 配置。

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -3,7 +3,13 @@ import type { AppTools, CliPlugin } from '@modern-js/app-tools';
 import { ApiRouter } from '@modern-js/bff-core';
 import { compile } from '@modern-js/server-utils';
 import type { ServerRoute } from '@modern-js/types';
-import { fs, API_DIR, SHARED_DIR, normalizeOutputPath } from '@modern-js/utils';
+import {
+  fs,
+  API_DIR,
+  type AliasOption,
+  SHARED_DIR,
+  normalizeOutputPath,
+} from '@modern-js/utils';
 import clientGenerator from './utils/clientGenerator';
 import pluginGenerator from './utils/pluginGenerator';
 import runtimeGenerator from './utils/runtimeGenerator';
@@ -43,6 +49,7 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
 
       const { server } = modernConfig;
       const { alias } = modernConfig.source;
+      const { alias: resolveAlias } = modernConfig.resolve;
       const { babel } = modernConfig.tools;
 
       if (sourceDirs.length > 0) {
@@ -50,7 +57,7 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
           appDirectory,
           {
             server,
-            alias,
+            alias: { ...alias, ...(resolveAlias as AliasOption) },
             babelConfig: babel,
           },
           {

--- a/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/uni-builder/src/shared/parseCommonConfig.ts
@@ -136,6 +136,7 @@ export async function parseCommonConfig(
       ...toolsConfig
     } = {},
     environments = {},
+    resolve = {},
   } = uniBuilderConfig;
 
   const rsbuildConfig: RsbuildConfig = {
@@ -146,6 +147,7 @@ export async function parseCommonConfig(
       sourceMap,
       ...outputConfig,
     },
+    resolve,
     source: {
       alias: alias as unknown as SourceConfig['alias'],
       ...sourceConfig,
@@ -156,6 +158,14 @@ export async function parseCommonConfig(
     security: securityConfig,
     environments,
   };
+
+  /**
+   * 在老版本中，默认 source.alias 为空对象。Rsbuild 新版本推荐使用 resolve.alias 代替 source.alias
+   * 因此如果 alias 为空对象，则删除 source.alias，避免在默认情况下出现警告
+   */
+  if (typeof alias === 'object' && Object.keys(alias).length === 0) {
+    delete rsbuildConfig.source?.alias;
+  }
 
   rsbuildConfig.tools!.htmlPlugin = htmlPlugin as ToolsConfig['htmlPlugin'];
 

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -461,6 +461,7 @@ export type UniBuilderConfig = {
   performance?: RsbuildConfig['performance'];
   security?: Omit<SecurityConfig, 'sri'>;
   tools?: Omit<ToolsConfig, 'htmlPlugin'>;
+  resolve?: RsbuildConfig['resolve'];
   source?: Omit<SourceConfig, 'alias' | 'transformImport'>;
   // plugins is a new field, should avoid adding modern plugin by mistake
   plugins?: RsbuildPlugins;

--- a/packages/cli/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/cli/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -32,6 +32,7 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "compress": false,
@@ -94,6 +95,7 @@ exports[`parseCommonConfig > dev.xxx 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -147,6 +149,7 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -202,6 +205,7 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -260,6 +264,7 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -315,6 +320,7 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -377,6 +383,7 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -432,6 +439,7 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -490,6 +498,7 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -545,6 +554,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -605,6 +615,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -662,6 +673,7 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -719,6 +731,7 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -776,6 +789,7 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -833,6 +847,7 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -886,6 +901,7 @@ exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,
@@ -937,6 +953,7 @@ exports[`parseCommonConfig > output.enableInlineStyles 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "security": {},
   "server": {
     "htmlFallback": false,

--- a/packages/runtime/plugin-garfish/src/cli/index.ts
+++ b/packages/runtime/plugin-garfish/src/cli/index.ts
@@ -118,7 +118,7 @@ export const garfishPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
         output: {
           disableCssExtract,
         },
-        source: {
+        resolve: {
           alias: {
             [`@${metaName}/runtime/garfish`]: `@${metaName}/plugin-garfish/runtime`,
           },

--- a/packages/runtime/plugin-router-v5/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v5/src/cli/index.ts
@@ -44,7 +44,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools> => ({
       );
 
       return {
-        source: {
+        resolve: {
           alias: {
             [`@${metaName}/runtime/router-v5`]: routerExportsUtils.getPath(),
           },

--- a/packages/runtime/plugin-router-v5/tests/index.test.ts
+++ b/packages/runtime/plugin-router-v5/tests/index.test.ts
@@ -61,7 +61,7 @@ describe('cli-router-legacy', () => {
     const config = await api.getHooks().config.call();
     expect(
       config.find(
-        (item: any) => item.source.alias['@modern-js/runtime/plugins'],
+        (item: any) => item.resolve.alias['@modern-js/runtime/plugins'],
       ),
     ).toBeTruthy();
   });

--- a/packages/runtime/plugin-router-v7/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v7/src/cli/index.ts
@@ -18,7 +18,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools> => ({
         });
       }
       return {
-        source: {
+        resolve: {
           alias: {
             'react-router-dom$': require
               .resolve('../runtime')

--- a/packages/runtime/plugin-router-v7/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v7/src/cli/index.ts
@@ -30,6 +30,8 @@ export const routerPlugin = (): CliPluginFuture<AppTools> => ({
               .resolve('../runtime')
               .replace(/\/cjs\//, '/esm/'),
           },
+        },
+        source: {
           globalVars: {
             'process.env._MODERN_ROUTER_VERSION': 'v7',
           },

--- a/packages/runtime/plugin-runtime/src/cli/alias.ts
+++ b/packages/runtime/plugin-runtime/src/cli/alias.ts
@@ -35,7 +35,7 @@ export const builderPluginAlias = ({
         }
       });
       return mergeRsbuildConfig(userConfig, {
-        source: {
+        resolve: {
           alias: { ...entrypointsAlias, ...mainEntrypointsAlias },
         },
       });

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -112,6 +112,8 @@ export const runtimePlugin = (params?: {
             ),
             '@meta/runtime$': require.resolve('@modern-js/runtime'),
           },
+        },
+        source: {
           globalVars: {
             'process.env.IS_REACT18': process.env.IS_REACT18,
           },

--- a/packages/runtime/plugin-runtime/src/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/index.ts
@@ -91,7 +91,7 @@ export const runtimePlugin = (params?: {
       return {
         runtime: {},
         runtimeByEntries: {},
-        source: {
+        resolve: {
           alias: {
             /**
              * twin.macro inserts styled-components into the code during the compilation process

--- a/packages/runtime/plugin-runtime/src/cli/ssr/index.ts
+++ b/packages/runtime/plugin-runtime/src/cli/ssr/index.ts
@@ -133,7 +133,7 @@ export const ssrPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
 
       return {
         builderPlugins: [ssrBuilderPlugin(api)],
-        source: {
+        resolve: {
           alias: {
             // ensure that all packages use the same storage in @modern-js/runtime-utils/node
             '@modern-js/runtime-utils/node$': require

--- a/packages/runtime/plugin-runtime/tests/router/index.test.ts
+++ b/packages/runtime/plugin-runtime/tests/router/index.test.ts
@@ -30,7 +30,7 @@ describe('cli-router', () => {
     const config = await runner.config();
     expect(
       config.find(
-        (item: any) => item.source.alias['@modern-js/runtime/plugins'],
+        (item: any) => item.resolve.alias['@modern-js/runtime/plugins'],
       ),
     ).toBeTruthy();
   });

--- a/packages/runtime/plugin-state/src/cli/index.ts
+++ b/packages/runtime/plugin-state/src/cli/index.ts
@@ -32,7 +32,7 @@ export const statePlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
     api.config(() => {
       const { metaName } = api.getAppContext();
       return {
-        source: {
+        resolve: {
           alias: {
             [`@${metaName}/runtime/model`]: `@${metaName}/plugin-state/runtime`,
           },

--- a/packages/runtime/plugin-testing/src/base/config/index.ts
+++ b/packages/runtime/plugin-testing/src/base/config/index.ts
@@ -25,6 +25,9 @@ export type UserConfig = {
   source?: {
     alias?: AliasOption;
   };
+  resolve?: {
+    alias?: AliasOption;
+  };
   testing?: TestConfig;
   tools?: {
     jest: JestConfig | ((config: JestConfig) => JestConfig);

--- a/packages/runtime/plugin-testing/src/cli/index.ts
+++ b/packages/runtime/plugin-testing/src/cli/index.ts
@@ -92,7 +92,7 @@ export const testingPlugin = (): CliPlugin<{
           );
 
           return {
-            source: {
+            resolve: {
               alias: {
                 // The module-tools alias configuration is different and more specific than app-tools.
                 // So for the time being, the @ alias is configured here.

--- a/packages/server/plugin-express/src/cli/index.ts
+++ b/packages/server/plugin-express/src/cli/index.ts
@@ -34,7 +34,7 @@ export const expressPlugin = (): CliPlugin<AppTools> => ({
             : '@modern-js/plugin-express/runtime';
 
         return {
-          source: {
+          resolve: {
             alias: {
               '@modern-js/runtime/server': runtimePath,
               '@modern-js/runtime/express': runtimePath,

--- a/packages/server/plugin-koa/src/cli/index.ts
+++ b/packages/server/plugin-koa/src/cli/index.ts
@@ -39,7 +39,7 @@ export const koaPlugin = (): CliPlugin<AppTools> => ({
               '@modern-js/runtime/koa': runtimePath,
             },
           },
-          source: {
+          resolve: {
             alias: {
               '@modern-js/runtime/server$': alias,
               '@modern-js/runtime/koa': alias,

--- a/packages/solutions/app-tools/src/builder/generator/createBuilderProviderConfig.ts
+++ b/packages/solutions/app-tools/src/builder/generator/createBuilderProviderConfig.ts
@@ -31,6 +31,9 @@ export function createBuilderProviderConfig<B extends Bundler>(
   const config = {
     ...resolveConfig,
     plugins: [],
+    resolve: {
+      ...resolveConfig.resolve,
+    },
     dev: {
       ...resolveConfig.dev,
       port: appContext.port,

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -1,5 +1,6 @@
 import type { CLIPluginAPI } from '@modern-js/plugin-v2';
-import { logger } from '@modern-js/utils';
+import { type Alias, logger } from '@modern-js/utils';
+import type { ConfigChain } from '@rsbuild/core';
 import type { AppTools } from '../types';
 import { buildServerConfig } from '../utils/config';
 import { loadServerPlugins } from '../utils/loadPlugins';
@@ -35,11 +36,10 @@ export const build = async (
     });
   }
 
-  await registerCompiler(
-    appContext.appDirectory,
-    appContext.distDirectory,
-    resolvedConfig?.source?.alias,
-  );
+  await registerCompiler(appContext.appDirectory, appContext.distDirectory, {
+    ...resolvedConfig?.resolve?.alias,
+    ...resolvedConfig?.source?.alias,
+  } as ConfigChain<Alias>);
 
   const { apiOnly } = appContext;
 

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -28,7 +28,10 @@ export const build = async (
     await registerEsm({
       appDir: appContext.appDirectory,
       distDir: appContext.distDirectory,
-      alias: resolvedConfig.source?.alias,
+      alias: {
+        ...resolvedConfig.resolve.alias,
+        ...resolvedConfig.source?.alias,
+      },
     });
   }
 

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -30,7 +30,7 @@ export const build = async (
       appDir: appContext.appDirectory,
       distDir: appContext.distDirectory,
       alias: {
-        ...resolvedConfig.resolve.alias,
+        ...resolvedConfig.resolve?.alias,
         ...resolvedConfig.source?.alias,
       },
     });

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -42,7 +42,7 @@ export const dev = async (
       appDir: appContext.appDirectory,
       distDir: appContext.distDirectory,
       alias: {
-        ...normalizedConfig.resolve.alias,
+        ...normalizedConfig.resolve?.alias,
         ...normalizedConfig.source?.alias,
       },
     });

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -3,11 +3,13 @@ import type { CLIPluginAPI } from '@modern-js/plugin-v2';
 import { applyPlugins } from '@modern-js/prod-server';
 import { type ApplyPlugins, createDevServer } from '@modern-js/server';
 import {
+  type Alias,
   DEFAULT_DEV_HOST,
   SERVER_DIR,
   getMeta,
   logger,
 } from '@modern-js/utils';
+import type { ConfigChain } from '@rsbuild/core';
 import type { AppNormalizedConfig, AppTools } from '../types';
 import { buildServerConfig } from '../utils/config';
 import { setServer } from '../utils/createServer';
@@ -46,11 +48,10 @@ export const dev = async (
     });
   }
 
-  await registerCompiler(
-    appContext.appDirectory,
-    appContext.distDirectory,
-    normalizedConfig?.source?.alias,
-  );
+  await registerCompiler(appContext.appDirectory, appContext.distDirectory, {
+    ...normalizedConfig?.source?.alias,
+    ...normalizedConfig?.resolve?.alias,
+  } as ConfigChain<Alias>);
 
   const {
     appDirectory,

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -39,7 +39,10 @@ export const dev = async (
     await registerEsm({
       appDir: appContext.appDirectory,
       distDir: appContext.distDirectory,
-      alias: normalizedConfig.source?.alias,
+      alias: {
+        ...normalizedConfig.resolve.alias,
+        ...normalizedConfig.source?.alias,
+      },
     });
   }
 

--- a/packages/solutions/app-tools/src/config/default.ts
+++ b/packages/solutions/app-tools/src/config/default.ts
@@ -45,6 +45,10 @@ export function createDefaultConfig(
     entriesDir: './src',
     configDir: './config',
     globalVars: getAutoInjectEnv(appContext),
+    alias: {},
+  };
+
+  const resolve: AppUserConfig['resolve'] = {
     alias: {
       [appContext.internalDirAlias]: appContext.internalDirectory,
       [appContext.internalSrcAlias]: appContext.srcDirectory!,
@@ -80,6 +84,7 @@ export function createDefaultConfig(
 
   return {
     source,
+    resolve,
     output,
     server,
     dev,

--- a/packages/solutions/app-tools/src/config/legacy/index.ts
+++ b/packages/solutions/app-tools/src/config/legacy/index.ts
@@ -29,6 +29,7 @@ export function transformNormalizedConfig(
     autoLoadPlugins,
   } = config;
   return {
+    resolve: {},
     source,
     html,
     output,

--- a/packages/solutions/app-tools/src/types/config/index.ts
+++ b/packages/solutions/app-tools/src/types/config/index.ts
@@ -11,6 +11,7 @@ import type { ExperimentsUserConfig } from './experiments';
 import type { HtmlUserConfig } from './html';
 import type { OutputUserConfig } from './output';
 import type { PerformanceUserConfig } from './performance';
+import type { ResolveUserConfig } from './resolve';
 import type { SecurityUserConfig } from './security';
 import type { SourceUserConfig } from './source';
 import type { TestingUserConfig } from './testing';
@@ -26,6 +27,7 @@ export interface RuntimeByEntriesUserConfig {
 }
 
 export interface AppToolsUserConfig<B extends Bundler> {
+  resolve?: ResolveUserConfig;
   server?: ServerUserConfig;
   source?: SourceUserConfig;
   output?: OutputUserConfig;

--- a/packages/solutions/app-tools/src/types/config/resolve.ts
+++ b/packages/solutions/app-tools/src/types/config/resolve.ts
@@ -1,0 +1,3 @@
+import type { UniBuilderConfig } from '@modern-js/uni-builder';
+
+export type ResolveUserConfig = UniBuilderConfig['resolve'];

--- a/packages/solutions/app-tools/tests/builder/__snapshots__/index.test.ts.snap
+++ b/packages/solutions/app-tools/tests/builder/__snapshots__/index.test.ts.snap
@@ -139,6 +139,7 @@ exports[`create builder provider config should add default config 1`] = `
   },
   "performance": {},
   "plugins": [],
+  "resolve": {},
   "server": undefined,
   "source": {},
 }

--- a/tests/integration/alias-set/modern.config.ts
+++ b/tests/integration/alias-set/modern.config.ts
@@ -1,3 +1,10 @@
+import path from 'path';
 import { applyBaseConfig } from '../../utils/applyBaseConfig';
 
-export default applyBaseConfig();
+export default applyBaseConfig({
+  resolve: {
+    alias: {
+      '@resolve-alias': path.resolve(__dirname, 'src/alias'),
+    },
+  },
+});

--- a/tests/integration/alias-set/src/App.tsx
+++ b/tests/integration/alias-set/src/App.tsx
@@ -1,4 +1,5 @@
 import test from '@common/constants';
+import '@resolve-alias';
 
 function App() {
   return <div>Hello Modern.js! {test} </div>;

--- a/tests/integration/alias-set/src/alias/index.ts
+++ b/tests/integration/alias-set/src/alias/index.ts
@@ -1,1 +1,1 @@
-console.log('my-alias');
+console.log('resolve-alias success');

--- a/tests/integration/alias-set/src/alias/index.ts
+++ b/tests/integration/alias-set/src/alias/index.ts
@@ -1,0 +1,1 @@
+console.log('my-alias');


### PR DESCRIPTION

This PR resolve the `resolve.alias` warning，and also update the internal alias usage in Modern.js.

#### 1. Add support for `resolve.alias` configuration
- Introduced the `resolve` field (with `resolve.alias`) in various configs such as `UniBuilderConfig`, `AppToolsUserConfig`, and `UserConfig`. Users are now encouraged to use `resolve.alias` instead of the legacy `source.alias`.
- Updated related type definitions, default configs, and legacy compatibility logic accordingly.

#### 2. Plugin and toolchain adaptation
- All plugins and tools that depend on alias configuration (e.g., runtime, router, state, testing, express, koa, etc.) have switched from `source.alias` to `resolve.alias`.
- The logic for passing alias config in build and dev commands has been adapted to the new structure, merging both `source.alias` and `resolve.alias` for compatibility.

#### 3. Compatibility handling
- Maintained backward compatibility for `source.alias`
- If `alias` is an empty object, it will be removed automatically to avoid warnings in the new Rsbuild version.
- Legacy logic such as `transformNormalizedConfig` now includes the `resolve` field to ensure a smooth migration.

#### 4. Integration tests
- Added/updated integration test cases to verify the effectiveness of the `resolve.alias` configuration, including config files, source code references, and actual runtime behavior.

---

这个 PR 处理了 `resolve.alias` 的警告问题，并更新了内部对别名的用法。

#### 1. 新增 `resolve.alias` 配置支持
- 在各类配置（如 `UniBuilderConfig`、`AppToolsUserConfig`、`UserConfig` 等）中引入了 `resolve` 字段，并支持 `resolve.alias` 配置，推荐用户使用 `resolve.alias` 替代原有的 `source.alias`。
- 相关类型定义、默认配置、legacy 兼容逻辑均已同步更新。

#### 2. 插件与工具链适配
- 所有依赖 `alias` 配置的插件（如 runtime、router、state、testing、express、koa 等）均已从 `source.alias` 切换为 `resolve.alias`。
- 构建、开发等命令行工具的 `alias` 传递逻辑已适配新结构，兼容 `source.alias` 和 `resolve.alias` 的合并。

#### 3. 兼容性处理
- 保持对老版本 `source.alias` 的兼容
- 若 `alias` 为空对象，则自动移除，避免新版 Rsbuild 警告。
- `transformNormalizedConfig` 等 legacy 逻辑已补充 `resolve` 字段，确保平滑迁移。

#### 4. 集成测试用例
- 新增/修改了集成测试用例，验证 `resolve.alias` 配置生效，包括配置文件、源码引用和实际运行效果。
