### PR TITLE
feat(server): unified dev-server runtime hot reload (replace BFF-local hot update)

### DIFF
--- a/.changeset/unified-dev-server-hot-reload.md
+++ b/.changeset/unified-dev-server-hot-reload.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server': patch
+'@modern-js/plugin-bff': patch
+---
+
+feat(server): unified dev-server runtime hot reload, replacing the BFF-local hot update
+feat(server): 统一 dev-server 运行时热更新，替换 BFF 本地热更

--- a/packages/cli/plugin-bff/src/runtime/hono/adapter.ts
+++ b/packages/cli/plugin-bff/src/runtime/hono/adapter.ts
@@ -1,27 +1,12 @@
 import type { APIHandlerInfo } from '@modern-js/bff-core';
-import type {
-  Context,
-  MiddlewareHandler,
-  Next,
-  ServerMiddleware,
-  ServerPluginAPI,
-} from '@modern-js/server-core';
-import { Hono, run } from '@modern-js/server-core';
+import type { ServerMiddleware, ServerPluginAPI } from '@modern-js/server-core';
 
-import { isProd, logger } from '@modern-js/utils';
 import createHonoRoutes from '../../utils/createHonoRoutes';
 
 const before = ['custom-server-hook', 'custom-server-middleware', 'render'];
-const kParentHonoVars = Symbol.for('modernjs.hono.parentVars');
-
-interface MiddlewareOptions {
-  prefix: string;
-  enableHandleWeb?: boolean;
-}
 
 export class HonoAdapter {
   apiMiddleware: ServerMiddleware[] = [];
-  apiServer: Hono | null = null;
   api: ServerPluginAPI;
   isHono = true;
   constructor(api: ServerPluginAPI) {
@@ -45,87 +30,16 @@ export class HonoAdapter {
     }));
   };
 
-  registerApiRoutes = async () => {
-    if (!this.isHono) {
-      return;
-    }
-    this.apiServer = new Hono();
-    this.apiServer.use('*', run);
-    this.apiServer.use('*', async (c, next) => {
-      const nodeReq = (c.env as any)?.node?.req;
-      const parentVars = nodeReq?.[kParentHonoVars];
-      if (parentVars && typeof parentVars === 'object') {
-        delete nodeReq[kParentHonoVars];
-        for (const [key, value] of Object.entries(parentVars)) {
-          if ((c as any).get(key) === undefined) {
-            (c as any).set(key, value);
-          }
-        }
-      }
-      await next();
-    });
-    this.apiMiddleware.forEach(({ path = '*', method = 'all', handler }) => {
-      const handlers = this.wrapInArray(handler);
-      if (handlers.length === 0) {
-        return;
-      }
-      const firstHandler = handlers[0]!;
-      const restHandlers = handlers.slice(1);
-      /**
-       * When we call `apiServer[method]` directly, TypeScript may choose the overload
-       * where the first argument is a handler (no `path`), and then rejects `path: string`.
-       * We ensure at least one handler exists and cast to the "path + handlers" signature.
-       */
-      type RouteMethod =
-        | 'options'
-        | 'get'
-        | 'post'
-        | 'put'
-        | 'delete'
-        | 'patch'
-        | 'all';
-      type Register = (
-        path: string,
-        handler: MiddlewareHandler,
-        ...handlers: MiddlewareHandler[]
-      ) => unknown;
-      const m = method as RouteMethod;
-      const server = this.apiServer;
-      if (!server) {
-        return;
-      }
-      const register = server[m] as unknown as Register;
-      register.call(server, path, firstHandler, ...restHandlers);
-    });
-
-    this.apiServer.onError(async (err, c) => {
-      try {
-        const serverConfig = this.api.getServerConfig();
-        const onErrorHandler = serverConfig?.onError;
-
-        if (onErrorHandler) {
-          const result = await onErrorHandler(err, c);
-          if (result instanceof Response) {
-            return result;
-          }
-        } else {
-          logger.error(err);
-        }
-      } catch (configError) {
-        logger.error(`Error in serverConfig.onError handler: ${configError}`);
-      }
-      return c.json(
-        {
-          message: (err as any)?.message || '[BFF] Internal Server Error',
-        },
-        (err as any)?.status || 500,
-      );
-    });
-  };
-
-  registerMiddleware = async (options: MiddlewareOptions) => {
-    const { prefix } = options;
-
+  /**
+   * Register the BFF API routes as ordinary server middlewares.
+   *
+   * Dev and prod now share this single path: the routes are pushed straight
+   * into the server's middleware list. In dev, hot updates are handled by the
+   * unified `@modern-js/server` runtime reload (which rebuilds the whole
+   * runtime — including this plugin — from scratch), so BFF no longer needs its
+   * own swappable Hono sub-app / dynamic dispatch middleware.
+   */
+  registerMiddleware = async () => {
     const { bffRuntimeFramework } = this.api.getServerContext();
 
     if (bffRuntimeFramework !== 'hono') {
@@ -137,45 +51,6 @@ export class HonoAdapter {
 
     await this.setHandlers();
 
-    if (isProd()) {
-      globalMiddlewares.push(...this.apiMiddleware);
-    } else {
-      await this.registerApiRoutes();
-      /** api hot update */
-      const dynamicApiMiddleware: ServerMiddleware = {
-        name: 'dynamic-bff-handler',
-        path: `${prefix}/*`,
-        method: 'all',
-        order: 'post',
-        before,
-        handler: async (c: Context, next: Next) => {
-          if (this.apiServer) {
-            const nodeReq = (c.env as any)?.node?.req;
-            if (nodeReq) {
-              const parentVars = (c as any)?.var;
-              nodeReq[kParentHonoVars] =
-                parentVars && typeof parentVars === 'object'
-                  ? { ...parentVars }
-                  : parentVars;
-            }
-            const response = await this.apiServer.fetch(c.req.raw, c.env);
-            if (response.status !== 404) {
-              return new Response(response.body, response);
-            }
-          }
-          await next();
-        },
-      };
-      globalMiddlewares.push(dynamicApiMiddleware);
-    }
+    globalMiddlewares.push(...this.apiMiddleware);
   };
-  wrapInArray(
-    handler: MiddlewareHandler[] | MiddlewareHandler,
-  ): MiddlewareHandler[] {
-    if (Array.isArray(handler)) {
-      return handler;
-    } else {
-      return [handler];
-    }
-  }
 }

--- a/packages/cli/plugin-bff/src/server.ts
+++ b/packages/cli/plugin-bff/src/server.ts
@@ -9,10 +9,6 @@ import { HonoAdapter } from './runtime/hono/adapter';
 type SF = (args: any) => void;
 class Storage {
   public middlewares: SF[] = [];
-
-  reset() {
-    this.middlewares = [];
-  }
 }
 
 export default (): ServerPlugin => ({
@@ -77,32 +73,11 @@ export default (): ServerPlugin => ({
         });
       }
 
-      honoAdapter.registerMiddleware({
-        prefix,
-        enableHandleWeb,
-      });
+      honoAdapter.registerMiddleware();
     });
-    api.onReset(async ({ event }) => {
-      storage.reset();
-      const appContext = api.getServerContext();
-      const { middlewares } = storage;
-      api.updateServerContext({
-        ...appContext,
-        apiMiddlewares: middlewares,
-      });
-
-      if (event.type === 'file-change') {
-        const apiHandlerInfos = await apiRouter.getApiHandlers();
-        const appContext = api.getServerContext();
-        api.updateServerContext({
-          ...appContext,
-          apiHandlerInfos,
-        });
-
-        await honoAdapter.setHandlers();
-        await honoAdapter.registerApiRoutes();
-      }
-    });
+    // No BFF-local onReset rebuild: in dev, `@modern-js/server` rebuilds the
+    // whole runtime (including this plugin) on file changes, so the API routes
+    // are re-registered from scratch on every reload.
     api.prepareApiServer((async (input: any, next: any) => {
       const { pwd, prefix, httpMethodDecider } = input;
       const apiDir = path.resolve(pwd, API_DIR);

--- a/packages/cli/plugin-bff/src/server.ts
+++ b/packages/cli/plugin-bff/src/server.ts
@@ -73,7 +73,9 @@ export default (): ServerPlugin => ({
         });
       }
 
-      honoAdapter.registerMiddleware();
+      // Await: this is the sole BFF Hono registration entry, and onPrepare must
+      // finish pushing routes before ServerBase#applyMiddlewares runs.
+      await honoAdapter.registerMiddleware();
     });
     // No BFF-local onReset rebuild: in dev, `@modern-js/server` rebuilds the
     // whole runtime (including this plugin) on file changes, so the API routes

--- a/packages/cli/plugin-bff/src/server.ts
+++ b/packages/cli/plugin-bff/src/server.ts
@@ -77,9 +77,24 @@ export default (): ServerPlugin => ({
       // finish pushing routes before ServerBase#applyMiddlewares runs.
       await honoAdapter.registerMiddleware();
     });
-    // No BFF-local onReset rebuild: in dev, `@modern-js/server` rebuilds the
-    // whole runtime (including this plugin) on file changes, so the API routes
-    // are re-registered from scratch on every reload.
+    // This plugin's own routes are re-registered from scratch on every unified
+    // runtime reload, so no BFF-local route rebuild is needed here. But the
+    // public `file-change` onReset signal is emitted on the LIVE runtime BEFORE
+    // that debounced rebuild runs, and downstream server plugins may re-register
+    // their BFF handlers from `appContext.apiHandlerInfos` inside their own
+    // onReset handler. So we refresh apiHandlerInfos into the server context on
+    // file-change, keeping the contract that this value is fresh when onReset
+    // fires — otherwise those consumers would re-register with stale handlers.
+    api.onReset(async ({ event }) => {
+      if (event.type === 'file-change' && apiRouter) {
+        const appContext = api.getServerContext();
+        const apiHandlerInfos = await apiRouter.getApiHandlers();
+        api.updateServerContext({
+          ...appContext,
+          apiHandlerInfos,
+        });
+      }
+    });
     api.prepareApiServer((async (input: any, next: any) => {
       const { pwd, prefix, httpMethodDecider } = input;
       const apiDir = path.resolve(pwd, API_DIR);

--- a/packages/cli/plugin-bff/tests/honoAdapter.test.ts
+++ b/packages/cli/plugin-bff/tests/honoAdapter.test.ts
@@ -1,0 +1,87 @@
+import 'reflect-metadata';
+import type { ServerPluginAPI } from '@modern-js/server-core';
+import { HonoAdapter } from '../src/runtime/hono/adapter';
+
+const before = ['custom-server-hook', 'custom-server-middleware', 'render'];
+
+const sampleApiHandlerInfos = [
+  { handler: () => ({ id: 'foo' }), routePath: '/api/foo', httpMethod: 'GET' },
+  { handler: () => ({ id: 'bar' }), routePath: '/api/bar', httpMethod: 'POST' },
+] as any;
+
+function createMockApi(overrides: {
+  bffRuntimeFramework?: string;
+  apiHandlerInfos?: any;
+  middlewares: any[];
+}): ServerPluginAPI {
+  const context = {
+    bffRuntimeFramework: overrides.bffRuntimeFramework ?? 'hono',
+    apiHandlerInfos: overrides.apiHandlerInfos ?? sampleApiHandlerInfos,
+    middlewares: overrides.middlewares,
+  };
+  return {
+    getServerContext: () => context,
+  } as unknown as ServerPluginAPI;
+}
+
+describe('HonoAdapter.registerMiddleware (dev/prod unified path)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  async function register(nodeEnv: string) {
+    process.env.NODE_ENV = nodeEnv;
+    const middlewares: any[] = [];
+    const adapter = new HonoAdapter(createMockApi({ middlewares }));
+    await adapter.registerMiddleware();
+    return middlewares;
+  }
+
+  it('registers the API routes directly and never the dev-only dynamic-bff-handler', async () => {
+    const middlewares = await register('development');
+
+    const names = middlewares.map(m => m.name);
+    expect(names).toEqual(['hono-bff-api', 'hono-bff-api']);
+    expect(names).not.toContain('dynamic-bff-handler');
+
+    // path / method / order / before are preserved for routing + ordering.
+    expect(
+      middlewares.map(m => ({
+        method: m.method,
+        path: m.path,
+        order: m.order,
+        before: m.before,
+      })),
+    ).toEqual([
+      { method: 'get', path: '/api/foo', order: 'post', before },
+      { method: 'post', path: '/api/bar', order: 'post', before },
+    ]);
+  });
+
+  it('produces an identical registration in dev and prod', async () => {
+    const devMiddlewares = await register('development');
+    const prodMiddlewares = await register('production');
+
+    const shape = (list: any[]) =>
+      list.map(m => ({ name: m.name, method: m.method, path: m.path }));
+
+    expect(shape(devMiddlewares)).toEqual(shape(prodMiddlewares));
+    expect(shape(devMiddlewares)).toEqual([
+      { name: 'hono-bff-api', method: 'get', path: '/api/foo' },
+      { name: 'hono-bff-api', method: 'post', path: '/api/bar' },
+    ]);
+  });
+
+  it('registers nothing when the BFF runtime framework is not hono', async () => {
+    const middlewares: any[] = [];
+    const adapter = new HonoAdapter(
+      createMockApi({ bffRuntimeFramework: 'express', middlewares }),
+    );
+
+    await adapter.registerMiddleware();
+
+    expect(adapter.isHono).toBe(false);
+    expect(middlewares).toHaveLength(0);
+  });
+});

--- a/packages/cli/plugin-bff/tests/honoAdapter.test.ts
+++ b/packages/cli/plugin-bff/tests/honoAdapter.test.ts
@@ -1,5 +1,10 @@
 import 'reflect-metadata';
-import type { ServerPluginAPI } from '@modern-js/server-core';
+import {
+  type ServerPlugin,
+  type ServerPluginAPI,
+  compatPlugin,
+  createServerBase,
+} from '@modern-js/server-core';
 import { HonoAdapter } from '../src/runtime/hono/adapter';
 
 const before = ['custom-server-hook', 'custom-server-middleware', 'render'];
@@ -83,5 +88,112 @@ describe('HonoAdapter.registerMiddleware (dev/prod unified path)', () => {
 
     expect(adapter.isHono).toBe(false);
     expect(middlewares).toHaveLength(0);
+  });
+});
+
+function getDefaultConfig() {
+  return {
+    html: {},
+    output: {},
+    source: {},
+    tools: {},
+    server: {},
+    bff: {},
+    dev: {},
+    security: {},
+  } as any;
+}
+
+/**
+ * Inject API handler infos into the server context, then register them through
+ * the (Phase 4) unified HonoAdapter path — exactly what the BFF plugin does on
+ * every runtime build.
+ */
+function bffRoutesPlugin(apiHandlerInfos: any[]): ServerPlugin {
+  return {
+    name: 'test-bff-routes',
+    setup(api) {
+      api.onPrepare(async () => {
+        const ctx = api.getServerContext();
+        api.updateServerContext({ ...ctx, apiHandlerInfos });
+        await new HonoAdapter(api).registerMiddleware();
+      });
+    },
+  };
+}
+
+/**
+ * A catch-all middleware named `render` so the `hono-bff-api` routes
+ * (before: ['render']) are ordered ahead of it — mirroring the real SSR fallback.
+ */
+function renderPlugin(): ServerPlugin {
+  return {
+    name: 'test-render',
+    setup(api) {
+      api.onPrepare(() => {
+        const { middlewares } = api.getServerContext();
+        middlewares.push({
+          name: 'render',
+          path: '*',
+          method: 'all',
+          order: 'post',
+          handler: (c: any) => c.json({ served: 'render' }),
+        });
+      });
+    },
+  };
+}
+
+async function buildServer(prefix: string) {
+  const server = createServerBase({
+    config: getDefaultConfig(),
+    pwd: '',
+    appContext: {
+      apiDirectory: '',
+      lambdaDirectory: '',
+      bffRuntimeFramework: 'hono',
+    } as any,
+  });
+  const apiHandlerInfos = [
+    {
+      routePath: `${prefix}/hello`,
+      httpMethod: 'GET',
+      handler: () => ({ msg: 'hello' }),
+    },
+  ];
+  server.addPlugins([
+    compatPlugin(),
+    bffRoutesPlugin(apiHandlerInfos),
+    renderPlugin(),
+  ]);
+  await server.init();
+  return server;
+}
+
+describe('BFF API route dispatch through ServerBase (dev == prod path)', () => {
+  it('serves a matching API route under a custom prefix', async () => {
+    const server = await buildServer('/custom-api');
+
+    const res = await server.request('/custom-api/hello');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ msg: 'hello' });
+  });
+
+  it('falls through to render when an API path does not match (no truncation)', async () => {
+    const server = await buildServer('/api');
+
+    const res = await server.request('/api/not-exist');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ served: 'render' });
+  });
+
+  it('does not intercept non-API paths', async () => {
+    const server = await buildServer('/api');
+
+    const res = await server.request('/some/page');
+
+    expect(await res.json()).toEqual({ served: 'render' });
   });
 });

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -10,6 +10,7 @@ import {
   type ReloadableHandle,
   createReloadManager,
 } from './dev-tools/reloadManager';
+import { createRuntimeServerOptions } from './dev-tools/runtimeOptions';
 import { getDevAssetPrefix, getDevOptions } from './helpers';
 import type { ApplyPlugins, ModernDevServerOptions } from './types';
 
@@ -57,6 +58,11 @@ export async function createDevServer(
     runCompile: options.runCompile,
   });
 
+  // Resolved once from the builder (the compiler exists after createDevServer).
+  // Woven into every per-build fresh config by `createRuntimeServerOptions`,
+  // never mutated onto the shared `prodServerOptions.config`.
+  const assetPrefix = await assetPrefixPromise;
+
   /**
    * The currently-active runtime ServerBase. Process-level infra (the file
    * watcher / SSR-cache reset) reaches the live hooks through this mutable ref
@@ -74,15 +80,21 @@ export async function createDevServer(
    * resource — the watcher / websocket / builderDevServer / close callbacks are
    * owned by `setupDevInfra` and survive reloads untouched.
    *
-   * A fresh options object is spread per build so a stray append can never leak
-   * across builds; every plugin is re-applied onto a brand-new ServerBase.
+   * Every build gets a fully fresh options object (fresh config / serverConfig
+   * / plugins, see `createRuntimeServerOptions`) and that same object is handed
+   * to both `createServerBase` and `applyPlugins`, so a stray append in one
+   * runtime can never leak into the next reload.
    */
   const buildRuntimeServer = async (): Promise<ReloadableHandle> => {
-    const runtimeServer = createServerBase({ ...prodServerOptions });
+    const runtimeOptions = createRuntimeServerOptions(
+      prodServerOptions,
+      assetPrefix,
+    );
+    const runtimeServer = createServerBase(runtimeOptions);
     runtimeServer.addPlugins([
       devRuntimeMiddlewarePlugin({ ...options, builderDevServer }, compiler),
     ]);
-    await applyPlugins(runtimeServer, prodServerOptions, nodeServer);
+    await applyPlugins(runtimeServer, runtimeOptions, nodeServer);
     await runtimeServer.init();
     currentRuntimeServer = runtimeServer;
     return runtimeServer.handle;
@@ -110,12 +122,6 @@ export async function createDevServer(
     );
   } else {
     nodeServer = await createNodeServer(reloadManager.handle);
-  }
-
-  // run after createDevServer, we can get assetPrefix from builder
-  const assetPrefix = await assetPrefixPromise;
-  if (assetPrefix) {
-    prodServerOptions.config.output.assetPrefix = assetPrefix;
   }
 
   /**

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -148,7 +148,8 @@ export async function createDevServer(
    * Process-level dev infra, created once. The file watcher triggers a unified
    * runtime reload via `onFileChange`; the builder-recompile SSR-cache reset
    * (onRepack) still reaches the live runtime via `getRuntimeServer` (a mutable
-   * ref). BFF's own onReset-based local rebuild is removed in a later phase.
+   * ref). BFF no longer has its own onReset-based local rebuild — it joins the
+   * unified runtime reload.
    */
   setupDevInfra({
     config,

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -86,8 +86,21 @@ export async function createDevServer(
    * runtime can never leak into the next reload.
    */
   const buildRuntimeServer = async (): Promise<ReloadableHandle> => {
+    // Re-load modern.server.ts on every build so its plugins / middlewares /
+    // onError changes are picked up on reload. The watcher has already busted
+    // the require cache for changed files; an unchanged config just returns the
+    // cached module, so this is cheap when nothing relevant changed.
+    const freshServerConfig =
+      (await loadServerRuntimeConfig(serverConfigPath)) || {};
     const runtimeOptions = createRuntimeServerOptions(
-      prodServerOptions,
+      {
+        ...prodServerOptions,
+        serverConfig: { ...freshServerConfig, ...options.serverConfig },
+        plugins: [
+          ...(freshServerConfig.plugins || []),
+          ...(options.plugins || []),
+        ],
+      },
       assetPrefix,
     );
     const runtimeServer = createServerBase(runtimeOptions);
@@ -132,9 +145,10 @@ export async function createDevServer(
   reloadManager.setHandle(await buildRuntimeServer());
 
   /**
-   * Process-level dev infra, created once. The watcher / onRepack reach the
-   * live runtime via `getRuntimeServer` (a mutable ref) and a later phase will
-   * swap the trigger to `reloadManager.schedule()`.
+   * Process-level dev infra, created once. The file watcher triggers a unified
+   * runtime reload via `onFileChange`; the builder-recompile SSR-cache reset
+   * (onRepack) still reaches the live runtime via `getRuntimeServer` (a mutable
+   * ref). BFF's own onReset-based local rebuild is removed in a later phase.
    */
   setupDevInfra({
     config,
@@ -147,6 +161,10 @@ export async function createDevServer(
     compiler,
     nodeServer,
     getRuntimeServer: () => currentRuntimeServer,
+    // A watched user server file changed -> schedule a unified runtime reload.
+    // (debounced + serial + last-write-wins; a failed build keeps the old
+    // handle serving, so a syntax error never takes the dev server down.)
+    onFileChange: () => reloadManager.schedule(),
   });
 
   const afterListen = async () => {

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -1,12 +1,15 @@
 import path from 'node:path';
 import type { Rspack } from '@modern-js/builder';
-import { createServerBase } from '@modern-js/server-core';
+import { type ServerBase, createServerBase } from '@modern-js/server-core';
 import {
   createNodeServer,
   loadServerRuntimeConfig,
 } from '@modern-js/server-core/node';
-import { devPlugin } from './dev';
-import { createReloadManager } from './dev-tools/reloadManager';
+import { devRuntimeMiddlewarePlugin, setupDevInfra } from './dev';
+import {
+  type ReloadableHandle,
+  createReloadManager,
+} from './dev-tools/reloadManager';
 import { getDevAssetPrefix, getDevOptions } from './helpers';
 import type { ApplyPlugins, ModernDevServerOptions } from './types';
 
@@ -36,34 +39,67 @@ export async function createDevServer(
     plugins: [...(serverConfig.plugins || []), ...(options.plugins || [])],
   };
 
-  const server = createServerBase(prodServerOptions);
-
   /**
-   * Stable request handle indirection.
-   *
-   * The Node server (and its HTTPS / WebSocket / Rsbuild dev middleware layer)
-   * is created exactly once. Every request is forwarded through the
-   * ReloadManager to the latest runtime handle, so a future runtime reload can
-   * atomically swap the whole server runtime without recreating the Node
-   * server. On a failed reload the previous handle keeps serving.
-   *
-   * NOTE (phase 1): the `build` callback and the file-change trigger that calls
-   * `reloadManager.schedule()` are wired in a later phase. For now nothing
-   * invokes a reload, so behavior is identical to binding `server.handle`
-   * directly — only one extra forwarding call is added per request.
+   * Process-level resources, created EXACTLY ONCE. A runtime hot reload never
+   * recreates or tears these down: the Rspack compiler reference, the builder
+   * dev server (with its HMR / websocket / dev middleware), and the Node server
+   * itself (set up further below).
    */
-  const reloadManager = createReloadManager({
-    initialHandle: server.handle,
-    build: async () => {
-      throw new Error(
-        '[dev-server] runtime reload is not wired yet (pending later phase)',
-      );
-    },
+  let compiler: Rspack.Compiler | Rspack.MultiCompiler | null = null;
+
+  builder?.onAfterCreateCompiler(context => {
+    compiler = context.compiler;
   });
 
+  const assetPrefixPromise = getDevAssetPrefix(builder);
+
+  const builderDevServer = await builder?.createDevServer({
+    runCompile: options.runCompile,
+  });
+
+  /**
+   * The currently-active runtime ServerBase. Process-level infra (the file
+   * watcher / SSR-cache reset) reaches the live hooks through this mutable ref
+   * instead of closing over a single runtime instance.
+   */
+  let currentRuntimeServer: ServerBase | undefined;
+
+  let nodeServer: Awaited<ReturnType<typeof createNodeServer>> | undefined;
+
+  /**
+   * Build a brand-new runtime ServerBase and return its request handle.
+   *
+   * Used for the initial boot AND every hot reload, so there is exactly one
+   * definition of "what a runtime server contains". It creates NO process-level
+   * resource — the watcher / websocket / builderDevServer / close callbacks are
+   * owned by `setupDevInfra` and survive reloads untouched.
+   *
+   * A fresh options object is spread per build so a stray append can never leak
+   * across builds; every plugin is re-applied onto a brand-new ServerBase.
+   */
+  const buildRuntimeServer = async (): Promise<ReloadableHandle> => {
+    const runtimeServer = createServerBase({ ...prodServerOptions });
+    runtimeServer.addPlugins([
+      devRuntimeMiddlewarePlugin({ ...options, builderDevServer }, compiler),
+    ]);
+    await applyPlugins(runtimeServer, prodServerOptions, nodeServer);
+    await runtimeServer.init();
+    currentRuntimeServer = runtimeServer;
+    return runtimeServer.handle;
+  };
+
+  const reloadManager = createReloadManager({
+    build: buildRuntimeServer,
+  });
+
+  /**
+   * Node server / HTTPS / WebSocket layer: created once. Every request is
+   * forwarded through the ReloadManager to the latest runtime handle, so a
+   * runtime reload can atomically swap the whole runtime without recreating
+   * the Node server.
+   */
   const devHttpsOption = typeof dev === 'object' && dev.https;
   const isHttp2 = !!devHttpsOption;
-  let nodeServer;
   if (devHttpsOption) {
     const { genHttpsOptions } = await import('./dev-tools/https');
     const httpsOptions = await genHttpsOptions(devHttpsOption, pwd);
@@ -76,37 +112,36 @@ export async function createDevServer(
     nodeServer = await createNodeServer(reloadManager.handle);
   }
 
-  const promise = getDevAssetPrefix(builder);
-
-  let compiler: Rspack.Compiler | Rspack.MultiCompiler | null = null;
-
-  builder?.onAfterCreateCompiler(context => {
-    compiler = context.compiler;
-  });
-
-  const builderDevServer = await builder?.createDevServer({
-    runCompile: options.runCompile,
-  });
-
-  server.addPlugins([
-    devPlugin(
-      {
-        ...options,
-        builderDevServer,
-      },
-      compiler,
-    ),
-  ]);
-
   // run after createDevServer, we can get assetPrefix from builder
-  const assetPrefix = await promise;
+  const assetPrefix = await assetPrefixPromise;
   if (assetPrefix) {
     prodServerOptions.config.output.assetPrefix = assetPrefix;
   }
 
-  await applyPlugins(server, prodServerOptions, nodeServer);
+  /**
+   * Initial runtime build. Done explicitly (not through the ReloadManager) so a
+   * boot failure propagates instead of being swallowed as "keep the previous
+   * handle". The resulting handle seeds the ReloadManager.
+   */
+  reloadManager.setHandle(await buildRuntimeServer());
 
-  await server.init();
+  /**
+   * Process-level dev infra, created once. The watcher / onRepack reach the
+   * live runtime via `getRuntimeServer` (a mutable ref) and a later phase will
+   * swap the trigger to `reloadManager.schedule()`.
+   */
+  setupDevInfra({
+    config,
+    pwd,
+    distDir,
+    apiDir: options.appContext?.apiDirectory,
+    sharedDir: options.appContext?.sharedDirectory,
+    builder,
+    builderDevServer,
+    compiler,
+    nodeServer,
+    getRuntimeServer: () => currentRuntimeServer,
+  });
 
   const afterListen = async () => {
     await builderDevServer?.afterListen();

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -6,6 +6,7 @@ import {
   loadServerRuntimeConfig,
 } from '@modern-js/server-core/node';
 import { devPlugin } from './dev';
+import { createReloadManager } from './dev-tools/reloadManager';
 import { getDevAssetPrefix, getDevOptions } from './helpers';
 import type { ApplyPlugins, ModernDevServerOptions } from './types';
 
@@ -37,6 +38,29 @@ export async function createDevServer(
 
   const server = createServerBase(prodServerOptions);
 
+  /**
+   * Stable request handle indirection.
+   *
+   * The Node server (and its HTTPS / WebSocket / Rsbuild dev middleware layer)
+   * is created exactly once. Every request is forwarded through the
+   * ReloadManager to the latest runtime handle, so a future runtime reload can
+   * atomically swap the whole server runtime without recreating the Node
+   * server. On a failed reload the previous handle keeps serving.
+   *
+   * NOTE (phase 1): the `build` callback and the file-change trigger that calls
+   * `reloadManager.schedule()` are wired in a later phase. For now nothing
+   * invokes a reload, so behavior is identical to binding `server.handle`
+   * directly — only one extra forwarding call is added per request.
+   */
+  const reloadManager = createReloadManager({
+    initialHandle: server.handle,
+    build: async () => {
+      throw new Error(
+        '[dev-server] runtime reload is not wired yet (pending later phase)',
+      );
+    },
+  });
+
   const devHttpsOption = typeof dev === 'object' && dev.https;
   const isHttp2 = !!devHttpsOption;
   let nodeServer;
@@ -44,12 +68,12 @@ export async function createDevServer(
     const { genHttpsOptions } = await import('./dev-tools/https');
     const httpsOptions = await genHttpsOptions(devHttpsOption, pwd);
     nodeServer = await createNodeServer(
-      server.handle.bind(server),
+      reloadManager.handle,
       httpsOptions,
       isHttp2,
     );
   } else {
-    nodeServer = await createNodeServer(server.handle.bind(server));
+    nodeServer = await createNodeServer(reloadManager.handle);
   }
 
   const promise = getDevAssetPrefix(builder);

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -5,6 +5,7 @@ import {
   createNodeServer,
   loadServerRuntimeConfig,
 } from '@modern-js/server-core/node';
+import { logger } from '@modern-js/utils';
 import { devRuntimeMiddlewarePlugin, setupDevInfra } from './dev';
 import {
   type ReloadableHandle,
@@ -113,8 +114,23 @@ export async function createDevServer(
     return runtimeServer.handle;
   };
 
+  // Files changed since the last completed reload. The debounced reload
+  // coalesces several changes into one rebuild, so we collect them here and
+  // report them in a single success log (a bundler-free reload — e.g. a
+  // config/mock or modern.server.ts change — otherwise prints nothing).
+  const pendingReloadFiles = new Set<string>();
+
   const reloadManager = createReloadManager({
     build: buildRuntimeServer,
+    onReload: () => {
+      const files = Array.from(pendingReloadFiles);
+      pendingReloadFiles.clear();
+      logger.info(
+        files.length > 0
+          ? `Server runtime reloaded (${files.join(', ')})`
+          : 'Server runtime reloaded',
+      );
+    },
   });
 
   /**
@@ -165,7 +181,10 @@ export async function createDevServer(
     // A watched user server file changed -> schedule a unified runtime reload.
     // (debounced + serial + last-write-wins; a failed build keeps the old
     // handle serving, so a syntax error never takes the dev server down.)
-    onFileChange: () => reloadManager.schedule(),
+    onFileChange: (filepath: string) => {
+      pendingReloadFiles.add(path.relative(pwd, filepath));
+      reloadManager.schedule();
+    },
     // On dev server close, stop the scheduler so a pending debounced reload
     // can't rebuild a runtime after the watcher / builder dev server are gone.
     onClose: () => reloadManager.close(),

--- a/packages/server/server/src/createDevServer.ts
+++ b/packages/server/server/src/createDevServer.ts
@@ -165,6 +165,9 @@ export async function createDevServer(
     // (debounced + serial + last-write-wins; a failed build keeps the old
     // handle serving, so a syntax error never takes the dev server down.)
     onFileChange: () => reloadManager.schedule(),
+    // On dev server close, stop the scheduler so a pending debounced reload
+    // can't rebuild a runtime after the watcher / builder dev server are gone.
+    onClose: () => reloadManager.close(),
   });
 
   const afterListen = async () => {

--- a/packages/server/server/src/dev-tools/reloadManager.ts
+++ b/packages/server/server/src/dev-tools/reloadManager.ts
@@ -10,22 +10,45 @@ export type ReloadableHandle = (
 ) => Response | Promise<Response>;
 
 export interface ReloadManagerOptions {
-  /** The handle used before the first successful reload. */
-  initialHandle: ReloadableHandle;
+  /**
+   * The handle used before the first successful build. Optional: when omitted
+   * the manager serves a 503 "starting" response until the first build swaps a
+   * real handle in (use `setHandle()` for a fail-fast initial boot).
+   */
+  initialHandle?: ReloadableHandle;
   /**
    * Build a fresh handle (e.g. a brand new runtime `ServerBase`).
-   * If this throws, the previously active handle is retained.
+   * If this throws, the previously active handle is retained (rollback).
    */
   build: () => Promise<ReloadableHandle>;
   /** Debounce window (ms) used to coalesce rapid `schedule()` calls. */
   debounceMs?: number;
-  /** Called after a handle is successfully swapped in. */
+  /**
+   * Called after a handle is successfully built and swapped in (e.g. to clean
+   * up the previous runtime). The swap has already been committed when this
+   * runs, so throwing here does NOT roll back — it is reported via
+   * `onReloadError` instead of `onError`.
+   */
   onReload?: (handle: ReloadableHandle) => void;
-  /** Called when `build()` throws. The previous handle is kept. */
+  /**
+   * Called when `build()` throws. The previous handle is kept serving. This is
+   * the only path that counts as a failed reload.
+   */
   onError?: (error: unknown) => void;
+  /**
+   * Called when the `onReload` callback throws. The new handle is already
+   * active; this is a post-swap cleanup/callback failure, never a rollback.
+   */
+  onReloadError?: (error: unknown) => void;
 }
 
 const DEFAULT_DEBOUNCE_MS = 300;
+
+const notReadyHandle: ReloadableHandle = () =>
+  new Response('Dev server is starting…', {
+    status: 503,
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+  });
 
 /**
  * Owns the single mutable request handle behind a stable forwarding listener.
@@ -50,6 +73,8 @@ export class ReloadManager {
 
   readonly #onError?: (error: unknown) => void;
 
+  readonly #onReloadError?: (error: unknown) => void;
+
   #debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   #running = false;
@@ -60,11 +85,21 @@ export class ReloadManager {
   #runningPromise: Promise<void> | null = null;
 
   constructor(options: ReloadManagerOptions) {
-    this.#current = options.initialHandle;
+    this.#current = options.initialHandle ?? notReadyHandle;
     this.#build = options.build;
     this.#debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
     this.#onReload = options.onReload;
     this.#onError = options.onError;
+    this.#onReloadError = options.onReloadError;
+  }
+
+  /**
+   * Replace the active handle directly, bypassing `build()`. Used to seed the
+   * initial known-good handle (a fail-fast boot builds the first runtime
+   * explicitly so build errors propagate, then seeds it here).
+   */
+  setHandle(handle: ReloadableHandle): void {
+    this.#current = handle;
   }
 
   /**
@@ -125,24 +160,51 @@ export class ReloadManager {
     // the most recent source. Only the latest successful build is retained.
     do {
       this.#pending = false;
+
+      let next: ReloadableHandle;
       try {
-        const next = await this.#build();
-        // Atomic swap: a single field assignment.
-        this.#current = next;
-        this.#onReload?.(next);
+        next = await this.#build();
       } catch (error) {
-        // Retain the previous handle; surface the failure but keep serving.
-        if (this.#onError) {
-          this.#onError(error);
-        } else {
-          logger.error(
-            `[dev-server] runtime reload failed, keep serving previous handle:\n${
-              error instanceof Error ? (error.stack ?? error.message) : error
-            }`,
-          );
-        }
+        // Build failure is the ONLY failed-reload path: retain the previous
+        // handle (rollback) and surface the error. Then re-check pending.
+        this.#reportBuildError(error);
+        continue;
+      }
+
+      // Build succeeded: commit the swap. From here on there is no rollback —
+      // a failure in the onReload callback (e.g. previous-runtime cleanup) is
+      // reported separately and never reverts the already-active handle.
+      this.#current = next; // atomic swap: a single field assignment
+      try {
+        this.#onReload?.(next);
+      } catch (callbackError) {
+        this.#reportReloadCallbackError(callbackError);
       }
     } while (this.#pending);
+  }
+
+  #reportBuildError(error: unknown): void {
+    if (this.#onError) {
+      this.#onError(error);
+    } else {
+      logger.error(
+        `[dev-server] runtime reload build failed, keep serving previous handle:\n${
+          error instanceof Error ? (error.stack ?? error.message) : error
+        }`,
+      );
+    }
+  }
+
+  #reportReloadCallbackError(error: unknown): void {
+    if (this.#onReloadError) {
+      this.#onReloadError(error);
+    } else {
+      logger.warn(
+        `[dev-server] onReload callback failed after a successful swap (handle is already active):\n${
+          error instanceof Error ? (error.stack ?? error.message) : error
+        }`,
+      );
+    }
   }
 
   /** Cancel any pending debounced reload. */

--- a/packages/server/server/src/dev-tools/reloadManager.ts
+++ b/packages/server/server/src/dev-tools/reloadManager.ts
@@ -1,0 +1,159 @@
+import { logger } from '@modern-js/utils';
+
+/**
+ * A request handle compatible with `ServerBase.handle` (Hono's `app.fetch`)
+ * and the handler accepted by `createNodeServer`.
+ */
+export type ReloadableHandle = (
+  request: Request,
+  ...args: any[]
+) => Response | Promise<Response>;
+
+export interface ReloadManagerOptions {
+  /** The handle used before the first successful reload. */
+  initialHandle: ReloadableHandle;
+  /**
+   * Build a fresh handle (e.g. a brand new runtime `ServerBase`).
+   * If this throws, the previously active handle is retained.
+   */
+  build: () => Promise<ReloadableHandle>;
+  /** Debounce window (ms) used to coalesce rapid `schedule()` calls. */
+  debounceMs?: number;
+  /** Called after a handle is successfully swapped in. */
+  onReload?: (handle: ReloadableHandle) => void;
+  /** Called when `build()` throws. The previous handle is kept. */
+  onError?: (error: unknown) => void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 300;
+
+/**
+ * Owns the single mutable request handle behind a stable forwarding listener.
+ *
+ * Guarantees required by the dev-server hot-reload design:
+ * - Atomic swap: the active handle is replaced by a single assignment, so
+ *   in-flight requests always run against a consistent handle.
+ * - Failure isolation: if `build()` rejects, the previous handle stays active
+ *   (the dev server never degrades to an empty / broken handle).
+ * - Serial execution: reloads never overlap. Requests that arrive while a
+ *   reload is running are coalesced into a single trailing reload so that the
+ *   final state always reflects the latest source ("last write wins").
+ */
+export class ReloadManager {
+  #current: ReloadableHandle;
+
+  readonly #build: () => Promise<ReloadableHandle>;
+
+  readonly #debounceMs: number;
+
+  readonly #onReload?: (handle: ReloadableHandle) => void;
+
+  readonly #onError?: (error: unknown) => void;
+
+  #debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  #running = false;
+
+  /** A reload was requested while another was in progress. */
+  #pending = false;
+
+  #runningPromise: Promise<void> | null = null;
+
+  constructor(options: ReloadManagerOptions) {
+    this.#current = options.initialHandle;
+    this.#build = options.build;
+    this.#debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.#onReload = options.onReload;
+    this.#onError = options.onError;
+  }
+
+  /**
+   * Stable forwarding handle. Pass this to `createNodeServer` once; it always
+   * dispatches to the latest active handle, so the Node server never needs to
+   * be recreated on reload.
+   */
+  get handle(): ReloadableHandle {
+    return (request, ...args) => this.#current(request, ...args);
+  }
+
+  /** The currently active resolved handle (introspection / tests). */
+  get currentHandle(): ReloadableHandle {
+    return this.#current;
+  }
+
+  /** Whether a reload is currently running (introspection / tests). */
+  get isReloading(): boolean {
+    return this.#running;
+  }
+
+  /**
+   * Request a reload, debounced. Multiple calls within the debounce window
+   * collapse into a single reload.
+   */
+  schedule(): void {
+    if (this.#debounceTimer) {
+      clearTimeout(this.#debounceTimer);
+    }
+    this.#debounceTimer = setTimeout(() => {
+      this.#debounceTimer = null;
+      void this.reloadNow();
+    }, this.#debounceMs);
+  }
+
+  /**
+   * Run a reload immediately. If one is already running, mark a trailing
+   * reload and return the in-flight promise (which will include the trailing
+   * run) so callers can await final settlement.
+   */
+  async reloadNow(): Promise<void> {
+    if (this.#running) {
+      this.#pending = true;
+      return this.#runningPromise ?? Promise.resolve();
+    }
+    this.#running = true;
+    this.#runningPromise = this.#runLoop();
+    try {
+      await this.#runningPromise;
+    } finally {
+      this.#running = false;
+      this.#runningPromise = null;
+    }
+  }
+
+  async #runLoop(): Promise<void> {
+    // Keep rebuilding while new requests arrive so the final handle reflects
+    // the most recent source. Only the latest successful build is retained.
+    do {
+      this.#pending = false;
+      try {
+        const next = await this.#build();
+        // Atomic swap: a single field assignment.
+        this.#current = next;
+        this.#onReload?.(next);
+      } catch (error) {
+        // Retain the previous handle; surface the failure but keep serving.
+        if (this.#onError) {
+          this.#onError(error);
+        } else {
+          logger.error(
+            `[dev-server] runtime reload failed, keep serving previous handle:\n${
+              error instanceof Error ? (error.stack ?? error.message) : error
+            }`,
+          );
+        }
+      }
+    } while (this.#pending);
+  }
+
+  /** Cancel any pending debounced reload. */
+  close(): void {
+    if (this.#debounceTimer) {
+      clearTimeout(this.#debounceTimer);
+      this.#debounceTimer = null;
+    }
+  }
+}
+
+export function createReloadManager(options: ReloadManagerOptions) {
+  return new ReloadManager(options);
+}

--- a/packages/server/server/src/dev-tools/reloadManager.ts
+++ b/packages/server/server/src/dev-tools/reloadManager.ts
@@ -84,6 +84,8 @@ export class ReloadManager {
 
   #runningPromise: Promise<void> | null = null;
 
+  #closed = false;
+
   constructor(options: ReloadManagerOptions) {
     this.#current = options.initialHandle ?? notReadyHandle;
     this.#build = options.build;
@@ -126,6 +128,9 @@ export class ReloadManager {
    * collapse into a single reload.
    */
   schedule(): void {
+    if (this.#closed) {
+      return;
+    }
     if (this.#debounceTimer) {
       clearTimeout(this.#debounceTimer);
     }
@@ -141,6 +146,9 @@ export class ReloadManager {
    * run) so callers can await final settlement.
    */
   async reloadNow(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
     if (this.#running) {
       this.#pending = true;
       return this.#runningPromise ?? Promise.resolve();
@@ -207,8 +215,14 @@ export class ReloadManager {
     }
   }
 
-  /** Cancel any pending debounced reload. */
+  /**
+   * Stop the manager: cancel any pending debounced reload and reject all
+   * further `schedule()` / `reloadNow()` calls. Wired into the dev server's
+   * close chain so a debounce timer that fires after teardown can never
+   * rebuild a runtime once the watcher / builder dev server are gone.
+   */
   close(): void {
+    this.#closed = true;
     if (this.#debounceTimer) {
       clearTimeout(this.#debounceTimer);
       this.#debounceTimer = null;

--- a/packages/server/server/src/dev-tools/reloadManager.ts
+++ b/packages/server/server/src/dev-tools/reloadManager.ts
@@ -179,6 +179,12 @@ export class ReloadManager {
         continue;
       }
 
+      // If the manager was closed while this build was in flight, drop the
+      // result without committing — no swap, no onReload after close.
+      if (this.#closed) {
+        return;
+      }
+
       // Build succeeded: commit the swap. From here on there is no rollback —
       // a failure in the onReload callback (e.g. previous-runtime cleanup) is
       // reported separately and never reverts the already-active handle.
@@ -188,7 +194,7 @@ export class ReloadManager {
       } catch (callbackError) {
         this.#reportReloadCallbackError(callbackError);
       }
-    } while (this.#pending);
+    } while (this.#pending && !this.#closed);
   }
 
   #reportBuildError(error: unknown): void {
@@ -223,6 +229,9 @@ export class ReloadManager {
    */
   close(): void {
     this.#closed = true;
+    // Drop any trailing reload that was coalesced while a build was running,
+    // so #runLoop won't start another build after close.
+    this.#pending = false;
     if (this.#debounceTimer) {
       clearTimeout(this.#debounceTimer);
       this.#debounceTimer = null;

--- a/packages/server/server/src/dev-tools/runtimeOptions.ts
+++ b/packages/server/server/src/dev-tools/runtimeOptions.ts
@@ -1,0 +1,55 @@
+interface RuntimeOptionsBase {
+  config: Record<string, any>;
+  serverConfig?: Record<string, any>;
+  plugins?: any[];
+}
+
+/**
+ * Produce a fully-isolated options object for a single runtime build.
+ *
+ * `buildRuntimeServer` runs for the initial boot AND for every hot reload, so
+ * each build must own every container that a plugin or the apply pipeline
+ * could append to / rewrite. A shallow `{ ...base }` is NOT enough: `config`,
+ * `serverConfig` and `plugins` would still share references, letting one
+ * runtime's appended middlewares / plugins leak into the next reload.
+ *
+ * This clones:
+ * - a fresh top-level options object
+ * - a fresh `config` with a fresh `config.output` (so writing `assetPrefix`
+ *   never mutates the caller's original `options.config`)
+ * - a fresh `serverConfig` whose `middlewares` / `renderMiddlewares` /
+ *   `plugins` are new arrays
+ * - a fresh top-level `plugins` array
+ *
+ * Nested config sub-objects that are only read (never appended to) stay shared
+ * by reference, which is intentional and cheap.
+ */
+export function createRuntimeServerOptions<T extends RuntimeOptionsBase>(
+  base: T,
+  assetPrefix?: string,
+): T {
+  const baseConfig = base.config ?? {};
+  const baseOutput =
+    (baseConfig as { output?: Record<string, any> }).output ?? {};
+  const baseServerConfig = base.serverConfig ?? {};
+
+  return {
+    ...base,
+    config: {
+      ...baseConfig,
+      output: {
+        ...baseOutput,
+        ...(assetPrefix ? { assetPrefix } : {}),
+      },
+    },
+    serverConfig: {
+      ...baseServerConfig,
+      middlewares: [...(baseServerConfig.middlewares ?? [])],
+      renderMiddlewares: [...(baseServerConfig.renderMiddlewares ?? [])],
+      ...(baseServerConfig.plugins
+        ? { plugins: [...baseServerConfig.plugins] }
+        : {}),
+    },
+    plugins: [...(base.plugins ?? [])],
+  } as T;
+}

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -10,6 +10,7 @@ import type {
 import { connectMid2HonoMid } from '@modern-js/server-core/node';
 import type { RequestHandler } from '@modern-js/types';
 import { API_DIR, SHARED_DIR } from '@modern-js/utils';
+import type { WatchEvent } from './dev-tools/watcher';
 import {
   getDevOptions,
   getMockMiddleware,
@@ -119,6 +120,11 @@ export interface DevInfraOptions {
   nodeServer?: NodeServer | NodeHttpsServer | Http2SecureServer;
   /** Accessor for the currently-active runtime ServerBase (a mutable ref). */
   getRuntimeServer: () => ServerBase | undefined;
+  /**
+   * Triggered when a watched user server file changes (require cache already
+   * busted). Wired to the runtime reload scheduler.
+   */
+  onFileChange: (filepath: string, event: WatchEvent) => void;
 }
 
 export interface DevInfra {
@@ -149,6 +155,7 @@ export function setupDevInfra({
   builder,
   builderDevServer,
   getRuntimeServer,
+  onFileChange,
   nodeServer,
 }: DevInfraOptions): DevInfra {
   const { close, connectWebSocket } = builderDevServer || {};
@@ -177,7 +184,7 @@ export function setupDevInfra({
     apiDir: apiDir || API_DIR,
     sharedDir: sharedDir || SHARED_DIR,
     watchOptions,
-    getServer: getRuntimeServer,
+    onChange: onFileChange,
   });
   closeCb.push(watcher.close.bind(watcher));
 

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -3,13 +3,14 @@ import type { Http2SecureServer } from 'node:http2';
 import type { Server as NodeHttpsServer } from 'node:https';
 import type { BuilderInstance, Rspack } from '@modern-js/builder';
 import type {
+  FileChangeEvent,
   ServerBase,
   ServerBaseOptions,
   ServerPlugin,
 } from '@modern-js/server-core';
 import { connectMid2HonoMid } from '@modern-js/server-core/node';
 import type { RequestHandler } from '@modern-js/types';
-import { API_DIR, SHARED_DIR } from '@modern-js/utils';
+import { API_DIR, SHARED_DIR, logger } from '@modern-js/utils';
 import type { WatchEvent } from './dev-tools/watcher';
 import {
   getDevOptions,
@@ -190,7 +191,26 @@ export function setupDevInfra({
     apiDir: apiDir || API_DIR,
     sharedDir: sharedDir || SHARED_DIR,
     watchOptions,
-    onChange: onFileChange,
+    onChange: (filepath, event) => {
+      // Backward-compat: re-emit the public `file-change` onReset signal on the
+      // LIVE runtime (via getRuntimeServer, never a stale closure). `onReset` is
+      // a documented ServerPlugin hook; downstream plugins legitimately tap it
+      // for their own dev refresh — e.g. EdenX gulu/gulux restart their BFF
+      // child process on this event. It is a no-op for modern.js's own plugins
+      // (none tap onReset anymore). The unified runtime reload below is the
+      // modern.js reaction and is unchanged.
+      const runtimeServer = getRuntimeServer();
+      if (runtimeServer) {
+        const fileChangeEvent: FileChangeEvent = {
+          type: 'file-change',
+          payload: [{ filename: filepath, event }],
+        };
+        Promise.resolve(
+          runtimeServer.hooks.onReset.call({ event: fileChangeEvent }),
+        ).catch(error => logger.error(error as Error));
+      }
+      onFileChange(filepath, event);
+    },
   });
   closeCb.push(watcher.close.bind(watcher));
 

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -1,7 +1,9 @@
 import type { Server as NodeServer } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import type { Server as NodeHttpsServer } from 'node:https';
+import path from 'node:path';
 import type { BuilderInstance, Rspack } from '@modern-js/builder';
+import { AGGRED_DIR } from '@modern-js/server-core';
 import type {
   FileChangeEvent,
   ServerBase,
@@ -185,6 +187,11 @@ export function setupDevInfra({
 
   // Handle watch
   const { watchOptions } = config.server;
+  // Mock files keep their original semantics: they refresh via the runtime
+  // reload (which re-runs getMockMiddleware) and were NEVER part of the
+  // `onReset` file-change signal pre-refactor, so they stay excluded here to
+  // keep `onReset`'s emission byte-identical to the old watcher behavior.
+  const mockPath = path.normalize(path.join(pwd, AGGRED_DIR.mock));
   const watcher = startWatcher({
     pwd,
     distDir,
@@ -192,15 +199,15 @@ export function setupDevInfra({
     sharedDir: sharedDir || SHARED_DIR,
     watchOptions,
     onChange: (filepath, event) => {
-      // Backward-compat: re-emit the public `file-change` onReset signal on the
-      // LIVE runtime (via getRuntimeServer, never a stale closure). `onReset` is
-      // a documented ServerPlugin hook; downstream plugins legitimately tap it
-      // for their own dev refresh — e.g. EdenX gulu/gulux restart their BFF
-      // child process on this event. It is a no-op for modern.js's own plugins
-      // (none tap onReset anymore). The unified runtime reload below is the
-      // modern.js reaction and is unchanged.
+      // Re-emit the public `file-change` onReset signal on the LIVE runtime
+      // (via getRuntimeServer, never a stale closure), preserving the exact
+      // pre-refactor emission. `onReset` is a documented ServerPlugin hook;
+      // downstream plugins (internal/external/EdenX) legitimately tap it for
+      // their own dev refresh — e.g. EdenX gulu/gulux restart their BFF child
+      // process on it. No-op for modern.js's own plugins. The unified runtime
+      // reload below is the modern.js reaction and is unchanged.
       const runtimeServer = getRuntimeServer();
-      if (runtimeServer) {
+      if (runtimeServer && !filepath.startsWith(mockPath)) {
         const fileChangeEvent: FileChangeEvent = {
           type: 'file-change',
           payload: [{ filename: filepath, event }],

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -125,6 +125,11 @@ export interface DevInfraOptions {
    * busted). Wired to the runtime reload scheduler.
    */
   onFileChange: (filepath: string, event: WatchEvent) => void;
+  /**
+   * Extra teardown run as part of the dev server close chain (e.g. stopping the
+   * reload scheduler so a pending debounced reload can't rebuild after close).
+   */
+  onClose?: () => void;
 }
 
 export interface DevInfra {
@@ -156,6 +161,7 @@ export function setupDevInfra({
   builderDevServer,
   getRuntimeServer,
   onFileChange,
+  onClose,
   nodeServer,
 }: DevInfraOptions): DevInfra {
   const { close, connectWebSocket } = builderDevServer || {};
@@ -187,6 +193,11 @@ export function setupDevInfra({
     onChange: onFileChange,
   });
   closeCb.push(watcher.close.bind(watcher));
+
+  // Stop the reload scheduler last, so any pending debounced reload is
+  // cancelled and no rebuild can run after the watcher / builder dev server
+  // have been closed.
+  onClose && closeCb.push(onClose);
 
   const close$ = () => {
     closeCb.forEach(cb => {

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -1,5 +1,12 @@
+import type { Server as NodeServer } from 'node:http';
+import type { Http2SecureServer } from 'node:http2';
+import type { Server as NodeHttpsServer } from 'node:https';
 import type { BuilderInstance, Rspack } from '@modern-js/builder';
-import type { ServerBaseOptions, ServerPlugin } from '@modern-js/server-core';
+import type {
+  ServerBase,
+  ServerBaseOptions,
+  ServerPlugin,
+} from '@modern-js/server-core';
 import { connectMid2HonoMid } from '@modern-js/server-core/node';
 import type { RequestHandler } from '@modern-js/types';
 import { API_DIR, SHARED_DIR } from '@modern-js/utils';
@@ -18,68 +25,34 @@ export type DevPluginOptions = ModernDevServerOptions<ServerBaseOptions> & {
   builderDevServer?: BuilderDevServer;
 };
 
-export const devPlugin = (
+/**
+ * Runtime-level dev middleware injection.
+ *
+ * This plugin is added to EVERY runtime `ServerBase` that `buildRuntimeServer`
+ * creates, so it must be safe to run repeatedly and must NOT touch any
+ * process-level resource (the file watcher / websocket / builder hooks / close
+ * callbacks all live in `setupDevInfra`). It only pushes request middlewares
+ * into the current server's middleware list:
+ * - user `dev.setupMiddlewares` (before / after)
+ * - the mock middleware
+ * - the rsbuild/builder dev middleware (a stable reference, just re-registered)
+ * - the file-reader middleware
+ */
+export const devRuntimeMiddlewarePlugin = (
   options: DevPluginOptions,
   compiler: Rspack.Compiler | Rspack.MultiCompiler | null,
 ): ServerPlugin => ({
   name: '@modern-js/plugin-dev',
 
   setup(api) {
-    const { config, pwd, builder, builderDevServer } = options;
-
-    const closeCb: Array<(...args: []) => any> = [];
+    const { pwd, builderDevServer } = options;
 
     const dev = getDevOptions(options.dev);
 
     api.onPrepare(async () => {
-      // https://github.com/web-infra-dev/rsbuild/blob/32fbb85e22158d5c4655505ce75e3452ce22dbb1/packages/shared/src/types/server.ts#L112
-      const {
-        middlewares: builderMiddlewares,
-        close,
-        connectWebSocket,
-      } = builderDevServer || {};
+      const { middlewares: builderMiddlewares } = builderDevServer || {};
 
-      close && closeCb.push(close);
-
-      const {
-        middlewares,
-        distDirectory,
-        nodeServer,
-        apiDirectory,
-        sharedDirectory,
-        serverBase,
-      } = api.getServerContext();
-
-      connectWebSocket &&
-        nodeServer &&
-        connectWebSocket({ server: nodeServer });
-      // TODO: remove any
-      const hooks = (api as any).getHooks();
-
-      // Handle webpack rebuild
-      builder?.onDevCompileDone(({ stats }) => {
-        if (stats.toJson({ all: false }).name !== 'server') {
-          onRepack(distDirectory!, hooks);
-        }
-      });
-
-      // Handle watch
-      const { watchOptions } = config.server;
-      const watcher = startWatcher({
-        pwd,
-        distDir: distDirectory!,
-        apiDir: apiDirectory || API_DIR,
-        sharedDir: sharedDirectory || SHARED_DIR,
-        watchOptions,
-        server: serverBase!,
-      });
-      closeCb.push(watcher.close.bind(watcher));
-      closeCb.length > 0 &&
-        nodeServer?.on('close', () => {
-          closeCb.forEach(cb => {
-            cb();
-          });
-        });
+      const { middlewares } = api.getServerContext();
 
       // Handle setupMiddlewares
       const before: RequestHandler[] = [];
@@ -133,3 +106,88 @@ export const devPlugin = (
     });
   },
 });
+
+export interface DevInfraOptions {
+  config: DevPluginOptions['config'];
+  pwd: string;
+  distDir: string;
+  apiDir?: string;
+  sharedDir?: string;
+  builder?: BuilderInstance;
+  builderDevServer?: BuilderDevServer;
+  compiler: Rspack.Compiler | Rspack.MultiCompiler | null;
+  nodeServer?: NodeServer | NodeHttpsServer | Http2SecureServer;
+  /** Accessor for the currently-active runtime ServerBase (a mutable ref). */
+  getRuntimeServer: () => ServerBase | undefined;
+}
+
+export interface DevInfra {
+  /** Tear down every process-level resource. Called when the dev server stops. */
+  close: () => void;
+}
+
+/**
+ * Process-level dev infrastructure, created EXACTLY ONCE for the lifetime of
+ * the dev server. None of these resources are recreated or torn down by a
+ * runtime hot reload:
+ * - the rsbuild/builder dev server websocket connection
+ * - the builder `onDevCompileDone` -> SSR cache reset hook
+ * - the file watcher
+ * - close callbacks registered on the Node server's `close` event
+ *
+ * The watcher / onRepack reach the LIVE runtime hooks through
+ * `getRuntimeServer()` (a mutable ref) instead of closing over the initial
+ * runtime, so a later phase can swap the trigger to the reload scheduler
+ * without leaking a stale closure to a dead runtime.
+ */
+export function setupDevInfra({
+  config,
+  pwd,
+  distDir,
+  apiDir,
+  sharedDir,
+  builder,
+  builderDevServer,
+  getRuntimeServer,
+  nodeServer,
+}: DevInfraOptions): DevInfra {
+  const { close, connectWebSocket } = builderDevServer || {};
+
+  const closeCb: Array<(...args: []) => any> = [];
+
+  close && closeCb.push(close);
+
+  connectWebSocket && nodeServer && connectWebSocket({ server: nodeServer });
+
+  // Handle server bundle rebuild: reset SSR cache against the live runtime.
+  builder?.onDevCompileDone(({ stats }) => {
+    if (stats.toJson({ all: false }).name !== 'server') {
+      const runtimeServer = getRuntimeServer();
+      if (runtimeServer) {
+        onRepack(distDir, runtimeServer.hooks);
+      }
+    }
+  });
+
+  // Handle watch
+  const { watchOptions } = config.server;
+  const watcher = startWatcher({
+    pwd,
+    distDir,
+    apiDir: apiDir || API_DIR,
+    sharedDir: sharedDir || SHARED_DIR,
+    watchOptions,
+    getServer: getRuntimeServer,
+  });
+  closeCb.push(watcher.close.bind(watcher));
+
+  const close$ = () => {
+    closeCb.forEach(cb => {
+      cb();
+    });
+  };
+
+  closeCb.length > 0 && nodeServer?.on('close', close$);
+
+  return { close: close$ };
+}

--- a/packages/server/server/src/helpers/index.ts
+++ b/packages/server/server/src/helpers/index.ts
@@ -26,13 +26,20 @@ async function onServerChange({
   pwd,
   filepath,
   event,
-  server,
+  getServer,
 }: {
   pwd: string;
   filepath: string;
   event: WatchEvent;
-  server: ServerBase;
+  getServer: () => ServerBase | undefined;
 }) {
+  // Resolve the live runtime server lazily so the watcher never closes over a
+  // stale (replaced) runtime instance.
+  const server = getServer();
+  if (!server) {
+    return;
+  }
+
   const { mock } = AGGRED_DIR;
   const mockPath = path.normalize(path.join(pwd, mock));
 
@@ -64,14 +71,14 @@ export function startWatcher({
   apiDir,
   sharedDir,
   watchOptions,
-  server,
+  getServer,
 }: {
   pwd: string;
   distDir: string;
   apiDir: string;
   sharedDir: string;
   watchOptions?: WatchOptions;
-  server: ServerBase;
+  getServer: () => ServerBase | undefined;
 }) {
   const { mock } = AGGRED_DIR;
   const defaultWatched = [
@@ -105,7 +112,7 @@ export function startWatcher({
       pwd,
       filepath,
       event,
-      server,
+      getServer,
     });
   });
 

--- a/packages/server/server/src/helpers/index.ts
+++ b/packages/server/server/src/helpers/index.ts
@@ -1,69 +1,19 @@
 import path from 'path';
-import {
-  AGGRED_DIR,
-  type FileChangeEvent,
-  type ServerBase,
-} from '@modern-js/server-core';
+import { AGGRED_DIR } from '@modern-js/server-core';
 import {
   SERVER_BUNDLE_DIRECTORY,
   SERVER_DIR,
   type WatchOptions,
-  logger,
 } from '@modern-js/utils';
 import Watcher, {
   type WatchEvent,
   mergeWatchOptions,
 } from '../dev-tools/watcher';
-import { initOrUpdateMockMiddlewares } from './mock';
-import { debug } from './utils';
 
 export * from './repack';
 export * from './devOptions';
 export * from './fileReader';
 export * from './mock';
-
-async function onServerChange({
-  pwd,
-  filepath,
-  event,
-  getServer,
-}: {
-  pwd: string;
-  filepath: string;
-  event: WatchEvent;
-  getServer: () => ServerBase | undefined;
-}) {
-  // Resolve the live runtime server lazily so the watcher never closes over a
-  // stale (replaced) runtime instance.
-  const server = getServer();
-  if (!server) {
-    return;
-  }
-
-  const { mock } = AGGRED_DIR;
-  const mockPath = path.normalize(path.join(pwd, mock));
-
-  const { hooks } = server;
-  if (filepath.startsWith(mockPath)) {
-    await initOrUpdateMockMiddlewares(pwd);
-    logger.info('Finish update the mock handlers');
-  } else {
-    try {
-      const fileChangeEvent: FileChangeEvent = {
-        type: 'file-change',
-        payload: [{ filename: filepath, event }],
-      };
-
-      // TODO: should update to new api in next major version, do not use serverBase.hooks
-      await hooks.onReset.call({
-        event: fileChangeEvent,
-      });
-      debug(`Finish reload server, trigger by ${filepath} ${event}`);
-    } catch (e) {
-      logger.error(e as Error);
-    }
-  }
-}
 
 export function startWatcher({
   pwd,
@@ -71,14 +21,19 @@ export function startWatcher({
   apiDir,
   sharedDir,
   watchOptions,
-  getServer,
+  onChange,
 }: {
   pwd: string;
   distDir: string;
   apiDir: string;
   sharedDir: string;
   watchOptions?: WatchOptions;
-  getServer: () => ServerBase | undefined;
+  /**
+   * Called after the require cache for a changed user server file has been
+   * busted, so the next runtime build re-imports fresh code. Server loader
+   * bundles are handled inline (cache drop only) and never reach this.
+   */
+  onChange: (filepath: string, event: WatchEvent) => void;
 }) {
   const { mock } = AGGRED_DIR;
   const defaultWatched = [
@@ -99,21 +54,19 @@ export function startWatcher({
   const watcher = new Watcher();
   watcher.createDepTree();
   watcher.listen(defaultWatchedPaths, mergedWatchOptions, (filepath, event) => {
-    // TODO: should delete this cache in onRepack
+    // Server loader bundles are re-read per request via the file reader; just
+    // drop the stale require cache, no runtime reload needed.
     if (filepath.includes('-server-loaders.js')) {
       delete require.cache[filepath];
       return;
-    } else {
-      watcher.updateDepTree();
-      watcher.cleanDepCache(filepath);
     }
 
-    onServerChange({
-      pwd,
-      filepath,
-      event,
-      getServer,
-    });
+    // Bust the require cache for the changed module and its parents (incl.
+    // modern.server.ts when it or one of its deps changes) so the next runtime
+    // build re-imports fresh code, then trigger a unified runtime reload.
+    watcher.updateDepTree();
+    watcher.cleanDepCache(filepath);
+    onChange(filepath, event);
   });
 
   return watcher;

--- a/packages/server/server/src/helpers/mock.ts
+++ b/packages/server/server/src/helpers/mock.ts
@@ -7,7 +7,7 @@ import {
 import { connectMockMid2HonoMid } from '@modern-js/server-core/node';
 import type { NextFunction } from '@modern-js/types';
 import type { NodeRequest, NodeResponse } from '@modern-js/types/server';
-import { fs } from '@modern-js/utils';
+import { fs, compatibleRequire } from '@modern-js/utils';
 import { match } from 'path-to-regexp';
 /** Types: Mock  */
 type MockHandler =
@@ -86,8 +86,17 @@ const getMockModule = async (
     return undefined;
   }
 
-  const { default: mockHandlers, config } = (await import(
-    mockFilePath
+  // Load through compatibleRequire (the same loader BFF API handlers use), not
+  // a raw `import()`:
+  // - it resolves `.ts` via the CJS require + ts-node/swc hook, so users can
+  //   author mocks in TypeScript (a native `import('*.ts')` throws
+  //   ERR_UNKNOWN_FILE_EXTENSION);
+  // - in dev the runtime reload re-reads the module fresh — the watcher busts
+  //   the require cache for the changed file, so `require()` returns the new
+  //   content (a raw `import()` would be served stale from the ESM URL cache).
+  const { default: mockHandlers, config } = (await compatibleRequire(
+    mockFilePath,
+    false,
   )) as MockModule;
 
   const enable = config?.enable as

--- a/packages/server/server/tests/devRuntimeReload.test.ts
+++ b/packages/server/server/tests/devRuntimeReload.test.ts
@@ -42,6 +42,7 @@ rstest.mock('../src/dev-tools/watcher', () => {
 });
 
 import { devRuntimeMiddlewarePlugin, setupDevInfra } from '../src/dev';
+import { createRuntimeServerOptions } from '../src/dev-tools/runtimeOptions';
 import * as watcherModule from '../src/dev-tools/watcher';
 
 rstest.useRealTimers();
@@ -229,5 +230,106 @@ describe('setupDevInfra (process-level singletons)', () => {
     await flush();
     expect(second.hooks.onReset.call).toHaveBeenCalledTimes(1);
     expect(first.hooks.onReset.call).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createRuntimeServerOptions (per-build option isolation)', () => {
+  it('returns fresh containers so one build cannot pollute another', () => {
+    const base = {
+      config: { output: { distPath: { root: 'dist' } } },
+      serverConfig: {
+        middlewares: [{ name: 'a' }],
+        renderMiddlewares: [{ name: 'r' }],
+        plugins: [{ name: 'p' }],
+      },
+      plugins: [{ name: 'top' }],
+    } as any;
+
+    const a = createRuntimeServerOptions(base);
+    const b = createRuntimeServerOptions(base);
+
+    // Distinct container identities from the base and from each other.
+    expect(a.config).not.toBe(base.config);
+    expect(a.config.output).not.toBe(base.config.output);
+    expect(a.serverConfig).not.toBe(base.serverConfig);
+    expect(a.serverConfig.middlewares).not.toBe(base.serverConfig.middlewares);
+    expect(a.serverConfig.renderMiddlewares).not.toBe(
+      base.serverConfig.renderMiddlewares,
+    );
+    expect(a.serverConfig.plugins).not.toBe(base.serverConfig.plugins);
+    expect(a.plugins).not.toBe(base.plugins);
+    expect(a.serverConfig.middlewares).not.toBe(b.serverConfig.middlewares);
+
+    // Pollute round A's arrays.
+    a.serverConfig.middlewares.push({ name: 'leak-mw' });
+    a.serverConfig.renderMiddlewares.push({ name: 'leak-render' });
+    a.serverConfig.plugins.push({ name: 'leak-plugin' });
+    a.plugins.push({ name: 'leak-top' });
+    (a.config.output as any).assetPrefix = '/leaked/';
+
+    // Round B and the base remain pristine.
+    expect(b.serverConfig.middlewares).toHaveLength(1);
+    expect(b.serverConfig.renderMiddlewares).toHaveLength(1);
+    expect(b.serverConfig.plugins).toHaveLength(1);
+    expect(b.plugins).toHaveLength(1);
+    expect((b.config.output as any).assetPrefix).toBeUndefined();
+
+    expect(base.serverConfig.middlewares).toHaveLength(1);
+    expect(base.serverConfig.renderMiddlewares).toHaveLength(1);
+    expect(base.serverConfig.plugins).toHaveLength(1);
+    expect(base.plugins).toHaveLength(1);
+    expect((base.config.output as any).assetPrefix).toBeUndefined();
+  });
+
+  it('weaves assetPrefix into the fresh config.output without touching the base', () => {
+    const base = {
+      config: { output: {} },
+      serverConfig: {},
+      plugins: [],
+    } as any;
+    const built = createRuntimeServerOptions(base, '/static/');
+
+    expect(built.config.output.assetPrefix).toBe('/static/');
+    // The original options.config.output is never mutated.
+    expect((base.config.output as any).assetPrefix).toBeUndefined();
+  });
+
+  it('isolates serverConfig.middlewares pollution across consecutive runtime builds', async () => {
+    const baseOptions = {
+      config: getDefaultConfig(),
+      appContext: getDefaultAppContext(),
+      pwd: '',
+      serverConfig: { middlewares: [], renderMiddlewares: [] },
+      plugins: [],
+    } as any;
+
+    // Mirror buildRuntimeServer: a fresh options object per build, with a
+    // plugin that appends to its own runtimeOptions.serverConfig.middlewares.
+    const buildOnce = async () => {
+      const runtimeOptions = createRuntimeServerOptions(baseOptions);
+      const polluter: ServerPlugin = {
+        name: 'polluter',
+        setup(api) {
+          api.onPrepare(async () => {
+            (runtimeOptions.serverConfig as any).middlewares.push({
+              name: 'leak',
+            });
+          });
+        },
+      };
+      const server = createServerBase(runtimeOptions);
+      server.addPlugins([compatPlugin(), polluter]);
+      await server.init();
+      return runtimeOptions;
+    };
+
+    const o1 = await buildOnce();
+    const o2 = await buildOnce();
+
+    expect((o1.serverConfig as any).middlewares).toHaveLength(1);
+    // Second build does NOT inherit the first build's appended middleware.
+    expect((o2.serverConfig as any).middlewares).toHaveLength(1);
+    // The shared base stays pristine.
+    expect((baseOptions.serverConfig as any).middlewares).toHaveLength(0);
   });
 });

--- a/packages/server/server/tests/devRuntimeReload.test.ts
+++ b/packages/server/server/tests/devRuntimeReload.test.ts
@@ -313,6 +313,21 @@ describe('setupDevInfra (process-level singletons)', () => {
     // and the unified reload is still triggered
     expect(onFileChange).toHaveBeenCalledTimes(1);
   });
+
+  it('does NOT emit onReset for mock files (preserves pre-refactor emission) but still reloads', async () => {
+    const runtime = makeFakeRuntimeServer();
+    const { onFileChange } = setup(() => runtime);
+
+    const watcher = getWatchers()[getWatchers().length - 1];
+    // config/mock/** was never part of the onReset file-change signal; it
+    // refreshes via the reload (getMockMiddleware re-runs) only.
+    watcher.listenCb(path.join('/tmp/app', 'config/mock/index.ts'), 'change');
+    await flush();
+
+    expect(runtime.hooks.onReset.call).not.toHaveBeenCalled();
+    // but the reload is still scheduled so the mock middleware refreshes
+    expect(onFileChange).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('createRuntimeServerOptions (per-build option isolation)', () => {

--- a/packages/server/server/tests/devRuntimeReload.test.ts
+++ b/packages/server/server/tests/devRuntimeReload.test.ts
@@ -1,0 +1,233 @@
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import {
+  type ServerPlugin,
+  compatPlugin,
+  createServerBase,
+} from '@modern-js/server-core';
+
+// Replace the real chokidar-backed Watcher with a controllable fake so the
+// tests neither touch the filesystem nor leak watchers. The registry lives
+// inside the factory (rstest.mock is hoisted) and is exposed via getters.
+rstest.mock('../src/dev-tools/watcher', () => {
+  const instances: any[] = [];
+  class FakeWatcher {
+    listenCb: ((filepath: string, event: string) => void) | null = null;
+    closed = false;
+    constructor() {
+      instances.push(this);
+    }
+    createDepTree() {}
+    updateDepTree() {}
+    cleanDepCache() {}
+    listen(
+      _paths: unknown,
+      _opts: unknown,
+      cb: (filepath: string, event: string) => void,
+    ) {
+      this.listenCb = cb;
+    }
+    close() {
+      this.closed = true;
+    }
+  }
+  return {
+    default: FakeWatcher,
+    mergeWatchOptions: (options: unknown) => options ?? {},
+    __getWatchers: () => instances,
+    __resetWatchers: () => {
+      instances.length = 0;
+    },
+  };
+});
+
+import { devRuntimeMiddlewarePlugin, setupDevInfra } from '../src/dev';
+import * as watcherModule from '../src/dev-tools/watcher';
+
+rstest.useRealTimers();
+
+const getWatchers = (): any[] => (watcherModule as any).__getWatchers();
+const resetWatchers = (): void => (watcherModule as any).__resetWatchers();
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+function getDefaultConfig() {
+  return {
+    html: {},
+    output: {},
+    source: {},
+    tools: {},
+    server: {},
+    bff: {},
+    dev: {},
+    security: {},
+  } as any;
+}
+
+function getDefaultAppContext() {
+  return { apiDirectory: '', lambdaDirectory: '' } as any;
+}
+
+function makeFakeRuntimeServer() {
+  return { hooks: { onReset: { call: rstest.fn() } } } as any;
+}
+
+function makeBuilderDevServer(withMiddleware = true) {
+  return {
+    close: rstest.fn(),
+    connectWebSocket: rstest.fn(),
+    afterListen: rstest.fn(),
+    middlewares: withMiddleware
+      ? (_req: any, _res: any, next: any) => next()
+      : undefined,
+  } as any;
+}
+
+beforeEach(() => {
+  resetWatchers();
+});
+
+describe('devRuntimeMiddlewarePlugin (per-runtime injection)', () => {
+  async function buildRuntimeMiddlewareNames(
+    builderDevServer: any,
+  ): Promise<string[]> {
+    let names: string[] = [];
+    const probe: ServerPlugin = {
+      name: 'probe',
+      setup(api) {
+        api.onPrepare(async () => {
+          names = api.getServerContext().middlewares.map(m => m.name);
+        });
+      },
+    };
+
+    const server = createServerBase({
+      config: getDefaultConfig(),
+      appContext: getDefaultAppContext(),
+      pwd: '',
+    });
+    server.addPlugins([
+      compatPlugin(),
+      devRuntimeMiddlewarePlugin(
+        { pwd: '', dev: {}, builderDevServer } as any,
+        null,
+      ),
+      probe,
+    ]);
+    await server.init();
+    return names;
+  }
+
+  it('injects mock / rsbuild / file-reader middlewares into every fresh runtime', async () => {
+    const builderDevServer = makeBuilderDevServer(true);
+
+    // Two independent fresh runtimes both get a complete dev middleware set.
+    const names1 = await buildRuntimeMiddlewareNames(builderDevServer);
+    const names2 = await buildRuntimeMiddlewareNames(builderDevServer);
+
+    for (const names of [names1, names2]) {
+      expect(names).toEqual(
+        expect.arrayContaining(['mock-dev', 'rsbuild-dev', 'init-file-reader']),
+      );
+    }
+  });
+
+  it('omits rsbuild-dev when the builder has no dev middleware', async () => {
+    const names = await buildRuntimeMiddlewareNames(
+      makeBuilderDevServer(false),
+    );
+    expect(names).toContain('mock-dev');
+    expect(names).not.toContain('rsbuild-dev');
+  });
+});
+
+describe('setupDevInfra (process-level singletons)', () => {
+  function setup(getRuntimeServer: () => any) {
+    const nodeServer = new EventEmitter() as any;
+    const builder = { onDevCompileDone: rstest.fn() } as any;
+    const builderDevServer = makeBuilderDevServer(true);
+    const infra = setupDevInfra({
+      config: { server: {} } as any,
+      pwd: '/tmp/app',
+      distDir: '/tmp/app/dist',
+      builder,
+      builderDevServer,
+      compiler: null,
+      nodeServer,
+      getRuntimeServer,
+    });
+    return { infra, nodeServer, builder, builderDevServer };
+  }
+
+  it('creates each process-level resource exactly once and releases them on close', () => {
+    const { infra, nodeServer, builder, builderDevServer } = setup(() =>
+      makeFakeRuntimeServer(),
+    );
+
+    expect(builderDevServer.connectWebSocket).toHaveBeenCalledTimes(1);
+    expect(builder.onDevCompileDone).toHaveBeenCalledTimes(1);
+    expect(getWatchers()).toHaveLength(1);
+    expect(nodeServer.listenerCount('close')).toBe(1);
+
+    infra.close();
+    expect(builderDevServer.close).toHaveBeenCalledTimes(1);
+    expect(getWatchers()[0].closed).toBe(true);
+  });
+
+  it('does not add process-level resources across runtime rebuilds', async () => {
+    let current = makeFakeRuntimeServer();
+    const { nodeServer, builder, builderDevServer } = setup(() => current);
+    const builderDevServerForRuntime = makeBuilderDevServer(true);
+
+    // Simulate several hot reloads, each building a brand-new runtime server,
+    // exactly like createDevServer's buildRuntimeServer does.
+    for (let i = 0; i < 3; i++) {
+      const runtimeServer = createServerBase({
+        config: getDefaultConfig(),
+        appContext: getDefaultAppContext(),
+        pwd: '',
+      });
+      runtimeServer.addPlugins([
+        compatPlugin(),
+        devRuntimeMiddlewarePlugin(
+          {
+            pwd: '',
+            dev: {},
+            builderDevServer: builderDevServerForRuntime,
+          } as any,
+          null,
+        ),
+      ]);
+      await runtimeServer.init();
+      current = runtimeServer as any;
+    }
+
+    // None of the process-level resources were touched by the rebuilds.
+    expect(builderDevServer.connectWebSocket).toHaveBeenCalledTimes(1);
+    expect(builder.onDevCompileDone).toHaveBeenCalledTimes(1);
+    expect(getWatchers()).toHaveLength(1);
+    expect(nodeServer.listenerCount('close')).toBe(1);
+  });
+
+  it('routes watcher changes to the live runtime via the mutable ref (no stale closure)', async () => {
+    let current = makeFakeRuntimeServer();
+    const first = current;
+    setup(() => current);
+
+    const watcher = getWatchers()[0];
+    expect(watcher.listenCb).toBeTypeOf('function');
+
+    // A server file change reaches the current runtime's reset hook.
+    watcher.listenCb(path.join('/tmp/app', 'api/foo.ts'), 'change');
+    await flush();
+    expect(first.hooks.onReset.call).toHaveBeenCalledTimes(1);
+
+    // After a reload swaps the runtime, the watcher must hit the NEW runtime,
+    // never the replaced one.
+    const second = makeFakeRuntimeServer();
+    current = second;
+    watcher.listenCb(path.join('/tmp/app', 'api/bar.ts'), 'change');
+    await flush();
+    expect(second.hooks.onReset.call).toHaveBeenCalledTimes(1);
+    expect(first.hooks.onReset.call).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/server/tests/devRuntimeReload.test.ts
+++ b/packages/server/server/tests/devRuntimeReload.test.ts
@@ -146,6 +146,7 @@ describe('setupDevInfra (process-level singletons)', () => {
     const nodeServer = new EventEmitter() as any;
     const builder = { onDevCompileDone: rstest.fn() } as any;
     const builderDevServer = makeBuilderDevServer(true);
+    const onFileChange = rstest.fn();
     const infra = setupDevInfra({
       config: { server: {} } as any,
       pwd: '/tmp/app',
@@ -155,8 +156,9 @@ describe('setupDevInfra (process-level singletons)', () => {
       compiler: null,
       nodeServer,
       getRuntimeServer,
+      onFileChange,
     });
-    return { infra, nodeServer, builder, builderDevServer };
+    return { infra, nodeServer, builder, builderDevServer, onFileChange };
   }
 
   it('creates each process-level resource exactly once and releases them on close', () => {
@@ -209,25 +211,42 @@ describe('setupDevInfra (process-level singletons)', () => {
     expect(nodeServer.listenerCount('close')).toBe(1);
   });
 
-  it('routes watcher changes to the live runtime via the mutable ref (no stale closure)', async () => {
-    let current = makeFakeRuntimeServer();
-    const first = current;
-    setup(() => current);
+  it('triggers onFileChange (runtime reload) on a watched user server change', async () => {
+    const { onFileChange } = setup(() => makeFakeRuntimeServer());
 
     const watcher = getWatchers()[0];
     expect(watcher.listenCb).toBeTypeOf('function');
 
-    // A server file change reaches the current runtime's reset hook.
+    // A user server file change schedules a runtime reload.
     watcher.listenCb(path.join('/tmp/app', 'api/foo.ts'), 'change');
     await flush();
+    expect(onFileChange).toHaveBeenCalledTimes(1);
+
+    // Server loader bundles only drop the require cache; they never reload.
+    watcher.listenCb(
+      path.join('/tmp/app/dist', 'bundles/x-server-loaders.js'),
+      'change',
+    );
+    await flush();
+    expect(onFileChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('onRepack reaches the live runtime via the mutable ref (no stale closure)', () => {
+    let current = makeFakeRuntimeServer();
+    const first = current;
+    const { builder } = setup(() => current);
+
+    // Capture the builder onDevCompileDone callback (server-bundle reset path).
+    const onCompileDone = builder.onDevCompileDone.mock.calls[0][0];
+    const clientStats = { stats: { toJson: () => ({ name: 'client' }) } };
+
+    onCompileDone(clientStats);
     expect(first.hooks.onReset.call).toHaveBeenCalledTimes(1);
 
-    // After a reload swaps the runtime, the watcher must hit the NEW runtime,
-    // never the replaced one.
+    // After a reload swaps the runtime, onRepack must hit the NEW runtime.
     const second = makeFakeRuntimeServer();
     current = second;
-    watcher.listenCb(path.join('/tmp/app', 'api/bar.ts'), 'change');
-    await flush();
+    onCompileDone(clientStats);
     expect(second.hooks.onReset.call).toHaveBeenCalledTimes(1);
     expect(first.hooks.onReset.call).toHaveBeenCalledTimes(1);
   });

--- a/packages/server/server/tests/devRuntimeReload.test.ts
+++ b/packages/server/server/tests/devRuntimeReload.test.ts
@@ -42,6 +42,7 @@ rstest.mock('../src/dev-tools/watcher', () => {
 });
 
 import { devRuntimeMiddlewarePlugin, setupDevInfra } from '../src/dev';
+import { ReloadManager } from '../src/dev-tools/reloadManager';
 import { createRuntimeServerOptions } from '../src/dev-tools/runtimeOptions';
 import * as watcherModule from '../src/dev-tools/watcher';
 
@@ -50,6 +51,7 @@ rstest.useRealTimers();
 const getWatchers = (): any[] => (watcherModule as any).__getWatchers();
 const resetWatchers = (): void => (watcherModule as any).__resetWatchers();
 const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 function getDefaultConfig() {
   return {
@@ -249,6 +251,45 @@ describe('setupDevInfra (process-level singletons)', () => {
     onCompileDone(clientStats);
     expect(second.hooks.onReset.call).toHaveBeenCalledTimes(1);
     expect(first.hooks.onReset.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a scheduled reload when the dev server closes (no build after close)', async () => {
+    // Wire a real ReloadManager exactly like createDevServer: watcher change ->
+    // schedule, dev server close -> reloadManager.close.
+    const build = rstest.fn(
+      async () => (() => new Response('ok')) as unknown as () => Response,
+    );
+    const reloadManager = new ReloadManager({
+      initialHandle: () => new Response('init') as any,
+      build,
+      debounceMs: 30,
+    });
+
+    const nodeServer = new EventEmitter() as any;
+    setupDevInfra({
+      config: { server: {} } as any,
+      pwd: '/tmp/app',
+      distDir: '/tmp/app/dist',
+      builder: { onDevCompileDone: rstest.fn() } as any,
+      builderDevServer: makeBuilderDevServer(true),
+      compiler: null,
+      nodeServer,
+      getRuntimeServer: () => makeFakeRuntimeServer(),
+      onFileChange: () => reloadManager.schedule(),
+      onClose: () => reloadManager.close(),
+    });
+
+    const watcher = getWatchers()[getWatchers().length - 1];
+
+    // A file change schedules a (debounced) reload.
+    watcher.listenCb(path.join('/tmp/app', 'api/foo.ts'), 'change');
+    // The dev server closes before the debounce fires.
+    nodeServer.emit('close');
+
+    // After the debounce window, no build ran: close cancelled the pending
+    // reload, so nothing rebuilds a runtime after teardown.
+    await sleep(60);
+    expect(build).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/packages/server/server/tests/devRuntimeReload.test.ts
+++ b/packages/server/server/tests/devRuntimeReload.test.ts
@@ -291,6 +291,28 @@ describe('setupDevInfra (process-level singletons)', () => {
     await sleep(60);
     expect(build).toHaveBeenCalledTimes(0);
   });
+
+  it('re-emits the public file-change onReset signal on the live runtime (downstream compat)', async () => {
+    // Downstream plugins (e.g. EdenX gulu/gulux) tap onReset({type:'file-change'})
+    // for their own dev refresh; the watcher must keep emitting it.
+    const runtime = makeFakeRuntimeServer();
+    const { onFileChange } = setup(() => runtime);
+
+    const watcher = getWatchers()[getWatchers().length - 1];
+    const file = path.join('/tmp/app', 'api/foo.ts');
+    watcher.listenCb(file, 'change');
+    await flush();
+
+    expect(runtime.hooks.onReset.call).toHaveBeenCalledTimes(1);
+    expect(runtime.hooks.onReset.call).toHaveBeenCalledWith({
+      event: {
+        type: 'file-change',
+        payload: [{ filename: file, event: 'change' }],
+      },
+    });
+    // and the unified reload is still triggered
+    expect(onFileChange).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('createRuntimeServerOptions (per-build option isolation)', () => {

--- a/packages/server/server/tests/mock.test.ts
+++ b/packages/server/server/tests/mock.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import {
   type ServerPlugin,
@@ -183,6 +185,45 @@ describe('should mock middleware work correctly', () => {
       await server.init();
     } catch (e: any) {
       expect(e.message).toMatch('should be object or function, but got string');
+    }
+  });
+
+  // Users author mocks in TypeScript. getMockModule loads through
+  // compatibleRequire's CJS `require()`, which strips `.ts` types (natively on
+  // Node >= 22.18) — a raw `import('*.ts')` would throw
+  // ERR_UNKNOWN_FILE_EXTENSION.
+  //
+  // The dev "edit -> new value on next reload" freshness cannot be asserted
+  // here: rstest runs the test in a module scope whose `require.cache` differs
+  // from the one the loader populates, so the test can't bust the cache the way
+  // the dev watcher does. That path is verified against a real `modern dev`
+  // server (compatibleRequire's require + the watcher's require.cache busting
+  // return fresh content on each reload).
+  it('loads a mock authored in TypeScript', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'modern-mock-'));
+    const mockDir = path.join(tmpRoot, 'config', 'mock');
+    fs.mkdirSync(mockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(mockDir, 'index.ts'),
+      // `: string` is TS-only syntax — proves the file is transpiled, not
+      // parsed as plain JS.
+      `const label: string = 'from-ts';\n` +
+        `export default { 'GET /api/ping': { value: label } };\n`,
+    );
+
+    const server = createServerBase({
+      config: getDefaultConfig(),
+      pwd: '',
+      appContext: getDefaultAppContext(),
+    });
+    server.addPlugins([compatPlugin(), createMockPlugin(tmpRoot)]);
+    await server.init();
+
+    try {
+      const response = await server.request('/api/ping');
+      expect(await response.json()).toEqual({ value: 'from-ts' });
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/server/server/tests/reloadManager.test.ts
+++ b/packages/server/server/tests/reloadManager.test.ts
@@ -214,6 +214,39 @@ describe('ReloadManager', () => {
     expect(build).toHaveBeenCalledTimes(0);
   });
 
+  it('does not start a trailing build or swap when closed during an in-flight reload', async () => {
+    const initial = makeHandle('initial');
+    const h1 = makeHandle('h1');
+    const d1 = defer<ReloadableHandle>();
+    const d2 = defer<ReloadableHandle>();
+    const deferreds = [d1, d2];
+    let buildIndex = 0;
+    const build = rstest.fn(() => deferreds[buildIndex++]!.promise);
+    const onReload = rstest.fn();
+
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build,
+      onReload,
+    });
+
+    // Build #1 is in flight; a second request coalesces into a trailing reload.
+    const p1 = manager.reloadNow();
+    void manager.reloadNow();
+    expect(build).toHaveBeenCalledTimes(1);
+
+    // Close while build #1 is still running, then let it resolve.
+    manager.close();
+    d1.resolve(h1);
+    await p1;
+
+    // The trailing build #2 never starts; the in-flight result is not committed
+    // (no swap) and the post-swap onReload callback never runs after close.
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(manager.currentHandle).toBe(initial);
+    expect(onReload).not.toHaveBeenCalled();
+  });
+
   it('serves a 503 until setHandle seeds the initial known-good handle', () => {
     const seeded = makeHandle('seeded');
     const manager = new ReloadManager({

--- a/packages/server/server/tests/reloadManager.test.ts
+++ b/packages/server/server/tests/reloadManager.test.ts
@@ -197,4 +197,47 @@ describe('ReloadManager', () => {
     expect(build).toHaveBeenCalledTimes(0);
     expect(manager.currentHandle).toBe(initial);
   });
+
+  it('serves a 503 until setHandle seeds the initial known-good handle', () => {
+    const seeded = makeHandle('seeded');
+    const manager = new ReloadManager({
+      build: async () => makeHandle('built'),
+    });
+
+    // Before any handle is seeded, the default handle replies 503.
+    const notReady = manager.currentHandle(fakeRequest) as Response;
+    expect(notReady.status).toBe(503);
+
+    manager.setHandle(seeded);
+    expect(manager.currentHandle).toBe(seeded);
+    manager.handle(fakeRequest);
+    expect(seeded).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not roll back when onReload throws; reports via onReloadError', async () => {
+    const initial = makeHandle('initial');
+    const next = makeHandle('next');
+    const onError = rstest.fn();
+    const onReloadError = rstest.fn();
+    const callbackError = new Error('previous-runtime cleanup failed');
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build: async () => next,
+      onReload: () => {
+        throw callbackError;
+      },
+      onError,
+      onReloadError,
+    });
+
+    await manager.reloadNow();
+
+    // The swap is committed even though the onReload callback threw.
+    expect(manager.currentHandle).toBe(next);
+    // A successful build is NOT a failed reload, so onError must not fire.
+    expect(onError).not.toHaveBeenCalled();
+    // The post-swap callback failure is surfaced separately.
+    expect(onReloadError).toHaveBeenCalledTimes(1);
+    expect(onReloadError).toHaveBeenCalledWith(callbackError);
+  });
 });

--- a/packages/server/server/tests/reloadManager.test.ts
+++ b/packages/server/server/tests/reloadManager.test.ts
@@ -1,0 +1,200 @@
+import {
+  ReloadManager,
+  type ReloadableHandle,
+  createReloadManager,
+} from '../src/dev-tools/reloadManager';
+
+rstest.useRealTimers();
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+/** Drain the microtask queue (and one macrotask tick). */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function defer<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** A handle whose identity we can assert; returns a tagged sentinel response. */
+function makeHandle(tag: string): ReloadableHandle {
+  return rstest.fn(() => ({ tag }) as unknown as Response) as ReloadableHandle;
+}
+
+const fakeRequest = {} as Request;
+
+describe('ReloadManager', () => {
+  it('forwards requests to the initial handle before any reload', () => {
+    const initial = makeHandle('initial');
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build: async () => makeHandle('next'),
+    });
+
+    const result = manager.handle(fakeRequest, { node: {} });
+
+    expect(initial).toHaveBeenCalledTimes(1);
+    expect(initial).toHaveBeenCalledWith(fakeRequest, { node: {} });
+    expect(result).toEqual({ tag: 'initial' });
+    expect(manager.currentHandle).toBe(initial);
+  });
+
+  it('atomically swaps to the freshly built handle on a successful reload', async () => {
+    const initial = makeHandle('initial');
+    const next = makeHandle('next');
+    const onReload = rstest.fn();
+    const manager = createReloadManager({
+      initialHandle: initial,
+      build: async () => next,
+      onReload,
+    });
+
+    await manager.reloadNow();
+
+    expect(manager.currentHandle).toBe(next);
+    expect(onReload).toHaveBeenCalledTimes(1);
+    expect(onReload).toHaveBeenCalledWith(next);
+
+    // The stable forwarding handle now dispatches to the new handle.
+    const result = manager.handle(fakeRequest);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ tag: 'next' });
+  });
+
+  it('keeps the previous handle and reports the error when build fails', async () => {
+    const initial = makeHandle('initial');
+    const error = new Error('boom');
+    const onError = rstest.fn();
+    const onReload = rstest.fn();
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build: async () => {
+        throw error;
+      },
+      onError,
+      onReload,
+    });
+
+    await manager.reloadNow();
+
+    // Failure isolation: previous handle is retained, no swap happened.
+    expect(manager.currentHandle).toBe(initial);
+    expect(onReload).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+
+    // The dev server keeps serving via the old handle.
+    const result = manager.handle(fakeRequest);
+    expect(initial).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ tag: 'initial' });
+  });
+
+  it('recovers: a failed reload followed by a successful one swaps in the new handle', async () => {
+    const initial = makeHandle('initial');
+    const recovered = makeHandle('recovered');
+    let shouldFail = true;
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build: async () => {
+        if (shouldFail) {
+          throw new Error('first build fails');
+        }
+        return recovered;
+      },
+      onError: () => {
+        // swallow
+      },
+    });
+
+    await manager.reloadNow();
+    expect(manager.currentHandle).toBe(initial);
+
+    shouldFail = false;
+    await manager.reloadNow();
+    expect(manager.currentHandle).toBe(recovered);
+  });
+
+  it('serializes overlapping reloads and keeps the last result', async () => {
+    const initial = makeHandle('initial');
+    const h1 = makeHandle('h1');
+    const h2 = makeHandle('h2');
+    const d1 = defer<ReloadableHandle>();
+    const d2 = defer<ReloadableHandle>();
+    const deferreds = [d1, d2];
+    let buildIndex = 0;
+    const build = rstest.fn(() => deferreds[buildIndex++]!.promise);
+
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build,
+    });
+
+    // First reload starts and is in-flight (build #1 not yet resolved).
+    const p1 = manager.reloadNow();
+    // Second request arrives while the first is running -> coalesced, no new
+    // build started yet (serial execution, no interleaving).
+    const p2 = manager.reloadNow();
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(manager.isReloading).toBe(true);
+
+    // Resolve build #1 -> swap to h1, then the trailing reload starts build #2.
+    d1.resolve(h1);
+    await flush();
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(manager.currentHandle).toBe(h1);
+
+    // Resolve build #2 -> final handle is h2 ("last write wins").
+    d2.resolve(h2);
+    await Promise.all([p1, p2]);
+    expect(manager.currentHandle).toBe(h2);
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(manager.isReloading).toBe(false);
+  });
+
+  it('debounces rapid schedule() calls into a single build', async () => {
+    const initial = makeHandle('initial');
+    const next = makeHandle('next');
+    const build = rstest.fn(async () => next);
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build,
+      debounceMs: 30,
+    });
+
+    manager.schedule();
+    manager.schedule();
+    manager.schedule();
+    expect(build).toHaveBeenCalledTimes(0);
+
+    await sleep(80);
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(manager.currentHandle).toBe(next);
+  });
+
+  it('close() cancels a pending debounced reload', async () => {
+    const initial = makeHandle('initial');
+    const build = rstest.fn(async () => makeHandle('next'));
+    const manager = new ReloadManager({
+      initialHandle: initial,
+      build,
+      debounceMs: 30,
+    });
+
+    manager.schedule();
+    manager.close();
+
+    await sleep(80);
+    expect(build).toHaveBeenCalledTimes(0);
+    expect(manager.currentHandle).toBe(initial);
+  });
+});

--- a/packages/server/server/tests/reloadManager.test.ts
+++ b/packages/server/server/tests/reloadManager.test.ts
@@ -198,6 +198,22 @@ describe('ReloadManager', () => {
     expect(manager.currentHandle).toBe(initial);
   });
 
+  it('ignores schedule() and reloadNow() after close()', async () => {
+    const build = rstest.fn(async () => makeHandle('next'));
+    const manager = new ReloadManager({
+      initialHandle: makeHandle('initial'),
+      build,
+      debounceMs: 10,
+    });
+
+    manager.close();
+    manager.schedule();
+    await manager.reloadNow();
+
+    await sleep(40);
+    expect(build).toHaveBeenCalledTimes(0);
+  });
+
   it('serves a 503 until setHandle seeds the initial known-good handle', () => {
     const seeded = makeHandle('seeded');
     const manager = new ReloadManager({

--- a/tests/integration/bff-hono/config/mock/index.ts
+++ b/tests/integration/bff-hono/config/mock/index.ts
@@ -1,0 +1,13 @@
+// 本地 mock（仅 dev 生效）。用户常用 .ts 编写。
+// key: "METHOD /path"（省略 method 默认 GET）；value: 对象(直接 JSON) 或 函数(中间件)。
+type MockHandlers = Record<string, unknown>;
+
+const handlers: MockHandlers = {
+  'GET /mock/hello': { message: 'mock v3' },
+  'GET /mock/fn': (_req: any, res: any) => {
+    res.setHeader('content-type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify({ message: 'mock fn v1' }));
+  },
+};
+
+export default handlers;


### PR DESCRIPTION
## What & Why

Replace BFF's problematic dev-only hot-update (`dynamic-bff-handler` + `onReset` local rebuild) with a single, lower-overhead **unified dev-server runtime hot reload** in `@modern-js/server`. Now `/api`, `/server` (`modern.server.ts`) and all server-side user logic reload through one path: on file change the server runtime is atomically rebuilt and swapped behind a stable request handle.

## Design

`stable request listener + currentHandle atomic swap + fresh ServerBase per reload`. The Node server is created once and forwards every request through a `ReloadManager` to the latest runtime handle; on file change a brand-new `ServerBase` is built and swapped in. A failed build keeps the previous handle serving (no downtime). Process-level infra (watcher / websocket / builderDevServer / compiler) is created once and never torn down by a reload.