### PR TITLE
fix: should get basename correctly

### DIFF
--- a/.changeset/beige-memes-relax.md
+++ b/.changeset/beige-memes-relax.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: should get basename correctly
+fix: 应该获取到正确的 basename

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.tsx
@@ -136,8 +136,12 @@ export const routerPlugin = (
           return App;
         }
 
-        const selectBasePath = (pathname: string) =>
-          serverBase.find(baseUrl => pathname.search(baseUrl) === 0) || '/';
+        const selectBasePath = (pathname: string) => {
+          const match = serverBase.find(baseUrl =>
+            isSegmentPrefix(pathname, baseUrl),
+          );
+          return match || '/';
+        };
 
         const RouterWrapper = (props: any) => {
           const { router, routes } = useRouterCreation(
@@ -196,6 +200,17 @@ const safeUse = (promise: Promise<unknown>) => {
   }
   return null;
 };
+
+function normalizeBase(b: string) {
+  if (b.length > 1 && b.endsWith('/')) return b.slice(0, -1);
+  return b || '/';
+}
+
+function isSegmentPrefix(pathname: string, base: string) {
+  const b = normalizeBase(base);
+  const p = pathname || '/';
+  return p === b || p.startsWith(`${b}/`);
+}
 
 function useRouterCreation(props: any, options: UseRouterCreationOptions) {
   const { api, createRoutes, supportHtml5History, selectBasePath, basename } =


### PR DESCRIPTION
## Summary

If `server.routes` is configured as follows：
```
server: {
    routes: {
      main: ['/shop', '/shop/us'],
    },
}
```
When accessing the `/shop/user` link, it will match the baseUrl `/shop/us`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
