### PR TITLE
fix(runtime): inject streaming SSR styles despite prefetch

### DIFF
--- a/packages/runtime/plugin-runtime/src/core/server/stream/beforeTemplate.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/beforeTemplate.ts
@@ -36,6 +36,42 @@ const checkIsInline = (
   }
 };
 
+export const hasStylesheetLink = (template: string, href: string) => {
+  const linkTags = template.match(/<link\b[^>]*>/gi) ?? [];
+  return linkTags.some(linkTag => {
+    const attributes = getLinkAttributes(linkTag);
+    const linkHref = attributes.get('href');
+    const rel = attributes.get('rel');
+
+    return (
+      linkHref === href &&
+      rel
+        ?.split(/\s+/)
+        .some(relToken => relToken.toLowerCase() === 'stylesheet')
+    );
+  });
+};
+
+const getLinkAttributes = (linkTag: string) => {
+  const attributes = new Map<string, string>();
+  const attributeRegExp =
+    /([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = attributeRegExp.exec(linkTag))) {
+    const [, name, doubleQuotedValue, singleQuotedValue, unquotedValue] = match;
+    if (name.toLowerCase() === 'link') {
+      continue;
+    }
+    attributes.set(
+      name.toLowerCase(),
+      doubleQuotedValue ?? singleQuotedValue ?? unquotedValue ?? '',
+    );
+  }
+
+  return attributes;
+};
+
 export interface BuildShellBeforeTemplateOptions {
   runtimeContext: TInternalRuntimeContext;
   entryName: string;
@@ -108,7 +144,7 @@ export async function buildShellBeforeTemplate(
             };
             const _cssChunks = referenceCssAssets.filter(
               (asset?: string) =>
-                asset?.endsWith('.css') && !template.includes(asset),
+                asset?.endsWith('.css') && !hasStylesheetLink(template, asset),
             );
             return [...chunks, ..._cssChunks];
           }, [] as string[])

--- a/packages/runtime/plugin-runtime/tests/ssr/beforeTemplate.test.ts
+++ b/packages/runtime/plugin-runtime/tests/ssr/beforeTemplate.test.ts
@@ -1,0 +1,53 @@
+import { hasStylesheetLink } from '../../src/core/server/stream/beforeTemplate';
+
+describe('hasStylesheetLink', () => {
+  const href = '/static/css/async/three_user/page.css';
+
+  test('returns true for stylesheet links', () => {
+    expect(
+      hasStylesheetLink(`<link href="${href}" rel="stylesheet" />`, href),
+    ).toBe(true);
+  });
+
+  test('returns true when attributes are reordered', () => {
+    expect(
+      hasStylesheetLink(
+        `<link rel="stylesheet" data-test="style" href="${href}">`,
+        href,
+      ),
+    ).toBe(true);
+  });
+
+  test('returns true for single quoted stylesheet links', () => {
+    expect(
+      hasStylesheetLink(`<link rel='stylesheet' href='${href}'>`, href),
+    ).toBe(true);
+  });
+
+  test('returns true when rel contains multiple tokens', () => {
+    expect(
+      hasStylesheetLink(`<link href="${href}" rel="preload stylesheet">`, href),
+    ).toBe(true);
+  });
+
+  test('returns false for prefetch links', () => {
+    expect(
+      hasStylesheetLink(`<link href="${href}" rel="prefetch">`, href),
+    ).toBe(false);
+  });
+
+  test('returns false for preload style links', () => {
+    expect(
+      hasStylesheetLink(`<link href="${href}" rel="preload" as="style">`, href),
+    ).toBe(false);
+  });
+
+  test('returns false for different hrefs', () => {
+    expect(
+      hasStylesheetLink(
+        `<link href="/static/css/async/other/page.css" rel="stylesheet">`,
+        href,
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/integration/ssr/fixtures/streaming/modern.config.ts
+++ b/tests/integration/ssr/fixtures/streaming/modern.config.ts
@@ -4,4 +4,7 @@ export default applyBaseConfig({
   server: {
     ssr: true,
   },
+  performance: {
+    prefetch: true,
+  },
 });

--- a/tests/integration/ssr/tests/streaming.test.ts
+++ b/tests/integration/ssr/tests/streaming.test.ts
@@ -11,6 +11,17 @@ import { expectPageToMatchTextContent } from '../../../utils/rstestPuppeteer';
 
 const fixtureDir = path.resolve(__dirname, '../fixtures');
 
+function getMatchedLinkHrefs(
+  html: string,
+  rel: 'prefetch' | 'stylesheet',
+  hrefPattern: RegExp,
+) {
+  return (html.match(/<link\b[^>]*>/g) ?? [])
+    .filter(link => new RegExp(`\\brel="${rel}"`).test(link))
+    .map(link => link.match(/\bhref="([^"]+)"/)?.[1])
+    .filter((href): href is string => Boolean(href?.match(hrefPattern)));
+}
+
 async function basicUsage(page: Page, appPort: number) {
   const res = await page.goto(`http://localhost:${appPort}/about`, {
     waitUntil: ['networkidle0'],
@@ -21,6 +32,12 @@ async function basicUsage(page: Page, appPort: number) {
   expect(body).toMatch(
     /<link href="\/static\/css\/async\/about\/page.css" rel="stylesheet" \/>/,
   );
+  const aboutPageCss = /\/static\/css\/async\/about\/page\.css$/;
+  const stylesheetHrefs = getMatchedLinkHrefs(body, 'stylesheet', aboutPageCss);
+  const prefetchHrefs = getMatchedLinkHrefs(body, 'prefetch', aboutPageCss);
+  expect(stylesheetHrefs.length).toBeGreaterThan(0);
+  expect(prefetchHrefs.length).toBeGreaterThan(0);
+  expect(stylesheetHrefs.some(href => prefetchHrefs.includes(href))).toBe(true);
 
   expect(body).toMatch(/<div>About content<\/div>/);
   expect(body).toMatch('reporter');


### PR DESCRIPTION
## Summary

  Fix streaming SSR CSS injection when `performance.prefetch` emits a same-URL CSS prefetch link.

  Previously, streaming SSR used `template.includes(asset)` to decide whether route CSS was already present. A `<link rel="prefetch">` for the same CSS
  URL could be mistaken for an injected stylesheet, so the current route CSS was not emitted as `<link rel="stylesheet">`.

  ## Changes

  - Add stylesheet-aware link detection for streaming SSR CSS dedupe.
  - Only skip CSS injection when a matching `href` has a `rel` token containing `stylesheet`.
  - Keep `rel="prefetch"` and `rel="preload" as="style"` from blocking stylesheet injection.
  - Add unit tests for stylesheet detection edge cases.
  - Move the regression integration test to the streaming SSR fixture and enable `performance.prefetch` there.
