### PR TITLE
feat(app-tools): add modifyBuilderEnvironments hook

### DIFF
--- a/.changeset/modify-builder-environments.md
+++ b/.changeset/modify-builder-environments.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/app-tools': minor
+---
+
+feat(app-tools): add `modifyBuilderEnvironments` hook to transform the builder environments map before the builder is created
+
+A new additive app-tools hook `modifyBuilderEnvironments` runs in `generateBuilder` after the framework's static environment merge and before `createBuilder`. It mirrors `modifyEntrypoints` as a transform-object async hook: each tapped callback receives `{ environments }` and may return a replacement map that chains to the next callback; tapping nothing leaves the environments byte-identical, so the change is fully backward compatible. This lets frameworks programmatically add environments (e.g. a custom browser worker environment), set per-environment `output`/`distPath`/ordering, or otherwise adjust the resolved environments map instead of being limited to a config-static merge.
+
+feat(app-tools): 新增 `modifyBuilderEnvironments` hook，可在创建 builder 前变换 builder 环境表
+
+新增的 app-tools hook `modifyBuilderEnvironments` 在 `generateBuilder` 中、框架静态环境合并之后、`createBuilder` 之前执行。它与 `modifyEntrypoints` 一致，是 transform-object 异步 hook：每个回调收到 `{ environments }`，可返回替换后的环境表并链式传给下一个回调；不挂载任何回调时环境表字节不变，完全向后兼容。框架可借此以编程方式新增环境（如自定义浏览器 worker 环境）、设置 per-environment 的 `output`/`distPath`/顺序，或调整已解析的环境表，而不再局限于静态配置合并。

--- a/packages/solutions/app-tools/src/builder/generator/index.ts
+++ b/packages/solutions/app-tools/src/builder/generator/index.ts
@@ -59,6 +59,22 @@ export async function generateBuilder(
     builderConfig.environments = environments;
   }
 
+  // Allow plugins to transform the fully-merged builder environments map after
+  // the static framework env-merge and before the builder is created. Mirrors
+  // `modifyEntrypoints`: a transform-object hook whose non-undefined return
+  // replaces `environments`; with no taps the map is left untouched (identity).
+  const hooks = appContext._internalContext.pluginAPI?.getHooks();
+  if (hooks?.modifyBuilderEnvironments) {
+    const { environments: modifiedEnvironments } =
+      await hooks.modifyBuilderEnvironments.call({
+        environments: builderConfig.environments as Record<
+          string,
+          EnvironmentConfig
+        >,
+      });
+    builderConfig.environments = modifiedEnvironments;
+  }
+
   const builder = await createBuilder({
     cwd: appContext.appDirectory,
     rscClientRuntimePath: `@${appContext.metaName}/runtime/rsc/client`,

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -34,6 +34,7 @@ import type {
   CheckEntryPointFn,
   DeplpoyFn,
   GenerateEntryCodeFn,
+  ModifyBuilderEnvironmentsFn,
   ModifyEntrypointsFn,
   ModifyFileSystemRoutesFn,
 } from './types/plugin';
@@ -66,6 +67,7 @@ export const appTools = (): CliPlugin<AppTools> => ({
     deploy: createAsyncHook<DeplpoyFn>(),
     checkEntryPoint: createAsyncHook<CheckEntryPointFn>(),
     modifyEntrypoints: createAsyncHook<ModifyEntrypointsFn>(),
+    modifyBuilderEnvironments: createAsyncHook<ModifyBuilderEnvironmentsFn>(),
     modifyFileSystemRoutes: createAsyncHook<ModifyFileSystemRoutesFn>(),
     generateEntryCode: createAsyncHook<GenerateEntryCodeFn>(),
     onBeforeGenerateRoutes: createAsyncHook<BeforeGenerateRoutesFn>(),

--- a/packages/solutions/app-tools/src/types/plugin.ts
+++ b/packages/solutions/app-tools/src/types/plugin.ts
@@ -18,6 +18,7 @@ import type {
   ServerRoute,
 } from '@modern-js/types';
 import type { EagerRouteComponentFilesByEntry } from '@modern-js/utils';
+import type { EnvironmentConfig } from '@rsbuild/core';
 import type { AppTools } from '.';
 import type { getHookRunners } from '../compat/hooks';
 import type { AppToolsNormalizedConfig, AppToolsUserConfig } from './config';
@@ -29,6 +30,9 @@ export type CheckEntryPointFn = TransformFunction<{
 }>;
 export type ModifyEntrypointsFn = TransformFunction<{
   entrypoints: Entrypoint[];
+}>;
+export type ModifyBuilderEnvironmentsFn = TransformFunction<{
+  environments: Record<string, EnvironmentConfig>;
 }>;
 export type ModifyFileSystemRoutesFn = TransformFunction<{
   entrypoint: Entrypoint;
@@ -53,6 +57,7 @@ export interface AppToolsExtendAPI {
 
   checkEntryPoint: PluginHookTap<CheckEntryPointFn>;
   modifyEntrypoints: PluginHookTap<ModifyEntrypointsFn>;
+  modifyBuilderEnvironments: PluginHookTap<ModifyBuilderEnvironmentsFn>;
   modifyFileSystemRoutes: PluginHookTap<ModifyFileSystemRoutesFn>;
 
   generateEntryCode: PluginHookTap<GenerateEntryCodeFn>;
@@ -85,6 +90,7 @@ export interface AppToolsExtendHooks
   deploy: AsyncHook<DeplpoyFn>;
   checkEntryPoint: AsyncHook<CheckEntryPointFn>;
   modifyEntrypoints: AsyncHook<ModifyEntrypointsFn>;
+  modifyBuilderEnvironments: AsyncHook<ModifyBuilderEnvironmentsFn>;
   modifyFileSystemRoutes: AsyncHook<ModifyFileSystemRoutesFn>;
   generateEntryCode: AsyncHook<GenerateEntryCodeFn>;
   onBeforeGenerateRoutes: AsyncHook<BeforeGenerateRoutesFn>;

--- a/packages/solutions/app-tools/tests/builder/modifyBuilderEnvironments.test.ts
+++ b/packages/solutions/app-tools/tests/builder/modifyBuilderEnvironments.test.ts
@@ -1,0 +1,44 @@
+import { createAsyncHook } from '@modern-js/plugin';
+import { appTools } from '../../src';
+import type { ModifyBuilderEnvironmentsFn } from '../../src/types/plugin';
+
+describe('modifyBuilderEnvironments hook', () => {
+  it('is registered on the app-tools registryHooks', () => {
+    const plugin = appTools();
+    expect(plugin.registryHooks?.modifyBuilderEnvironments).toBeDefined();
+  });
+
+  it('identity default: with no taps, environments is byte-identical (same ref)', async () => {
+    const hook = createAsyncHook<ModifyBuilderEnvironmentsFn>();
+    const environments = { web: { output: { target: 'web' } } } as any;
+    const { environments: out } = await hook.call({ environments });
+    expect(out).toBe(environments);
+  });
+
+  it('a tap returning undefined leaves environments untouched', async () => {
+    const hook = createAsyncHook<ModifyBuilderEnvironmentsFn>();
+    hook.tap(() => undefined as any);
+    const environments = { web: {} } as any;
+    const { environments: out } = await hook.call({ environments });
+    expect(out).toBe(environments);
+  });
+
+  it('a transform replaces the environments map and chains to the next tap', async () => {
+    const hook = createAsyncHook<ModifyBuilderEnvironmentsFn>();
+    hook.tap(({ environments }) => ({
+      environments: {
+        ...environments,
+        Worker: { output: { target: 'web-worker' } } as any,
+      },
+    }));
+    hook.tap(({ environments }) => {
+      // the second tap sees the first tap's output
+      expect(environments.Worker).toBeDefined();
+      return { environments };
+    });
+    const { environments: out } = await hook.call({
+      environments: { web: {} } as any,
+    });
+    expect(Object.keys(out)).toEqual(['web', 'Worker']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an additive `modifyBuilderEnvironments` hook to `@modern-js/app-tools` that lets plugins/frameworks transform the resolved Rsbuild **environments** map programmatically — after the framework's static environment merge and right before `createBuilder` is called in `generateBuilder`.

Today the only way to influence the environments map is a static `builderConfig.environments` merge. Frameworks built on app-tools that need to add an environment programmatically (e.g. a custom browser web-worker environment), set per-environment `output`/`distPath`/ordering, or adjust the resolved environments based on runtime context have no seam to do so. This hook provides that seam.

## What it does

- New hook `modifyBuilderEnvironments`, declared in `appTools().registryHooks` and typed in `types/plugin.ts` as `ModifyBuilderEnvironmentsFn = TransformFunction<{ environments: Record<string, EnvironmentConfig> }>`, mirroring the existing `modifyEntrypoints` transform-object hook exactly.
- Invoked in `builder/generator/index.ts` after the static env-merge block and before `createBuilder`. A tapped callback receives `{ environments }` and may return a replacement map that chains to the next callback.
- **Fully backward compatible**: with no taps, the environments map is returned byte-identical (same reference), so existing builds are unchanged.

## Usage

```ts
api.modifyBuilderEnvironments(({ environments }) => ({
  environments: {
    ...environments,
    worker: {
      output: { target: 'web-worker' },
      source: { entry: { worker: './src/worker.ts' } },
    },
  },
}));
```

## Tests & changeset

- `packages/solutions/app-tools/tests/builder/modifyBuilderEnvironments.test.ts` — registration + identity-default + transform/chaining (4 tests, green). Full `@modern-js/app-tools` suite passes (89/89). Build + biome clean.
- Changeset: `@modern-js/app-tools` minor.
