### PR TITLE
feat: req support node 24

### DIFF
--- a/.changeset/young-comics-drive.md
+++ b/.changeset/young-comics-drive.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+feat: hono bff req support node 24
+feat: hono bff req 支持 node 24


### PR DESCRIPTION
## Summary

#7448

In node24, undici has added strict access restrictions to the private field #state of the Response object. Accessing it indirectly through a Proxy object will trigger a TypeError: Cannot read private member #state.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
