### PR TITLE
fix: should not rely on renderLevel to execute renderToString

### DIFF
--- a/packages/runtime/plugin-runtime/src/core/server/string/index.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/string/index.ts
@@ -103,10 +103,8 @@ async function generateHtml(
   try {
     const end = time();
     // react render to string
-    if (chunkSet.renderLevel >= RenderLevel.SERVER_PREFETCH) {
-      html = ReactDomServer.renderToString(finalApp);
-      chunkSet.renderLevel = RenderLevel.SERVER_RENDER;
-    }
+    html = ReactDomServer.renderToString(finalApp);
+    chunkSet.renderLevel = RenderLevel.SERVER_RENDER;
     helmetData = ReactHelmet.renderStatic();
 
     const cost = end();


### PR DESCRIPTION
## Summary

Removed the logic of useLoader, so it is not necessary to determine whether to renderToString based on prefetch is successful.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
