### PR TITLE
refactor: move serverPayload logic to a separate directory

### DIFF
--- a/packages/runtime/plugin-runtime/src/core/context/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/index.ts
@@ -75,7 +75,10 @@ interface GlobalContext {
 
 const globalContext: GlobalContext = {};
 
-export { getServerPayload, setServerPayload } from './serverPayload.server';
+export {
+  getServerPayload,
+  setServerPayload,
+} from './serverPayload/index';
 
 export function getGlobalIsRscClient() {
   return globalContext.isRscClient;

--- a/packages/runtime/plugin-runtime/src/core/context/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/context/index.ts
@@ -1,9 +1,9 @@
 import type { InternalRuntimeContext } from '@modern-js/plugin-v2';
-import type { RouterState } from '@modern-js/runtime-utils/remix-router';
 import type { NestedRoute, PageRoute } from '@modern-js/types';
 import type React from 'react';
 import type { AppConfig } from '../../common';
 import type { RuntimeExtends } from '../plugin/types';
+import type { ServerPayload } from './serverPayload/index';
 
 export {
   type RuntimeContext,
@@ -11,34 +11,7 @@ export {
   getInitialContext,
 } from './runtime';
 
-export type PayloadRoute = {
-  clientAction?: any;
-  clientLoader?: any;
-  element?: React.ReactNode;
-  errorElement?: React.ReactNode;
-  handle?: any;
-  hasAction: boolean;
-  hasErrorBoundary: boolean;
-  hasLoader: boolean;
-  id: string;
-  index?: boolean;
-  params: Record<string, string>;
-  parentId?: string;
-  path?: string;
-  pathname: string;
-  pathnameBase: string;
-  shouldRevalidate?: any;
-};
-
-export type ServerPayload = {
-  type: 'render';
-  actionData: RouterState['actionData'];
-  errors: RouterState['errors'];
-  loaderData: RouterState['loaderData'];
-  location: RouterState['location'];
-  routes: PayloadRoute[];
-  originalRoutes?: PayloadRoute[];
-};
+export type { ServerPayload, PayloadRoute } from './serverPayload/index';
 
 interface GlobalContext {
   entryName?: string;

--- a/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.server.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.server.tsx
@@ -1,5 +1,34 @@
 import { storage } from '@modern-js/runtime-utils/node';
-import type { ServerPayload } from '../index';
+import type { RouterState } from '@modern-js/runtime-utils/remix-router';
+
+export type PayloadRoute = {
+  clientAction?: any;
+  clientLoader?: any;
+  element?: React.ReactNode;
+  errorElement?: React.ReactNode;
+  handle?: any;
+  hasAction: boolean;
+  hasErrorBoundary: boolean;
+  hasLoader: boolean;
+  id: string;
+  index?: boolean;
+  params: Record<string, string>;
+  parentId?: string;
+  path?: string;
+  pathname: string;
+  pathnameBase: string;
+  shouldRevalidate?: any;
+};
+
+export type ServerPayload = {
+  type: 'render';
+  actionData: RouterState['actionData'];
+  errors: RouterState['errors'];
+  loaderData: RouterState['loaderData'];
+  location: RouterState['location'];
+  routes: PayloadRoute[];
+  originalRoutes?: PayloadRoute[];
+};
 
 export const getServerPayload = (): ServerPayload | undefined => {
   const context = storage.useContext() as any;

--- a/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.server.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.server.tsx
@@ -1,5 +1,5 @@
 import { storage } from '@modern-js/runtime-utils/node';
-import type { ServerPayload } from './index';
+import type { ServerPayload } from '../index';
 
 export const getServerPayload = (): ServerPayload | undefined => {
   const context = storage.useContext() as any;

--- a/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.tsx
@@ -1,4 +1,5 @@
-import type { ServerPayload } from '../index';
+import type { PayloadRoute, ServerPayload } from './index.server';
+export type { ServerPayload, PayloadRoute };
 
 export const getServerPayload = (): ServerPayload | undefined => {
   return undefined;

--- a/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.tsx
+++ b/packages/runtime/plugin-runtime/src/core/context/serverPayload/index.tsx
@@ -1,0 +1,7 @@
+import type { ServerPayload } from '../index';
+
+export const getServerPayload = (): ServerPayload | undefined => {
+  return undefined;
+};
+
+export const setServerPayload = (payload: ServerPayload): void => {};

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
@@ -20,7 +20,7 @@ import {
   getGlobalRSCRoot,
 } from '../context';
 import { getInitialContext } from '../context/runtime';
-import { getServerPayload } from '../context/serverPayload.server';
+import { getServerPayload } from '../context/serverPayload/index';
 import { createLoaderManager } from '../loader/loaderManager';
 import { createRoot } from '../react';
 import type { SSRServerContext } from '../types';

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -25,7 +25,7 @@ import {
   getGlobalLayoutApp,
   getGlobalRoutes,
 } from '../../core/context';
-import { setServerPayload } from '../../core/context/serverPayload.server';
+import { setServerPayload } from '../../core/context/serverPayload/index.server';
 import DeferredDataScripts from './DeferredDataScripts.node';
 import {
   type RouterExtendsHooks,


### PR DESCRIPTION
## Summary

1. Move the logic of serverPayload to a separate directory and add a `serverPayload/index.ts` file to make the code clearer.
2. Note that the code worked fine before the changes, relying on `serverModuleLoader.ts`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
