### PR TITLE
feat(bff): should not compress the api response

### DIFF
--- a/.changeset/cool-numbers-laugh.md
+++ b/.changeset/cool-numbers-laugh.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/plugin-bff': patch
+---
+
+feat(bff):should not compress the api response
+feat(bff): 不应该压缩 bff 的响应

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from 'http';
 import path from 'path';
 import type { AppTools, CliPlugin } from '@modern-js/app-tools';
 import { ApiRouter } from '@modern-js/bff-core';
@@ -143,6 +144,25 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
         const honoRuntimePath = isHono()
           ? { [RUNTIME_HONO]: RUNTIME_HONO }
           : undefined;
+
+        const devServer = api.useConfigContext()?.tools?.devServer;
+        const prefix =
+          api.useConfigContext()?.bff?.prefix || DEFAULT_API_PREFIX;
+
+        if (
+          typeof devServer === 'object' &&
+          devServer !== null &&
+          !Array.isArray(devServer)
+        ) {
+          const compress = devServer.compress;
+          if (typeof compress === 'undefined' || compress === true) {
+            devServer.compress = {
+              filter: (req: IncomingMessage) => {
+                return !req.url?.includes(prefix);
+              },
+            };
+          }
+        }
 
         return {
           tools: {


### PR DESCRIPTION
## Summary

When the streaming response is returned, if it is compressed, the streaming fails, here we make the bff's response not to be streamed.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
