### PR TITLE
fix: netlify server missed the hono middleware features

### DIFF
--- a/.changeset/whole-parents-love.md
+++ b/.changeset/whole-parents-love.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/prod-server': patch
+---
+
+fix: netlify deployment missed the latest Hono middleware capabilities
+fix: 修复 netlify 部署时丢失了最新的 Hono 中间件能力的问题

--- a/packages/server/prod-server/src/netlify.ts
+++ b/packages/server/prod-server/src/netlify.ts
@@ -10,6 +10,8 @@ import type { BaseEnv, ProdServerOptions } from './types';
 export type { ProdServerOptions, BaseEnv } from './types';
 
 export const createNetlifyFunction = async (options: ProdServerOptions) => {
+  await loadServerEnv(options);
+
   const serverBaseOptions = options;
 
   const serverCliConfig = loadServerCliConfig(options.pwd, options.config);
@@ -26,6 +28,7 @@ export const createNetlifyFunction = async (options: ProdServerOptions) => {
   );
 
   if (serverRuntimeConfig) {
+    serverBaseOptions.serverConfig = serverRuntimeConfig;
     serverBaseOptions.plugins = [
       ...(serverRuntimeConfig.plugins || []),
       ...(options.plugins || []),
@@ -33,7 +36,6 @@ export const createNetlifyFunction = async (options: ProdServerOptions) => {
   }
   const server = createServerBase<BaseEnv>(serverBaseOptions);
 
-  await loadServerEnv(options);
   await applyPlugins(server, options);
   await server.init();
   return (request: Request, context: unknown) => {

--- a/tests/integration/server-config-v2/netlify.toml
+++ b/tests/integration/server-config-v2/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "dist"
+  command = "modern deploy"
+
+[functions]
+  directory = ".netlify/functions"
+  node_bundler = "none"
+  included_files = [".netlify/functions/**"]


### PR DESCRIPTION
## Summary

#7453 

Netlify did not follow the unified `createProdServer` due to some special reasons, missing support for Hono Middleware, which is fixed in this PR.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
