### PR TITLE
fix(runtime): use final HTML template parameters when rendering custom Document

### DIFF
--- a/.changeset/fix-document-template-parameters.md
+++ b/.changeset/fix-document-template-parameters.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix(runtime): use the final HTML template parameters when rendering custom Document
+
+The custom Document renderer previously rebuilt its template parameters by calling `options.templateParameters` with empty stubs, which silently dropped any parameters resolved asynchronously by Rsbuild. It now reuses the final `templateData` passed by the HTML plugin (stripping `compilation` / `htmlPlugin` / `rspackConfig` bundler internals), so async and user-supplied template parameters are correctly forwarded to Document.
+
+fix(runtime): 渲染自定义 Document 时使用最终的 HTML 模板参数
+
+之前自定义 Document 渲染流程会用空对象重新调用 `options.templateParameters` 来拼装模板参数，导致 Rsbuild 异步解析出的参数被静默丢弃。现已改为直接复用 HTML 插件传入的最终 `templateData`（剥掉 `compilation` / `htmlPlugin` / `rspackConfig` 等 bundler 内部字段），确保异步及用户自定义的模板参数能正确传递到 Document。

--- a/.changeset/fix-document-template-parameters.md
+++ b/.changeset/fix-document-template-parameters.md
@@ -4,8 +4,4 @@
 
 fix(runtime): use the final HTML template parameters when rendering custom Document
 
-The custom Document renderer previously rebuilt its template parameters by calling `options.templateParameters` with empty stubs, which silently dropped any parameters resolved asynchronously by Rsbuild. It now reuses the final `templateData` passed by the HTML plugin (stripping `compilation` / `htmlPlugin` / `rspackConfig` bundler internals), so async and user-supplied template parameters are correctly forwarded to Document.
-
 fix(runtime): 渲染自定义 Document 时使用最终的 HTML 模板参数
-
-之前自定义 Document 渲染流程会用空对象重新调用 `options.templateParameters` 来拼装模板参数，导致 Rsbuild 异步解析出的参数被静默丢弃。现已改为直接复用 HTML 插件传入的最终 `templateData`（剥掉 `compilation` / `htmlPlugin` / `rspackConfig` 等 bundler 内部字段），确保异步及用户自定义的模板参数能正确传递到 Document。

--- a/packages/runtime/plugin-runtime/src/document/cli/index.ts
+++ b/packages/runtime/plugin-runtime/src/document/cli/index.ts
@@ -62,8 +62,7 @@ interface HtmlRspackPlugin {
 
 interface HtmlTemplateData {
   htmlPlugin?: HtmlRspackPlugin;
-  htmlWebpackPlugin?: HtmlRspackPlugin;
-  htmlRspackPlugin?: HtmlRspackPlugin;
+  [key: string]: unknown;
 }
 
 interface ExternalRequest {
@@ -639,10 +638,7 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
         .replace(DOCUMENT_TITLE_PLACEHOLDER, () => titles);
     };
 
-    const documentEntry = (
-      entryName: string,
-      templateParameters: Record<string, unknown>,
-    ) => {
+    const documentEntry = (entryName: string) => {
       const { entrypoints, internalDirectory, appDirectory } =
         api.getAppContext();
 
@@ -657,6 +653,12 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
       }
       return async (templateData: HtmlTemplateData) => {
         const config = api.getNormalizedConfig();
+        const {
+          compilation: _compilation,
+          htmlPlugin,
+          rspackConfig: _rspackConfig,
+          ...templateParameters
+        } = templateData;
         const documentParams = getDocParams({
           config: config as NormalizedConfig,
           entryName,
@@ -679,10 +681,6 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
 
         const { partialsByEntrypoint } = api.getAppContext();
         html = processPartials(html, entryName, partialsByEntrypoint || {});
-        const htmlPlugin =
-          templateData.htmlPlugin ||
-          templateData.htmlWebpackPlugin ||
-          templateData.htmlRspackPlugin;
         if (!htmlPlugin) {
           throw new Error(
             'Failed to get HTML plugin tags from template parameters.',
@@ -714,22 +712,7 @@ export const documentPlugin = (): CliPlugin<AppTools> => ({
       return {
         tools: {
           htmlPlugin: (options: any, entry: any) => {
-            // reuse builder's computed base parameters
-            // https://github.com/web-infra-dev/modern.js/blob/1abb452a87ae1adbcf8da47d62c05da39cbe4d69/packages/builder/builder-webpack-provider/src/plugins/html.ts#L69-L103
-            const hackParameters: Record<string, unknown> =
-              typeof options?.templateParameters === 'function'
-                ? options?.templateParameters(
-                    {} as any,
-                    {} as any,
-                    {} as any,
-                    {} as any,
-                  )
-                : { ...options?.templateParameters };
-
-            const templateContent = documentEntry(
-              entry.entryName,
-              hackParameters,
-            );
+            const templateContent = documentEntry(entry.entryName);
 
             const documentHtmlOptions = templateContent
               ? {

--- a/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/document/cli.test.tsx
@@ -6,6 +6,7 @@ import {
   createPluginManager,
 } from '@modern-js/plugin';
 import { createContext, initPluginAPI } from '@modern-js/plugin/cli';
+import { rs } from '@rstest/core';
 
 import type { AppTools, AppToolsContext } from '@modern-js/app-tools';
 import { getBundleEntry } from '../../../../solutions/app-tools/src/plugins/analyze/getBundleEntry';
@@ -65,57 +66,54 @@ describe('plugin runtime cli', () => {
       config.find((item: any) => item.tools.htmlPlugin)! as any
     ).tools;
 
+    const templateParameters = rs.fn(async () => {
+      return {
+        title: 'abc',
+      };
+    });
     const mockBuilderOptions = {
-      templateParameters: () => {
-        return {
-          title: 'abc',
-        };
-      },
+      templateParameters,
       k: 'k',
     };
     const result = htmlPlugin(mockBuilderOptions, { entryName: 'main' });
 
     // mock renderer to bypass child-compiler output in unit test
+    let documentParams: any;
     (global as any).__MODERN_DOC_RENDERERS__ = {
-      main: () => '<html><head></head><body>mock</body></html>',
+      main: (params: any) => {
+        documentParams = params;
+        return '<html><head></head><body>mock</body></html>';
+      },
     };
 
     expect(result.k).toEqual(mockBuilderOptions.k);
     expect(result.templateParameters).toEqual(
       mockBuilderOptions.templateParameters,
     );
+    expect(templateParameters).not.toHaveBeenCalled();
     expect(Object.keys(result).length > 2).toBeTruthy();
     const htmlPluginFn = result.templateContent;
 
+    const compilation: Record<string, unknown> = {};
+    compilation.self = compilation;
     const html = await htmlPluginFn({
+      compilation,
       htmlPlugin: {
         tags: {
           headTags: [],
           bodyTags: '',
         },
       },
+      rspackConfig: { name: 'client' },
+      title: 'abc',
+      asyncValue: 'resolved',
     });
     expect(html.includes('<!DOCTYPE html>')).toBeTruthy();
-
-    const htmlWithHtmlWebpackPlugin = await htmlPluginFn({
-      htmlWebpackPlugin: {
-        tags: {
-          headTags: [],
-          bodyTags: '',
-        },
-      },
+    expect(documentParams.templateParams).toEqual({
+      title: 'abc',
+      asyncValue: 'resolved',
     });
-    expect(htmlWithHtmlWebpackPlugin.includes('<!DOCTYPE html>')).toBeTruthy();
-
-    const htmlWithHtmlRspackPlugin = await htmlPluginFn({
-      htmlRspackPlugin: {
-        tags: {
-          headTags: [],
-          bodyTags: '',
-        },
-      },
-    });
-    expect(htmlWithHtmlRspackPlugin.includes('<!DOCTYPE html>')).toBeTruthy();
+    expect(() => JSON.stringify(documentParams.templateParams)).not.toThrow();
   });
   it('when user config set empty entries and disableDefaultEntries true, should get the ', async () => {
     const hooks: any = pluginAPI.getHooks();


### PR DESCRIPTION
## Summary

- Reuse the final `templateData` passed by the HTML plugin when rendering the custom Document, stripping `compilation` / `htmlPlugin` / `rspackConfig` bundler internals before forwarding to Document.
- Drop the previous hack that rebuilt template parameters by calling `options.templateParameters` with empty stubs, which silently dropped async-resolved parameters from Rsbuild.
- Update unit tests: mock `__MODERN_DOC_RENDERERS__` to capture the params handed to the renderer, assert async / user-supplied parameters are forwarded, and verify the circular `compilation` reference is stripped.

---

- 自定义 Document 渲染时改为复用 HTML 插件传入的最终 `templateData`，剥掉 `compilation` / `htmlPlugin` / `rspackConfig` 这些 bundler 内部字段后透传给 Document。
- 移除原本用空对象重新调用 `options.templateParameters` 拼装模板参数的 hack —— 这种写法会丢掉 Rsbuild 异步解析出来的参数。
- 单测同步更新：mock `__MODERN_DOC_RENDERERS__` 抓取传给 renderer 的 `templateParams`，断言 async 参数与用户自定义参数都能正确透传，并验证循环引用的 `compilation` 已被剥离。

## Test plan

- [x] `npx rstest run packages/runtime/plugin-runtime/tests/document/cli.test.tsx`
