### PR TITLE
chore(CI): run builder E2E cases on pull request

### DIFF
--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -1,14 +1,11 @@
 name: E2E Test (Builder)
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on pull request events but only for the main branch
   pull_request:
     branches: [main]
 
   merge_group:
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright
-        run: node packages/toolkit/e2e/node_modules/@playwright/test/cli.js install chrome
+        run: node packages/toolkit/e2e/node_modules/@playwright/test/cli.js install
 
       - name: Test
         run: cd ./tests/e2e/builder && pnpm run test

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -1,9 +1,14 @@
 name: E2E Test (Builder)
 
+# Controls when the action will run.
 on:
-  push:
-    branches: [main, renovate/main-rsbuild]
+  # Triggers the workflow on pull request events but only for the main branch
+  pull_request:
+    branches: [main]
 
+  merge_group:
+
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -18,16 +18,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Nx Cache
-        id: nx-cache
-        uses: actions/cache@v3
-        with:
-          path: .nx/cache
-          key: nx-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            nx-${{ github.ref_name }}-
-            nx-
-
       - name: Install Pnpm
         run: npm i -g --force corepack && corepack enable
 
@@ -41,7 +31,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright
-        run: node packages/toolkit/e2e/node_modules/@playwright/test/cli.js install
+        run: node packages/toolkit/e2e/node_modules/@playwright/test/cli.js install chrome
 
       - name: Test
         run: cd ./tests/e2e/builder && pnpm run test

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -18,6 +18,16 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Nx Cache
+        id: nx-cache
+        uses: actions/cache@v3
+        with:
+          path: .nx/cache
+          key: nx-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ github.ref_name }}-
+            nx-
+
       - name: Install Pnpm
         run: npm i -g --force corepack && corepack enable
 


### PR DESCRIPTION
## Summary

The builder E2E cases all much faster since https://github.com/web-infra-dev/modern.js/pull/7352. So we can run the CI on pull request to detect builder related failure cases early.

Currently, the Nx cache is the slowest part of the workflow, but I believe it is possible to optimize dependencies and speed up the workflow:

<img width="2258" height="1066" alt="image" src="https://github.com/user-attachments/assets/39ba4dcf-4764-4790-b200-b60e4a93b059" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
