### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -17,6 +20,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       issues: write
       pull-requests: write
     steps:
@@ -21,11 +21,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/integration-test-Linux.yml
+++ b/.github/workflows/integration-test-Linux.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   integration-test-linux:
@@ -26,6 +29,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -35,7 +39,9 @@ jobs:
         id: skip-ci
 
       - name: Log skip CI result
-        run: echo "${{steps.skip-ci.outputs.RESULT}}"
+        env:
+          SKIP_CI_RESULT: ${{ steps.skip-ci.outputs.RESULT }}
+        run: echo "$SKIP_CI_RESULT"
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3

--- a/.github/workflows/integration-test-Windows.yml
+++ b/.github/workflows/integration-test-Windows.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   integration-test-windows:
@@ -31,9 +34,10 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Pnpm
-        run: npm i -g --force corepack && corepack enable
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Check skip CI
         shell: bash
@@ -41,7 +45,9 @@ jobs:
         id: skip-ci
 
       - name: Log skip CI result
-        run: echo "${{steps.skip-ci.outputs.RESULT}}"
+        env:
+          SKIP_CI_RESULT: ${{ steps.skip-ci.outputs.RESULT }}
+        run: echo "$env:SKIP_CI_RESULT"
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3

--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-Linux.yml
+++ b/.github/workflows/lint-Linux.yml
@@ -15,6 +15,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint-linux:
@@ -27,10 +30,11 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           # This makes Actions fetch only one branch to release
-            fetch-depth: 1
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Pnpm
-        run: npm i -g --force corepack && corepack enable
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js 22
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3

--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -8,6 +8,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
@@ -17,6 +20,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Nx Cache
         id: nx-cache
@@ -29,7 +33,7 @@ jobs:
             nx-
 
       - name: Install Pnpm
-        run: npm i -g --force corepack && corepack enable
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js 22
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -8,6 +8,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   type-check:
     runs-on: ${{ fromJSON(vars.SELF_LINUX_LABELS || '"ubuntu-latest"') }}
@@ -22,6 +25,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -37,7 +41,9 @@ jobs:
         id: skip-ci
 
       - name: Log skip CI result
-        run: echo "${{steps.skip-ci.outputs.RESULT}}"
+        env:
+          SKIP_CI_RESULT: ${{ steps.skip-ci.outputs.RESULT }}
+        run: echo "$SKIP_CI_RESULT"
 
       - name: Nx Cache
         id: nx-cache

--- a/.github/workflows/ut-Windows.yml
+++ b/.github/workflows/ut-Windows.yml
@@ -15,6 +15,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ut-windows:
@@ -27,9 +30,10 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Pnpm
-        run: npm i -g --force corepack && corepack enable
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Check skip CI
         shell: bash
@@ -37,7 +41,9 @@ jobs:
         id: skip-ci
 
       - name: Log skip CI result
-        run: echo "${{steps.skip-ci.outputs.RESULT}}"
+        env:
+          SKIP_CI_RESULT: ${{ steps.skip-ci.outputs.RESULT }}
+        run: echo "$env:SKIP_CI_RESULT"
 
       - name: Setup Node.js 22
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3

--- a/.github/workflows/ut-macOS.yml
+++ b/.github/workflows/ut-macOS.yml
@@ -15,6 +15,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ut-mac:
@@ -27,16 +30,19 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Pnpm
-        run: npm i -g --force corepack && corepack enable
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Check skip CI
         run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"
         id: skip-ci
 
       - name: Log skip CI result
-        run: echo "${{steps.skip-ci.outputs.RESULT}}"
+        env:
+          SKIP_CI_RESULT: ${{ steps.skip-ci.outputs.RESULT }}
+        run: echo "$SKIP_CI_RESULT"
 
       - name: Setup Node.js 22
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3


### PR DESCRIPTION
## Summary
- add explicit least-privilege workflow permissions
- set checkout `persist-credentials: false` where jobs only need read access
- move skip-CI output interpolation through environment variables before shell use
- replace ad hoc global Corepack setup with the pinned `pnpm/action-setup` action already used by this repository

## Verification
- `uvx zizmor -q --format json --no-progress --no-exit-codes --collect=workflows .github/workflows`
  - before: 29 findings, H0/M18/L6/I5
  - after: 0 findings
- `/Users/satan/side/experiments/skills/actionlint/scripts/run_actionlint.sh /Users/satan/worktrees/modernjs-zizmor-actions`
- `git diff --check`