### PR TITLE
feat: support rsc for spa projects

### DIFF
--- a/.changeset/long-donuts-care.md
+++ b/.changeset/long-donuts-care.md
@@ -1,0 +1,12 @@
+---
+'@modern-js/flight-server-transform-plugin': patch
+'@modern-js/plugin-router-v7': patch
+'@modern-js/runtime': patch
+'@modern-js/app-tools': patch
+'@modern-js/uni-builder': patch
+'@modern-js/render': patch
+'@modern-js/server-core': patch
+---
+
+feat: support rsc for spa projects
+feat: 为 SPA 项目支持 RSC

--- a/.changeset/pink-doodles-cheat.md
+++ b/.changeset/pink-doodles-cheat.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/runtime': patch
+'@modern-js/app-tools': patch
+'@modern-js/server-core': patch
+---
+
+feat: inject the rsc payload into the html for csr
+feat: 为 CSR 项目，注入 rsc payload 到 html 中

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,5 +81,8 @@
   },
   "rust-analyzer.linkedProjects": [
     "./packages/cli/flight-server-transform-plugin/Cargo.toml"
-  ]
+  ],
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:package-json": "cd ./scripts/lint-package-json && pnpm start",
     "prepare-build": "cross-env NX_DAEMON=false NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t build -p @modern-js/* --exclude=@modern-js/main-doc,@modern-js/module-tools-docs --maxParallel=4",
     "prepare": "npm run prepare-build && husky install",
+    "prepare-build-continue": "cross-env NX_DAEMON=false NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t build -p @modern-js/* --exclude=@modern-js/main-doc,@modern-js/module-tools-docs --nxBail=false --maxParallel=4 || echo 'Build completed with some failures, continuing...'",
     "build:required": "cross-env NX_DAEMON=false nx run-many -t build -p @modern-js/uni-builder",
     "lint": "biome check",
     "change": "modern change",

--- a/packages/cli/flight-server-transform-plugin/tests/fixture/client-components-cjs/input.jsx
+++ b/packages/cli/flight-server-transform-plugin/tests/fixture/client-components-cjs/input.jsx
@@ -1,0 +1,53 @@
+'use client';
+
+// @ts-ignore
+const React = require('react');
+
+class ClassA extends React.Component {
+  render() {
+    return React.createElement('div');
+  }
+}
+
+function ComponentA(arg0) {
+  return React.createElement(`div`);
+}
+
+const MemoizedComponentA = React.memo(ComponentA);
+
+const ComponentB = function () {
+  return React.createElement(`div`);
+};
+
+const foo = 1;
+
+// @ts-ignore
+exports.ClassA = ClassA;
+// @ts-ignore
+exports.ComponentA = ComponentA;
+// @ts-ignore
+exports.MemoizedComponentA = MemoizedComponentA;
+// @ts-ignore
+exports.ComponentB = ComponentB;
+// @ts-ignore
+exports.foo = foo;
+
+const bar = 2;
+
+const ComponentF = () => React.createElement(`div`);
+
+function D() {
+  return React.createElement(`div`);
+}
+
+function ComponentE() {
+  return React.createElement(`div`);
+}
+
+// @ts-ignore
+module.exports = {
+  ComponentD: D,
+  bar,
+  ComponentE,
+  ComponentF
+};

--- a/packages/cli/flight-server-transform-plugin/tests/fixture/client-components-cjs/output.js
+++ b/packages/cli/flight-server-transform-plugin/tests/fixture/client-components-cjs/output.js
@@ -1,0 +1,20 @@
+/* @modern-js-rsc-metadata
+{"directive":"client","exportNames":[{"exportName":"ClassA","id":"tests/fixture/client-components-cjs/input.jsx#ClassA"},{"exportName":"ComponentA","id":"tests/fixture/client-components-cjs/input.jsx#ComponentA"},{"exportName":"MemoizedComponentA","id":"tests/fixture/client-components-cjs/input.jsx#MemoizedComponentA"},{"exportName":"ComponentB","id":"tests/fixture/client-components-cjs/input.jsx#ComponentB"},{"exportName":"foo","id":"tests/fixture/client-components-cjs/input.jsx#foo"},{"exportName":"ComponentD","id":"tests/fixture/client-components-cjs/input.jsx#ComponentD"},{"exportName":"bar","id":"tests/fixture/client-components-cjs/input.jsx#bar"},{"exportName":"ComponentE","id":"tests/fixture/client-components-cjs/input.jsx#ComponentE"},{"exportName":"ComponentF","id":"tests/fixture/client-components-cjs/input.jsx#ComponentF"}]}*/
+"use client";
+import { registerClientReference } from "@modern-js/runtime/rsc/server";
+function createClientReferenceProxy(exportName) {
+    const filename = "tests/fixture/client-components-cjs/input.jsx";
+    return ()=>{
+        throw new Error(`Attempted to call ${exportName}() from the server of ${filename} but ${exportName} is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.`);
+    };
+}
+export const ClassA = registerClientReference(createClientReferenceProxy("ClassA"), "tests/fixture/client-components-cjs/input.jsx#ClassA", "ClassA");
+export const ComponentA = registerClientReference(createClientReferenceProxy("ComponentA"), "tests/fixture/client-components-cjs/input.jsx#ComponentA", "ComponentA");
+export const MemoizedComponentA = registerClientReference(createClientReferenceProxy("MemoizedComponentA"), "tests/fixture/client-components-cjs/input.jsx#MemoizedComponentA", "MemoizedComponentA");
+export const ComponentB = registerClientReference(createClientReferenceProxy("ComponentB"), "tests/fixture/client-components-cjs/input.jsx#ComponentB", "ComponentB");
+export const foo = registerClientReference(createClientReferenceProxy("foo"), "tests/fixture/client-components-cjs/input.jsx#foo", "foo");
+export const ComponentD = registerClientReference(createClientReferenceProxy("ComponentD"), "tests/fixture/client-components-cjs/input.jsx#ComponentD", "ComponentD");
+export const bar = registerClientReference(createClientReferenceProxy("bar"), "tests/fixture/client-components-cjs/input.jsx#bar", "bar");
+export const ComponentE = registerClientReference(createClientReferenceProxy("ComponentE"), "tests/fixture/client-components-cjs/input.jsx#ComponentE", "ComponentE");
+export const ComponentF = registerClientReference(createClientReferenceProxy("ComponentF"), "tests/fixture/client-components-cjs/input.jsx#ComponentF", "ComponentF");
+

--- a/packages/cli/plugin-data-loader/src/runtime/errors.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/errors.ts
@@ -132,7 +132,7 @@ export function serializeErrors(
 }
 
 export function errorResponseToJson(errorResponse: ErrorResponse): Response {
-  return json(
+  return Response.json(
     // @ts-expect-error This is "private" from users but intended for internal use
     serializeError(errorResponse.error || new Error('Unexpected Server Error')),
     {

--- a/packages/cli/plugin-data-loader/src/runtime/errors.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/errors.ts
@@ -12,10 +12,7 @@ import type {
   ErrorResponse,
   StaticHandlerContext,
 } from '@modern-js/runtime-utils/remix-router';
-import {
-  isRouteErrorResponse,
-  json,
-} from '@modern-js/runtime-utils/remix-router';
+import { isRouteErrorResponse } from '@modern-js/runtime-utils/remix-router';
 
 /**
  * This thing probably warrants some explanation.

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -5,7 +5,7 @@ import {
 } from '@modern-js/runtime-utils/node';
 import { storage } from '@modern-js/runtime-utils/node';
 import {
-  UNSAFE_DEFERRED_SYMBOL as DEFERRED_SYMBOL,
+  DEFERRED_SYMBOL,
   type UNSAFE_DeferredData as DeferredData,
   createStaticHandler,
   isRouteErrorResponse,

--- a/packages/cli/plugin-data-loader/tests/server.test.ts
+++ b/packages/cli/plugin-data-loader/tests/server.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import type { IncomingMessage, ServerResponse } from 'http';
 import path from 'path';
 import qs from 'querystring';

--- a/packages/cli/uni-builder/src/rspack/index.ts
+++ b/packages/cli/uni-builder/src/rspack/index.ts
@@ -126,13 +126,15 @@ export async function parseConfig(
 
   const enableRsc = uniBuilderConfig.server?.rsc ?? false;
   if (enableRsc) {
-    const { rscClientRuntimePath, rscServerRuntimePath } = options;
+    const { rscClientRuntimePath, rscServerRuntimePath, internalDirectory } =
+      options;
     rsbuildPlugins.push(
       rsbuildRscPlugin({
         appDir: options.cwd,
         isRspack: true,
         rscClientRuntimePath,
         rscServerRuntimePath,
+        internalDirectory,
       }),
     );
   }

--- a/packages/cli/uni-builder/src/shared/rsc/plugins/rspack-rsc-server-plugin.ts
+++ b/packages/cli/uni-builder/src/shared/rsc/plugins/rspack-rsc-server-plugin.ts
@@ -172,6 +172,7 @@ export class RscServerPlugin {
   ): string | undefined {
     const entryDependency = compilation.entries.get(entryName);
     if (entryDependency && entryDependency.dependencies.length > 0) {
+      // The first dependency is the entry point of the entry
       const firstDep = entryDependency.dependencies[0];
       if ('request' in firstDep && typeof firstDep.request === 'string') {
         return firstDep.request;

--- a/packages/cli/uni-builder/src/shared/rsc/rsc-server-loader.ts
+++ b/packages/cli/uni-builder/src/shared/rsc/rsc-server-loader.ts
@@ -59,6 +59,7 @@ export default async function rscServerLoader(
         ],
       },
     },
+    isModule: true,
   });
 
   const { code, map } = result;

--- a/packages/cli/uni-builder/src/types.ts
+++ b/packages/cli/uni-builder/src/types.ts
@@ -72,6 +72,7 @@ export type CreateBuilderCommonOptions = {
   cwd: string;
   rscClientRuntimePath?: string;
   rscServerRuntimePath?: string;
+  internalDirectory?: string;
 };
 
 export type BundlerType = 'rspack' | 'webpack';

--- a/packages/cli/uni-builder/src/webpack/index.ts
+++ b/packages/cli/uni-builder/src/webpack/index.ts
@@ -105,13 +105,15 @@ export async function parseConfig(
 
   const enableRsc = uniBuilderConfig.server?.rsc ?? false;
   if (enableRsc) {
-    const { rscClientRuntimePath, rscServerRuntimePath } = options;
+    const { rscClientRuntimePath, rscServerRuntimePath, internalDirectory } =
+      options;
     rsbuildPlugins.push(
       rsbuildRscPlugin({
         appDir: options.cwd,
         isRspack: false,
         rscClientRuntimePath,
         rscServerRuntimePath,
+        internalDirectory,
       }),
     );
   }

--- a/packages/runtime/plugin-router-v7/package.json
+++ b/packages/runtime/plugin-router-v7/package.json
@@ -47,6 +47,9 @@
       ],
       "runtime": [
         "./dist/types/runtime/index.d.ts"
+      ],
+      "rsc": [
+        "./dist/types/runtime/rsc.d.ts"
       ]
     }
   },
@@ -61,7 +64,7 @@
     "@modern-js/runtime-utils": "workspace:*",
     "@modern-js/utils": "workspace:*",
     "@swc/helpers": "^0.5.17",
-    "react-router": "^7.5.0"
+    "react-router": "7.6.0"
   },
   "peerDependencies": {
     "react": ">=17",

--- a/packages/runtime/plugin-router-v7/package.json
+++ b/packages/runtime/plugin-router-v7/package.json
@@ -47,9 +47,6 @@
       ],
       "runtime": [
         "./dist/types/runtime/index.d.ts"
-      ],
-      "rsc": [
-        "./dist/types/runtime/rsc.d.ts"
       ]
     }
   },

--- a/packages/runtime/plugin-router-v7/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v7/src/cli/index.ts
@@ -37,8 +37,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools> => ({
             'react-router-dom$': runtimeAlias,
             '@remix-run/router': runtimeAlias,
             'react-router-dom/server$': runtimeAlias,
-            // TODO: try remove this
-            [`@${appContext.metaName}/runtime/router/server`]: require
+            [`@${appContext.metaName}/runtime/router/rsc`]: require
               .resolve('../runtime/rsc')
               .replace(/\/cjs\//, '/esm/'),
           },

--- a/packages/runtime/plugin-router-v7/src/cli/index.ts
+++ b/packages/runtime/plugin-router-v7/src/cli/index.ts
@@ -37,7 +37,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools> => ({
         'react-router-dom/server$': runtimeAlias,
         [`@${appContext.metaName}/runtime/router/rsc`]: require
           .resolve('../runtime/rsc')
-          .replace(/\/cjs\//, '/esm/'),
+          .replace(cjs, esm),
       };
 
       if (hasReactRouterDep) {

--- a/packages/runtime/plugin-router-v7/src/runtime/rsc.ts
+++ b/packages/runtime/plugin-router-v7/src/runtime/rsc.ts
@@ -1,0 +1,3 @@
+// Currently, only the experimental version of react-router exports rsc APIs.
+// @ts-ignore
+export * from 'react-router/rsc';

--- a/packages/runtime/plugin-router-v7/tsconfig.json
+++ b/packages/runtime/plugin-router-v7/tsconfig.json
@@ -6,6 +6,8 @@
     "jsx": "preserve",
     "baseUrl": "./",
     "isolatedModules": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "paths": {}
   },
   "include": ["src", "types"]

--- a/packages/runtime/plugin-runtime/package.json
+++ b/packages/runtime/plugin-runtime/package.json
@@ -106,6 +106,11 @@
       "jsnext:source": "./src/router/runtime/server.ts",
       "default": "./dist/esm/router/runtime/server.js"
     },
+    "./router/internal": {
+      "types": "./dist/types/router/internal.d.ts",
+      "jsnext:source": "./src/router/internal.ts",
+      "default": "./dist/esm/router/internal.js"
+    },
     "./loadable-bundler-plugin": {
       "types": "./dist/types/cli/ssr/loadable-bundler-plugin.d.ts",
       "jsnext:source": "./src/cli/ssr/loadable-bundler-plugin.ts",
@@ -177,6 +182,9 @@
       ],
       "router/server": [
         "./dist/types/router/runtime/server.d.ts"
+      ],
+      "router/internal": [
+        "./dist/types/router/internal.d.ts"
       ],
       "loadable-bundler-plugin": [
         "./dist/types/cli/ssr/loadable-bundler-plugin.d.ts"
@@ -251,7 +259,8 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5",
-    "webpack": "^5.99.8"
+    "webpack": "^5.99.8",
+    "@modern-js/core": "workspace:*"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/runtime/plugin-runtime/src/cli/code.ts
+++ b/packages/runtime/plugin-runtime/src/cli/code.ts
@@ -87,6 +87,7 @@ export const generateCode = async (
             mountId,
             urlPath: serverRoutes.find(route => route.entryName === entryName)
               ?.urlPath,
+            isNestedRouter: entrypoint.nestedRoutesEntry,
           });
         } else {
           indexCode = template.index({
@@ -99,6 +100,7 @@ export const generateCode = async (
             customBootstrap,
             mountId,
             enableRsc: config.server.rsc,
+            isNestedRouter: !!entrypoint.nestedRoutesEntry,
           });
         }
 
@@ -161,6 +163,7 @@ export const generateCode = async (
           );
 
           const indexServerCode = serverTemplate.entryForCSRWithRSC({
+            entryName,
             metaName,
           });
           await fs.outputFile(indexServerFile, indexServerCode, 'utf8');
@@ -191,7 +194,7 @@ export const generateCode = async (
 
         // runtime-global-context.js
         let contextCode = '';
-        if (!config.server.rsc) {
+        if (!config.server.rsc || entrypoint.nestedRoutesEntry) {
           contextCode = template.runtimeGlobalContext({
             entryName,
             srcDirectory,

--- a/packages/runtime/plugin-runtime/src/cli/template.server.ts
+++ b/packages/runtime/plugin-runtime/src/cli/template.server.ts
@@ -37,7 +37,7 @@ const handleRequest = async (request, ServerRoot, options) => {
     </ServerRoot>,
     {
       ...options,
-      rscRoot: options.rscRoot || <options.RSCRoot />,
+      rscRoot: options.rscRoot,
     },
   );
 
@@ -63,7 +63,7 @@ const handleRSCRequest = async (request, ServerRoot, options) => {
 }
 
 
-export const rscRequestHandler = createRequestHandler(handleRSCRequest, {
+export const rscPayloadHandler = createRequestHandler(handleRSCRequest, {
   enableRsc: true
 });
 `;
@@ -98,7 +98,7 @@ export const entryForCSRWithRSC = ({
 
   const handleCSRRender = async (request, ServerRoot, options) => {
     const rscPayloadStream = renderRsc({
-      element: options.rscRoot || <options.RSCRoot/>,
+      element: options.rscRoot,
       clientManifest: options.rscClientManifest!,
     });
     const stream = new ReadableStream({
@@ -128,14 +128,14 @@ export const entryForCSRWithRSC = ({
 
   const handleRequest = async (request, ServerRoot, options) => {
     const stream = renderRsc({
-            element: options.rscRoot || <options.RSCRoot/>,
+            element: options.rscRoot,
       clientManifest: options.rscClientManifest!,
     });
 
     return new Response(stream);
   }
 
-  export const rscRequestHandler = createRequestHandler(handleRequest, {
+  export const rscPayloadHandler = createRequestHandler(handleRequest, {
     enableRsc: true
   });
 `;

--- a/packages/runtime/plugin-runtime/src/cli/template.ts
+++ b/packages/runtime/plugin-runtime/src/cli/template.ts
@@ -137,35 +137,34 @@ export const entryForCSRWithRSC = ({
     return res;
   };
 
-  createFromFetch(
+  const res = createFromFetch(
     fetch(location.pathname, {
       headers: {
         'x-rsc-tree': 'true',
       },
     }).then(handleRedirectResponse),
-  ).then((content) => {
-    const ModernRoot = createRoot();
+  )
 
-    ${
-      isNestedRouter
-        ? `
-        render(
-          <ModernRoot rscPayload={Promise.resolve(content)}>
-          </ModernRoot>,
-          '${mountId}',
-        );
-      `
-        : `
-        render(
-          <ModernRoot>
-            <RscClientRoot rscPayload={Promise.resolve(content)} />
-          </ModernRoot>,
-          '${mountId}',
-        );
-      `
-    }
+  const ModernRoot = createRoot();
 
-  })
+  ${
+    isNestedRouter
+      ? `
+      render(
+        <ModernRoot rscPayload={res}>
+        </ModernRoot>,
+        '${mountId}',
+      );
+      `
+      : `
+      render(
+        <ModernRoot>
+          <RscClientRoot rscPayload={res} />
+        </ModernRoot>,
+        '${mountId}',
+      );
+      `
+  }
   `;
 };
 

--- a/packages/runtime/plugin-runtime/src/common.ts
+++ b/packages/runtime/plugin-runtime/src/common.ts
@@ -1,5 +1,5 @@
 import type { Plugin, RuntimePluginFuture } from './core/plugin';
-import type { RouterConfig } from './router';
+import type { RouterConfig } from './router/internal';
 
 export const isBrowser = () =>
   typeof window !== 'undefined' && window.name !== 'nodejs';

--- a/packages/runtime/plugin-runtime/src/config.ts
+++ b/packages/runtime/plugin-runtime/src/config.ts
@@ -1,4 +1,4 @@
-import type { RouterConfig } from './router';
+import type { RouterConfig } from './router/internal';
 
 export interface RuntimeUserConfig {
   runtime?: {

--- a/packages/runtime/plugin-runtime/src/core/context/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/index.ts
@@ -75,15 +75,7 @@ interface GlobalContext {
 
 const globalContext: GlobalContext = {};
 
-export function setGlobalServerPayload(
-  payload: GlobalContext['serverPayload'],
-) {
-  globalContext.serverPayload = payload;
-}
-
-export function getGlobalServerPayload() {
-  return globalContext.serverPayload;
-}
+export { getServerPayload, setServerPayload } from './serverPayload.server';
 
 export function getGlobalIsRscClient() {
   return globalContext.isRscClient;

--- a/packages/runtime/plugin-runtime/src/core/context/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/index.ts
@@ -1,5 +1,7 @@
 import type { InternalRuntimeContext } from '@modern-js/plugin-v2';
+import type { RouterState } from '@modern-js/runtime-utils/remix-router';
 import type { NestedRoute, PageRoute } from '@modern-js/types';
+import type React from 'react';
 import type { AppConfig } from '../../common';
 import type { RuntimeExtends } from '../plugin/types';
 
@@ -8,6 +10,35 @@ export {
   RuntimeReactContext,
   getInitialContext,
 } from './runtime';
+
+export type PayloadRoute = {
+  clientAction?: any;
+  clientLoader?: any;
+  element?: React.ReactNode;
+  errorElement?: React.ReactNode;
+  handle?: any;
+  hasAction: boolean;
+  hasErrorBoundary: boolean;
+  hasLoader: boolean;
+  id: string;
+  index?: boolean;
+  params: Record<string, string>;
+  parentId?: string;
+  path?: string;
+  pathname: string;
+  pathnameBase: string;
+  shouldRevalidate?: any;
+};
+
+export type ServerPayload = {
+  type: 'render';
+  actionData: RouterState['actionData'];
+  errors: RouterState['errors'];
+  loaderData: RouterState['loaderData'];
+  location: RouterState['location'];
+  routes: PayloadRoute[];
+  originalRoutes?: PayloadRoute[];
+};
 
 interface GlobalContext {
   entryName?: string;
@@ -37,9 +68,30 @@ interface GlobalContext {
    * RSCRoot
    */
   RSCRoot?: React.ComponentType;
+  isRscClient?: boolean;
+  serverPayload?: ServerPayload;
+  enableRsc?: boolean;
 }
 
 const globalContext: GlobalContext = {};
+
+export function setGlobalServerPayload(
+  payload: GlobalContext['serverPayload'],
+) {
+  globalContext.serverPayload = payload;
+}
+
+export function getGlobalServerPayload() {
+  return globalContext.serverPayload;
+}
+
+export function getGlobalIsRscClient() {
+  return globalContext.isRscClient;
+}
+
+export function getGlobalEnableRsc() {
+  return globalContext.enableRsc;
+}
 
 export function setGlobalContext(
   context: Omit<GlobalContext, 'appConfig' | 'internalRuntimeContext'> & {
@@ -56,6 +108,8 @@ export function setGlobalContext(
       : context.appConfig;
   globalContext.layoutApp = context.layoutApp;
   globalContext.RSCRoot = context.RSCRoot;
+  globalContext.isRscClient = context.isRscClient;
+  globalContext.enableRsc = context.enableRsc;
 }
 
 export function getCurrentEntryName() {

--- a/packages/runtime/plugin-runtime/src/core/context/serverPayload.server.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/serverPayload.server.tsx
@@ -1,0 +1,14 @@
+import { storage } from '@modern-js/runtime-utils/node';
+import type { ServerPayload } from './index';
+
+export const getServerPayload = (): ServerPayload | undefined => {
+  const context = storage.useContext() as any;
+  return context?.serverPayload;
+};
+
+export const setServerPayload = (payload: ServerPayload): void => {
+  const context = storage.useContext() as any;
+  if (context) {
+    context.serverPayload = payload;
+  }
+};

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
@@ -18,9 +18,9 @@ import {
   getGlobalAppInit,
   getGlobalInternalRuntimeContext,
   getGlobalRSCRoot,
-  getGlobalServerPayload,
 } from '../context';
 import { getInitialContext } from '../context/runtime';
+import { getServerPayload } from '../context/serverPayload.server';
 import { createLoaderManager } from '../loader/loaderManager';
 import { createRoot } from '../react';
 import type { SSRServerContext } from '../types';
@@ -35,13 +35,13 @@ async function handleRSCRequest(
   options: RequestHandlerOptions,
   handleRequest: HandleRequest,
 ): Promise<Response> {
-  const serverPayload = getGlobalServerPayload();
+  const serverPayload = getServerPayload();
 
   if (typeof serverPayload !== 'undefined') {
     return await handleRequest(request, Root, {
       ...options,
       runtimeContext: context,
-      rscRoot: getGlobalServerPayload(),
+      rscRoot: serverPayload,
     });
   }
 
@@ -208,6 +208,7 @@ export const createRequestHandler: CreateRequestHandler = async (
         monitors: options.monitors,
         responseProxy,
         activeDeferreds,
+        serverPayload: undefined,
       },
       async () => {
         const Root = createRoot();

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
@@ -331,7 +331,6 @@ export const createRequestHandler: CreateRequestHandler = async (
           response = await handleRequest(request, Root, {
             ...options,
             runtimeContext: context,
-            RSCRoot: createRequestOptions?.enableRsc && getGlobalRSCRoot(),
           });
         }
 

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
@@ -308,9 +308,8 @@ export const createRequestHandler: CreateRequestHandler = async (
           }
         }
 
-        const htmlTemplate = options.resource?.htmlTemplate;
-
-        if (htmlTemplate) {
+        if (!createRequestOptions?.enableRsc) {
+          const { htmlTemplate } = options.resource;
           options.resource.htmlTemplate = htmlTemplate.replace(
             '</head>',
             `${CHUNK_CSS_PLACEHOLDER}</head>`,

--- a/packages/runtime/plugin-runtime/src/index.ts
+++ b/packages/runtime/plugin-runtime/src/index.ts
@@ -1,4 +1,4 @@
-import type { RouterConfig } from './router';
+import type { RouterConfig } from './router/internal';
 
 export type { Plugin, RuntimePluginFuture } from './core';
 export type { AppConfig, RuntimeConfig } from './common';

--- a/packages/runtime/plugin-runtime/src/router/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/cli/index.ts
@@ -54,7 +54,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
       if ((nestedRoutesEntry || pageRoutesEntry) && !isRouterV5) {
         plugins.push({
           name: 'router',
-          path: `@${metaName}/runtime/router`,
+          path: `@${metaName}/runtime/router/internal`,
           config:
             typeof routerConfig === 'boolean'
               ? { serverBase }
@@ -77,6 +77,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
             /node_modules\/react-router/,
             /node_modules\/react-router-dom/,
             /node_modules\/@remix-run\/router/,
+            path.resolve(__dirname, '../runtime').replace('cjs', 'esm'),
           ],
           globalVars: {
             'process.env._MODERN_ROUTER_VERSION': 'v6',
@@ -103,7 +104,7 @@ export const routerPlugin = (): CliPluginFuture<AppTools<'shared'>> => ({
       );
       if (!isRouterV5) {
         pluginsExportsUtils.addExport(
-          `export { default as router } from '@${metaName}/runtime/router'`,
+          `export { default as router } from '@${metaName}/runtime/router/internal'`,
         );
       }
     });

--- a/packages/runtime/plugin-runtime/src/router/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/index.ts
@@ -1,3 +1,1 @@
-export { default as router } from './runtime';
-export { default } from './runtime';
 export * from './runtime';

--- a/packages/runtime/plugin-runtime/src/router/internal.ts
+++ b/packages/runtime/plugin-runtime/src/router/internal.ts
@@ -1,0 +1,2 @@
+export * from './runtime/internal';
+export { routerPlugin as default } from './runtime/internal';

--- a/packages/runtime/plugin-runtime/src/router/runtime/DefaultNotFound.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/DefaultNotFound.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 export const DefaultNotFound = () => (

--- a/packages/runtime/plugin-runtime/src/router/runtime/DefaultNotFound.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/DefaultNotFound.tsx
@@ -1,4 +1,3 @@
-'use client';
 import React from 'react';
 
 export const DefaultNotFound = () => (

--- a/packages/runtime/plugin-runtime/src/router/runtime/PrefetchLink.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/PrefetchLink.tsx
@@ -1,3 +1,4 @@
+'use client';
 import {
   type Path,
   type RouteObject,
@@ -31,9 +32,7 @@ declare const __webpack_chunk_load__:
   | ((chunkId: string | number) => Promise<void>)
   | undefined;
 
-export function composeEventHandlers<
-  EventType extends React.SyntheticEvent | Event,
->(
+function composeEventHandlers<EventType extends React.SyntheticEvent | Event>(
   theirHandler: ((event: EventType) => any) | undefined,
   ourHandler: (event: EventType) => any,
 ): (event: EventType) => any {

--- a/packages/runtime/plugin-runtime/src/router/runtime/browser.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/browser.ts
@@ -1,1 +1,0 @@
-export * from '@modern-js/runtime-utils/router';

--- a/packages/runtime/plugin-runtime/src/router/runtime/browser.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/browser.ts
@@ -1,0 +1,1 @@
+export * from '@modern-js/runtime-utils/router';

--- a/packages/runtime/plugin-runtime/src/router/runtime/index.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/index.ts
@@ -1,19 +1,6 @@
 import { useRouteLoaderData as useRouteData } from '@modern-js/runtime-utils/router';
-import { routerPlugin } from './plugin';
-import type { RouterConfig, SingleRouteConfig } from './types';
 
 export * from '@modern-js/runtime-utils/router';
-
-export type { SingleRouteConfig, RouterConfig };
-export { renderRoutes } from './utils';
-
-export { routerPlugin };
-export default routerPlugin;
-
-export { modifyRoutes } from './plugin';
-export type { RouterExtendsHooks } from './hooks';
-
-export * from './withRouter';
 
 export { Link, NavLink } from './PrefetchLink';
 export type { LinkProps, NavLinkProps } from './PrefetchLink';
@@ -28,5 +15,7 @@ export {
   handleRouteModule,
   handleRouteModuleError,
 } from './routeModule';
+
+export * from './withRouter';
 
 export type { LoaderFunction, LoaderFunctionArgs } from './types';

--- a/packages/runtime/plugin-runtime/src/router/runtime/internal.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/internal.ts
@@ -1,0 +1,8 @@
+import { routerPlugin } from './plugin';
+import type { RouterConfig, SingleRouteConfig } from './types';
+export { routerPlugin };
+export default routerPlugin;
+export type { SingleRouteConfig, RouterConfig };
+export type { RouterExtendsHooks } from './hooks';
+export { renderRoutes } from './utils';
+export { modifyRoutes } from './plugin';

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -158,7 +158,11 @@ export const routerPlugin = (
           // Throw the Response to bail out and let the server handle it with an HTTP redirect
           if (enableRsc && isRSNavigation) {
             return interrupt(
-              handleRSCRedirect(routerContext.headers, _basename),
+              handleRSCRedirect(
+                routerContext.headers,
+                _basename,
+                routerContext.status,
+              ),
             );
           } else {
             return interrupt(routerContext);

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -20,13 +20,12 @@ import { JSX_SHELL_STREAM_END_MARK } from '../../common';
 import { RuntimeReactContext } from '../../core';
 import type { RuntimePluginFuture } from '../../core';
 import {
-  type PayloadRoute,
   type ServerPayload,
   getGlobalEnableRsc,
   getGlobalLayoutApp,
   getGlobalRoutes,
-  setGlobalServerPayload,
 } from '../../core/context';
+import { setServerPayload } from '../../core/context/serverPayload.server';
 import DeferredDataScripts from './DeferredDataScripts.node';
 import {
   type RouterExtendsHooks,
@@ -193,8 +192,7 @@ export const routerPlugin = (
           }
 
           payload = createServerPayload(routerContext, routes);
-          // TODO: 不能在这里存储，并行多个请求会有问题
-          setGlobalServerPayload(payload);
+          setServerPayload(payload);
         }
 
         // private api, pass to React Component in `wrapRoot`

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -193,6 +193,7 @@ export const routerPlugin = (
           }
 
           payload = createServerPayload(routerContext, routes);
+          // TODO: 不能在这里存储，并行多个请求会有问题
           setGlobalServerPayload(payload);
         }
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -151,12 +151,12 @@ export const routerPlugin = (
         const cost = end();
         context.ssrContext?.onTiming?.(LOADER_REPORTER_NAME, cost);
 
-        const isRSNavigation =
+        const isRSCNavigation =
           remixRequest.headers.get('x-rsc-tree') === 'true';
         if (routerContext instanceof Response) {
           // React Router would return a Response when redirects occur in loader.
           // Throw the Response to bail out and let the server handle it with an HTTP redirect
-          if (enableRsc && isRSNavigation) {
+          if (enableRsc && isRSCNavigation) {
             return interrupt(
               handleRSCRedirect(
                 routerContext.headers,
@@ -187,7 +187,7 @@ export const routerPlugin = (
         let payload: ServerPayload;
         if (enableRsc) {
           // In order to execute the client loader, refer to the ServerRouter implementation of react-router.
-          if (isRSNavigation) {
+          if (isRSCNavigation) {
             for (const match of routerContext.matches) {
               if ((match.route as any).hasClientLoader) {
                 delete routerContext.loaderData[match.route.id];

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -1,8 +1,10 @@
+import type { RuntimePluginAPI } from '@modern-js/plugin-v2/runtime';
 import { merge } from '@modern-js/runtime-utils/merge';
 import type { RouterSubscriber } from '@modern-js/runtime-utils/remix-router';
 import {
   type RouteObject,
   RouterProvider,
+  type RouterProviderProps,
   createBrowserRouter,
   createHashRouter,
   createRoutesFromElements,
@@ -11,17 +13,25 @@ import {
   useMatches,
 } from '@modern-js/runtime-utils/router';
 import { normalizePathname } from '@modern-js/runtime-utils/url';
-import type React from 'react';
-import { useContext, useMemo } from 'react';
+import * as React from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import { type RuntimePluginFuture, RuntimeReactContext } from '../../core';
 import { getGlobalLayoutApp, getGlobalRoutes } from '../../core/context';
+import { getGlobalIsRscClient } from '../../core/context';
+import type { RuntimeContext } from '../../core/context/runtime';
 import {
   type RouterExtendsHooks,
   modifyRoutes as modifyRoutesHook,
   onBeforeCreateRoutes as onBeforeCreateRoutesHook,
 } from './hooks';
+import { createClientRouterFromPayload } from './rsc-router';
 import type { RouterConfig, Routes } from './types';
-import { deserializeErrors, renderRoutes, urlJoin } from './utils';
+import {
+  createRouteObjectsFromConfig,
+  deserializeErrors,
+  renderRoutes,
+  urlJoin,
+} from './utils';
 
 export let finalRouteConfig: RouterConfig['routesConfig'] = {
   routes: [],
@@ -41,6 +51,19 @@ export function modifyRoutes(modifyFunction: (routes: Routes) => Routes) {
   }
 }
 
+type RouterPluginAPI = RuntimePluginAPI<{
+  extendHooks: RouterExtendsHooks;
+}>;
+
+interface UseRouterCreationOptions {
+  api: RouterPluginAPI;
+  createRoutes?: RouterConfig['createRoutes'];
+  supportHtml5History: boolean;
+  selectBasePath: (pathname: string) => string;
+  basename: string;
+  future?: RouterProviderProps['future'];
+}
+
 export const routerPlugin = (
   userConfig: Partial<RouterConfig> = {},
 ): RuntimePluginFuture<{
@@ -53,7 +76,9 @@ export const routerPlugin = (
       onBeforeCreateRoutes: onBeforeCreateRoutesHook,
     },
     setup: api => {
-      let routes: RouteObject[] = [];
+      const routesContainer = {
+        current: [] as RouteObject[],
+      };
 
       api.onBeforeRender(context => {
         // In some scenarios, the initial pathname and the current pathname do not match.
@@ -84,13 +109,16 @@ export const routerPlugin = (
         // Prefetch Link will use routes for match next route
         Object.defineProperty(context, 'routes', {
           get() {
-            return routes;
+            return routesContainer.current;
           },
           enumerable: true,
         });
       });
       api.wrapRoot(App => {
-        const pluginConfig: Record<string, any> = api.getRuntimeConfig();
+        const mergedConfig = merge(
+          api.getRuntimeConfig().router || {},
+          userConfig,
+        ) as RouterConfig;
         const {
           serverBase = [],
           supportHtml5History = true,
@@ -98,121 +126,176 @@ export const routerPlugin = (
           routesConfig,
           createRoutes,
           future,
-        } = merge(pluginConfig.router || {}, userConfig) as RouterConfig;
-        const select = (pathname: string) =>
-          serverBase.find(baseUrl => pathname.search(baseUrl) === 0) || '/';
+        } = mergedConfig;
+
         finalRouteConfig = {
           routes: getGlobalRoutes(),
           globalApp: getGlobalLayoutApp(),
           ...routesConfig,
         };
 
-        // can not get routes config, skip wrapping React Router.
-        // e.g. App.tsx as the entrypoint
-        if (!finalRouteConfig.routes && !createRoutes) {
+        const isRscClient = getGlobalIsRscClient();
+
+        if (!finalRouteConfig.routes && !createRoutes && !isRscClient) {
           return App;
         }
 
-        const getRouteApp = () => {
-          const useCreateRouter = (props: any) => {
-            const runtimeContext = useContext(RuntimeReactContext);
-            /**
-             * _internalRouterBaseName: garfish plugin params, priority
-             * basename: modern config file config
-             */
-            const baseUrl = select(location.pathname).replace(/^\/*/, '/');
-            const _basename =
-              baseUrl === '/'
-                ? urlJoin(
-                    baseUrl,
-                    runtimeContext._internalRouterBaseName || basename,
-                  )
-                : baseUrl;
+        const selectBasePath = (pathname: string) =>
+          serverBase.find(baseUrl => pathname.search(baseUrl) === 0) || '/';
 
-            let hydrationData = window._ROUTER_DATA;
+        const RouterWrapper = (props: any) => {
+          const { router, routes } = useRouterCreation(
+            {
+              ...props,
+              rscPayload: props?.rscPayload,
+            },
+            {
+              api: api as any,
+              createRoutes,
+              supportHtml5History,
+              selectBasePath,
+              basename,
+              future,
+            },
+          );
 
-            const { unstable_getBlockNavState: getBlockNavState } =
-              runtimeContext;
+          useEffect(() => {
+            routesContainer.current = routes;
+          }, [routes]);
 
-            return useMemo(() => {
-              if (hydrationData?.errors) {
-                hydrationData = {
-                  ...hydrationData,
-                  errors: deserializeErrors(hydrationData.errors),
-                };
-              }
+          beforeCreateRouter = false;
 
-              routes = createRoutes
-                ? createRoutes()
-                : createRoutesFromElements(
-                    renderRoutes({
-                      routesConfig: finalRouteConfig,
-                      props,
-                    }),
-                  );
+          // To match the node tree about https://github.com/web-infra-dev/modern.js/blob/v2.59.0/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx#L150-L168
+          // According to react [useId generation algorithm](https://github.com/facebook/react/pull/22644), `useId` will generate id with the react node react struct.
+          // To void hydration failed, we must guarantee that the node tree when browser hydrate must have same struct with node tree when ssr render.
+          const RouterContent = () => (
+            <>
+              <RouterProvider router={router} future={future} />
+              <EmptyComponent />
+              <EmptyComponent />
+            </>
+          );
 
-              const hooks = api.getHooks();
-              // inhouse private, try deprecated, different from the export function
-              routes = hooks.modifyRoutes.call(routes);
-
-              const router = supportHtml5History
-                ? createBrowserRouter(routes, {
-                    basename: _basename,
-                    hydrationData,
-                  })
-                : createHashRouter(routes, {
-                    basename: _basename,
-                    hydrationData,
-                  });
-
-              const originSubscribe = router.subscribe;
-
-              router.subscribe = (listener: RouterSubscriber) => {
-                const wrapedListener: RouterSubscriber = (...args) => {
-                  const blockRoute = getBlockNavState
-                    ? getBlockNavState()
-                    : false;
-
-                  if (blockRoute) {
-                    return;
-                  }
-                  return listener(...args);
-                };
-                return originSubscribe(wrapedListener);
-              };
-
-              return router;
-            }, [
-              finalRouteConfig,
-              props,
-              _basename,
-              hydrationData,
-              getBlockNavState,
-            ]);
-          };
-
-          const Null = () => null;
-
-          return (props => {
-            beforeCreateRouter = false;
-            const router = useCreateRouter(props);
-            const routerWrapper = (
-              // To match the node tree about https://github.com/web-infra-dev/modern.js/blob/v2.59.0/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx#L150-L168
-              // According to react [useId generation algorithm](https://github.com/facebook/react/pull/22644), `useId` will generate id with the react node react struct.
-              // To void hydration failed, we must guarantee that the node tree when browser hydrate must have same struct with node tree when ssr render.
-              <>
-                <RouterProvider router={router} future={future} />
-                <Null />
-                <Null />
-              </>
-            );
-
-            return App ? <App>{routerWrapper}</App> : routerWrapper;
-          }) as React.ComponentType<any>;
+          return App ? (
+            <App>
+              <RouterContent />
+            </App>
+          ) : (
+            <RouterContent />
+          );
         };
 
-        return getRouteApp();
+        return RouterWrapper;
       });
     },
   };
 };
+
+const EmptyComponent = () => null;
+
+const safeUse = (promise: Promise<unknown>) => {
+  const useProp = 'use';
+  const useHook = React && (React as any)[useProp];
+  if (typeof useHook === 'function') {
+    return useHook(promise);
+  }
+  return null;
+};
+
+function useRouterCreation(props: any, options: UseRouterCreationOptions) {
+  const { api, createRoutes, supportHtml5History, selectBasePath, basename } =
+    options;
+  const runtimeContext = useContext(RuntimeReactContext);
+
+  const baseUrl = selectBasePath(location.pathname).replace(/^\/*/, '/');
+  const _basename =
+    baseUrl === '/'
+      ? urlJoin(baseUrl, runtimeContext._internalRouterBaseName || basename)
+      : baseUrl;
+
+  const { unstable_getBlockNavState: getBlockNavState } = runtimeContext;
+  const rscPayload = props?.rscPayload ? safeUse(props.rscPayload) : null;
+
+  let hydrationData = window._ROUTER_DATA || rscPayload;
+
+  return useMemo(() => {
+    if (hydrationData?.errors) {
+      hydrationData = {
+        ...hydrationData,
+        errors: deserializeErrors(hydrationData.errors),
+      };
+    }
+
+    const isRscClient = getGlobalIsRscClient();
+
+    let routes: RouteObject[] | null = null;
+    if (isRscClient) {
+      routes = createRoutes
+        ? createRoutes()
+        : createRouteObjectsFromConfig({
+            routesConfig: finalRouteConfig,
+          });
+    } else {
+      routes = createRoutes
+        ? createRoutes()
+        : createRoutesFromElements(
+            renderRoutes({
+              routesConfig: finalRouteConfig,
+              props,
+            }),
+          );
+    }
+
+    if (!routes) {
+      routes = [];
+    }
+
+    const hooks = api.getHooks();
+
+    if (rscPayload) {
+      try {
+        const router = createClientRouterFromPayload(
+          rscPayload,
+          routes,
+          _basename,
+        );
+
+        return {
+          router,
+          routes: router.routes || [],
+        };
+      } catch (e) {
+        console.error('Failed to create router from RSC payload:', e);
+      }
+    }
+
+    const modifiedRoutes = hooks.modifyRoutes.call(routes);
+
+    const router = supportHtml5History
+      ? createBrowserRouter(modifiedRoutes, {
+          basename: _basename,
+          hydrationData,
+        })
+      : createHashRouter(modifiedRoutes, {
+          basename: _basename,
+          hydrationData,
+        });
+
+    const originSubscribe = router.subscribe;
+    router.subscribe = (listener: RouterSubscriber) => {
+      const wrappedListener: RouterSubscriber = (...args) => {
+        const blockRoute = getBlockNavState ? getBlockNavState() : false;
+        if (blockRoute) {
+          return;
+        }
+        return listener(...args);
+      };
+      return originSubscribe(wrappedListener);
+    };
+
+    return {
+      router,
+      routes: modifiedRoutes,
+    };
+  }, [finalRouteConfig, props, _basename, hydrationData, getBlockNavState]);
+}

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -134,9 +134,7 @@ export const routerPlugin = (
           ...routesConfig,
         };
 
-        const isRscClient = getGlobalIsRscClient();
-
-        if (!finalRouteConfig.routes && !createRoutes && !isRscClient) {
+        if (!finalRouteConfig.routes && !createRoutes) {
           return App;
         }
 
@@ -270,6 +268,12 @@ function useRouterCreation(props: any, options: UseRouterCreationOptions) {
     }
 
     const modifiedRoutes = hooks.modifyRoutes.call(routes);
+    console.log(
+      'modifiedRoutes111111',
+      modifiedRoutes,
+      _basename,
+      hydrationData,
+    );
 
     const router = supportHtml5History
       ? createBrowserRouter(modifiedRoutes, {

--- a/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
@@ -93,6 +93,7 @@ export const isRSCNavigation = (request: Request): boolean => {
 export const handleRSCRedirect = (
   headers: Headers,
   basename: string,
+  status: number,
 ): Response => {
   const newHeaders = new Headers(headers);
   let redirectUrl = headers.get('Location')!;
@@ -106,8 +107,7 @@ export const handleRSCRedirect = (
   newHeaders.delete('Location');
 
   return new Response(null, {
-    // TODO: status code should not be hardcoded
-    status: 302,
+    status: status,
     headers: newHeaders,
   });
 };

--- a/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
@@ -289,7 +289,7 @@ export const createClientRouterFromPayload = (
 
       const payload = await createFromReadableStream(res.body);
 
-      if (payload.type !== 'render') {
+      if (typeof payload.type === 'undefined' || payload.type !== 'render') {
         throw new Error('Unexpected payload type');
       }
 

--- a/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
@@ -1,0 +1,391 @@
+import {
+  ElementsContext,
+  createFromReadableStream,
+} from '@modern-js/render/client';
+import {
+  type StaticHandlerContext,
+  StaticRouterProvider,
+  createStaticRouter,
+} from '@modern-js/runtime-utils/node/router';
+import type { AgnosticRouteMatch } from '@modern-js/runtime-utils/remix-router';
+import {
+  type RouteObject,
+  createBrowserRouter,
+  redirect,
+} from '@modern-js/runtime-utils/router';
+import React from 'react';
+import type { PayloadRoute, ServerPayload } from '../../core/context';
+
+// There is no `use` method in the following version of react19.
+// In order to avoid errors, it is compatible here.
+const safeUse = (promise: any) => {
+  if (typeof (React as any).use === 'function') {
+    return (React as any).use(promise);
+  }
+  return null;
+};
+
+export const createServerPayload = (
+  routerContext: StaticHandlerContext,
+  routes: RouteObject[],
+): ServerPayload => {
+  return {
+    type: 'render' as const,
+    actionData: routerContext.actionData,
+    errors: routerContext.errors,
+    loaderData: routerContext.loaderData,
+    location: routerContext.location,
+    routes: routerContext.matches.map(
+      (
+        match: AgnosticRouteMatch,
+        index: number,
+        matches: AgnosticRouteMatch[],
+      ) => {
+        const element = (match.route as any).element;
+        const parentMatch = index > 0 ? matches[index - 1] : undefined;
+
+        let processedElement;
+
+        if (element) {
+          const ElementComponent = element.type;
+          processedElement = React.createElement(ElementComponent, {
+            loaderData: routerContext?.loaderData?.[(match.route as any).id],
+            actionData: routerContext?.actionData?.[(match.route as any).id],
+            params: match.params,
+            matches: routerContext.matches.map((m: any) => {
+              const { route, pathname, params } = m;
+              return {
+                id: route.id,
+                pathname,
+                params,
+                data: routerContext?.loaderData?.[route.id],
+                handle: route.handle,
+              };
+            }),
+          });
+        }
+
+        return {
+          element: processedElement,
+          errorElement: (match.route as any).errorElement,
+          handle: (match.route as any).handle,
+          hasAction: !!(match.route as any).action,
+          hasErrorBoundary: !!(match.route as any).hasErrorBoundary,
+          hasLoader: !!(match.route as any).loader,
+          hasClientLoader: !!(match.route as any).hasClientLoader,
+          id: match.route.id,
+          index: (match.route as any).index,
+          params: match.params,
+          parentId: parentMatch?.route.id || (match.route as any).parentId,
+          path: match.route.path,
+          pathname: match.pathname,
+          pathnameBase: match.pathnameBase,
+        } as PayloadRoute;
+      },
+    ),
+  };
+};
+
+export const isRSCNavigation = (request: Request): boolean => {
+  return request.headers.get('x-rsc-tree') === 'true';
+};
+
+export const handleRSCRedirect = (
+  headers: Headers,
+  basename: string,
+): Response => {
+  const newHeaders = new Headers(headers);
+  let redirectUrl = headers.get('Location')!;
+
+  if (basename !== '/') {
+    redirectUrl = redirectUrl.replace(basename, '');
+  }
+
+  newHeaders.set('X-Modernjs-Redirect', redirectUrl);
+  newHeaders.set('X-Modernjs-BaseUrl', basename);
+  newHeaders.delete('Location');
+
+  return new Response(null, {
+    status: 302,
+    headers: newHeaders,
+  });
+};
+
+export const prepareRSCRoutes = async (
+  routes: RouteObject[],
+): Promise<void> => {
+  const isLazyComponent = (component: any) => {
+    return (
+      component &&
+      typeof component === 'object' &&
+      component._init !== undefined &&
+      component._payload !== undefined
+    );
+  };
+
+  const processRoutes = async (routesList: RouteObject[]): Promise<void> => {
+    await Promise.all(
+      routesList.map(async (route: any) => {
+        if ('lazyImport' in route && isLazyComponent(route.component)) {
+          route.component = (await route.lazyImport()).default;
+        }
+
+        if (route.children && Array.isArray(route.children)) {
+          await processRoutes(route.children);
+        }
+      }),
+    );
+  };
+
+  await processRoutes(routes);
+};
+
+export const mergeRoutes = (
+  routes: PayloadRoute[],
+  originalRoutes: any[] | undefined,
+): any[] => {
+  if (!originalRoutes || !Array.isArray(originalRoutes)) {
+    return routes;
+  }
+  const routesMap = new Map<string, PayloadRoute>();
+
+  const buildRoutesMap = (routesList: PayloadRoute[]) => {
+    routesList.forEach(route => {
+      if (route.id) {
+        routesMap.set(route.id, route);
+      }
+
+      if (
+        'children' in route &&
+        route.children &&
+        Array.isArray(route.children)
+      ) {
+        buildRoutesMap(route.children as PayloadRoute[]);
+      }
+    });
+  };
+
+  buildRoutesMap(routes);
+
+  const mergeRoutesRecursive = (origRoutes: any[]): any[] => {
+    return origRoutes.map(origRoute => {
+      if (origRoute.id && routesMap.has(origRoute.id)) {
+        const matchedRoute = routesMap.get(origRoute.id)!;
+
+        const result = {
+          loader: origRoute.hasClientLoader ? origRoute.loader : undefined,
+          ...matchedRoute,
+        };
+
+        if (origRoute.children && Array.isArray(origRoute.children)) {
+          (result as any).children = mergeRoutesRecursive(origRoute.children);
+        }
+
+        return result;
+      }
+
+      return origRoute;
+    });
+  };
+
+  return mergeRoutesRecursive(originalRoutes);
+};
+
+export const findRouteInTree = (
+  routes: RouteObject[],
+  routeId: string,
+): RouteObject | null => {
+  for (const route of routes) {
+    if (route.id === routeId) {
+      return route;
+    }
+    if (route.children && Array.isArray(route.children)) {
+      const found = findRouteInTree(route.children, routeId);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+};
+
+export const createClientRouterFromPayload = (
+  payload: ServerPayload,
+  originalRoutes: RouteObject[],
+  basename = '',
+) => {
+  const processedRoutes = payload.routes.reduceRight<PayloadRoute[]>(
+    (previous, route) => {
+      if (previous.length > 0) {
+        return [
+          {
+            ...route,
+            children: previous,
+          },
+        ];
+      }
+      return [route];
+    },
+    [],
+  );
+
+  const mergedRoutes = mergeRoutes(processedRoutes, originalRoutes);
+
+  const router = createBrowserRouter(mergedRoutes, {
+    //@ts-ignore
+    hydrationData: payload,
+    basename: basename,
+    dataStrategy: async context => {
+      const { request, matches } = context;
+      const results: Record<string, any> = {};
+      const clientMatches = matches.filter(
+        match => (match.route as any).hasClientLoader,
+      );
+
+      const fetchPromise = fetch(request.url, {
+        headers: {
+          'x-rsc-tree': 'true',
+        },
+      });
+
+      const clientLoadersPromise =
+        clientMatches.length > 0
+          ? Promise.all(
+              clientMatches.map(async clientMatch => {
+                const foundRoute = findRouteInTree(
+                  originalRoutes,
+                  clientMatch.route.id,
+                );
+                clientMatch.route.loader = foundRoute?.loader;
+                const res = await clientMatch.resolve();
+                return { routeId: clientMatch.route.id, result: res };
+              }),
+            )
+          : Promise.resolve([]);
+
+      const res = await fetchPromise;
+
+      const redirectLocation = res.headers.get('X-Modernjs-Redirect');
+
+      if (redirectLocation) {
+        matches.forEach(match => {
+          const routeId = match.route.id;
+          if (routeId) {
+            results[routeId] = {
+              type: 'redirect',
+              result: redirect(redirectLocation),
+            };
+          }
+        });
+
+        return results;
+      }
+
+      const [clientLoaderResults] = await Promise.all([clientLoadersPromise]);
+
+      clientLoaderResults.forEach(({ routeId, result }) => {
+        results[routeId] = result;
+      });
+
+      const payload = await createFromReadableStream(res.body);
+
+      if (payload.type !== 'render') {
+        throw new Error('Unexpected payload type');
+      }
+
+      matches.forEach(match => {
+        const routeId = match.route.id;
+        const matchedRoute = payload.routes.find(
+          (route: PayloadRoute) => route.id === routeId,
+        );
+        if (matchedRoute) {
+          // @ts-ignore
+          router.patchRoutes(matchedRoute.parentId, [matchedRoute], true);
+        }
+        if (payload.loaderData?.[routeId]) {
+          results[routeId] = {
+            type: 'data',
+            result: payload.loaderData[routeId],
+          };
+        }
+      });
+
+      return results;
+    },
+  });
+  return router;
+};
+
+export interface RSCStaticRouterProps {
+  basename?: string;
+  useJsonScript?: boolean;
+}
+
+export const createRSCStaticRouterComponent = (
+  payload: ServerPayload,
+  basename?: string,
+) => {
+  const routerContext = {
+    actionData: payload.actionData,
+    actionHeaders: {},
+    activeDeferreds: {},
+    basename: basename || '',
+    errors: payload.errors,
+    loaderData: payload.loaderData,
+    loaderHeaders: {},
+    location: payload.location,
+    statusCode: 200,
+    matches: payload.routes.map(match => ({
+      params: match.params,
+      pathname: match.pathname,
+      pathnameBase: match.pathnameBase,
+      route: {
+        id: match.id,
+        action: match.hasAction || !!match.clientAction,
+        handle: match.handle,
+        hasErrorBoundary: match.hasErrorBoundary,
+        loader: match.hasLoader || !!match.clientLoader,
+        index: match.index,
+        path: match.path,
+        shouldRevalidate: match.shouldRevalidate,
+      },
+    })),
+  };
+
+  const processedRoutes = payload.routes.reduceRight<PayloadRoute[]>(
+    (previous, route) => {
+      if (previous.length > 0) {
+        return [
+          {
+            ...route,
+            children: previous,
+          },
+        ];
+      }
+      return [route];
+    },
+    [],
+  );
+
+  const router = createStaticRouter(processedRoutes, routerContext);
+
+  return (
+    <StaticRouterProvider
+      context={routerContext}
+      router={router}
+      hydrate={false}
+    />
+  );
+};
+
+export const RSCStaticRouter: React.FC<RSCStaticRouterProps> = ({
+  basename,
+}) => {
+  const payload: ServerPayload = safeUse(safeUse(ElementsContext));
+
+  if (!payload || payload.type !== 'render') {
+    return null;
+  }
+
+  return <>{createRSCStaticRouterComponent(payload, basename)}</>;
+};

--- a/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
@@ -106,6 +106,7 @@ export const handleRSCRedirect = (
   newHeaders.delete('Location');
 
   return new Response(null, {
+    // TODO: status code should not be hardcoded
     status: 302,
     headers: newHeaders,
   });

--- a/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/rsc-router.tsx
@@ -86,10 +86,6 @@ export const createServerPayload = (
   };
 };
 
-export const isRSCNavigation = (request: Request): boolean => {
-  return request.headers.get('x-rsc-tree') === 'true';
-};
-
 export const handleRSCRedirect = (
   headers: Headers,
   basename: string,
@@ -141,7 +137,7 @@ export const prepareRSCRoutes = async (
   await processRoutes(routes);
 };
 
-export const mergeRoutes = (
+const mergeRoutes = (
   routes: PayloadRoute[],
   originalRoutes: any[] | undefined,
 ): any[] => {
@@ -192,7 +188,7 @@ export const mergeRoutes = (
   return mergeRoutesRecursive(originalRoutes);
 };
 
-export const findRouteInTree = (
+const findRouteInTree = (
   routes: RouteObject[],
   routeId: string,
 ): RouteObject | null => {
@@ -317,12 +313,12 @@ export const createClientRouterFromPayload = (
   return router;
 };
 
-export interface RSCStaticRouterProps {
+interface RSCStaticRouterProps {
   basename?: string;
   useJsonScript?: boolean;
 }
 
-export const createRSCStaticRouterComponent = (
+const createRSCStaticRouterComponent = (
   payload: ServerPayload,
   basename?: string,
 ) => {

--- a/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
@@ -27,18 +27,13 @@ export function getRouteComponents(
     props?: Record<string, unknown>;
   },
 ) {
-  const Layout = ({
-    Component,
-    ...props
-  }: { Component: React.ComponentType | string; [key: string]: unknown }) => {
+  const Layout = ({ Component, ...props }: any) => {
     const GlobalLayout = globalApp;
     if (!GlobalLayout) {
-      return typeof Component === 'function' ? <Component {...props} /> : null;
+      return <Component {...props} />;
     }
 
-    return typeof Component === 'function' ? (
-      <GlobalLayout Component={Component} {...props} />
-    ) : null;
+    return <GlobalLayout Component={Component} {...props} />;
   };
   const routeElements: React.ReactElement[] = [];
   for (const route of routes) {

--- a/packages/runtime/plugin-runtime/src/rsc/client.ts
+++ b/packages/runtime/plugin-runtime/src/rsc/client.ts
@@ -1,1 +1,4 @@
 export * from '@modern-js/render/client';
+export const isRedirectResponse = (res: Response) => {
+  return res.headers.get('X-Modernjs-Redirect') != null;
+};

--- a/packages/runtime/plugin-runtime/src/rsc/server.ts
+++ b/packages/runtime/plugin-runtime/src/rsc/server.ts
@@ -1,1 +1,37 @@
 export * from '@modern-js/render/rsc';
+
+export async function processRSCStream(
+  rscStream: ReadableStream,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+) {
+  try {
+    const reader = rscStream.getReader();
+    const decoder = new TextDecoder('utf-8', { fatal: true });
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      try {
+        const chunk = JSON.stringify(decoder.decode(value, { stream: true }));
+        const scriptTag = `<script>(self.__FLIGHT_DATA||=[]).push(${chunk})</script>`;
+        controller.enqueue(encoder.encode(scriptTag));
+      } catch (err) {
+        const base64 = JSON.stringify(btoa(String.fromCodePoint(...value)));
+        const scriptTag = `<script>(self.__FLIGHT_DATA||=[]).push(Uint8Array.from(atob(${base64}), m => m.codePointAt(0)))</script>`;
+        controller.enqueue(encoder.encode(scriptTag));
+      }
+    }
+
+    const remaining = decoder.decode();
+    if (remaining.length) {
+      const scriptTag = `<script>(self.__FLIGHT_DATA||=[]).push(${JSON.stringify(remaining)})</script>`;
+      controller.enqueue(encoder.encode(scriptTag));
+    }
+
+    controller.close();
+  } catch (error) {
+    controller.error(error);
+  }
+}

--- a/packages/runtime/plugin-runtime/tests/core/createApp.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/core/createApp.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { render } from '@testing-library/react';
 import React from 'react';
 import { type Plugin, createApp, useRuntimeContext } from '../../src/core';

--- a/packages/runtime/plugin-runtime/tests/router/__snapshots__/templates.test.ts.snap
+++ b/packages/runtime/plugin-runtime/tests/router/__snapshots__/templates.test.ts.snap
@@ -52,21 +52,21 @@ import loader_1 from "@_modern_js_src/routes/layout.loader.ts";
               "id": "user/[id]/page",
               "loader": loader_0,
               "type": "nested",
-              "lazyImport": () => import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx').then(routeModule => handleRouteModule(routeModule, "user/[id]/page")).catch(handleRouteModuleError) ,
-              "component": lazy(() => import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx').then(routeModule => handleRouteModule(routeModule, "user/[id]/page")).catch(handleRouteModuleError) ),
+              "lazyImport": () => import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx').then(routeModule => handleRouteModule(routeModule, "user/[id]/page")).catch(handleRouteModuleError),
+              "component": lazy(() => import(/* webpackChunkName: "user/[id]/page" */  '@_modern_js_src/routes/user/[id]/page.tsx').then(routeModule => handleRouteModule(routeModule, "user/[id]/page")).catch(handleRouteModuleError)),
               "shouldRevalidate": createShouldRevalidate("user/[id]/page")
             }
           ],
           "lazyImport": null
         }
       ],
-      "lazyImport": () => import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx').then(routeModule => handleRouteModule(routeModule, "user/layout")).catch(handleRouteModuleError) ,
-      "component": lazy(() => import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx').then(routeModule => handleRouteModule(routeModule, "user/layout")).catch(handleRouteModuleError) ),
+      "lazyImport": () => import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx').then(routeModule => handleRouteModule(routeModule, "user/layout")).catch(handleRouteModuleError),
+      "component": lazy(() => import(/* webpackChunkName: "user/layout" */  '@_modern_js_src/routes/user/layout.tsx').then(routeModule => handleRouteModule(routeModule, "user/layout")).catch(handleRouteModuleError)),
       "shouldRevalidate": createShouldRevalidate("user/layout")
     }
   ],
-  "lazyImport": () => import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx').then(routeModule => handleRouteModule(routeModule, "layout")).catch(handleRouteModuleError) ,
-  "component": lazy(() => import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx').then(routeModule => handleRouteModule(routeModule, "layout")).catch(handleRouteModuleError) )
+  "lazyImport": () => import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx').then(routeModule => handleRouteModule(routeModule, "layout")).catch(handleRouteModuleError),
+  "component": lazy(() => import(/* webpackChunkName: "layout" */  '@_modern_js_src/routes/layout.tsx').then(routeModule => handleRouteModule(routeModule, "layout")).catch(handleRouteModuleError))
 },
 ];
   

--- a/packages/runtime/plugin-runtime/tests/router/prefetch.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/router/prefetch.test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import {
   type LoaderFunctionArgs,
   RouterProvider,

--- a/packages/runtime/render/package.json
+++ b/packages/runtime/render/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "@modern-js/types": "workspace:*",
     "@modern-js/utils": "workspace:*",
-    "@swc/helpers": "^0.5.17",
-    "rsc-html-stream": "0.0.6"
+    "@swc/helpers": "^0.5.17"
   },
   "devDependencies": {
     "@modern-js/server-core": "workspace:*",

--- a/packages/runtime/render/src/client/index.tsx
+++ b/packages/runtime/render/src/client/index.tsx
@@ -2,7 +2,8 @@ import {
   createFromReadableStream,
   createServerReference,
 } from '@modern-js/utils/react-server-dom-webpack/client.browser';
-import { type ReactNode, createContext, use, useState } from 'react';
+import React from 'react';
+import { type ReactNode, createContext, useState } from 'react';
 export { rscStream } from 'rsc-html-stream/client';
 export { createFromReadableStream, createServerReference };
 export { callServer } from './callServer';
@@ -14,19 +15,17 @@ declare global {
   }
 }
 
-interface RootProps {
-  data: Promise<React.ReactNode>;
-}
-
-export function RscClientRoot({ data }: RootProps) {
-  const elements = use(data);
+export function RscClientRoot({
+  rscPayload,
+}: { rscPayload: Promise<React.ReactNode> }) {
+  const elements = React.use(rscPayload);
   const [root, setRoot] = useState<React.ReactNode>(elements);
   return <>{root}</>;
 }
 
 type Elements = Promise<ReactNode[]>;
 
-const ElementsContext = createContext<Elements | null>(null);
+export const ElementsContext = createContext<Elements | null>(null);
 
 // For users to pass an element, not a Component.
 const JSX_SHELL_STREAM_END_MARK = '<!--<?- SHELL_STREAM_END ?>-->';
@@ -48,6 +47,6 @@ export const ServerElementsProvider = ({
 };
 
 export const RSCServerSlot = () => {
-  const elements = use(ElementsContext);
+  const elements = React.use(ElementsContext);
   return elements;
 };

--- a/packages/runtime/render/src/client/index.tsx
+++ b/packages/runtime/render/src/client/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@modern-js/utils/react-server-dom-webpack/client.browser';
 import React from 'react';
 import { type ReactNode, createContext, useState } from 'react';
-export { rscStream } from 'rsc-html-stream/client';
+export { rscStream } from '../rsc-html-stream/client';
 export { createFromReadableStream, createServerReference };
 export { callServer } from './callServer';
 export { createFromFetch } from '@modern-js/utils/react-server-dom-webpack/client.browser';

--- a/packages/runtime/render/src/rsc-html-stream/client.ts
+++ b/packages/runtime/render/src/rsc-html-stream/client.ts
@@ -1,0 +1,43 @@
+/**
+ * forked and modified from https://github.com/devongovett/rsc-html-stream/blob/main/client.js
+ * license at https://github.com/devongovett/rsc-html-stream/blob/main/LICENSE
+ */
+
+const encoder = new TextEncoder();
+let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+export const rscStream = new ReadableStream<Uint8Array>({
+  start(controller) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleChunk = (chunk: string | Uint8Array) => {
+      if (typeof chunk === 'string') {
+        controller.enqueue(encoder.encode(chunk));
+      } else {
+        controller.enqueue(chunk);
+      }
+    };
+
+    (window as any).__FLIGHT_DATA = (window as any).__FLIGHT_DATA || [];
+
+    ((window as any).__FLIGHT_DATA as (string | Uint8Array)[]).forEach(
+      handleChunk,
+    );
+
+    (window as any).__FLIGHT_DATA.push = (chunk: string | Uint8Array) => {
+      handleChunk(chunk);
+    };
+
+    streamController = controller;
+  },
+});
+
+if (typeof document !== 'undefined' && document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    streamController?.close();
+  });
+} else {
+  streamController?.close();
+}

--- a/packages/server/core/src/plugins/render/csrRscRender.ts
+++ b/packages/server/core/src/plugins/render/csrRscRender.ts
@@ -1,0 +1,77 @@
+import { MAIN_ENTRY_NAME } from '@modern-js/utils/universal/constants';
+import type { RscPayloadHandlerOptions } from '../../types/server';
+import type { SSRRenderOptions } from './ssrRender';
+import { createRequestHandlerConfig } from './utils';
+
+export const csrRscRender = async (req: Request, options: SSRRenderOptions) => {
+  const {
+    routeInfo,
+    serverManifest,
+    rscSSRManifest,
+    rscClientManifest,
+    rscServerManifest,
+    locals,
+    params,
+    loaderContext,
+    reporter,
+    monitors,
+    logger,
+    metrics,
+    onError,
+    onTiming,
+    staticGenerate,
+    html,
+  } = options;
+
+  const serverBundle =
+    serverManifest?.renderBundles?.[routeInfo.entryName || MAIN_ENTRY_NAME];
+
+  const loadableStats = serverManifest.loadableStats || {};
+  const routeManifest = serverManifest.routeManifest || {};
+  const config = createRequestHandlerConfig(options.config);
+
+  const requestHandlerOptions: RscPayloadHandlerOptions = {
+    resource: {
+      route: routeInfo,
+      loadableStats,
+      routeManifest,
+      entryName: routeInfo.entryName || MAIN_ENTRY_NAME,
+    },
+    config,
+    params,
+    loaderContext,
+    html,
+
+    rscSSRManifest,
+    rscClientManifest,
+    rscServerManifest,
+
+    locals,
+    reporter,
+    staticGenerate,
+    logger,
+    metrics,
+    monitors,
+
+    onError,
+    onTiming,
+  };
+
+  if (!serverBundle) {
+    return new Response('Cannot find server bundle for RSC', { status: 500 });
+  }
+
+  const renderRscStreamHandler = await serverBundle.renderRscStreamHandler;
+
+  if (!renderRscStreamHandler) {
+    return new Response('Cannot find render handler for RSC', { status: 500 });
+  }
+
+  if (!rscClientManifest) {
+    return new Response('Cannot find rsc client manifest', { status: 500 });
+  }
+
+  const response = await renderRscStreamHandler(req, requestHandlerOptions);
+
+  return response;
+};

--- a/packages/server/core/src/plugins/render/renderRscHandler.ts
+++ b/packages/server/core/src/plugins/render/renderRscHandler.ts
@@ -1,18 +1,68 @@
 import { MAIN_ENTRY_NAME } from '@modern-js/utils/universal/constants';
+import type { RscPayloadHandlerOptions } from '../../types/server';
 import type { SSRRenderOptions } from './ssrRender';
+import { createRequestHandlerConfig } from './utils';
 
 export const renderRscHandler = async (
   req: Request,
-  { serverManifest, routeInfo, rscClientManifest }: SSRRenderOptions,
+  options: SSRRenderOptions,
 ) => {
+  const {
+    routeInfo,
+    serverManifest,
+    rscSSRManifest,
+    rscClientManifest,
+    rscServerManifest,
+    locals,
+    params,
+    loaderContext,
+    reporter,
+    monitors,
+    logger,
+    metrics,
+    onError,
+    onTiming,
+    staticGenerate,
+  } = options;
+
   const serverBundle =
     serverManifest?.renderBundles?.[routeInfo.entryName || MAIN_ENTRY_NAME];
+
+  const loadableStats = serverManifest.loadableStats || {};
+  const routeManifest = serverManifest.routeManifest || {};
+  const config = createRequestHandlerConfig(options.config);
+
+  const requestHandlerOptions: RscPayloadHandlerOptions = {
+    resource: {
+      route: routeInfo,
+      loadableStats,
+      routeManifest,
+      entryName: routeInfo.entryName || MAIN_ENTRY_NAME,
+    },
+    config,
+    params,
+    loaderContext,
+
+    rscSSRManifest,
+    rscClientManifest,
+    rscServerManifest,
+
+    locals,
+    reporter,
+    staticGenerate,
+    logger,
+    metrics,
+    monitors,
+
+    onError,
+    onTiming,
+  };
 
   if (!serverBundle) {
     return new Response('Cannot find server bundle for RSC', { status: 500 });
   }
 
-  const { rscRequestHandler } = serverBundle;
+  const rscRequestHandler = await serverBundle.rscRequestHandler;
 
   if (!rscRequestHandler) {
     return new Response('Cannot find request handler for RSC', { status: 500 });
@@ -22,7 +72,5 @@ export const renderRscHandler = async (
     return new Response('Cannot find rsc client manifest', { status: 500 });
   }
 
-  return rscRequestHandler({
-    clientManifest: rscClientManifest,
-  });
+  return rscRequestHandler(req, requestHandlerOptions);
 };

--- a/packages/server/core/src/plugins/render/renderRscHandler.ts
+++ b/packages/server/core/src/plugins/render/renderRscHandler.ts
@@ -62,9 +62,9 @@ export const renderRscHandler = async (
     return new Response('Cannot find server bundle for RSC', { status: 500 });
   }
 
-  const rscRequestHandler = await serverBundle.rscRequestHandler;
+  const rscPayloadHandler = await serverBundle.rscPayloadHandler;
 
-  if (!rscRequestHandler) {
+  if (!rscPayloadHandler) {
     return new Response('Cannot find request handler for RSC', { status: 500 });
   }
 
@@ -72,5 +72,5 @@ export const renderRscHandler = async (
     return new Response('Cannot find rsc client manifest', { status: 500 });
   }
 
-  return rscRequestHandler(req, requestHandlerOptions);
+  return rscPayloadHandler(req, requestHandlerOptions);
 };

--- a/packages/server/core/src/plugins/render/ssrRender.ts
+++ b/packages/server/core/src/plugins/render/ssrRender.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../types/requestHandler';
 import { getPathname, parseHeaders } from '../../utils';
 import { getCacheResult, matchCacheControl } from './ssrCache';
+import { createRequestHandlerConfig } from './utils';
 
 // TODO: It's a type combine by RenderOptions and CreateRenderOptions, improve it.
 export interface SSRRenderOptions {
@@ -168,22 +169,4 @@ class IncomingMessgeProxy {
 
     this.url = getPathname(req);
   }
-}
-
-function createRequestHandlerConfig(
-  userConfig: UserConfig,
-): RequestHandlerConfig {
-  const { output, server, security, html, source } = userConfig;
-
-  return {
-    ssr: server?.ssr,
-    ssrByEntries: server?.ssrByEntries,
-    nonce: security?.nonce,
-    enableInlineScripts: output?.enableInlineScripts,
-    enableInlineStyles: output?.enableInlineStyles,
-    crossorigin: html?.crossorigin,
-    scriptLoading: html?.scriptLoading,
-    useJsonScript: server?.useJsonScript,
-    enableAsyncEntry: source?.enableAsyncEntry,
-  };
 }

--- a/packages/server/core/src/plugins/render/utils.ts
+++ b/packages/server/core/src/plugins/render/utils.ts
@@ -1,0 +1,20 @@
+import type { UserConfig } from '../../types';
+import type { RequestHandlerConfig } from '../../types/requestHandler';
+
+export function createRequestHandlerConfig(
+  userConfig: UserConfig,
+): RequestHandlerConfig {
+  const { output, server, security, html, source } = userConfig;
+
+  return {
+    ssr: server?.ssr,
+    ssrByEntries: server?.ssrByEntries,
+    nonce: security?.nonce,
+    enableInlineScripts: output?.enableInlineScripts,
+    enableInlineStyles: output?.enableInlineStyles,
+    crossorigin: html?.crossorigin,
+    scriptLoading: html?.scriptLoading,
+    useJsonScript: server?.useJsonScript,
+    enableAsyncEntry: source?.enableAsyncEntry,
+  };
+}

--- a/packages/server/core/src/types/requestHandler.ts
+++ b/packages/server/core/src/types/requestHandler.ts
@@ -50,6 +50,8 @@ export type RequestHandlerOptions = {
   RSCRoot?: any;
   rscRoot?: any;
 
+  serverPayload?: any;
+
   /** @deprecated  */
   locals?: Record<string, any>;
 

--- a/packages/server/core/src/types/requestHandler.ts
+++ b/packages/server/core/src/types/requestHandler.ts
@@ -44,6 +44,8 @@ export type RequestHandlerOptions = {
 
   loaderContext: LoaderContext;
 
+  html?: string;
+
   rscServerManifest?: RscServerManifest;
   rscClientManifest?: RscClientManifest;
   rscSSRManifest?: RscSSRManifest;

--- a/packages/server/core/src/types/server.ts
+++ b/packages/server/core/src/types/server.ts
@@ -11,10 +11,13 @@ import type {
   SSRManifest as RscSSRManifest,
   ServerManifest as RscServerManifest,
 } from '@modern-js/types/server';
+import type { SSRRenderOptions } from '../plugins/render/ssrRender';
 import type {
   RequestHandler as BundleRequestHandler,
   OnError,
   OnTiming,
+  RequestHandlerOptions,
+  Resource,
 } from './requestHandler';
 
 export type RequestHandler = (
@@ -39,15 +42,23 @@ export type ServerLoaderBundle = {
   }) => Promise<any>;
 };
 
+export type RscPayloadHandlerOptions = Omit<
+  RequestHandlerOptions,
+  'resource'
+> & {
+  resource: Omit<Resource, 'htmlTemplate'>;
+};
+
 type ServerRenderBundle = {
   requestHandler?: Promise<BundleRequestHandler>;
   handleAction?: (
     req: Request,
     options: { clientManifest: RscClientManifest },
   ) => Promise<Response>;
-  rscRequestHandler?: (options: {
-    clientManifest: RscClientManifest;
-  }) => Promise<Response>;
+  rscRequestHandler?: (
+    req: Request,
+    options: RscPayloadHandlerOptions,
+  ) => Promise<Response>;
 };
 
 export type ServerManifest = {

--- a/packages/server/core/src/types/server.ts
+++ b/packages/server/core/src/types/server.ts
@@ -59,6 +59,10 @@ type ServerRenderBundle = {
     req: Request,
     options: RscPayloadHandlerOptions,
   ) => Promise<Response>;
+  renderRscStreamHandler?: (
+    req: Request,
+    options: RscPayloadHandlerOptions,
+  ) => Promise<Response>;
 };
 
 export type ServerManifest = {

--- a/packages/server/core/src/types/server.ts
+++ b/packages/server/core/src/types/server.ts
@@ -55,7 +55,7 @@ type ServerRenderBundle = {
     req: Request,
     options: { clientManifest: RscClientManifest },
   ) => Promise<Response>;
-  rscRequestHandler?: (
+  rscPayloadHandler?: (
     req: Request,
     options: RscPayloadHandlerOptions,
   ) => Promise<Response>;

--- a/packages/solutions/app-tools/src/builder/generator/index.ts
+++ b/packages/solutions/app-tools/src/builder/generator/index.ts
@@ -41,6 +41,7 @@ export async function generateBuilder<B extends Bundler>(
     cwd: appContext.appDirectory,
     rscClientRuntimePath: `@${appContext.metaName}/runtime/rsc/client`,
     rscServerRuntimePath: `@${appContext.metaName}/runtime/rsc/server`,
+    internalDirectory: appContext.internalDirectory,
     frameworkConfigPath: appContext.configFile || undefined,
     bundlerType,
     config: builderConfig,

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -4,7 +4,7 @@ import {
   SERVICE_WORKER_ENVIRONMENT_NAME,
   isHtmlDisabled,
 } from '@modern-js/uni-builder';
-import { fs, isUseSSRBundle } from '@modern-js/utils';
+import { fs, isUseRsc, isUseSSRBundle } from '@modern-js/utils';
 import {
   type RsbuildPlugin,
   type RspackChain,
@@ -72,7 +72,7 @@ export const builderPluginAdapterSSR = <B extends Bundler>(
           });
         }
 
-        if (isUseSSRBundle(normalizedConfig)) {
+        if (isUseSSRBundle(normalizedConfig) || isUseRsc(normalizedConfig)) {
           await applySSRLoaderEntry(chain, options, isServer);
           applySSRDataLoader(chain, options);
         }

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -35,7 +35,10 @@ export const builderPluginAdapterSSR = <B extends Bundler>(
         server: {
           // the http-compression can't handler stream http.
           // so we disable compress when user use stream ssr temporarily.
-          compress: isStreamingSSR(normalizedConfig) ? false : undefined,
+          compress:
+            isStreamingSSR(normalizedConfig) || isUseRsc(normalizedConfig)
+              ? false
+              : undefined,
         },
       });
     });
@@ -121,7 +124,7 @@ function applyAsyncChunkHtmlPlugin({
   modernConfig: AppNormalizedConfig<'shared'>;
   HtmlBundlerPlugin: any;
 }) {
-  if (isStreamingSSR(modernConfig)) {
+  if (isStreamingSSR(modernConfig) || isUseRsc(modernConfig)) {
     chain
       .plugin('html-async-chunk')
       .use(HtmlAsyncChunkPlugin, [HtmlBundlerPlugin]);

--- a/packages/storybook/builder/src/addons/components/modern.tsx
+++ b/packages/storybook/builder/src/addons/components/modern.tsx
@@ -5,7 +5,7 @@ import type {
   RouterConfig,
   RuntimePluginFuture,
 } from '@modern-js/runtime';
-import router from '@modern-js/runtime/router';
+import router from '@modern-js/runtime/router/internal';
 import React from 'react';
 import type { IConfig } from '../type';
 

--- a/packages/toolkit/plugin-v2/package.json
+++ b/packages/toolkit/plugin-v2/package.json
@@ -42,7 +42,7 @@
     },
     "./runtime": {
       "types": "./dist/types/runtime/index.d.ts",
-      "jsnext:source": "./src/runtime/index.ts",
+      "jsnext:source": "./src/runtime/index.tsx",
       "node": {
         "import": "./dist/esm/runtime/index.js",
         "require": "./dist/cjs/runtime/index.js"

--- a/packages/toolkit/runtime-utils/src/remixRouter.ts
+++ b/packages/toolkit/runtime-utils/src/remixRouter.ts
@@ -1,2 +1,10 @@
-// guarantee all other packages use the absolute same package of '@remix-run/router'
 export * from '@remix-run/router';
+
+import * as remixRouter from '@remix-run/router';
+
+const symbolName = 'UNSAFE_DEFERRED_SYMBOL';
+
+export const DEFERRED_SYMBOL =
+  symbolName in remixRouter
+    ? ((remixRouter as any)[symbolName] as symbol)
+    : Symbol('deferred');

--- a/packages/toolkit/runtime-utils/src/universal/async_storage.server.ts
+++ b/packages/toolkit/runtime-utils/src/universal/async_storage.server.ts
@@ -56,6 +56,7 @@ const storage = createStorage<{
     status: number;
   };
   activeDeferreds?: Map<string, unknown>;
+  serverPayload?: unknown;
 }>();
 
 type Storage = typeof storage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2470,8 +2470,8 @@ importers:
         specifier: ^0.5.17
         version: 0.5.17
       react-router:
-        specifier: ^7.5.0
-        version: 7.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.6.0
+        version: 7.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@modern-js/app-tools':
         specifier: workspace:*
@@ -2594,6 +2594,9 @@ importers:
       '@modern-js/app-tools':
         specifier: workspace:*
         version: link:../../solutions/app-tools
+      '@modern-js/core':
+        specifier: workspace:*
+        version: link:../../cli/core
       '@remix-run/web-fetch':
         specifier: ^4.1.3
         version: 4.4.2
@@ -2869,9 +2872,6 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.17
-      rsc-html-stream:
-        specifier: 0.0.6
-        version: 0.0.6
     devDependencies:
       '@modern-js/server-core':
         specifier: workspace:*
@@ -7090,6 +7090,52 @@ importers:
         specifier: ^5
         version: 5.6.3
 
+  tests/integration/rsc-csr-routes:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime/plugin-runtime
+      client-only:
+        specifier: ^0.0.1
+        version: 0.0.1
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
+      react-router:
+        specifier: 0.0.0-experimental-3f68c7c20
+        version: 0.0.0-experimental-3f68c7c20(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../packages/solutions/app-tools
+      '@modern-js/plugin-swc':
+        specifier: workspace:*
+        version: link:../../../packages/cli/plugin-swc
+      '@types/jest':
+        specifier: ^29
+        version: 29.5.14
+      '@types/node':
+        specifier: ^14
+        version: 14.18.35
+      '@types/react':
+        specifier: ^18
+        version: 18.3.18
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.5(@types/react@18.3.18)
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
+      typescript:
+        specifier: ^5
+        version: 5.6.3
+
   tests/integration/rsc-ssr-app:
     dependencies:
       '@modern-js/render':
@@ -7138,6 +7184,52 @@ importers:
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
+      typescript:
+        specifier: ^5
+        version: 5.6.3
+
+  tests/integration/rsc-ssr-routes:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime/plugin-runtime
+      client-only:
+        specifier: ^0.0.1
+        version: 0.0.1
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.1.0(react@19.1.0)
+      react-router:
+        specifier: 0.0.0-experimental-3f68c7c20
+        version: 0.0.0-experimental-3f68c7c20(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../packages/solutions/app-tools
+      '@modern-js/plugin-swc':
+        specifier: workspace:*
+        version: link:../../../packages/cli/plugin-swc
+      '@types/jest':
+        specifier: ^29
+        version: 29.5.14
+      '@types/node':
+        specifier: ^14
+        version: 14.18.35
+      '@types/react':
+        specifier: ^18
+        version: 18.3.18
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.5(@types/react@18.3.18)
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       typescript:
         specifier: ^5
         version: 5.6.3
@@ -21536,6 +21628,16 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  react-router@0.0.0-experimental-3f68c7c20:
+    resolution: {integrity: sha512-j3swHqxK61kUn4nXQLhPewuwbwNeZAAJ74zDGaT7bTHspyuBM8TdQ93t1XGyMRa93niDrHDUPjfwkooyZ0gPQA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-router@5.3.4:
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
@@ -21559,8 +21661,8 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  react-router@7.5.3:
-    resolution: {integrity: sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==}
+  react-router@7.6.0:
+    resolution: {integrity: sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -21970,9 +22072,6 @@ packages:
         optional: true
       typescript:
         optional: true
-
-  rsc-html-stream@0.0.6:
-    resolution: {integrity: sha512-oZUJ5AH0oDo9QywxD9yMY6N5Z3VwX2YfQg0FanNdCmvXmO0itTfv7BMkbMSwxg7JmBjYmefU8DTW0EcLsePPgQ==}
 
   rslog@1.2.3:
     resolution: {integrity: sha512-antALPJaKBRPBU1X2q9t085K4htWDOOv/K1qhTUk7h0l1ePU/KbDqKJn19eKP0dk7PqMioeA0+fu3gyPXCsXxQ==}
@@ -23090,9 +23189,6 @@ packages:
 
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
-
-  turbo-stream@2.4.0:
-    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
   twin.macro@2.8.2:
     resolution: {integrity: sha512-2Vg09mp+nA70AWUedJ8WRgB2me3buq7JGbOnjHnFnNaBzomVu5k7lJ9YGpByIlre+UYr7QRhtlj7+IUKxvCrUA==}
@@ -41460,6 +41556,14 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-router: 6.29.0(react@19.1.0)
 
+  react-router@0.0.0-experimental-3f68c7c20(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      cookie: 1.0.2
+      react: 19.1.0
+      set-cookie-parser: 2.7.1
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
   react-router@5.3.4(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.27.0
@@ -41493,12 +41597,11 @@ snapshots:
       '@remix-run/router': 1.22.0
       react: 19.1.0
 
-  react-router@7.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router@7.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       cookie: 1.0.2
       react: 18.3.1
       set-cookie-parser: 2.7.1
-      turbo-stream: 2.4.0
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
@@ -42120,8 +42223,6 @@ snapshots:
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.6.3
-
-  rsc-html-stream@0.0.6: {}
 
   rslog@1.2.3: {}
 
@@ -43548,8 +43649,6 @@ snapshots:
       fsevents: 2.3.3
 
   tty-browserify@0.0.1: {}
-
-  turbo-stream@2.4.0: {}
 
   twin.macro@2.8.2(ts-node@10.9.2(@swc/core@1.11.31(@swc/helpers@0.5.17))(@types/node@20.5.1)(typescript@5.6.3)):
     dependencies:

--- a/tests/integration/routes/modern.config.ts
+++ b/tests/integration/routes/modern.config.ts
@@ -6,7 +6,7 @@ const bundler = process.env.BUNDLER;
 export default defineConfig({
   plugins: [
     appTools({
-      bundler: bundler === 'rspack' ? 'rspack' : 'webpack',
+      bundler: bundler === 'webpack' ? 'webpack' : 'rspack',
     }),
     routerPlugin(),
   ],

--- a/tests/integration/routes/src/three/routes/layout.tsx
+++ b/tests/integration/routes/src/three/routes/layout.tsx
@@ -9,7 +9,7 @@ export default function Layout() {
     <div>
       {data?.message}
       <Link to="/" className="root-btn" prefetch="intent">
-        /user
+        /home
       </Link>
       <Link to="user" className="user-btn" prefetch="intent">
         /user

--- a/tests/integration/routes/src/three/routes/page.tsx
+++ b/tests/integration/routes/src/three/routes/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Page</div>;
+}

--- a/tests/integration/rsc-csr-app/src/components/Counter.tsx
+++ b/tests/integration/rsc-csr-app/src/components/Counter.tsx
@@ -44,7 +44,7 @@ export const Counter = () => {
         </form>
       </div>
 
-      <Suspense fallback={<div>加载中...</div>}>
+      <Suspense fallback={<div>loading...</div>}>
         <DynamicMessage />
       </Suspense>
     </>

--- a/tests/integration/rsc-csr-routes/.browserslistrc
+++ b/tests/integration/rsc-csr-routes/.browserslistrc
@@ -1,0 +1,5 @@
+chrome >= 51
+edge >= 15
+firefox >= 54
+safari >= 10
+ios_saf >= 10

--- a/tests/integration/rsc-csr-routes/modern.config.ts
+++ b/tests/integration/rsc-csr-routes/modern.config.ts
@@ -1,0 +1,18 @@
+import path from 'path';
+import pluginRouterV7 from '@modern-js/plugin-router-v7';
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  plugins: [pluginRouterV7()],
+  server: {
+    rsc: true,
+  },
+  tools: {
+    bundlerChain(chain) {
+      chain.resolve.modules
+        .clear()
+        .add(path.resolve(__dirname, 'node_modules'))
+        .add('node_modules');
+    },
+  },
+});

--- a/tests/integration/rsc-csr-routes/package.json
+++ b/tests/integration/rsc-csr-routes/package.json
@@ -1,0 +1,34 @@
+{
+  "private": true,
+  "name": "rsc-csr-routes",
+  "version": "2.66.0",
+  "scripts": {
+    "dev": "cross-env BUNDLER=rspack modern dev",
+    "dev:webpack": "cross-env BUNDLER=webpack modern dev",
+    "build": "cross-env BUNDLER=rspack modern build",
+    "build:webpack": "cross-env BUNDLER=webpack modern build",
+    "serve": "modern serve",
+    "new": "modern new"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "client-only": "^0.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router": "0.0.0-experimental-3f68c7c20",
+    "server-only": "^0.0.1"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/plugin-swc": "workspace:*",
+    "@types/jest": "^29",
+    "@types/node": "^14",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "cross-env": "^7.0.3",
+    "typescript": "^5"
+  }
+}

--- a/tests/integration/rsc-csr-routes/src/component/routes/Message.tsx
+++ b/tests/integration/rsc-csr-routes/src/component/routes/Message.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { use } from 'react';
+
+export function Message({
+  messagePromise,
+}: { messagePromise: Promise<string> }) {
+  const messageContent = use(messagePromise);
+  return <p className="message">{messageContent}</p>;
+}

--- a/tests/integration/rsc-csr-routes/src/component/routes/layout.tsx
+++ b/tests/integration/rsc-csr-routes/src/component/routes/layout.tsx
@@ -1,0 +1,16 @@
+import 'server-only';
+import { Link, Outlet } from '@modern-js/runtime/router';
+export default function Layout() {
+  return (
+    <div className="root-layout">
+      root layout
+      <Link className="home-link" to="/">
+        home
+      </Link>
+      <Link className="user-link" to="user">
+        user
+      </Link>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-csr-routes/src/component/routes/page.tsx
+++ b/tests/integration/rsc-csr-routes/src/component/routes/page.tsx
@@ -1,0 +1,20 @@
+import 'server-only';
+import { Suspense } from 'react';
+import { Message } from './Message';
+
+const fetchData = async (): Promise<string> => {
+  return new Promise(resolve =>
+    setTimeout(() => resolve('root page from server'), 100),
+  );
+};
+
+export default function Page() {
+  const dataPromise = fetchData();
+  return (
+    <Suspense fallback={<p>waiting for message...</p>}>
+      <div className="root-page">
+        <Message messagePromise={dataPromise} />
+      </div>
+    </Suspense>
+  );
+}

--- a/tests/integration/rsc-csr-routes/src/component/routes/user/page.tsx
+++ b/tests/integration/rsc-csr-routes/src/component/routes/user/page.tsx
@@ -1,0 +1,26 @@
+import UserData from '@/loader/routes/user/UserData';
+import { Outlet } from '@modern-js/runtime/router';
+import { Suspense } from 'react';
+
+const fetchUserData = async (): Promise<string> => {
+  return new Promise(resolve =>
+    setTimeout(() => resolve('user data from server'), 100),
+  );
+};
+
+const SubPage = () => {
+  return <div>sub page</div>;
+};
+
+export default function UserPage() {
+  const userDataPromise = fetchUserData();
+  return (
+    <div className="user-layout">
+      user page
+      <Suspense fallback={<div>Loading...</div>}>
+        <UserData userData={userDataPromise} />
+      </Suspense>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-csr-routes/src/component/routes/user/page.tsx
+++ b/tests/integration/rsc-csr-routes/src/component/routes/user/page.tsx
@@ -8,10 +8,6 @@ const fetchUserData = async (): Promise<string> => {
   );
 };
 
-const SubPage = () => {
-  return <div>sub page</div>;
-};
-
 export default function UserPage() {
   const userDataPromise = fetchUserData();
   return (

--- a/tests/integration/rsc-csr-routes/src/loader/routes/layout.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/layout.tsx
@@ -1,0 +1,19 @@
+import 'server-only';
+import { Link, Outlet } from '@modern-js/runtime/router';
+export default function Layout() {
+  return (
+    <div className="root-layout">
+      root layout
+      <Link className="home-link" to="/">
+        home
+      </Link>
+      <Link className="user-link" to="user">
+        user
+      </Link>
+      <Link className="redirect-link" to="redirect">
+        redirect
+      </Link>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-csr-routes/src/loader/routes/page.data.client.ts
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/page.data.client.ts
@@ -1,0 +1,3 @@
+export const loader = async () => {
+  return 'root page from client';
+};

--- a/tests/integration/rsc-csr-routes/src/loader/routes/page.data.ts
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/page.data.ts
@@ -1,0 +1,3 @@
+export const loader = async () => {
+  return 'root page from server';
+};

--- a/tests/integration/rsc-csr-routes/src/loader/routes/page.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useLoaderData } from '@modern-js/runtime/router';
+
+export default function Page() {
+  const loaderData = useLoaderData() as string;
+  return <div className="root-page">{loaderData}</div>;
+}

--- a/tests/integration/rsc-csr-routes/src/loader/routes/redirect/page.data.ts
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/redirect/page.data.ts
@@ -1,4 +1,4 @@
-import { redirect } from '@modern-js/runtime/router/server';
+import { redirect } from '@modern-js/runtime/router/rsc';
 
 export const loader = () => {
   return redirect('/user');

--- a/tests/integration/rsc-csr-routes/src/loader/routes/redirect/page.data.ts
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/redirect/page.data.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@modern-js/runtime/router/server';
+
+export const loader = () => {
+  return redirect('/user');
+};

--- a/tests/integration/rsc-csr-routes/src/loader/routes/redirect/page.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/redirect/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>redirect page</div>;
+}

--- a/tests/integration/rsc-csr-routes/src/loader/routes/user/UserData.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/user/UserData.tsx
@@ -1,0 +1,6 @@
+import { use } from 'react';
+
+export default function UserData({ userData }: { userData: Promise<any> }) {
+  const value = use(userData);
+  return <div className="user-data">{value}</div>;
+}

--- a/tests/integration/rsc-csr-routes/src/loader/routes/user/layout.data.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/user/layout.data.tsx
@@ -1,0 +1,15 @@
+function Profile() {
+  return <div>Profile Component</div>;
+}
+
+export const loader = async ({
+  request,
+}: {
+  request: Request;
+}) => {
+  const user = new Promise(resolve =>
+    setTimeout(() => resolve('John Doe'), 500),
+  );
+
+  return { user, Profile: <Profile /> };
+};

--- a/tests/integration/rsc-csr-routes/src/loader/routes/user/layout.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/user/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { Outlet } from '@modern-js/runtime/router';
+import { Suspense } from 'react';
+import UserData from './UserData';
+
+export default function UserLayout({ loaderData }: { loaderData: any }) {
+  const { user, Profile } = loaderData;
+  return (
+    <div className="user-layout">
+      user layout
+      {Profile}
+      <Suspense fallback={<div>Loading...</div>}>
+        <UserData userData={user} />
+      </Suspense>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-csr-routes/src/loader/routes/user/page.data.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/user/page.data.tsx
@@ -1,0 +1,11 @@
+export const loader = async ({
+  request,
+}: {
+  request: Request;
+}) => {
+  const user = new Promise(resolve =>
+    setTimeout(() => resolve('user page data'), 1000),
+  );
+
+  return { user };
+};

--- a/tests/integration/rsc-csr-routes/src/loader/routes/user/page.tsx
+++ b/tests/integration/rsc-csr-routes/src/loader/routes/user/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react';
+import UserData from './UserData';
+
+export default function UserPage({ loaderData }: { loaderData: any }) {
+  const { user } = loaderData;
+  return (
+    <div>
+      User page
+      <Suspense fallback={<div>Loading...</div>}>
+        <div className="user-page-data-container">
+          <UserData userData={user} />
+        </div>
+      </Suspense>
+    </div>
+  );
+}

--- a/tests/integration/rsc-csr-routes/src/modern-app-env.d.ts
+++ b/tests/integration/rsc-csr-routes/src/modern-app-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@modern-js/runtime/types/router' />
+/// <reference types='@modern-js/plugin-garfish/type' />
+/// <reference types='@modern-js/plugin-express/types' />
+/// <reference types='@modern-js/plugin-koa/types' />
+/// <reference types="react/canary" />
+/// <reference types="react-dom/canary" />

--- a/tests/integration/rsc-csr-routes/tests/index.test.ts
+++ b/tests/integration/rsc-csr-routes/tests/index.test.ts
@@ -1,0 +1,259 @@
+import path from 'path';
+import { isVersionAtLeast18 } from '@modern-js/utils';
+import type { Browser, Page } from 'puppeteer';
+import puppeteer from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchApp,
+  launchOptions,
+  modernBuild,
+  modernServe,
+} from '../../../utils/modernTestUtils';
+
+const appDir = path.resolve(__dirname, '../');
+
+interface TestConfig {
+  bundler: 'webpack' | 'rspack';
+  mode: 'dev' | 'build';
+}
+
+interface TestOptions {
+  baseUrl: string;
+  appPort: number;
+  page: Page;
+}
+
+function skipForLowerNodeVersion() {
+  if (!isVersionAtLeast18()) {
+    test('should skip in lower node version', () => {
+      expect(true).toBe(true);
+    });
+    return true;
+  }
+  return false;
+}
+
+function runTests({ bundler, mode }: TestConfig) {
+  describe(`${mode} with ${bundler}`, () => {
+    let app: any;
+    let appPort: number;
+    let page: Page;
+    let browser: Browser;
+    const errors: string[] = [];
+
+    if (skipForLowerNodeVersion()) {
+      return;
+    }
+
+    beforeAll(async () => {
+      appPort = await getPort();
+
+      if (mode === 'dev') {
+        app = await launchApp(
+          appDir,
+          appPort,
+          {},
+          {
+            BUNDLER: bundler,
+          },
+        );
+      } else {
+        await modernBuild(appDir, [], {
+          env: {
+            BUNDLER: bundler,
+          },
+        });
+        app = await modernServe(appDir, appPort, {
+          cwd: appDir,
+        });
+      }
+
+      browser = await puppeteer.launch(launchOptions as any);
+      page = await browser.newPage();
+
+      if (mode === 'build') {
+        page.on('pageerror', error => {
+          errors.push(error.message);
+        });
+      }
+    });
+
+    afterAll(async () => {
+      await killApp(app);
+      await page.close();
+      await browser.close();
+    });
+
+    describe('csr-rsc-routes-with-loader', () => {
+      const baseUrl = `/loader`;
+
+      it('support route as server component and client component', () =>
+        supportRouteAsServerComponent({ baseUrl, appPort, page }));
+
+      it('support route as client component and navigation', () =>
+        suppportRouteAsClientComponentAndNavigation({
+          baseUrl,
+          appPort,
+          page,
+        }));
+
+      it('support direct redirect navigation', () =>
+        supportDirectRedirectNavigation({ baseUrl, appPort, page }));
+
+      it('support redirect on first screen load', () =>
+        supportRedirectOnFirstScreenLoad({ baseUrl, appPort, page }));
+    });
+
+    describe('csr-rsc-routes-with-fetch', () => {
+      const baseUrl = `/component`;
+
+      it('should render with fetch correctly', () =>
+        shouldRenderWithFetchCorrectly({ baseUrl, appPort, page }));
+    });
+  });
+}
+
+async function verifyUserPageElements(page: Page) {
+  const elementsToCheck = [
+    { name: 'root layout', selector: 'body' },
+    { name: 'user layout', selector: '.user-layout' },
+    { name: 'John Doe', selector: '.user-layout' },
+    { name: 'user page data', selector: '.user-layout' },
+  ];
+
+  for (const { name, selector } of elementsToCheck) {
+    const elementExists = await page.$eval(
+      selector,
+      (el, name) => {
+        return el.textContent?.includes(name);
+      },
+      name,
+    );
+    expect(elementExists).toBe(true);
+  }
+}
+
+async function suppportRouteAsClientComponentAndNavigation({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  await page.waitForSelector('.root-page', { timeout: 5000 });
+
+  const elementsToCheck = [
+    { name: 'root layout', selector: 'body' },
+    { name: 'root page from client', selector: '.root-page' },
+  ];
+
+  for (const { name, selector } of elementsToCheck) {
+    await page.waitForFunction(
+      (selector, name) => {
+        const el = document.querySelector(selector);
+        return el?.textContent?.includes(name);
+      },
+      { timeout: 5000 },
+      selector,
+      name,
+    );
+
+    const elementExists = await page.$eval(
+      selector,
+      (el, name) => {
+        return el.textContent?.includes(name);
+      },
+      name,
+    );
+    expect(elementExists).toBe(true);
+  }
+
+  await page.click('.user-link');
+
+  await page.waitForSelector('.user-page-data-container');
+  await verifyUserPageElements(page);
+}
+
+async function supportRouteAsServerComponent({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}/user`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+  await page.waitForSelector('.user-page-data-container');
+  await verifyUserPageElements(page);
+}
+
+async function supportDirectRedirectNavigation({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  const rootPageExists = await page.$eval('.root-page', el =>
+    el.textContent?.includes('root page from client'),
+  );
+  expect(rootPageExists).toBe(true);
+
+  await page.click('.redirect-link');
+
+  await page.waitForSelector('.user-page-data-container', { timeout: 5000 });
+  await verifyUserPageElements(page);
+
+  const currentUrl = page.url();
+  expect(currentUrl).toContain('/user');
+}
+
+async function supportRedirectOnFirstScreenLoad({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}/redirect`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  await page.waitForSelector('.user-page-data-container', { timeout: 5000 });
+  await verifyUserPageElements(page);
+
+  const currentUrl = page.url();
+  expect(currentUrl).toContain('/user');
+  expect(currentUrl).not.toContain('/redirect');
+}
+
+async function shouldRenderWithFetchCorrectly({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  await page.waitForSelector('.message', { timeout: 5000 });
+  const message = await page.$eval('.message', el => el.textContent);
+  expect(message).toBe('root page from server');
+
+  await page.click('.user-link');
+  await page.waitForSelector('.user-data', { timeout: 5000 });
+  const userData = await page.$eval('.user-data', el => el.textContent);
+  expect(userData).toBe('user data from server');
+
+  await page.click('.home-link');
+  await page.waitForSelector('.message', { timeout: 5000 });
+  const message2 = await page.$eval('.message', el => el.textContent);
+  expect(message2).toBe('root page from server');
+}
+
+runTests({ bundler: 'rspack', mode: 'dev' });
+runTests({ bundler: 'rspack', mode: 'build' });
+runTests({ bundler: 'webpack', mode: 'dev' });
+runTests({ bundler: 'webpack', mode: 'build' });

--- a/tests/integration/rsc-csr-routes/tests/index.test.ts
+++ b/tests/integration/rsc-csr-routes/tests/index.test.ts
@@ -147,7 +147,7 @@ async function suppportRouteAsClientComponentAndNavigation({
 
   const elementsToCheck = [
     { name: 'root layout', selector: 'body' },
-    { name: 'root page from client', selector: '.root-page' },
+    { name: 'root page from server', selector: '.root-page' },
   ];
 
   for (const { name, selector } of elementsToCheck) {
@@ -175,6 +175,14 @@ async function suppportRouteAsClientComponentAndNavigation({
 
   await page.waitForSelector('.user-page-data-container');
   await verifyUserPageElements(page);
+
+  await page.click('.home-link');
+
+  await page.waitForSelector('.root-page');
+  const rootPageExists = await page.$eval('.root-page', el =>
+    el.textContent?.includes('root page from client'),
+  );
+  expect(rootPageExists).toBe(true);
 }
 
 async function supportRouteAsServerComponent({
@@ -199,7 +207,7 @@ async function supportDirectRedirectNavigation({
   });
 
   const rootPageExists = await page.$eval('.root-page', el =>
-    el.textContent?.includes('root page from client'),
+    el.textContent?.includes('root page from server'),
   );
   expect(rootPageExists).toBe(true);
 

--- a/tests/integration/rsc-csr-routes/tests/tsconfig.json
+++ b/tests/integration/rsc-csr-routes/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "paths": {},
+    "types": ["node", "jest"]
+  }
+}

--- a/tests/integration/rsc-csr-routes/tsconfig.json
+++ b/tests/integration/rsc-csr-routes/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "shared", "config"]
+}

--- a/tests/integration/rsc-ssr-app/tests/index.test.ts
+++ b/tests/integration/rsc-ssr-app/tests/index.test.ts
@@ -226,5 +226,3 @@ async function supportResponseAPIForClientRoot({
 
 runTests({ bundler: 'rspack', mode: 'dev' });
 runTests({ bundler: 'rspack', mode: 'build' });
-runTests({ bundler: 'webpack', mode: 'dev' });
-runTests({ bundler: 'webpack', mode: 'build' });

--- a/tests/integration/rsc-ssr-routes/.browserslistrc
+++ b/tests/integration/rsc-ssr-routes/.browserslistrc
@@ -1,0 +1,5 @@
+chrome >= 51
+edge >= 15
+firefox >= 54
+safari >= 10
+ios_saf >= 10

--- a/tests/integration/rsc-ssr-routes/modern.config.ts
+++ b/tests/integration/rsc-ssr-routes/modern.config.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import pluginRouterV7 from '@modern-js/plugin-router-v7';
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  plugins: [pluginRouterV7()],
+  server: {
+    rsc: true,
+    ssr: {
+      mode: 'stream',
+    },
+  },
+  tools: {
+    bundlerChain(chain) {
+      chain.resolve.modules
+        .clear()
+        .add(path.resolve(__dirname, 'node_modules'))
+        .add('node_modules');
+    },
+    rspack(config, { appendPlugins }) {
+      config.optimization.sideEffects = false;
+    },
+  },
+});

--- a/tests/integration/rsc-ssr-routes/package.json
+++ b/tests/integration/rsc-ssr-routes/package.json
@@ -1,0 +1,34 @@
+{
+  "private": true,
+  "name": "rsc-ssr-routes",
+  "version": "2.66.0",
+  "scripts": {
+    "dev": "cross-env BUNDLER=rspack modern dev",
+    "dev:webpack": "cross-env BUNDLER=webpack modern dev",
+    "build": "cross-env BUNDLER=rspack modern build",
+    "build:webpack": "cross-env BUNDLER=webpack modern build",
+    "serve": "modern serve",
+    "new": "modern new"
+  },
+  "engines": {
+    "node": ">=14.17.6"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "client-only": "^0.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router": "0.0.0-experimental-3f68c7c20",
+    "server-only": "^0.0.1"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/plugin-swc": "workspace:*",
+    "@types/jest": "^29",
+    "@types/node": "^14",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "cross-env": "^7.0.3",
+    "typescript": "^5"
+  }
+}

--- a/tests/integration/rsc-ssr-routes/src/component/routes/Message.tsx
+++ b/tests/integration/rsc-ssr-routes/src/component/routes/Message.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { use } from 'react';
+
+export function Message({
+  messagePromise,
+}: { messagePromise: Promise<string> }) {
+  const messageContent = use(messagePromise);
+  return <p className="message">{messageContent}</p>;
+}

--- a/tests/integration/rsc-ssr-routes/src/component/routes/layout.tsx
+++ b/tests/integration/rsc-ssr-routes/src/component/routes/layout.tsx
@@ -1,0 +1,16 @@
+import 'server-only';
+import { Link, Outlet } from '@modern-js/runtime/router';
+export default function Layout() {
+  return (
+    <div className="root-layout">
+      root layout
+      <Link className="home-link" to="/">
+        home
+      </Link>
+      <Link className="user-link" to="user">
+        user
+      </Link>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-ssr-routes/src/component/routes/page.tsx
+++ b/tests/integration/rsc-ssr-routes/src/component/routes/page.tsx
@@ -1,0 +1,20 @@
+import 'server-only';
+import { Suspense } from 'react';
+import { Message } from './Message';
+
+const fetchData = async (): Promise<string> => {
+  return new Promise(resolve =>
+    setTimeout(() => resolve('root page from server'), 100),
+  );
+};
+
+export default function Page() {
+  const dataPromise = fetchData();
+  return (
+    <Suspense fallback={<p>waiting for message...</p>}>
+      <div className="root-page">
+        <Message messagePromise={dataPromise} />
+      </div>
+    </Suspense>
+  );
+}

--- a/tests/integration/rsc-ssr-routes/src/component/routes/user/page.tsx
+++ b/tests/integration/rsc-ssr-routes/src/component/routes/user/page.tsx
@@ -1,0 +1,22 @@
+import UserData from '@/loader/routes/user/UserData';
+import { Outlet } from '@modern-js/runtime/router';
+import { Suspense } from 'react';
+
+const fetchUserData = async (): Promise<string> => {
+  return new Promise(resolve =>
+    setTimeout(() => resolve('user data from server'), 100),
+  );
+};
+
+export default function UserPage() {
+  const userDataPromise = fetchUserData();
+  return (
+    <div className="user-layout">
+      user page
+      <Suspense fallback={<div>Loading...</div>}>
+        <UserData userData={userDataPromise} />
+      </Suspense>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/layout.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/layout.tsx
@@ -1,0 +1,22 @@
+import 'server-only';
+import { Link, Outlet } from '@modern-js/runtime/router';
+export default function Layout() {
+  return (
+    <div className="root-layout">
+      root layout
+      <Link className="home-link" to="/">
+        home
+      </Link>
+      <Link className="user-link" to="user">
+        user
+      </Link>
+      <Link className="redirect-link" to="redirect">
+        redirect
+      </Link>
+      <Link className="match-link" to="match/123">
+        match
+      </Link>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/match/[id]/page.data.ts
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/match/[id]/page.data.ts
@@ -1,0 +1,13 @@
+export type LoaderResult = {
+  matchedId: string;
+};
+
+export const loader = async ({
+  request,
+  params,
+}: {
+  request: Request;
+  params: { id: string };
+}): Promise<LoaderResult> => {
+  return { matchedId: params.id };
+};

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/match/[id]/page.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/match/[id]/page.tsx
@@ -1,0 +1,16 @@
+import type { LoaderResult } from './page.data';
+
+export default function MatchedPage({
+  loaderData,
+  matches,
+}: {
+  loaderData: LoaderResult;
+  matches: any[];
+}) {
+  const lastMatch = matches[matches.length - 1];
+  if (lastMatch.params.id !== loaderData.matchedId) {
+    return <div>Not Matched</div>;
+  }
+
+  return <div className="matched">Matched</div>;
+}

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/page.data.client.ts
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/page.data.client.ts
@@ -1,0 +1,3 @@
+export const loader = async () => {
+  return 'root page from client';
+};

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/page.data.ts
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/page.data.ts
@@ -1,0 +1,3 @@
+export const loader = async () => {
+  return 'root page from server';
+};

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/page.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useLoaderData } from '@modern-js/runtime/router';
+
+export default function Page() {
+  const loaderData = useLoaderData() as string;
+  return <div className="root-page">{loaderData}</div>;
+}

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/redirect/page.data.ts
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/redirect/page.data.ts
@@ -1,4 +1,4 @@
-import { redirect } from '@modern-js/runtime/router/server';
+import { redirect } from '@modern-js/runtime/router/rsc';
 
 export const loader = () => {
   return redirect('/user');

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/redirect/page.data.ts
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/redirect/page.data.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@modern-js/runtime/router/server';
+
+export const loader = () => {
+  return redirect('/user');
+};

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/redirect/page.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/redirect/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>redirect page</div>;
+}

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/user/UserData.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/user/UserData.tsx
@@ -1,0 +1,6 @@
+import { use } from 'react';
+
+export default function UserData({ userData }: { userData: Promise<any> }) {
+  const value = use(userData);
+  return <div className="user-data">{value}</div>;
+}

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/user/layout.data.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/user/layout.data.tsx
@@ -1,0 +1,15 @@
+function Profile() {
+  return <div>Profile Component</div>;
+}
+
+export const loader = async ({
+  request,
+}: {
+  request: Request;
+}) => {
+  const user = new Promise(resolve =>
+    setTimeout(() => resolve('John Doe'), 500),
+  );
+
+  return { user, Profile: <Profile /> };
+};

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/user/layout.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/user/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { Outlet } from '@modern-js/runtime/router';
+import { Suspense } from 'react';
+import UserData from './UserData';
+
+export default function UserLayout({ loaderData }: { loaderData: any }) {
+  const { user, Profile } = loaderData;
+  return (
+    <div className="user-layout">
+      user layout
+      {Profile}
+      <Suspense fallback={<div>Loading...</div>}>
+        <UserData userData={user} />
+      </Suspense>
+      <Outlet />
+    </div>
+  );
+}

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/user/page.data.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/user/page.data.tsx
@@ -1,0 +1,11 @@
+export const loader = async ({
+  request,
+}: {
+  request: Request;
+}) => {
+  const user = new Promise(resolve =>
+    setTimeout(() => resolve('user page data'), 1000),
+  );
+
+  return { user };
+};

--- a/tests/integration/rsc-ssr-routes/src/loader/routes/user/page.tsx
+++ b/tests/integration/rsc-ssr-routes/src/loader/routes/user/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import UserData from './UserData';
+
+export default function UserPage({
+  loaderData,
+  matches,
+}: { loaderData: any; matches: any[] }) {
+  const { user } = loaderData;
+  return (
+    <div>
+      User page
+      <Suspense fallback={<div>Loading...</div>}>
+        <div className="user-page-data-container">
+          <UserData userData={user} />
+        </div>
+      </Suspense>
+    </div>
+  );
+}

--- a/tests/integration/rsc-ssr-routes/src/modern-app-env.d.ts
+++ b/tests/integration/rsc-ssr-routes/src/modern-app-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types='@modern-js/app-tools/types' />
+/// <reference types='@modern-js/runtime/types/router' />
+/// <reference types='@modern-js/plugin-garfish/type' />
+/// <reference types='@modern-js/plugin-express/types' />
+/// <reference types='@modern-js/plugin-koa/types' />
+/// <reference types="react/canary" />
+/// <reference types="react-dom/canary" />

--- a/tests/integration/rsc-ssr-routes/tests/index.test.ts
+++ b/tests/integration/rsc-ssr-routes/tests/index.test.ts
@@ -1,0 +1,289 @@
+import path from 'path';
+import { isVersionAtLeast18 } from '@modern-js/utils';
+import type { Browser, Page } from 'puppeteer';
+import puppeteer from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchApp,
+  launchOptions,
+  modernBuild,
+  modernServe,
+} from '../../../utils/modernTestUtils';
+
+const appDir = path.resolve(__dirname, '../');
+
+interface TestConfig {
+  bundler: 'webpack' | 'rspack';
+  mode: 'dev' | 'build';
+}
+
+interface TestOptions {
+  baseUrl: string;
+  appPort: number;
+  page: Page;
+}
+
+async function verifyUserPageElements(page: Page) {
+  const elementsToCheck = [
+    { name: 'root layout', selector: 'body' },
+    { name: 'user layout', selector: '.user-layout' },
+    { name: 'Profile Component', selector: '.user-layout' },
+    { name: 'John Doe', selector: '.user-layout' },
+    { name: 'user page data', selector: '.user-layout' },
+  ];
+
+  for (const { name, selector } of elementsToCheck) {
+    const elementExists = await page.$eval(
+      selector,
+      (el, name) => {
+        return el.textContent?.includes(name);
+      },
+      name,
+    );
+    expect(elementExists).toBe(true);
+  }
+}
+
+function skipForLowerNodeVersion() {
+  if (!isVersionAtLeast18()) {
+    test('should skip in lower node version', () => {
+      expect(true).toBe(true);
+    });
+    return true;
+  }
+  return false;
+}
+
+function runTests({ bundler, mode }: TestConfig) {
+  describe(`${mode} with ${bundler}`, () => {
+    let app: any;
+    let appPort: number;
+    let page: Page;
+    let browser: Browser;
+    const errors: string[] = [];
+
+    if (skipForLowerNodeVersion()) {
+      return;
+    }
+
+    beforeAll(async () => {
+      appPort = await getPort();
+
+      if (mode === 'dev') {
+        app = await launchApp(
+          appDir,
+          appPort,
+          {},
+          {
+            BUNDLER: bundler,
+          },
+        );
+      } else {
+        await modernBuild(appDir, [], {
+          env: {
+            BUNDLER: bundler,
+          },
+        });
+        app = await modernServe(appDir, appPort, {
+          cwd: appDir,
+        });
+      }
+
+      browser = await puppeteer.launch(launchOptions as any);
+      page = await browser.newPage();
+
+      if (mode === 'build') {
+        page.on('pageerror', error => {
+          errors.push(error.message);
+        });
+      }
+    });
+
+    afterAll(async () => {
+      await killApp(app);
+      await page.close();
+      await browser.close();
+    });
+
+    describe('ssr-rsc-routes-with-loader', () => {
+      const baseUrl = `/loader`;
+
+      it('support route as server component and client component', () =>
+        supportRouteAsServerComponent({ baseUrl, appPort, page }));
+
+      it('support route as client component and navigation', () =>
+        suppportRouteAsClientComponentAndNavigation({
+          baseUrl,
+          appPort,
+          page,
+        }));
+
+      it('support direct redirect navigation', () =>
+        supportDirectRedirectNavigation({ baseUrl, appPort, page }));
+
+      it('support redirect on first screen load', () =>
+        supportRedirectOnFirstScreenLoad({ baseUrl, appPort, page }));
+
+      it('support client loader', () =>
+        supportClientLoader({ baseUrl, appPort, page }));
+
+      it('support pass matches to server component', () =>
+        supportMatchRoute({ baseUrl, appPort, page }));
+    });
+
+    describe('ssr-rsc-routes-with-fetch', () => {
+      const baseUrl = `/component`;
+
+      it('should render with fetch correctly', () =>
+        shouldRenderWithFetchCorrectly({ baseUrl, appPort, page }));
+    });
+  });
+}
+
+async function suppportRouteAsClientComponentAndNavigation({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+  const elementsToCheck = [
+    { name: 'root layout', selector: 'body' },
+    { name: 'root page from server', selector: '.root-page' },
+  ];
+
+  for (const { name, selector } of elementsToCheck) {
+    const elementExists = await page.$eval(
+      selector,
+      (el, name) => {
+        return el.textContent?.includes(name);
+      },
+      name,
+    );
+    expect(elementExists).toBe(true);
+  }
+
+  await page.click('.user-link');
+
+  await page.waitForSelector('.user-page-data-container');
+  await verifyUserPageElements(page);
+}
+
+async function supportRouteAsServerComponent({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}/user`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+  await page.waitForSelector('.user-page-data-container');
+  await verifyUserPageElements(page);
+}
+
+async function supportDirectRedirectNavigation({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  const rootLayoutExists = await page.$eval('.root-layout', el =>
+    el.textContent?.includes('root layout'),
+  );
+  expect(rootLayoutExists).toBe(true);
+
+  await page.click('.redirect-link');
+
+  await page.waitForSelector('.user-page-data-container', { timeout: 5000 });
+  await verifyUserPageElements(page);
+
+  const currentUrl = page.url();
+  expect(currentUrl).toContain('/user');
+}
+
+async function supportRedirectOnFirstScreenLoad({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}/redirect`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  await page.waitForSelector('.user-page-data-container', { timeout: 5000 });
+  await verifyUserPageElements(page);
+
+  const currentUrl = page.url();
+  expect(currentUrl).toContain('/user');
+  expect(currentUrl).not.toContain('/redirect');
+}
+
+async function supportClientLoader({ baseUrl, appPort, page }: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}/user`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  await page.click('.home-link');
+
+  await page.waitForSelector('.root-page', { timeout: 5000 });
+
+  const elementsToCheck = [
+    { name: 'root layout', selector: 'body' },
+    { name: 'root page from client', selector: '.root-page' },
+  ];
+
+  for (const { name, selector } of elementsToCheck) {
+    const elementExists = await page.$eval(
+      selector,
+      (el, name) => {
+        return el.textContent?.includes(name);
+      },
+      name,
+    );
+    expect(elementExists).toBe(true);
+  }
+}
+
+async function supportMatchRoute({ baseUrl, appPort, page }: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}/match/123`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  await page.waitForSelector('.matched', { timeout: 2000 });
+  const matched = await page.$eval('.matched', el => el.textContent);
+  expect(matched).toBe('Matched');
+}
+
+async function shouldRenderWithFetchCorrectly({
+  baseUrl,
+  appPort,
+  page,
+}: TestOptions) {
+  await page.goto(`http://localhost:${appPort}${baseUrl}`, {
+    waitUntil: ['networkidle0', 'domcontentloaded'],
+  });
+
+  await page.waitForSelector('.message', { timeout: 5000 });
+  const message = await page.$eval('.message', el => el.textContent);
+  expect(message).toBe('root page from server');
+
+  await page.click('.user-link');
+  await page.waitForSelector('.user-data', { timeout: 5000 });
+  const userData = await page.$eval('.user-data', el => el.textContent);
+  expect(userData).toBe('user data from server');
+
+  await page.click('.home-link');
+  await page.waitForSelector('.message', { timeout: 5000 });
+  const message2 = await page.$eval('.message', el => el.textContent);
+  expect(message2).toBe('root page from server');
+}
+
+runTests({ bundler: 'rspack', mode: 'dev' });
+runTests({ bundler: 'rspack', mode: 'build' });
+runTests({ bundler: 'webpack', mode: 'dev' });
+runTests({ bundler: 'webpack', mode: 'build' });

--- a/tests/integration/rsc-ssr-routes/tests/tsconfig.json
+++ b/tests/integration/rsc-ssr-routes/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "paths": {},
+    "types": ["node", "jest"]
+  }
+}

--- a/tests/integration/rsc-ssr-routes/tsconfig.json
+++ b/tests/integration/rsc-ssr-routes/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "shared", "config"]
+}


### PR DESCRIPTION
## Summary

This PR adds React Server Component(RSC) support for Single Page Applications (SPAs) in Modern.js，
This is the first version, which mainly supports rendering and navigation, but does not support all the capabilities we anticipated.

### Build

- Refactored the build process for module-to-entry relationships to resolve edge cases and improve performance
Enhanced build efficiency and stability across different project structures
- Added support for compiling client components exported as CommonJS modules
- Added support for plugin-router-v7 using the project's react-router, because the official version of react-router v7 has not yet exposed the API required by RSC

### Runtime

1. The main changes are in entry, `requestHandler.tsx`, `plugin.node.tsx`, `plugin.tsx`, `rsc-router.tsx`
> Encapsulate the relevant functions of RSC in the `rsc-router.tsx` file as much as possible for easy maintenance and reading. Because react-router v6 and react18 lack some types required for rsc, there will be more `any` types in `rsc-router.tsx`, but this also avoids more any types in other files.

2. The export of router is divided into user-oriented API and internal API, user-oriented API can be imported in client component and server component，Mainly in `router/runtime/index.tsx` 和 `router/runtime/internal.tsx`.

### Server

Modify `renderRscHandler` to support both RSC scenes with a router and RSC scenes without a router.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
