### PR TITLE
feat: support output modern config when calling `modern inspect`

### DIFF
--- a/.changeset/dry-donkeys-stay.md
+++ b/.changeset/dry-donkeys-stay.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat: support output modern config when calling inspectConfig
+
+feat: 当 inspectConfig 调用时，支持输出 modern 配置

--- a/.changeset/dry-donkeys-stay.md
+++ b/.changeset/dry-donkeys-stay.md
@@ -2,6 +2,6 @@
 '@modern-js/app-tools': patch
 ---
 
-feat: support output modern config when calling inspectConfig
+feat: support output Modern.js config when calling inspectConfig
 
-feat: 当 inspectConfig 调用时，支持输出 modern 配置
+feat: 当 inspectConfig 调用时，支持输出 Modern.js 配置

--- a/.changeset/dry-donkeys-stay.md
+++ b/.changeset/dry-donkeys-stay.md
@@ -2,6 +2,6 @@
 '@modern-js/app-tools': patch
 ---
 
-feat: support output Modern.js config when calling inspectConfig
+feat: support output Modern.js config when calling `modern inspect`
 
-feat: 当 inspectConfig 调用时，支持输出 Modern.js 配置
+feat: 当 `modern inspect` 命令调用时，支持输出 Modern.js 配置

--- a/packages/document/main-doc/docs/en/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/commands.mdx
@@ -190,7 +190,7 @@ Options:
 
 After executing the command `npx modern inspect` in the project root directory, the following files will be generated in the `dist` directory of the project:
 
-- `modern-js.config.mjs`:The Modern.js configuration currently used.
+- `modern.js.config.mjs`:The Modern.js configuration currently used.
 - `rsbuild.config.mjs`: The Rsbuild config to use at build time.
 - `webpack.config.web.mjs`: The webpack config used by to use at build time.
 
@@ -201,6 +201,7 @@ Inspect config succeed, open following files to view the content:
 
   - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
   - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
+  - Modern.js Config: /root/my-project/dist/modern.js.config.mjs
 ```
 
 ### Configuration Env
@@ -231,7 +232,7 @@ Inspect config succeed, open following files to view the content:
   - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
   - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
   - Webpack Config (node): /root/my-project/dist/webpack.config.node.mjs
-  - Modern-js Config: /root/my-project/dist/modern-js.config.mjs
+  - Modern.js Config: /root/my-project/dist/modern.js.config.mjs
 ```
 
 import DeployCommand from '@site-docs-en/components/deploy-command';

--- a/packages/document/main-doc/docs/en/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/en/apis/app/commands.mdx
@@ -175,7 +175,7 @@ Options:
 
 ## modern inspect
 
-The `modern inspect` command is used to view the [Rsbuild config](https://rsbuild.rs/config/index) and webpack or Rspack config of the project.
+The `modern inspect` command is used to view the Modern.js config, [Rsbuild config](https://rsbuild.rs/config/index) and webpack or Rspack config of the project.
 
 ```bash
 Usage: modern inspect [options]
@@ -190,6 +190,7 @@ Options:
 
 After executing the command `npx modern inspect` in the project root directory, the following files will be generated in the `dist` directory of the project:
 
+- `modern-js.config.mjs`:The Modern.js configuration currently used.
 - `rsbuild.config.mjs`: The Rsbuild config to use at build time.
 - `webpack.config.web.mjs`: The webpack config used by to use at build time.
 
@@ -230,6 +231,7 @@ Inspect config succeed, open following files to view the content:
   - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
   - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
   - Webpack Config (node): /root/my-project/dist/webpack.config.node.mjs
+  - Modern-js Config: /root/my-project/dist/modern-js.config.mjs
 ```
 
 import DeployCommand from '@site-docs-en/components/deploy-command';

--- a/packages/document/main-doc/docs/zh/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/commands.mdx
@@ -175,7 +175,7 @@ Options:
 
 ## modern inspect
 
-`modern inspect` 命令用于查看项目的 [Rsbuild 配置](https://rsbuild.rs/zh/config/index) 以及 webpack 或 Rspack 配置。
+`modern inspect` 命令用于查看项目的 Modern.js 配置、[Rsbuild 配置](https://rsbuild.rs/zh/config/index) 以及 webpack 或 Rspack 配置。
 
 ```bash
 Usage: modern inspect [options]
@@ -190,6 +190,7 @@ Options:
 
 在项目根目录下执行命令 `npx modern inspect` 后，会在项目的 `dist` 目录生成以下文件：
 
+- `modern-js.config.mjs`: 表示当前使用的 Modern.js 配置。
 - `rsbuild.config.mjs`: 表示在构建时使用的 Rsbuild 配置。
 - `webpack.config.web.mjs`: 表示在构建时使用的 webpack 配置。
 
@@ -200,6 +201,7 @@ Inspect config succeed, open following files to view the content:
 
   - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
   - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
+  - Modern-js Config: /root/my-project/dist/modern-js.config.mjs
 ```
 
 ### 指定环境
@@ -230,6 +232,7 @@ Inspect config succeed, open following files to view the content:
   - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
   - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
   - Webpack Config (node): /root/my-project/dist/webpack.config.node.mjs
+  - Modern-js Config: /root/my-project/dist/modern-js.config.mjs
 ```
 
 import DeployCommand from '@site-docs/components/deploy-command';

--- a/packages/document/main-doc/docs/zh/apis/app/commands.mdx
+++ b/packages/document/main-doc/docs/zh/apis/app/commands.mdx
@@ -190,7 +190,7 @@ Options:
 
 在项目根目录下执行命令 `npx modern inspect` 后，会在项目的 `dist` 目录生成以下文件：
 
-- `modern-js.config.mjs`: 表示当前使用的 Modern.js 配置。
+- `modern.js.config.mjs`: 表示当前使用的 Modern.js 配置。
 - `rsbuild.config.mjs`: 表示在构建时使用的 Rsbuild 配置。
 - `webpack.config.web.mjs`: 表示在构建时使用的 webpack 配置。
 
@@ -201,7 +201,7 @@ Inspect config succeed, open following files to view the content:
 
   - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
   - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
-  - Modern-js Config: /root/my-project/dist/modern-js.config.mjs
+  - Modern.js Config: /root/my-project/dist/modern.js.config.mjs
 ```
 
 ### 指定环境
@@ -232,7 +232,7 @@ Inspect config succeed, open following files to view the content:
   - Rsbuild Config: /root/my-project/dist/rsbuild.config.mjs
   - Webpack Config (web): /root/my-project/dist/webpack.config.web.mjs
   - Webpack Config (node): /root/my-project/dist/webpack.config.node.mjs
-  - Modern-js Config: /root/my-project/dist/modern-js.config.mjs
+  - Modern.js Config: /root/my-project/dist/modern.js.config.mjs
 ```
 
 import DeployCommand from '@site-docs/components/deploy-command';

--- a/packages/solutions/app-tools/src/commands/inspect.ts
+++ b/packages/solutions/app-tools/src/commands/inspect.ts
@@ -13,13 +13,16 @@ export const inspect = async (
       'Expect the Builder to have been initialized, But the appContext.builder received `undefined`',
     );
   }
+  const metaName =
+    appContext.metaName === 'modern-js' ? 'modern.js' : appContext.metaName;
+
   return appContext.builder.inspectConfig({
     mode: options.env as RsbuildMode,
     verbose: options.verbose,
     outputPath: options.output,
     writeToDisk: true,
     extraConfigs: {
-      [appContext.metaName]: api.getNormalizedConfig(),
+      [metaName]: api.getNormalizedConfig(),
     },
   });
 };

--- a/packages/solutions/app-tools/src/commands/inspect.ts
+++ b/packages/solutions/app-tools/src/commands/inspect.ts
@@ -18,5 +18,8 @@ export const inspect = async (
     verbose: options.verbose,
     outputPath: options.output,
     writeToDisk: true,
+    extraConfigs: {
+      [appContext.metaName]: api.getNormalizedConfig(),
+    },
   });
 };


### PR DESCRIPTION
## Summary

support output modern config when calling `modern inspect`

<img width="900" alt="image" src="https://github.com/user-attachments/assets/67c2fc62-8283-4a2f-938b-69cd0df31b86" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
