### PR TITLE
fix: update setupMiddleware type in modern.js

### DIFF
--- a/packages/cli/builder/src/types.ts
+++ b/packages/cli/builder/src/types.ts
@@ -278,7 +278,7 @@ export type DistPath = DistPathConfig & {
 };
 
 export type BuilderConfig = {
-  dev?: RsbuildConfig['dev'];
+  dev?: Omit<DevConfig, 'setupMiddlewares'>;
   html?: Omit<HtmlConfig, 'appIcon'>;
   output?: Omit<OutputConfig, 'polyfill' | 'distPath'> & {
     polyfill?: Polyfill | 'ua';

--- a/packages/solutions/app-tools/src/builder/generator/index.ts
+++ b/packages/solutions/app-tools/src/builder/generator/index.ts
@@ -43,7 +43,7 @@ export async function generateBuilder(
     internalDirectory: appContext.internalDirectory,
     frameworkConfigPath: appContext.configFile || undefined,
     bundlerType,
-    config: builderConfig as any,
+    config: builderConfig,
   });
 
   await applyBuilderPlugins(builder, options);

--- a/packages/solutions/app-tools/src/types/config/dev.ts
+++ b/packages/solutions/app-tools/src/types/config/dev.ts
@@ -1,9 +1,17 @@
 import type { BuilderConfig } from '@modern-js/builder';
+import type { SetupMiddlewares } from '@modern-js/server';
 
-type BuilderDevConfig = Required<BuilderConfig>['dev'];
+type BuilderDevConfig = Omit<
+  Required<BuilderConfig>['dev'],
+  'setupMiddlewares'
+>;
 
 export type DevProxyOptions = string | Record<string, string>;
 
+/**
+ * setupMiddlewares is a special field, it will not be passed to Rsbuild.
+ * Although its name is the same as in Rsbuild, it is consumed by Modern.js.
+ */
 export interface DevUserConfig extends BuilderDevConfig {
-  setupMiddlewares?: any;
+  setupMiddlewares?: SetupMiddlewares;
 }


### PR DESCRIPTION
## Summary

`dev.setupMiddlewares` is a special field, it will not be passed to Rsbuild. Although its name is the same as in Rsbuild, it is consumed by Modern.js.

This PR separates the type of this field to prevent errors caused by updates to Rsbuild.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
