### PR TITLE
feat(builder): support customizing RSC server/client environment names

### DIFF
--- a/.changeset/rsc-custom-environments.md
+++ b/.changeset/rsc-custom-environments.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/builder': minor
+---
+
+feat(builder): support customizing RSC server/client environment names via `server.rsc.environments`
+
+`server.rsc` now accepts an object form `{ environments?: { server?: string; client?: string } }` in addition to a boolean. This forwards the existing `environments` option of `rsbuild-plugin-rsc`, letting frameworks that declare their own Rsbuild environments map RSC onto them instead of having the plugin create new empty `server`/`client` environments (which otherwise fall back to the default `./src` entry and fail to resolve in non-convention setups). Passing `true`/`false` keeps the previous default behavior, so the change is fully backward compatible.
+
+feat(builder): 支持通过 `server.rsc.environments` 自定义 RSC server/client 环境名
+
+`server.rsc` 在原有 boolean 之外新增对象形式 `{ environments?: { server?: string; client?: string } }`，透传 `rsbuild-plugin-rsc` 已有的 `environments` 选项，使已声明自有 Rsbuild 环境的框架可将 RSC 映射到这些环境，而不必让插件新建空的 `server`/`client` 环境（否则会回落到默认入口 `./src` 而无法解析）。传 `true`/`false` 时行为不变，完全向后兼容。

--- a/packages/cli/builder/src/createBuilder.ts
+++ b/packages/cli/builder/src/createBuilder.ts
@@ -53,11 +53,15 @@ export async function parseConfig(
     );
   }
 
-  const enableRsc = builderConfig.server?.rsc ?? false;
+  const rscConfig = builderConfig.server?.rsc ?? false;
+  const enableRsc = Boolean(rscConfig);
   if (enableRsc) {
+    const rscEnvironments =
+      typeof rscConfig === 'object' ? rscConfig.environments : undefined;
     const rscPlugins = await getRscPlugins(
       enableRsc,
       options.internalDirectory!,
+      rscEnvironments,
     );
     rsbuildPlugins.push(...rscPlugins);
   } else {

--- a/packages/cli/builder/src/plugins/rscConfig.ts
+++ b/packages/cli/builder/src/plugins/rscConfig.ts
@@ -210,11 +210,18 @@ export function pluginRscConfig(): RsbuildPlugin {
  * Get RSC plugins based on configuration
  * @param enableRsc - Whether RSC is enabled
  * @param internalDirectory - Internal directory path for route matching
+ * @param environments - Optional mapping of the RSC plugin's `server`/`client`
+ *   environments onto existing Rsbuild environment names. When omitted, the RSC
+ *   plugin uses its defaults (`'server'` / `'client'`). Frameworks that already
+ *   declare their own environments can point RSC at them instead of having the
+ *   plugin create new empty environments (which would otherwise fall back to the
+ *   default `./src` entry and fail to resolve).
  * @returns Array of RSC-related plugins
  */
 export async function getRscPlugins(
   enableRsc: boolean,
   internalDirectory: string,
+  environments?: { server?: string; client?: string },
 ): Promise<RsbuildPlugin[]> {
   if (enableRsc) {
     const routesFileReg = new RegExp(
@@ -226,6 +233,7 @@ export async function getRscPlugins(
     const { pluginRSC } = await import('rsbuild-plugin-rsc');
     return [
       pluginRSC({
+        ...(environments ? { environments } : {}),
         layers: {
           rsc: [/render[/\\].*[/\\]server[/\\]rsc/, /AppProxy/, routesFileReg],
         },

--- a/packages/cli/builder/src/types.ts
+++ b/packages/cli/builder/src/types.ts
@@ -286,6 +286,33 @@ export type DistPath = DistPathConfig & {
   worker?: string;
 };
 
+/**
+ * RSC (React Server Components) configuration.
+ *
+ * - `true` / `false`: enable or disable RSC with the default `'server'` and
+ *   `'client'` environment names.
+ * - object form: enable RSC and customize which Rsbuild environments the RSC
+ *   plugin attaches to. Frameworks whose environment names differ from the
+ *   defaults (e.g. multi-page builders that already declare their own
+ *   server/client environments) can map RSC onto those existing environments
+ *   instead of letting the plugin create new empty `'server'`/`'client'` ones.
+ */
+export type RscConfig =
+  | boolean
+  | {
+      /**
+       * Map the RSC plugin's server/client environments onto existing Rsbuild
+       * environment names. Omitted keys fall back to the defaults
+       * (`'server'` / `'client'`).
+       */
+      environments?: {
+        /** Rsbuild environment name for the React Server Components (server) bundle. @default 'server' */
+        server?: string;
+        /** Rsbuild environment name for the client (browser) bundle. @default 'client' */
+        client?: string;
+      };
+    };
+
 export type BuilderConfig = {
   dev?: Omit<DevConfig, 'setupMiddlewares'> & {
     server?: {
@@ -302,7 +329,7 @@ export type BuilderConfig = {
     distPath?: DistPath;
   };
   server?: {
-    rsc?: boolean;
+    rsc?: RscConfig;
     port?: number;
     cors?: ServerConfig['cors'];
   };

--- a/packages/cli/builder/tests/rscConfig.test.ts
+++ b/packages/cli/builder/tests/rscConfig.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from '@rstest/core';
+import { getRscPlugins } from '../src/plugins/rscConfig';
+
+describe('getRscPlugins', () => {
+  const internalDir = '/tmp/internal';
+
+  it('returns no plugins when RSC is disabled', async () => {
+    const plugins = await getRscPlugins(false, internalDir);
+    expect(plugins).toHaveLength(0);
+  });
+
+  it('returns the RSC plugins when enabled (default environments)', async () => {
+    const plugins = await getRscPlugins(true, internalDir);
+    expect(plugins).toHaveLength(2);
+    expect(plugins.map(p => p.name)).toContain('builder:rsc-config');
+  });
+
+  it('accepts a custom environments mapping without throwing', async () => {
+    const plugins = await getRscPlugins(true, internalDir, {
+      server: 'Server',
+      client: 'Render',
+    });
+    expect(plugins).toHaveLength(2);
+    expect(plugins.map(p => p.name)).toContain('builder:rsc-config');
+  });
+});


### PR DESCRIPTION
## Summary

`server.rsc` in `@modern-js/builder` is currently a `boolean`. When enabled, `getRscPlugins` calls `rsbuild-plugin-rsc`'s `pluginRSC({ layers })` **without** forwarding its `environments` option, so the plugin always creates its default `server` / `client` Rsbuild environments. Those environments have no `source.entry`, so Rsbuild falls back to the default `./src` entry.

This works for convention-based apps (where `./src` is the real app root) but breaks any framework that declares **its own** Rsbuild environments and explicit entries (e.g. multi-page builders): RSC silently spins up empty `server`/`client` environments that fail with `Module not found: Can't resolve './src'`.

`rsbuild-plugin-rsc` already supports an `environments: { server?, client? }` option precisely to remap those environment names onto existing ones — `@modern-js/builder` just never exposed it.

## Change

- Widen `server.rsc` from `boolean` to `boolean | { environments?: { server?: string; client?: string } }` (new exported `RscConfig` type).
- `parseConfig` extracts `environments` from the object form and passes it to `getRscPlugins`.
- `getRscPlugins` forwards `environments` into `pluginRSC({ environments, layers })` when provided.

Passing `true` / `false` is unchanged, so this is **fully backward compatible** (truthiness-based readers in `app-tools` keep working, since the object form is truthy).

```ts
// before — only on/off
server: { rsc: true }

// after — opt into mapping RSC onto your own environments
server: { rsc: { environments: { server: 'Server', client: 'Render' } } }
```

## Test plan

- `pnpm --filter @modern-js/builder build` — declaration build passes.
- `pnpm --filter @modern-js/builder test` — full suite green; added `tests/rscConfig.test.ts` covering disabled / default-environments / custom-environments cases.
- `biome check` clean on all changed files.
- Validated downstream against a multi-page framework (PIA): mapping `{ server: 'Server', client: 'Render' }` onto its existing environments makes the previously-failing `./src` resolution succeed and the RSC build proceed.