### PR TITLE
docs: update lazyCompilation docs for rspack

### DIFF
--- a/packages/document/main-doc/docs/en/configure/app/experiments/lazy-compilation.mdx
+++ b/packages/document/main-doc/docs/en/configure/app/experiments/lazy-compilation.mdx
@@ -25,6 +25,17 @@ Used to enable the lazy compilation (i.e. compile on demand). When this config i
 
 Lazy compilation only takes effect in the development.
 
+## Rspack
+
+import RsbuildLink from '@site/src/components/RsbuildLink';
+
+:::info
+The usage of this configuration item is exactly the same as that of Rsbuild. For detailed information, please refer to <RsbuildLink configName="dev.lazyCompilation"/>。
+In Rspack build mode,
+:::
+
+## Webapck
+
 ### Lazy Compilation for Dynamic Imports
 
 Lazy compile async modules introduced by [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import):

--- a/packages/document/main-doc/docs/zh/configure/app/experiments/lazy-compilation.mdx
+++ b/packages/document/main-doc/docs/zh/configure/app/experiments/lazy-compilation.mdx
@@ -25,6 +25,16 @@ type LazyCompilationOptions =
 
 延迟编译只在开发环境下生效。
 
+## Rspack
+
+import RsbuildLink from '@site/src/components/RsbuildLink';
+
+:::info
+该配置项的使用方式与 Rsbuild 完全一致，详细信息可参考 <RsbuildLink configName="dev.lazyCompilation"/>。
+:::
+
+## Webpack
+
 ### 延迟编译异步模块
 
 延迟编译 [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) 引入的异步模块：


### PR DESCRIPTION
## Summary

Now, lazyCompilation already supports by Rspack, so point the docs to Rsbuild.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
