### PR TITLE
fix: process should not exit caused when user abort the request

### DIFF
--- a/.changeset/clever-stars-stand.md
+++ b/.changeset/clever-stars-stand.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime-utils': patch
+'@modern-js/server-core': patch
+---
+
+fix: process should not exit caused when user abort the request in development
+fix: 开发阶段，进程不应该因为用户中止请求而退出

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -144,7 +144,7 @@ const handleResponseError = (e: unknown, res: NodeResponse) => {
   ) as Error & {
     code: string;
   };
-  if (err.code === 'ABORT_ERR') {
+  if (err.code === 'ABORT_ERR' || err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
     console.info('The user aborted a request.');
   } else {
     console.error(e);

--- a/packages/server/core/src/adapters/node/node.ts
+++ b/packages/server/core/src/adapters/node/node.ts
@@ -144,7 +144,7 @@ const handleResponseError = (e: unknown, res: NodeResponse) => {
   ) as Error & {
     code: string;
   };
-  if (err.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+  if (err.code === 'ABORT_ERR') {
     console.info('The user aborted a request.');
   } else {
     console.error(e);

--- a/packages/toolkit/runtime-utils/src/node/stream.ts
+++ b/packages/toolkit/runtime-utils/src/node/stream.ts
@@ -63,10 +63,12 @@ class StreamPump {
       this.stream.destroy(reason);
     }
 
-    this.stream.off('data', this.enqueue);
-    this.stream.off('error', this.error);
-    this.stream.off('end', this.close);
-    this.stream.off('close', this.close);
+    process.nextTick(() => {
+      this.stream.off('data', this.enqueue);
+      this.stream.off('error', this.error);
+      this.stream.off('end', this.close);
+      this.stream.off('close', this.close);
+    });
   }
 
   enqueue(chunk: Uint8Array | string) {


### PR DESCRIPTION
## Summary

This PR avoid the process exit when user abort the request.

1. The error judgment for `abort code` is incorrect.
2. When the stream is destroyed, Node.js will throw an error. The `error` listener should be removed in the nextTick,  otherwise, the error will not be caught.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
