### PR TITLE
fix: replace second param can be see as pattern replace

### DIFF
--- a/.changeset/bitter-cars-drive.md
+++ b/.changeset/bitter-cars-drive.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: replace should use function as second param in case not be a pattern replace
+fix: replace 应该使用函数，防止成为模式替换

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -37,7 +37,7 @@ import {
   TOP_PARTICALS_SEPARATOR,
 } from '../constants';
 
-const debug = createDebugger('html_genarate');
+const debug = createDebugger('html_generate');
 
 // get the entry document file,
 // if not exist, fallback to src/
@@ -209,9 +209,12 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
         }
 
         html = html
-          .replace(TOP_PARTICALS_SEPARATOR, partialsContent.partialsTop)
-          .replace(HEAD_PARTICALS_SEPARATOR, partialsContent.partialsHead)
-          .replace(BODY_PARTICALS_SEPARATOR, partialsContent.partialsBody);
+          .replace(TOP_PARTICALS_SEPARATOR, () => partialsContent.partialsTop)
+          .replace(HEAD_PARTICALS_SEPARATOR, () => partialsContent.partialsHead)
+          .replace(
+            BODY_PARTICALS_SEPARATOR,
+            () => partialsContent.partialsBody,
+          );
 
         const links = [
           htmlWebpackPlugin.tags.headTags
@@ -284,19 +287,19 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
 
         // replace the html placeholder while transfer string to jsx component is not a easy way
         const finalHtml = `<!DOCTYPE html>${html}`
-          .replace(DOCUMENT_META_PLACEHOLDER, metas)
-          .replace(DOCUMENT_SSR_PLACEHOLDER, HTML_SEPARATOR)
-          .replace(DOCUMENT_SCRIPTS_PLACEHOLDER, scripts)
-          .replace(DOCUMENT_LINKS_PLACEHOLDER, links)
+          .replace(DOCUMENT_META_PLACEHOLDER, () => metas)
+          .replace(DOCUMENT_SSR_PLACEHOLDER, () => HTML_SEPARATOR)
+          .replace(DOCUMENT_SCRIPTS_PLACEHOLDER, () => scripts)
+          .replace(DOCUMENT_LINKS_PLACEHOLDER, () => links)
           .replace(
             DOCUMENT_CHUNKSMAP_PLACEHOLDER,
-            PLACEHOLDER_REPLACER_MAP[DOCUMENT_CHUNKSMAP_PLACEHOLDER],
+            () => PLACEHOLDER_REPLACER_MAP[DOCUMENT_CHUNKSMAP_PLACEHOLDER],
           )
           .replace(
             DOCUMENT_SSRDATASCRIPT_PLACEHOLDER,
-            PLACEHOLDER_REPLACER_MAP[DOCUMENT_SSRDATASCRIPT_PLACEHOLDER],
+            () => PLACEHOLDER_REPLACER_MAP[DOCUMENT_SSRDATASCRIPT_PLACEHOLDER],
           )
-          .replace(DOCUMENT_TITLE_PLACEHOLDER, titles);
+          .replace(DOCUMENT_TITLE_PLACEHOLDER, () => titles);
         return finalHtml;
       };
     };


### PR DESCRIPTION
## Summary
<img width="816" height="122" alt="image" src="https://github.com/user-attachments/assets/5b7a31c6-d697-48ad-ac5b-8a1cb63fde94" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
