### PR TITLE
fix: use require to import runtime-utils/router

### DIFF
--- a/packages/cli/plugin-data-loader/src/runtime/errors.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/errors.ts
@@ -11,8 +11,8 @@
 import type {
   ErrorResponse,
   StaticHandlerContext,
-} from '@modern-js/runtime-utils/remix-router';
-import { isRouteErrorResponse } from '@modern-js/runtime-utils/remix-router';
+} from '@modern-js/runtime-utils/router';
+import { isRouteErrorResponse } from '@modern-js/runtime-utils/router';
 
 /**
  * This thing probably warrants some explanation.

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -9,7 +9,7 @@ import {
   DEFERRED_SYMBOL,
   createStaticHandler,
   isRouteErrorResponse,
-} from '@modern-js/runtime-utils/remix-router';
+} from '@modern-js/runtime-utils/router';
 import { matchEntry } from '@modern-js/runtime-utils/server';
 import { time } from '@modern-js/runtime-utils/time';
 import { parseHeaders } from '@modern-js/runtime-utils/universal/request';

--- a/packages/runtime/plugin-runtime/src/core/context/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/index.ts
@@ -1,5 +1,5 @@
 import type { InternalRuntimeContext } from '@modern-js/plugin';
-import type { RouterState } from '@modern-js/runtime-utils/remix-router';
+import type { RouterState } from '@modern-js/runtime-utils/router';
 import type { NestedRoute, PageRoute } from '@modern-js/types';
 import type React from 'react';
 import type { AppConfig } from '../../common';

--- a/packages/runtime/plugin-runtime/src/core/context/runtime.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/runtime.ts
@@ -1,4 +1,4 @@
-import type { StaticHandlerContext } from '@modern-js/runtime-utils/remix-router';
+import type { StaticHandlerContext } from '@modern-js/runtime-utils/router';
 import type { RouteObject } from '@modern-js/runtime-utils/router';
 import { ROUTE_MANIFEST } from '@modern-js/utils/universal/constants';
 import { createContext, useContext, useMemo } from 'react';

--- a/packages/runtime/plugin-runtime/src/core/server/string/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/string/index.ts
@@ -1,4 +1,4 @@
-import type { StaticHandlerContext } from '@modern-js/runtime-utils/remix-router';
+import type { StaticHandlerContext } from '@modern-js/runtime-utils/router';
 import { time } from '@modern-js/runtime-utils/time';
 import type React from 'react';
 import ReactDomServer from 'react-dom/server';

--- a/packages/runtime/plugin-runtime/src/core/server/string/ssrData.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/string/ssrData.ts
@@ -1,6 +1,6 @@
 import type { IncomingHttpHeaders } from 'http';
 import { serializeJson } from '@modern-js/runtime-utils/node';
-import type { StaticHandlerContext } from '@modern-js/runtime-utils/remix-router';
+import type { StaticHandlerContext } from '@modern-js/runtime-utils/router';
 import type { HeadersData } from '@modern-js/runtime-utils/universal/request';
 import { ROUTER_DATA_JSON_ID, SSR_DATA_JSON_ID } from '../../constants';
 import type { SSRContainer, SSRServerContext } from '../../types';

--- a/packages/runtime/plugin-runtime/src/core/server/utils.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/utils.ts
@@ -2,7 +2,7 @@ import type { ServerUserConfig } from '@modern-js/app-tools';
 import {
   type StaticHandlerContext,
   isRouteErrorResponse,
-} from '@modern-js/runtime-utils/remix-router';
+} from '@modern-js/runtime-utils/router';
 import type { SSRConfig } from './shared';
 
 export function attributesToString(attributes: Record<string, any>) {

--- a/packages/runtime/plugin-runtime/src/router/runtime/DeferredDataScripts.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/DeferredDataScripts.node.tsx
@@ -1,7 +1,7 @@
 import type { DeferredData } from '@modern-js/runtime-utils/browser';
 import type { TrackedPromise } from '@modern-js/runtime-utils/browser';
 import { serializeJson, storage } from '@modern-js/runtime-utils/node';
-import type { StaticHandlerContext } from '@modern-js/runtime-utils/remix-router';
+import type { StaticHandlerContext } from '@modern-js/runtime-utils/router';
 import { Await, useAsyncError } from '@modern-js/runtime-utils/router';
 import { type JSX, Suspense, useEffect, useMemo, useRef } from 'react';
 import { ROUTER_DATA_JSON_ID } from '../../core/constants';

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -3,7 +3,7 @@ import {
   createRequestContext,
   reporterCtx,
 } from '@modern-js/runtime-utils/node';
-import { createStaticHandler } from '@modern-js/runtime-utils/remix-router';
+import { createStaticHandler } from '@modern-js/runtime-utils/router';
 import {
   StaticRouterProvider,
   createStaticRouter,

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -1,6 +1,6 @@
 import type { RuntimePluginAPI } from '@modern-js/plugin/runtime';
 import { merge } from '@modern-js/runtime-utils/merge';
-import type { RouterSubscriber } from '@modern-js/runtime-utils/remix-router';
+import type { RouterSubscriber } from '@modern-js/runtime-utils/router';
 import {
   type RouteObject,
   RouterProvider,

--- a/packages/runtime/plugin-runtime/src/router/runtime/routeModule.ts
+++ b/packages/runtime/plugin-runtime/src/router/runtime/routeModule.ts
@@ -1,5 +1,5 @@
 import type Module from 'module';
-import type { ShouldRevalidateFunction } from '@modern-js/runtime-utils/remix-router';
+import type { ShouldRevalidateFunction } from '@modern-js/runtime-utils/router';
 import { ROUTE_MODULES } from '@modern-js/utils/universal/constants';
 
 export const createShouldRevalidate = (

--- a/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/utils.tsx
@@ -2,7 +2,7 @@ import { renderNestedRoute } from '@modern-js/runtime-utils/browser';
 import {
   UNSAFE_ErrorResponseImpl as ErrorResponseImpl,
   type StaticHandlerContext,
-} from '@modern-js/runtime-utils/remix-router';
+} from '@modern-js/runtime-utils/router';
 import type { DataRouter } from '@modern-js/runtime-utils/router';
 import {
   Route,

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -1,4 +1,3 @@
-import type { IncomingMessage } from 'http';
 import type { ServerRoute } from '@modern-js/types';
 import type { NodeRequest } from '@modern-js/types/server';
 import { cutNameByHyphen } from '@modern-js/utils/universal';
@@ -303,11 +302,7 @@ async function renderHandler(
     const routes = nestedRoutesJson?.[options.routeInfo.entryName!];
 
     if (routes) {
-      const urlPath = 'node:url';
-      const { pathToFileURL } = await import(urlPath);
-      const { matchRoutes } = await import(
-        pathToFileURL(require.resolve('@modern-js/runtime-utils/router')).href
-      );
+      const { matchRoutes } = require('@modern-js/runtime-utils/router');
 
       const url = new URL(request.url);
       const matchedRoutes = matchRoutes(

--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -30,12 +30,6 @@
       "require": "./dist/cjs/rsc.js",
       "default": "./dist/esm/rsc.js"
     },
-    "./remix-router": {
-      "types": "./dist/types/remixRouter.d.ts",
-      "jsnext:source": "./src/remixRouter.ts",
-      "require": "./dist/cjs/remixRouter.js",
-      "default": "./dist/esm/remixRouter.js"
-    },
     "./browser": {
       "types": "./dist/types/browser/index.d.ts",
       "jsnext:source": "./src/browser/index.ts",

--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -112,11 +112,6 @@
         "require": "./dist/cjs/rsc.js",
         "default": "./dist/esm/rsc.js"
       },
-      "./remix-router": {
-        "types": "./dist/types/remixRouter.d.ts",
-        "require": "./dist/cjs/remixRouter.js",
-        "default": "./dist/esm/remixRouter.js"
-      },
       "./browser": {
         "types": "./dist/types/browser/index.d.ts",
         "require": "./dist/cjs/browser/index.js",
@@ -181,9 +176,6 @@
       ],
       "router/rsc": [
         "./dist/types/rsc.d.ts"
-      ],
-      "remix-router": [
-        "./dist/types/remixRouter.d.ts"
       ],
       "browser": [
         "./dist/types/browser/index.d.ts"

--- a/packages/toolkit/runtime-utils/src/router.ts
+++ b/packages/toolkit/runtime-utils/src/router.ts
@@ -1,4 +1,5 @@
 export * from 'react-router';
+export const DEFERRED_SYMBOL = Symbol('deferred');
 /** @deprecated Please use Response.json instead. */
 export const json = (data: any, init?: number | ResponseInit): Response => {
   const responseInit = init


### PR DESCRIPTION
## Summary
This PR does two things:
1. Use `require` to import `runtime-utils/router` to avoid the interoperability issue between cjs and esm in node 22 and above.

2. Remove the `remix-router` export.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
