### PR TITLE
fix(plugin-runtime): fix document CLI compatibility with ESM lib format

### DIFF
--- a/.changeset/funny-turkeys-switch.md
+++ b/.changeset/funny-turkeys-switch.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(plugin-runtime): fix document CLI compatibility with ESM lib format
+
+fix(plugin-runtime): 修复 document CLI 在 ESM 构建格式下的兼容性问题

--- a/.changeset/funny-turkeys-switch.md
+++ b/.changeset/funny-turkeys-switch.md
@@ -2,6 +2,8 @@
 '@modern-js/runtime': patch
 ---
 
+fix(app-tools): fix BFF ts-node-loader compatibility with ESM
 fix(plugin-runtime): fix document CLI compatibility with ESM lib format
 
+fix(app-tools): 修复 BFF ts-node-loader 在 ESM 构建格式下的兼容性问题
 fix(plugin-runtime): 修复 document CLI 在 ESM 构建格式下的兼容性问题

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -181,7 +181,12 @@ const processCommentPlaceholders = (html: string): string => {
 
 // load CommonJS module from code string (evaluated in Node), returns exports
 const requireFromString = (code: string, filename: string) => {
-  const m = new Module.Module(filename, module.parent as Module);
+  const m = new Module.Module(
+    filename,
+    process.env.MODERN_LIB_FORMAT === 'esm'
+      ? undefined
+      : (module.parent as Module),
+  );
   m.filename = filename;
   // set proper resolution paths for nested requires
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -269,10 +274,14 @@ const applyExternalsPlugin = (child: Compiler, compiler: Compiler) => {
 };
 
 const generateEntryCode = (docPath: string, _entryName: string): string => {
-  const runtimeAPI = require.resolve('../');
-  const esmRuntimeAPI = runtimeAPI
-    .replace(`cjs`, `esm`)
-    .replace(/.js$/, '.mjs');
+  const runtimeAPI =
+    process.env.MODERN_LIB_FORMAT === 'esm'
+      ? // @ts-ignore
+        import.meta.resolve('../index.mjs')
+      : require.resolve('../');
+  const esmRuntimeAPI = runtimeAPI.endsWith('.mjs')
+    ? runtimeAPI
+    : runtimeAPI.replace(`cjs`, `esm`).replace(/\.js$/, '.mjs');
 
   return `import React from 'react';
 import ReactDomServer from 'react-dom/server';

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -274,14 +274,8 @@ const applyExternalsPlugin = (child: Compiler, compiler: Compiler) => {
 };
 
 const generateEntryCode = (docPath: string, _entryName: string): string => {
-  const runtimeAPI =
-    process.env.MODERN_LIB_FORMAT === 'esm'
-      ? // @ts-ignore
-        import.meta.resolve('../index.mjs')
-      : require.resolve('../');
-  const esmRuntimeAPI = runtimeAPI.endsWith('.mjs')
-    ? runtimeAPI
-    : runtimeAPI.replace(`cjs`, `esm`).replace(/\.js$/, '.mjs');
+  // this entry will always resolve to "./dist/esm/document/index.mjs"
+  const esmRuntimeAPI = require.resolve('@modern-js/runtime/document');
 
   return `import React from 'react';
 import ReactDomServer from 'react-dom/server';

--- a/packages/solutions/app-tools/src/esm/register-esm.mjs
+++ b/packages/solutions/app-tools/src/esm/register-esm.mjs
@@ -25,6 +25,7 @@ export const registerModuleHooks = async ({
   )}/`;
   register('./ts-node-loader.mjs', import.meta.url, {
     data: {
+      appDir,
       baseUrl,
       paths,
     },

--- a/packages/solutions/app-tools/src/esm/ts-node-loader.mjs
+++ b/packages/solutions/app-tools/src/esm/ts-node-loader.mjs
@@ -1,27 +1,18 @@
-import { pathToFileURL } from 'url';
-import { findMatchedSourcePath, findSourceEntry } from '@modern-js/utils';
-import { createMatchPath } from '@modern-js/utils/tsconfig-paths';
 import { resolve as tsNodeResolve } from 'ts-node/esm';
 import { load as tsNodeLoad } from 'ts-node/esm';
+import {
+  initialize as initializeTsPathsLoader,
+  resolve as resolveTsPaths,
+} from './ts-paths-loader.mjs';
 
-let matchPath;
-
-export async function initialize({ baseUrl, paths }) {
-  matchPath = createMatchPath(baseUrl || './', paths || {});
+export async function initialize(config) {
+  await initializeTsPathsLoader(config);
 }
 
 export function resolve(specifier, context, defaultResolve) {
-  // Without this rewrite, aliases such as `@service/user` and
-  // `@service/user.js` would never reach ts-node as real source files.
-  const match = findMatchedSourcePath(matchPath, specifier);
-
-  return match
-    ? tsNodeResolve(
-        pathToFileURL(findSourceEntry(match) || match).href,
-        context,
-        defaultResolve,
-      )
-    : tsNodeResolve(specifier, context, defaultResolve);
+  return resolveTsPaths(specifier, context, (specifier, context) => {
+    return tsNodeResolve(specifier, context, defaultResolve);
+  });
 }
 
 export function load(url, context, defaultLoad) {

--- a/packages/solutions/app-tools/tests/utils/ts-node-loader.test.ts
+++ b/packages/solutions/app-tools/tests/utils/ts-node-loader.test.ts
@@ -2,24 +2,19 @@ import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 describe('ts-node-loader', () => {
-  it('should resolve prefix aliases from source.alias to TypeScript files', async () => {
+  const loaderPath = path.resolve(
+    __dirname,
+    '../../src/esm/ts-node-loader.mjs',
+  );
+
+  function createTmpApp() {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'app-tools-loader-'));
     const appDir = path.join(rootDir, 'app');
-    const serviceDir = path.join(rootDir, 'service');
-    const serviceFile = path.join(serviceDir, 'user.ts');
     const tsconfigPath = path.join(rootDir, 'tsconfig.json');
-    const loaderPath = path.resolve(
-      __dirname,
-      '../../src/esm/ts-node-loader.mjs',
-    );
-
     fs.mkdirSync(appDir, { recursive: true });
-    fs.mkdirSync(serviceDir, { recursive: true });
-    fs.writeFileSync(serviceFile, 'export const user = 1;\n');
-    // Keep ts-node isolated from workspace-level tsconfig files in CI.
     fs.writeFileSync(
       tsconfigPath,
       JSON.stringify({
@@ -30,6 +25,16 @@ describe('ts-node-loader', () => {
         },
       }),
     );
+    return { rootDir, appDir, tsconfigPath };
+  }
+
+  it('should resolve prefix aliases from source.alias to TypeScript files', async () => {
+    const { rootDir, appDir, tsconfigPath } = createTmpApp();
+    const serviceDir = path.join(rootDir, 'service');
+    const serviceFile = path.join(serviceDir, 'user.ts');
+
+    fs.mkdirSync(serviceDir, { recursive: true });
+    fs.writeFileSync(serviceFile, 'export const user = 1;\n');
 
     try {
       const output = childProcess.execFileSync(
@@ -37,7 +42,6 @@ describe('ts-node-loader', () => {
         [
           '-e',
           `
-            const path = require('node:path');
             const { pathToFileURL } = require('node:url');
 
             (async () => {
@@ -45,6 +49,7 @@ describe('ts-node-loader', () => {
                 pathToFileURL(${JSON.stringify(loaderPath)}).href,
               );
               await loader.initialize({
+                appDir: ${JSON.stringify(appDir)},
                 baseUrl: ${JSON.stringify(appDir)},
                 paths: {
                   '@service': [${JSON.stringify('../service')}],
@@ -83,6 +88,125 @@ describe('ts-node-loader', () => {
       expect(
         fs.realpathSync(fileURLToPath(resolved['@service/user.js'].url)),
       ).toBe(fs.realpathSync(serviceFile));
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should resolve relative imports without extension from within the app directory', async () => {
+    const { rootDir, appDir, tsconfigPath } = createTmpApp();
+    const entryFile = path.join(appDir, 'index.ts');
+    const helperFile = path.join(appDir, 'helper.ts');
+
+    fs.writeFileSync(entryFile, '');
+    fs.writeFileSync(helperFile, 'export const helper = 1;\n');
+
+    try {
+      const output = childProcess.execFileSync(
+        process.execPath,
+        [
+          '-e',
+          `
+            const { pathToFileURL } = require('node:url');
+
+            (async () => {
+              const loader = await import(
+                pathToFileURL(${JSON.stringify(loaderPath)}).href,
+              );
+              await loader.initialize({
+                appDir: ${JSON.stringify(appDir)},
+                baseUrl: ${JSON.stringify(appDir)},
+                paths: {},
+              });
+              // Extensionless relative import resolved from a file: parentURL inside
+              // the app directory must be forwarded to ts-node as a real .ts path.
+              const result = await loader.resolve(
+                './helper',
+                { parentURL: pathToFileURL(${JSON.stringify(entryFile)}).href },
+                value => ({ url: value }),
+              );
+              console.log(JSON.stringify(result));
+            })().catch(error => {
+              console.error(error);
+              process.exit(1);
+            });
+          `,
+        ],
+        {
+          cwd: rootDir,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            TS_NODE_PROJECT: tsconfigPath,
+          },
+        },
+      );
+
+      const result = JSON.parse(output.trim());
+      expect(fs.realpathSync(fileURLToPath(result.url))).toBe(
+        fs.realpathSync(helperFile),
+      );
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should not crash when parentURL is a non-file URL such as data:', async () => {
+    const { rootDir, appDir, tsconfigPath } = createTmpApp();
+    const serviceDir = path.join(rootDir, 'service');
+    const serviceFile = path.join(serviceDir, 'user.ts');
+
+    fs.mkdirSync(serviceDir, { recursive: true });
+    fs.writeFileSync(serviceFile, 'export const user = 1;\n');
+
+    try {
+      const output = childProcess.execFileSync(
+        process.execPath,
+        [
+          '-e',
+          `
+            const { pathToFileURL } = require('node:url');
+
+            (async () => {
+              const loader = await import(
+                pathToFileURL(${JSON.stringify(loaderPath)}).href,
+              );
+              await loader.initialize({
+                appDir: ${JSON.stringify(appDir)},
+                baseUrl: ${JSON.stringify(appDir)},
+                paths: {
+                  '@service': [${JSON.stringify('../service')}],
+                  '@service/*': [${JSON.stringify('../service/*')}],
+                },
+              });
+              // Alias resolution must still work when parentURL is a synthetic non-file
+              // URL (e.g. Tailwind v4 data: modules). getParentPath must not crash.
+              const result = await loader.resolve(
+                '@service/user',
+                { parentURL: 'data:text/javascript,export default 1' },
+                value => ({ url: value }),
+              );
+              console.log(JSON.stringify(result));
+            })().catch(error => {
+              console.error(error);
+              process.exit(1);
+            });
+          `,
+        ],
+        {
+          cwd: rootDir,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            TS_NODE_PROJECT: tsconfigPath,
+          },
+        },
+      );
+
+      const result = JSON.parse(output.trim());
+      expect(fs.realpathSync(fileURLToPath(result.url))).toBe(
+        fs.realpathSync(serviceFile),
+      );
     } finally {
       fs.rmSync(rootDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

### Problem

The document plugin's CLI helpers (`requireFromString` and `generateEntryCode`) relied on CJS-only Node.js APIs that are unavailable or incorrect when the package is built and consumed as an ES module:

1. **`module.parent` in `requireFromString`**: In ESM context, the CommonJS `module` global does not exist, so passing `module.parent` as the parent to `new Module.Module()` throws a `ReferenceError` at runtime.

2. **`require.resolve('../')` in `generateEntryCode`**: `createRequire().resolve('../')` cannot resolve to `index` file in an ESM module context.

### Solution

Both helpers are now guarded by a `process.env.MODERN_LIB_FORMAT === 'esm'` check so they use the appropriate API depending on the module format:

- **`requireFromString`**: passes `undefined` as the parent module when in ESM mode, which is a safe no-op for `Module.Module` and avoids the CJS `module.parent` reference.
- **`generateEntryCode`**: uses `import.meta.resolve('../index.mjs')` to resolve the runtime API path in ESM mode (the `.mjs` entry is already the correct target), falling back to `require.resolve('../')` in CJS mode.

### Affected package

- `@modern-js/runtime` (patch)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
