### PR TITLE
feat(plugin-bff): retarget bff-core import types at declaration emit

### DIFF
--- a/.changeset/bff-client-types-package.md
+++ b/.changeset/bff-client-types-package.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-bff': patch
+'@modern-js/server-utils': patch
+---
+
+feat: retarget bff-core import types at declaration emit (`afterDeclarations` transformer in api compilation) via an internal `clientTypesPackage` option injected by upper-layer frameworks, so generated crossProject client d.ts references a framework-owned types package instead of `@modern-js/bff-core`; `server-utils` compile now accepts `declarationTransformers`
+feat: 在 api 编译的 declaration emit 阶段（`afterDeclarations` transformer）将 bff-core 的 import type 引用重定向到上层框架注入的内部 `clientTypesPackage`，crossProject 生成的 client d.ts 不再引用 `@modern-js/bff-core`；`server-utils` 的 compile 支持传入 `declarationTransformers`

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -16,10 +16,15 @@ import {
 } from '@modern-js/utils';
 import type { ConfigChain } from '@rsbuild/core';
 import clientGenerator from './utils/clientGenerator';
+import { createImportTypeRetargetTransformer } from './utils/clientTypesTransformer';
 import pluginGenerator from './utils/pluginGenerator';
 import runtimeGenerator from './utils/runtimeGenerator';
 
 const RUNTIME_CREATE_REQUEST = '@modern-js/plugin-bff/client';
+// The package that declares the server-side api types (kept in lockstep with
+// the `@modern-js/bff-core` import above — renaming the package breaks that
+// import loudly, which forces this constant to be updated with it).
+const BFF_CORE_PACKAGE = '@modern-js/bff-core';
 
 export const bffPlugin = (): CliPlugin<AppTools> => ({
   name: '@modern-js/plugin-bff',
@@ -55,6 +60,8 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
       const { server } = modernConfig;
       const { alias } = modernConfig.source;
       const { alias: resolveAlias } = modernConfig.resolve;
+      const clientTypesPackage = (modernConfig?.bff as any)
+        ?.clientTypesPackage as string | undefined;
 
       if (sourceDirs.length > 0) {
         const combinedAlias = ([] as unknown[])
@@ -72,6 +79,17 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
             tsconfigPath,
             moduleType,
             throwErrorInsteadOfExit: true,
+            // Internal, injected into the normalized config by upper-layer
+            // frameworks (same convention as `requestCreator` /
+            // `runtimeCreateRequest`); not part of the public bff config.
+            declarationTransformers: clientTypesPackage
+              ? [
+                  createImportTypeRetargetTransformer(
+                    BFF_CORE_PACKAGE,
+                    clientTypesPackage,
+                  ),
+                ]
+              : undefined,
           },
         );
       }

--- a/packages/cli/plugin-bff/src/utils/clientTypesTransformer.ts
+++ b/packages/cli/plugin-bff/src/utils/clientTypesTransformer.ts
@@ -1,0 +1,42 @@
+import type { DeclarationTransformerFactory } from '@modern-js/server-utils';
+import type ts from 'typescript';
+
+/**
+ * Declaration-emit transformer (tsc `afterDeclarations`).
+ *
+ * When tsc emits declarations for api files, types inferred from handler
+ * factories are printed as synthesized `import("<declaring package>")` type
+ * references. For BFF that declaring package is the server-only
+ * `@modern-js/bff-core`, which consumers of a crossProject api package do
+ * not depend on — so an upper-layer framework can retarget those references
+ * to a package it owns at the moment the declaration AST is produced,
+ * instead of post-processing emitted files.
+ *
+ * The rewrite happens on `ImportTypeNode`s in the declaration AST, not on
+ * output text, so quoting/formatting never matters and nothing but module
+ * specifiers can be affected.
+ */
+export const createImportTypeRetargetTransformer =
+  (from: string, to: string): DeclarationTransformerFactory =>
+  tsInstance =>
+  context => {
+    const { factory } = context;
+    const visit = (node: ts.Node): ts.Node => {
+      const retargeted =
+        tsInstance.isImportTypeNode(node) &&
+        tsInstance.isLiteralTypeNode(node.argument) &&
+        tsInstance.isStringLiteral(node.argument.literal) &&
+        node.argument.literal.text === from
+          ? factory.updateImportTypeNode(
+              node,
+              factory.createLiteralTypeNode(factory.createStringLiteral(to)),
+              node.attributes,
+              node.qualifier,
+              node.typeArguments,
+              node.isTypeOf,
+            )
+          : node;
+      return tsInstance.visitEachChild(retargeted, visit, context);
+    };
+    return node => tsInstance.visitEachChild(node, visit, context);
+  };

--- a/packages/cli/plugin-bff/tests/clientTypesTransformer.test.ts
+++ b/packages/cli/plugin-bff/tests/clientTypesTransformer.test.ts
@@ -1,0 +1,97 @@
+import os from 'os';
+import path from 'path';
+import { fs } from '@modern-js/utils';
+import ts from 'typescript';
+import { createImportTypeRetargetTransformer } from '../src/utils/clientTypesTransformer';
+
+// Real tsc declaration emit against a fixture package, so the tests prove
+// the d.ts is correct at the moment it is generated — not that some text
+// replacement works on a hand-written string.
+const setupFixture = async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'bff-dts-transform-'));
+  const pkgDir = path.join(dir, 'node_modules', 'fake-bff-core');
+  await fs.outputFile(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({
+      name: 'fake-bff-core',
+      version: '1.0.0',
+      main: 'index.js',
+      types: 'index.d.ts',
+    }),
+  );
+  await fs.outputFile(path.join(pkgDir, 'index.js'), 'exports.Api = f => f;');
+  await fs.outputFile(
+    path.join(pkgDir, 'index.d.ts'),
+    [
+      'export type ApiRunner<I, O> = (input: I) => O;',
+      'export declare function Api<I, O>(handler: (input: I) => O): ApiRunner<I, O>;',
+    ].join('\n'),
+  );
+  await fs.outputFile(
+    path.join(dir, 'upload.ts'),
+    [
+      "import { Api } from 'fake-bff-core';",
+      'export const upload = Api((input: { name: string }) =>',
+      '  Promise.resolve({ code: 0 }),',
+      ');',
+    ].join('\n'),
+  );
+  return dir;
+};
+
+const emitDts = async (
+  dir: string,
+  transformerFactory?: ReturnType<typeof createImportTypeRetargetTransformer>,
+) => {
+  const program = ts.createProgram([path.join(dir, 'upload.ts')], {
+    declaration: true,
+    emitDeclarationOnly: true,
+    outDir: path.join(dir, 'dist'),
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    strict: true,
+  });
+  const result = program.emit(undefined, undefined, undefined, true, {
+    afterDeclarations: transformerFactory
+      ? [transformerFactory(ts)]
+      : undefined,
+  });
+  expect(result.diagnostics).toHaveLength(0);
+  return fs.readFile(path.join(dir, 'dist', 'upload.d.ts'), 'utf8');
+};
+
+describe('createImportTypeRetargetTransformer', () => {
+  it('tsc synthesizes an import type of the declaring package by default', async () => {
+    const dir = await setupFixture();
+    const dts = await emitDts(dir);
+    // the leak this feature exists to fix
+    expect(dts).toContain('import("fake-bff-core").ApiRunner');
+  });
+
+  it('retargets synthesized import types at declaration emit', async () => {
+    const dir = await setupFixture();
+    const dts = await emitDts(
+      dir,
+      createImportTypeRetargetTransformer('fake-bff-core', '@edenx/plugin-bff'),
+    );
+    expect(dts).not.toContain('fake-bff-core');
+    expect(dts).toContain('import("@edenx/plugin-bff").ApiRunner');
+    // the rest of the declaration is untouched
+    expect(dts).toContain('export declare const upload:');
+    expect(dts).toContain('name: string');
+  });
+
+  it('leaves other module specifiers untouched', async () => {
+    const dir = await setupFixture();
+    const dts = await emitDts(
+      dir,
+      createImportTypeRetargetTransformer(
+        'some-other-package',
+        '@edenx/plugin-bff',
+      ),
+    );
+    expect(dts).toContain('import("fake-bff-core").ApiRunner');
+    expect(dts).not.toContain('@edenx/plugin-bff');
+  });
+});

--- a/packages/server/utils/src/common/index.ts
+++ b/packages/server/utils/src/common/index.ts
@@ -4,6 +4,7 @@ import type {
   ToolsNormalizedConfig,
 } from '@modern-js/server-core';
 import { fs } from '@modern-js/utils';
+import type ts from 'typescript';
 
 export interface Pattern {
   from: string;
@@ -18,12 +19,22 @@ export interface IConfig {
   };
 }
 
+export type DeclarationTransformerFactory = (
+  tsInstance: typeof ts,
+) => ts.TransformerFactory<ts.SourceFile | ts.Bundle>;
+
 export interface CompileOptions {
   sourceDirs: string[];
   distDir: string;
   tsconfigPath?: string;
   moduleType?: 'module' | 'commonjs';
   throwErrorInsteadOfExit?: boolean;
+  /**
+   * Custom transformers applied to declaration emit (tsc
+   * `afterDeclarations`), so callers can shape the generated d.ts at the
+   * point it is produced.
+   */
+  declarationTransformers?: DeclarationTransformerFactory[];
 }
 
 export type CompileFunc = (

--- a/packages/server/utils/src/compilers/typescript/index.ts
+++ b/packages/server/utils/src/compilers/typescript/index.ts
@@ -88,6 +88,9 @@ export const compileByTs: CompileFunc = async (
 
   const emitResult = program.emit(undefined, undefined, undefined, undefined, {
     before: [tsconfigPathsPlugin!],
+    afterDeclarations: compileOptions.declarationTransformers?.map(factory =>
+      factory(ts),
+    ),
   });
 
   const allDiagnostics = ts

--- a/packages/server/utils/src/index.ts
+++ b/packages/server/utils/src/index.ts
@@ -1,1 +1,5 @@
 export { compile } from './common';
+export type {
+  CompileOptions,
+  DeclarationTransformerFactory,
+} from './common';


### PR DESCRIPTION
crossProject client d.ts files are copied from tsc declaration emit, which references server-side types via synthesized import("@modern-js/bff-core") type nodes. Consumers of a crossProject api package do not depend on bff-core, so under strict package managers those references fail to resolve and every api function degrades to any.

Fix it at the point the declarations are generated instead of post-processing emitted files:

- server-utils: compile() accepts declarationTransformers, forwarded to program.emit afterDeclarations (symmetric to the existing before transformer used by tsconfigPathsPlugin for JS emit)
- plugin-bff: createImportTypeRetargetTransformer rewrites matching ImportTypeNode module specifiers on the declaration AST; attached only when the internal clientTypesPackage option is injected into the normalized bff config by an upper-layer framework (same convention as requestCreator / runtimeCreateRequest, not part of public BffUserConfig)
- tests run real tsc declaration emit against a fixture package: baseline leak reproduction, retargeting, and no-op for other specifiers

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
