### PR TITLE
fix: resolve tsconfig-path errors when using destructuring aliases

### DIFF
--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -58,6 +58,10 @@ export const build = async (
   const appContext = api.getAppContext();
   const hooks = api.getHooks();
 
+  const combinedAlias = ([] as unknown[])
+    .concat(resolvedConfig?.resolve?.alias ?? [])
+    .concat(resolvedConfig?.source?.alias ?? []) as ConfigChain<Alias>;
+
   // we need load server plugin to appContext for ssg & deploy commands.
   await loadServerPlugins(api, appContext.appDirectory, appContext.metaName);
 
@@ -66,17 +70,15 @@ export const build = async (
     await registerEsm({
       appDir: appContext.appDirectory,
       distDir: appContext.distDirectory,
-      alias: {
-        ...resolvedConfig.resolve?.alias,
-        ...resolvedConfig.source?.alias,
-      },
+      alias: combinedAlias,
     });
   }
 
-  await registerCompiler(appContext.appDirectory, appContext.distDirectory, {
-    ...resolvedConfig?.resolve?.alias,
-    ...resolvedConfig?.source?.alias,
-  } as ConfigChain<Alias>);
+  await registerCompiler(
+    appContext.appDirectory,
+    appContext.distDirectory,
+    combinedAlias,
+  );
 
   const { apiOnly } = appContext;
 

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -40,22 +40,24 @@ export const dev = async (
   const appContext = api.getAppContext();
   const hooks = api.getHooks();
 
+  const combinedAlias = ([] as unknown[])
+    .concat(normalizedConfig?.resolve?.alias ?? [])
+    .concat(normalizedConfig?.source?.alias ?? []) as ConfigChain<Alias>;
+
   if (appContext.moduleType && appContext.moduleType === 'module') {
     const { registerEsm } = await import('../esm/register-esm.mjs');
     await registerEsm({
       appDir: appContext.appDirectory,
       distDir: appContext.distDirectory,
-      alias: {
-        ...normalizedConfig.resolve?.alias,
-        ...normalizedConfig.source?.alias,
-      },
+      alias: combinedAlias,
     });
   }
 
-  await registerCompiler(appContext.appDirectory, appContext.distDirectory, {
-    ...normalizedConfig?.source?.alias,
-    ...normalizedConfig?.resolve?.alias,
-  } as ConfigChain<Alias>);
+  await registerCompiler(
+    appContext.appDirectory,
+    appContext.distDirectory,
+    combinedAlias,
+  );
 
   const { appDirectory, port, apiOnly, metaName, serverRoutes } = appContext;
 


### PR DESCRIPTION
## Summary

same as #7574

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
