### PR TITLE
test: run runtime .ts fixtures on Node < 22.18

### DIFF
--- a/packages/server/server/rstest.config.mts
+++ b/packages/server/server/rstest.config.mts
@@ -1,5 +1,6 @@
 import { withTestPreset } from '@scripts/rstest-config';
 
 export default withTestPreset({
+  setupFiles: ['@scripts/rstest-config/setup.ts'],
   globals: true,
 });

--- a/scripts/rstest-config/setup.ts
+++ b/scripts/rstest-config/setup.ts
@@ -1,9 +1,46 @@
 import { Console } from 'console';
+import { readFileSync } from 'fs';
+import Module, { register } from 'module';
 import path from 'path';
+import { pathToFileURL } from 'url';
 import { expect } from '@rstest/core';
 import { createSnapshotSerializer } from 'path-serializer';
 
 global.console.Console = Console;
+
+// Some tests load a `.ts` file at runtime (BFF api handlers / mock config are
+// read on demand, not statically imported by the test) — via `require()`
+// (CJS) or `await import()` (ESM). Node only strips TypeScript types on those
+// from v22.18 onward; on older versions they throw "Unexpected token" /
+// "Unknown file extension", failing those tests. Install fallbacks that use
+// Node's own type-stripper: a require hook for `require`, and an ESM loader for
+// `import`. Both are gated on `process.features.typescript`, so on Node >= 22.18
+// (and CI) this whole block is a no-op — Node already handles `.ts` natively.
+const nodeModule = Module as unknown as {
+  _extensions: Record<string, (m: any, filename: string) => void>;
+  stripTypeScriptTypes?: (code: string, options?: { mode?: string }) => string;
+};
+if (
+  !process.features.typescript &&
+  typeof nodeModule.stripTypeScriptTypes === 'function'
+) {
+  if (!nodeModule._extensions['.ts']) {
+    nodeModule._extensions['.ts'] = (m, filename) => {
+      const source = readFileSync(filename, 'utf8');
+      const js = nodeModule.stripTypeScriptTypes!(source, {
+        mode: 'transform',
+      });
+      (
+        m as unknown as { _compile: (code: string, fn: string) => void }
+      )._compile(js, filename);
+    };
+  }
+  const registered = globalThis as unknown as { __tsStripLoader?: boolean };
+  if (!registered.__tsStripLoader) {
+    register(pathToFileURL(path.join(__dirname, 'ts-strip-loader.mjs')).href);
+    registered.__tsStripLoader = true;
+  }
+}
 
 // Disable chalk in test
 process.env.FORCE_COLOR = '0';

--- a/scripts/rstest-config/ts-strip-loader.mjs
+++ b/scripts/rstest-config/ts-strip-loader.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import Module from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * ESM loader hook that strips TypeScript types from `.ts` files imported at
+ * runtime (e.g. `await import(mockFile)`), using Node's own type-stripper.
+ *
+ * Only registered on Node < 22.18 (see setup.ts), where Node does not yet strip
+ * types on its own; on newer Node this file is never registered.
+ */
+export function load(url, context, nextLoad) {
+  if (url.endsWith('.ts')) {
+    const source = readFileSync(fileURLToPath(url), 'utf8');
+    const code = Module.stripTypeScriptTypes(source, { mode: 'transform' });
+    return { format: 'module', source: code, shortCircuit: true };
+  }
+  return nextLoad(url, context);
+}


### PR DESCRIPTION
Some tests load a `.ts` file at runtime — BFF api handlers and mock config are read on demand via `require()` / `await import()`, not statically imported by the test. Node only strips TypeScript types on those from v22.18; on older Node they throw "Unexpected token" (require) / "Unknown file extension" (import), so those suites fail locally on Node 22.x < 22.18.

Add gated fallbacks to the shared test setup that use Node's own type-stripper (`module.stripTypeScriptTypes`): a require hook for CJS `require('*.ts')` and an ESM loader for `await import('*.ts')`. Both are gated on `process.features.typescript`, so on Node >= 22.18 (and CI) they never install — a complete no-op. Wire the shared setup into @modern-js/server's rstest config so its mock tests get the fallback too.

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
