### PR TITLE
fix(app-tools): scope adapterSSR SSR entry filtering to Modern server/service-worker envs

### DIFF
--- a/.changeset/adapter-ssr-custom-node-env.md
+++ b/.changeset/adapter-ssr-custom-node-env.md
@@ -1,0 +1,11 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix(app-tools): scope adapterSSR's SSR entry filtering to Modern server / service-worker environments
+
+`builderPluginAdapterSSR` ran `applyFilterEntriesBySSRConfig` for every `target === 'node'` environment, which wrongly captured custom node environments added via the new `modifyBuilderEnvironments` hook — their entry was filtered out (it is not a Modern SSR entry) and the bundler fell back to its default `./src` entry. Gate the entry filtering to Modern's own `server` and service-worker environments by name, so a custom node environment keeps its own entry. Modern SSR behavior is unchanged (the `server` / service-worker envs are still filtered).
+
+fix(app-tools): 把 adapterSSR 的 SSR entry 过滤限定到 Modern server / service-worker 环境
+
+`builderPluginAdapterSSR` 原先对所有 `target === 'node'` 环境执行 `applyFilterEntriesBySSRConfig`，这会误伤通过新 `modifyBuilderEnvironments` hook 注入的自定义 node 环境——它们的 entry 被过滤空（不是 Modern SSR entry），打包器回落到默认 `./src` entry。现按环境名把 entry 过滤限定到 Modern 自己的 `server` 与 service-worker 环境，自定义 node 环境保留自己的 entry。Modern SSR 行为不变（`server` / service-worker 环境仍会被过滤）。

--- a/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
+++ b/packages/solutions/app-tools/src/builder/shared/builderPlugins/adapterSSR.ts
@@ -86,8 +86,15 @@ export const builderPluginAdapterSSR = (
 
         const isServiceWorker =
           environment.name === SERVICE_WORKER_ENVIRONMENT_NAME;
+        // Only Modern's own SSR server / service-worker environments get the Modern
+        // SSR entry filtering. A custom node environment injected via
+        // `modifyBuilderEnvironments` (e.g. a framework's own server bundle env) keeps
+        // its own entry and must NOT be filtered against the Modern SSR entry config —
+        // gating on `target === 'node'` alone wrongly captured every custom node env.
+        const isModernServerEnvironment =
+          environment.name === 'server' || isServiceWorker;
 
-        if (target === 'node' || isServiceWorker) {
+        if (isModernServerEnvironment) {
           applyFilterEntriesBySSRConfig({
             isProd,
             chain,

--- a/packages/solutions/app-tools/tests/builder/adapterSSR.test.ts
+++ b/packages/solutions/app-tools/tests/builder/adapterSSR.test.ts
@@ -1,0 +1,95 @@
+import { builderPluginAdapterSSR } from '../../src/builder/shared/builderPlugins/adapterSSR';
+
+/**
+ * A minimal bundler-chain stub: real `entry` / `entryPoints` tracking, with every
+ * other access a self-returning chainable so `applyRouterPlugin` and the html/async
+ * plugins are inert no-ops. We only assert on entry survival.
+ */
+function createMockChain() {
+  const entries: Record<string, { paths: string[] }> = {};
+  const chainable: any = new Proxy(() => chainable, {
+    // `then: undefined` so the proxy is not thenable (else `await`-ing a returned
+    // chain would try to unwrap it forever).
+    get: (_t, k) => (k === 'then' ? undefined : chainable),
+    apply: () => chainable,
+  });
+  const base: any = {
+    entry(name: string) {
+      return {
+        add(p: string) {
+          (entries[name] ||= { paths: [] }).paths.push(p);
+          return chainable;
+        },
+      };
+    },
+    entryPoints: {
+      entries: () => entries,
+      has: (name: string) => name in entries,
+      delete: (name: string) => {
+        delete entries[name];
+      },
+    },
+  };
+  return new Proxy(base, {
+    get: (t, k) =>
+      k in t ? (t as any)[k] : k === 'then' ? undefined : chainable,
+  });
+}
+
+async function runAdapterChain(environmentName: string) {
+  let chainCb: any;
+  const api: any = {
+    modifyRsbuildConfig: () => {},
+    modifyBundlerChain: (cb: any) => {
+      chainCb = cb;
+    },
+  };
+  const options: any = {
+    // non-SSR config: applyFilterEntriesBySSRConfig (if it runs) deletes the entry
+    normalizedConfig: {
+      server: {},
+      output: {},
+      html: {},
+      source: {},
+      tools: {},
+      deploy: {},
+      bff: {},
+    },
+    appContext: { entrypoints: [], internalDirectory: '/tmp/.modern-internal' },
+    eagerRouteComponentFilesByEntry: {},
+  };
+  builderPluginAdapterSSR(options).setup(api);
+
+  const chain = createMockChain();
+  chain.entry('index').add('/custom/server-entry.js');
+  await chainCb(chain, {
+    target: 'node',
+    isProd: true,
+    HtmlPlugin: class {},
+    isServer: true,
+    // node env: html disabled (tools.htmlPlugin:false) so applyAsyncChunkHtmlPlugin
+    // is skipped — we only exercise the entry-filter gate here.
+    environment: {
+      name: environmentName,
+      config: { tools: { htmlPlugin: false } },
+    },
+  });
+  return chain;
+}
+
+describe('builderPluginAdapterSSR — SSR entry filtering is gated to Modern server envs', () => {
+  it('keeps a custom node env (e.g. piaServer) entry — applyFilterEntriesBySSRConfig is NOT applied', async () => {
+    const chain = await runAdapterChain('piaServer');
+    // The custom server bundle entry must survive. Gating on `target === 'node'`
+    // alone wrongly filtered every custom node env, leaving it empty so rsbuild fell
+    // back to its default `./src` entry.
+    expect(chain.entryPoints.has('index')).toBe(true);
+  });
+
+  it('filters the Modern `server` env entry under a non-SSR config — proving the filter is active, just gated', async () => {
+    const chain = await runAdapterChain('server');
+    // The Modern `server` env DOES get SSR entry filtering; with no ssr config the
+    // non-ssr entry is removed (the exact behavior the custom-env gate must avoid).
+    expect(chain.entryPoints.has('index')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #8717 (the `modifyBuilderEnvironments` hook). `builderPluginAdapterSSR` ran `applyFilterEntriesBySSRConfig` for **every** `target === 'node'` environment, which wrongly captured custom node environments added via that hook: their entry was filtered out (it is not a Modern SSR entry) and the bundler fell back to its default `./src` entry. Gate the entry filtering to Modern's own `server` and service-worker environments by name so a custom node environment keeps its own entry. Modern SSR behavior is unchanged (the `server` / service-worker envs are still filtered).

## Tests

`tests/builder/adapterSSR.test.ts` — a custom node env keeps its entry; the Modern `server` env entry is still filtered under a non-SSR config.

Changeset included.