### PR TITLE
fix(plugin-i18n): detect custom instance language from SSR requests

### DIFF
--- a/.changeset/i18n-wrapper-ssr-language.md
+++ b/.changeset/i18n-wrapper-ssr-language.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/plugin-i18n': patch
+---
+
+fix(plugin-i18n): detect wrapper i18n language from SSR request

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/detection/index.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/detection/index.ts
@@ -528,9 +528,9 @@ export const detectLanguageWithPriority = async (
     );
   }
 
-  // Priority 3: i18next detector (reads from cookie/localStorage)
+  // Priority 3: i18next detector (reads from request in SSR or storage in CSR)
   if (!detectedLanguage && i18nextDetector) {
-    if (isI18nWrapperInstance(i18nInstance)) {
+    if (isI18nWrapperInstance(i18nInstance) && isBrowser()) {
       detectedLanguage = readLanguageFromStorage(
         mergeDetectionOptions(
           i18nextDetector,

--- a/packages/runtime/plugin-i18n/src/runtime/i18n/detection/middleware.node.ts
+++ b/packages/runtime/plugin-i18n/src/runtime/i18n/detection/middleware.node.ts
@@ -1,5 +1,9 @@
 import { LanguageDetector } from 'i18next-http-middleware';
-import type { I18nInstance } from '../instance';
+import {
+  type I18nInstance,
+  getActualI18nextInstance,
+  isI18nWrapperInstance,
+} from '../instance';
 
 export const cacheUserLanguage = (
   _i18nInstance: I18nInstance,
@@ -25,6 +29,12 @@ export const readLanguageFromStorage = (
  */
 export const useI18nextLanguageDetector = (i18nInstance: I18nInstance) => {
   if (!i18nInstance.isInitialized) {
+    if (isI18nWrapperInstance(i18nInstance)) {
+      const actualInstance = getActualI18nextInstance(i18nInstance);
+      if (actualInstance && !actualInstance.isInitialized) {
+        actualInstance.use(LanguageDetector);
+      }
+    }
     return i18nInstance.use(LanguageDetector);
   }
   return i18nInstance;
@@ -44,9 +54,14 @@ export const detectLanguage = (
   }
 
   try {
-    const detector = i18nInstance.services?.languageDetector;
+    const actualInstance = isI18nWrapperInstance(i18nInstance)
+      ? getActualI18nextInstance(i18nInstance)
+      : i18nInstance;
+    const detector =
+      actualInstance?.services?.languageDetector ||
+      i18nInstance.services?.languageDetector;
     if (detector && typeof detector.detect === 'function') {
-      const result = detector.detect(request, {});
+      const result = detector.detect(request, {}, detectionOptions?.order);
       if (typeof result === 'string') {
         return result;
       }
@@ -57,15 +72,17 @@ export const detectLanguage = (
     }
 
     if (
-      i18nInstance.isInitialized &&
-      i18nInstance.services &&
-      i18nInstance.options
+      (i18nInstance.isInitialized || actualInstance?.isInitialized) &&
+      (actualInstance?.services || i18nInstance.services) &&
+      (actualInstance?.options || i18nInstance.options)
     ) {
       const manualDetector = new LanguageDetector();
+      const servicesToUse = actualInstance?.services || i18nInstance.services;
+      const instanceOptions = actualInstance?.options || i18nInstance.options;
       const optionsToUse = detectionOptions
-        ? { ...i18nInstance.options, detection: detectionOptions }
-        : i18nInstance.options;
-      manualDetector.init(i18nInstance.services, optionsToUse as any);
+        ? { ...instanceOptions, detection: detectionOptions }
+        : instanceOptions;
+      manualDetector.init(servicesToUse!, optionsToUse as any);
 
       const result = (manualDetector.detect as any)(request, {}, undefined);
       if (typeof result === 'string') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2962,6 +2962,31 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/solutions/app-tools
 
+  tests/integration/i18n/custom-i18n-wrapper-ssr:
+    dependencies:
+      '@modern-js/plugin-i18n':
+        specifier: workspace:*
+        version: link:../../../../packages/runtime/plugin-i18n
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../../packages/runtime/plugin-runtime
+      i18next:
+        specifier: 25.7.4
+        version: 25.7.4(typescript@5.9.3)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: 15.7.4
+        version: 15.7.4(i18next@25.7.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../../packages/solutions/app-tools
+
   tests/integration/i18n/mf: {}
 
   tests/integration/i18n/mf/mf-app-provider:

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/modern.config.ts
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/modern.config.ts
@@ -1,0 +1,29 @@
+import { appTools, defineConfig } from '@modern-js/app-tools';
+import { i18nPlugin } from '@modern-js/plugin-i18n';
+
+export default defineConfig({
+  performance: {
+    buildCache: false,
+  },
+  server: {
+    ssr: {
+      mode: 'string',
+    },
+    publicDir: './locales',
+  },
+  plugins: [
+    appTools(),
+    i18nPlugin({
+      localeDetection: {
+        languages: ['en', 'zh'],
+        fallbackLanguage: 'en',
+        localePathRedirect: true,
+        i18nextDetector: true,
+      },
+      backend: {
+        enabled: true,
+        sdk: true,
+      },
+    }),
+  ],
+});

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/package.json
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "name": "i18n-custom-i18n-wrapper-ssr",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build"
+  },
+  "dependencies": {
+    "@modern-js/plugin-i18n": "workspace:*",
+    "@modern-js/runtime": "workspace:*",
+    "i18next": "25.7.4",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-i18next": "15.7.4"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*"
+  }
+}

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/src/App.tsx
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/src/App.tsx
@@ -1,0 +1,53 @@
+import { useModernI18n } from '@modern-js/plugin-i18n/runtime';
+import { useEffect, useState } from 'react';
+
+export default function App() {
+  const { language, changeLanguage, i18nInstance } = useModernI18n();
+  const [text, setText] = useState('');
+
+  const updateText = () => {
+    if (i18nInstance) {
+      setText((i18nInstance as any).t('key'));
+    }
+  };
+
+  useEffect(() => {
+    updateText();
+
+    const loadedHandler = () => {
+      updateText();
+    };
+    const languageChangedHandler = () => {
+      updateText();
+    };
+
+    if (i18nInstance) {
+      i18nInstance.on?.('loaded', loadedHandler);
+      i18nInstance.on?.('languageChanged', languageChangedHandler);
+    }
+
+    return () => {
+      if (i18nInstance) {
+        i18nInstance.off?.('loaded', loadedHandler);
+        i18nInstance.off?.('languageChanged', languageChangedHandler);
+      }
+    };
+  }, [i18nInstance]);
+
+  useEffect(() => {
+    updateText();
+  }, [language, i18nInstance]);
+
+  return (
+    <div>
+      <h1 id="sdk-text">{text}</h1>
+      <p id="current-lang">Current Language: {language}</p>
+      <button id="switch-en" onClick={() => changeLanguage('en')}>
+        Switch to EN
+      </button>
+      <button id="switch-zh" onClick={() => changeLanguage('zh')}>
+        切换到中文
+      </button>
+    </div>
+  );
+}

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/src/mock-sdk.ts
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/src/mock-sdk.ts
@@ -1,0 +1,24 @@
+import type { Resources } from '@modern-js/plugin-i18n/runtime';
+
+const baseResources: Resources = {
+  en: {
+    translation: {
+      key: 'Hello World from SDK',
+      about: 'About page from SDK',
+    },
+  },
+  zh: {
+    translation: {
+      key: '你好，世界（SDK）',
+      about: '关于（SDK）',
+    },
+  },
+};
+
+export function createMockSdkLoader() {
+  return async (_options: any): Promise<Resources> => {
+    console.log('mock sdk loader: fetching resources');
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return baseResources;
+  };
+}

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/src/modern-app-env.d.ts
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/src/modern-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types='@modern-js/app-tools/types' />

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/src/modern.runtime.tsx
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/src/modern.runtime.tsx
@@ -1,0 +1,16 @@
+import { defineRuntimeConfig } from '@modern-js/runtime';
+import { createMockSdkLoader } from './mock-sdk';
+import { createStarlingWrapper } from './starlingWrapper';
+
+const starlingWrapper = createStarlingWrapper();
+
+export default defineRuntimeConfig({
+  i18n: {
+    i18nInstance: starlingWrapper,
+    initOptions: {
+      backend: {
+        sdk: createMockSdkLoader(),
+      },
+    },
+  },
+});

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/src/starlingWrapper.ts
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/src/starlingWrapper.ts
@@ -1,0 +1,97 @@
+import i18next from 'i18next';
+
+export function createStarlingWrapper() {
+  const inner = i18next.createInstance();
+
+  const wrapper = {
+    i18nInstance: {
+      instance: inner,
+    },
+    plugins: [] as any[],
+    ignoreWarning: false,
+    init: async (config?: any, callback?: any) => {
+      const result = await inner.init(config, callback);
+      return { err: null, t: inner.t.bind(inner), ...result };
+    },
+    use(plugin: any) {
+      if (!plugin) {
+        return this;
+      }
+      if (typeof plugin.init === 'function') {
+        plugin.init(inner);
+      }
+      this.plugins.push(plugin);
+      inner.use(plugin);
+      return this;
+    },
+    setLang(lng: string) {
+      if (typeof inner.changeLanguage === 'function') {
+        return inner.changeLanguage(lng);
+      }
+      return Promise.resolve();
+    },
+    changeLanguage(lng: string) {
+      return inner.changeLanguage(lng);
+    },
+    get language() {
+      return inner.language;
+    },
+    get languages() {
+      return inner.languages;
+    },
+    t(...args: any[]) {
+      return inner.t.apply(inner, args as any);
+    },
+    // Event system: forward to inner i18next instance
+    on(event: string, callback: (...args: any[]) => void) {
+      if (typeof inner.on === 'function') {
+        inner.on(event, callback);
+      }
+      return this;
+    },
+    off(event: string, callback?: (...args: any[]) => void) {
+      if (typeof inner.off === 'function') {
+        inner.off(event, callback);
+      }
+      return this;
+    },
+    emit(event: string, ...args: any[]) {
+      if (typeof inner.emit === 'function') {
+        inner.emit(event, ...args);
+      }
+      return this;
+    },
+    get isInitialized() {
+      return inner.isInitialized;
+    },
+    get options() {
+      return inner.options;
+    },
+    get store() {
+      return inner.store;
+    },
+    get services() {
+      return inner.services;
+    },
+    reloadResources(lng?: string, ns?: string) {
+      if (typeof inner.reloadResources === 'function') {
+        return inner.reloadResources(lng, ns);
+      }
+      return Promise.resolve();
+    },
+    cloneInstance(opts?: any) {
+      const cloned = inner.cloneInstance(opts);
+      const clonedWrapper = createStarlingWrapper();
+      clonedWrapper.i18nInstance.instance = cloned;
+      clonedWrapper.plugins = [...this.plugins];
+      clonedWrapper.plugins.forEach((plugin: any) => {
+        if (typeof plugin.init === 'function') {
+          plugin.init(cloned);
+        }
+      });
+      return clonedWrapper;
+    },
+  } as any;
+
+  return wrapper;
+}

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/tests/index.test.ts
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/tests/index.test.ts
@@ -1,0 +1,47 @@
+import path from 'path';
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchApp,
+  launchOptions,
+} from '../../../../utils/modernTestUtils';
+import { gotoWithSSRRetry } from '../../test-utils';
+
+const projectDir = path.resolve(__dirname, '..');
+
+describe('i18n-custom-i18n-wrapper-ssr', () => {
+  let app: Awaited<ReturnType<typeof launchApp>>;
+  let page: Page;
+  let browser: Browser;
+  let appPort: number;
+
+  beforeAll(async () => {
+    appPort = await getPort();
+    app = await launchApp(projectDir, appPort);
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    if (browser) {
+      await browser.close();
+    }
+    if (app) {
+      await killApp(app);
+    }
+  });
+
+  test('detects wrapper language from SSR request', async () => {
+    const html = await gotoWithSSRRetry(
+      page,
+      `http://localhost:${appPort}/?lng=zh`,
+    );
+
+    expect(html).toBeDefined();
+    expect(html).toContain('Current Language: <!-- -->zh');
+    expect(html).toContain('i18nData');
+    expect(html).toContain('"lng":"zh"');
+    expect(page.url()).toBe(`http://localhost:${appPort}/zh?lng=zh`);
+  });
+});

--- a/tests/integration/i18n/custom-i18n-wrapper-ssr/tsconfig.json
+++ b/tests/integration/i18n/custom-i18n-wrapper-ssr/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "outDir": "dist",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    },
+    "types": ["@rstest/core/globals"]
+  },
+  "include": ["src", "tests", "modern.config.ts"]
+}


### PR DESCRIPTION
## Summary

Fix SSR language detection when an application provides a custom i18n instance built on top of i18next. A request such as `?lng=zh-Hant-TW` could render the fallback English translation and serialize `i18nData.lng` as `en`, causing an incorrect first render or a language change during hydration.

These instances previously used `readLanguageFromStorage` in both browser and Node environments. In Node, it returns `undefined`, so language detection did not read query parameters, cookies, or headers from `ssrContext.request`.

Keep storage detection in the browser and use request-based detection during SSR. The custom instance still receives its normal initialization, so application code that imports it and calls `I18n.t()` continues to work in CSR.

## Changes

- Register and access the Node language detector through the underlying i18next instance, including its services and options.
- Extend the existing custom-instance integration application with SSR and CSR entries, and rename it to `custom-i18n-instance`.
- Retain the two existing resource-loading and language-switching cases; add five cases for SSR query/cookie/header detection, hydration, and direct `I18n.t()` calls in CSR.
- Add a patch changeset for `@modern-js/plugin-i18n`. No public API or configuration changes.

## Validation

- All 7 integration cases pass with retries disabled. SSR assertions inspect the raw HTTP response without following redirects or retrying SSR fallbacks.
- Regression controls: restoring the old SSR condition fails the query-language case; passing only the underlying i18next instance fails the direct-call CSR case.
- Six native i18next detection scenarios produce the same results on main and this branch.
- Plugin build, fixture TypeScript checking, Biome, dependency consistency, and changeset validation pass.

```sh
pnpm --filter tests test:framework run integration/i18n/custom-i18n-instance/tests/index.test.ts --pool.maxWorkers=1 --retry=0
pnpm --filter tests exec tsc --noEmit -p integration/i18n/custom-i18n-instance/tsconfig.json
pnpm run check-dependencies
BASE_BRANCH=upstream/main pnpm run check-changeset
```

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation (integration fixture README).
- [x] I have added tests to cover my changes.
