### PR TITLE
fix: preserve the default behavior of scope for compiling JS when use webpack

### DIFF
--- a/packages/cli/uni-builder/src/webpack/index.ts
+++ b/packages/cli/uni-builder/src/webpack/index.ts
@@ -17,6 +17,7 @@ import type {
   UniBuilderConfig,
 } from '../types';
 import { pluginBabel } from './plugins/babel';
+import { pluginInclude } from './plugins/include';
 import { pluginModuleScopes } from './plugins/moduleScopes';
 import { pluginReact } from './plugins/react';
 
@@ -157,6 +158,8 @@ export async function parseConfig(
   rsbuildPlugins.push(
     pluginModuleScopes(uniBuilderConfig.source?.moduleScopes),
   );
+
+  rsbuildPlugins.push(pluginInclude());
 
   return {
     rsbuildConfig,

--- a/packages/cli/uni-builder/src/webpack/plugins/include.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/include.ts
@@ -1,5 +1,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 
+// Preserve the default behavior of compilation scope to the current directory when using webpack.
+// TODO: Remove this plugin in next major version.
 export const pluginInclude = (): RsbuildPlugin => ({
   name: 'uni-builder:babel-include',
 

--- a/packages/cli/uni-builder/src/webpack/plugins/include.ts
+++ b/packages/cli/uni-builder/src/webpack/plugins/include.ts
@@ -1,0 +1,23 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const pluginInclude = (): RsbuildPlugin => ({
+  name: 'uni-builder:babel-include',
+
+  setup(api) {
+    api.modifyWebpackChain((chain, { CHAIN_ID }) => {
+      const includes = chain.module.rule(CHAIN_ID.RULE.JS).include.values();
+      includes.forEach(include => {
+        if (
+          typeof include === 'object' &&
+          !Array.isArray(include) &&
+          !(include instanceof RegExp) &&
+          include.not &&
+          include.not.toString() === /[\\/]node_modules[\\/]/.toString()
+        ) {
+          include.and = [api.context.rootPath, { not: include.not }];
+          delete include.not;
+        }
+      });
+    });
+  },
+});

--- a/packages/runtime/plugin-router-v7/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v7/src/cli/index.ts
@@ -1,3 +1,4 @@
+import { sep } from 'path';
 import type { AppTools, CliPluginFuture } from '@modern-js/app-tools';
 import { logger } from '@modern-js/utils';
 
@@ -17,18 +18,19 @@ export const routerPlugin = (): CliPluginFuture<AppTools> => ({
           }
         });
       }
+
+      const cjsRegex = new RegExp(`${sep}cjs${sep}`);
+      const esm = `${sep}esm${sep}`;
       return {
         resolve: {
           alias: {
-            'react-router-dom$': require
-              .resolve('../runtime')
-              .replace(/\/cjs\//, '/esm/'),
+            'react-router-dom$': require.resolve('../runtime'),
             '@remix-run/router': require
               .resolve('../runtime')
-              .replace(/\/cjs\//, '/esm/'),
+              .replace(cjsRegex, esm),
             'react-router-dom/server': require
               .resolve('../runtime')
-              .replace(/\/cjs\//, '/esm/'),
+              .replace(cjsRegex, esm),
           },
         },
         source: {


### PR DESCRIPTION
## Summary

Rsbuild 1.4.0 modify the default behavior for compile js file(https://github.com/web-infra-dev/rsbuild/pull/5345).

When use rspack + swc, this is no problem. But Modern.js still supports the webpack + babel, and in this mode, unexpected behavior may occur. 

Therefore, when using webpack mode, we maintain the original compilation scope.

---

This is a hack. In the next major version, we will remove support for webpack, then it can be deleted.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
