### PR TITLE
fix(plugin-bff): preserve package manifest trailing newline

### DIFF
--- a/packages/cli/plugin-bff/src/utils/clientGenerator.ts
+++ b/packages/cli/plugin-bff/src/utils/clientGenerator.ts
@@ -203,10 +203,13 @@ async function setPackage(
 
     mergePackageJson(packageJson, addFiles, typesVersions, exports);
 
-    await fs.promises.writeFile(
-      packagePath,
-      JSON.stringify(packageJson, null, 2),
-    );
+    const handle = await fs.promises.open(packagePath, 'w');
+    try {
+      await handle.write(JSON.stringify(packageJson, null, 2));
+      await handle.write('\n');
+    } finally {
+      await handle.close();
+    }
   } catch (error) {
     logger.error(`package.json update failed: ${error}`);
   }
@@ -275,7 +278,11 @@ async function clientGenerator(draftOptions: APILoaderOptions) {
     logger.error(`Client bundle generate failed: ${error}`);
   }
 
-  setPackage(sourceList, draftOptions.appDir, draftOptions.relativeDistPath);
+  await setPackage(
+    sourceList,
+    draftOptions.appDir,
+    draftOptions.relativeDistPath,
+  );
 }
 
 export default clientGenerator;

--- a/packages/cli/plugin-bff/tests/clientGenerator.test.ts
+++ b/packages/cli/plugin-bff/tests/clientGenerator.test.ts
@@ -1,0 +1,43 @@
+import os from 'os';
+import path from 'path';
+import { fs } from '@modern-js/utils';
+import clientGenerator from '../src/utils/clientGenerator';
+
+describe('clientGenerator', () => {
+  it('writes package.json with a trailing newline', async () => {
+    const appDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bff-client-gen-'));
+    const lambdaDir = path.join(appDir, 'api', 'lambda');
+
+    try {
+      await fs.mkdir(lambdaDir, { recursive: true });
+      await fs.writeFile(
+        path.join(lambdaDir, 'user.ts'),
+        'export default function handler() {}',
+      );
+      await fs.writeFile(
+        path.join(appDir, 'package.json'),
+        JSON.stringify({ name: 'test-app' }, null, 2),
+      );
+
+      await clientGenerator({
+        prefix: '/api',
+        appDir,
+        apiDir: path.join(appDir, 'api'),
+        lambdaDir,
+        existLambda: false,
+        relativeDistPath: 'dist',
+        relativeApiPath: 'api',
+      });
+
+      const packageContent = await fs.readFile(
+        path.join(appDir, 'package.json'),
+        'utf8',
+      );
+
+      expect(packageContent.endsWith('\n')).toBe(true);
+      expect(JSON.parse(packageContent).exports).toHaveProperty('./api/user');
+    } finally {
+      await fs.remove(appDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Preserve a trailing newline when the BFF client generator rewrites `package.json`.

Also await the package manifest update so callers do not race the generated manifest write.

## Problem

`plugin-bff` rewrites `package.json` with `JSON.stringify(packageJson, null, 2)` and no trailing newline. In repositories that normalize manifests during dependency install, this makes framework generation and package manager normalization fight each other.

## Changes

- Append `\n` when writing the generated package manifest.
- Await `setPackage` from `clientGenerator`.
- Add regression coverage for generated package manifests.

## Validation

- `pnpm --filter @modern-js/plugin-bff test`
- `pnpm exec biome check packages/cli/plugin-bff/src/utils/clientGenerator.ts packages/cli/plugin-bff/tests/clientGenerator.test.ts`