### PR TITLE
fix(server-core): prevent path traversal in static asset middleware

### DIFF
--- a/.changeset/safe-static-pathname.md
+++ b/.changeset/safe-static-pathname.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix: prevent path traversal in static asset middleware
+fix: 修复静态资源中间件的路径穿越问题

--- a/packages/server/core/src/adapters/node/plugins/static.ts
+++ b/packages/server/core/src/adapters/node/plugins/static.ts
@@ -99,6 +99,19 @@ function matchPublicRoute(req: HonoRequest, routes: ServerRoute[]) {
   return undefined;
 }
 
+// Check whether `target` is located inside `root` (or is `root` itself),
+// so a resolved static-asset path cannot escape the serving directory via
+// `../` traversal sequences.
+const isPathInside = (target: string, root: string): boolean => {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== '..' &&
+      !path.isAbsolute(relative))
+  );
+};
+
 // Remove domain name from assetPrefix if it exists
 const extractPathname = (url: string): string => {
   try {
@@ -191,6 +204,12 @@ export function createStaticMiddleware(
         pwd,
         pathname.replace(pathPrefix, () => ''),
       );
+      // Prevent path traversal: `pathname` is user-controlled and may contain
+      // `../` sequences (Hono decodes `%2e%2e` in `c.req.path`), which
+      // `path.join` resolves. Reject any resolved path that escapes `pwd`.
+      if (!isPathInside(filepath, pwd)) {
+        return next();
+      }
       if (!(await fs.pathExists(filepath))) {
         // FIXME: we shoud return a response with status is 404, if we can't found static asset
         // return c.html(createErrorHtml(404), 404);


### PR DESCRIPTION
## Summary / 概述

**EN:** Fixes a path traversal / arbitrary file read vulnerability in the Node static asset middleware (`@modern-js/server-core`). The served file path was built directly from the user-controlled request path, and the `staticPathRegExp` guard only checks the prefix (e.g. `/static/`) — it does not block `../` sequences that follow. Because Hono's `getPath` runs the path through `decodeURI` (which decodes `%2e%2e` to `..`), `c.req.path` can literally contain `../`, and `path.join` resolves it, letting a request like `/static/../../../../etc/passwd` escape the serving directory and read arbitrary files.

**中文：** 修复 Node 静态资源中间件（`@modern-js/server-core`）中的路径穿越 / 任意文件读取漏洞。此前文件路径直接由用户可控的请求路径拼接而成，而 `staticPathRegExp` 只做前缀校验（如 `/static/`），无法拦截后续的 `../` 序列。由于 Hono 的 `getPath` 会用 `decodeURI` 解码路径（会将 `%2e%2e` 解码为 `..`），`c.req.path` 可以包含真实的 `../`，再经 `path.join` 解析后，`/static/../../../../etc/passwd` 之类的请求即可逃逸出服务目录读取任意文件。

## Changes / 改动

- Add an `isPathInside(target, root)` containment check based on `path.relative`, and reject the request (fall through to `next()`) before any filesystem access whenever the resolved path escapes `pwd`.
- 新增基于 `path.relative` 的 `isPathInside(target, root)` 包含性校验；当解析后的路径逃逸出 `pwd` 时，在任何文件系统访问之前拒绝请求（交给 `next()`）。

Legitimate assets under `static/`, `upload/` and configured public dirs are unaffected. The sibling `createPublicMiddleware` is not affected — it derives its filename from server-side `route.entryPath`, not the request path.

`static/`、`upload/` 及配置的 public 目录下的正常资源不受影响。相邻的 `createPublicMiddleware` 不受影响——它的文件名来自服务端的 `route.entryPath`，而非请求路径。
