### PR TITLE
chore(@modern-js/utils): add sub-path exports for require and env modules

### DIFF
--- a/.changeset/khaki-coins-sit.md
+++ b/.changeset/khaki-coins-sit.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/utils': patch
+---
+
+chore(@modern-js/utils): re-exports require, env module using sub-paths
+chore(@modern-js/utils): 使用 sub-paths 导出 require, env 模块

--- a/packages/toolkit/utils/package.json
+++ b/packages/toolkit/utils/package.json
@@ -35,6 +35,16 @@
       "jsnext:source": "./src/cli/constants/chainId.ts",
       "default": "./dist/cjs/cli/constants/chainId.js"
     },
+    "./require": {
+      "jsnext:source": "./src/cli/require.ts",
+      "import": "./dist/esm/cli/require.js",
+      "default": "./dist/cjs/cli/require.js"
+    },
+    "./env": {
+      "jsnext:source": "./src/cli/is/env.ts",
+      "import": "./dist/esm/cli/is/env.js",
+      "default": "./dist/cjs/cli/is/env.js"
+    },
     "./universal": {
       "jsnext:source": "./src/universal/index.ts",
       "import": "./dist/esm/universal/index.js",
@@ -109,6 +119,16 @@
         "types": "./dist/types/cli/logger.d.ts",
         "default": "./dist/cjs/cli/logger.js"
       },
+      "./require": {
+        "jsnext:source": "./src/cli/require.ts",
+        "import": "./dist/esm/cli/require.js",
+        "default": "./dist/cjs/cli/require.js"
+      },
+      "./env": {
+        "jsnext:source": "./src/cli/is/env.ts",
+        "import": "./dist/esm/cli/is/env.js",
+        "default": "./dist/cjs/cli/is/env.js"
+      },
       "./chain-id": {
         "types": "./dist/types/cli/constants/chainId.d.ts",
         "default": "./dist/cjs/cli/constants/chainId.js"
@@ -182,6 +202,12 @@
       ],
       "chain-id": [
         "./dist/types/cli/constants/chainId.d.ts"
+      ],
+      "require": [
+        "./dist/types/cli/require.d.ts"
+      ],
+      "env": [
+        "./dist/types/cli/is/env.d.ts"
       ],
       "universal": [
         "./dist/types/universal/index.d.ts"


### PR DESCRIPTION

## Summary

This PR adds sub-path exports for the require and env modules in the @modern-js/utils package, improving the module's accessibility and enabling more granular imports.

Enhanced Package Exports: Added new sub-path exports in [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for two specific modules:

- `./require` - exports the CLI require utility module
- `./env` - exports the environment detection utilities

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
