### PR TITLE
feat(app-tools): export setupTsRuntime from the public entry

### DIFF
--- a/.changeset/export-setup-ts-runtime.md
+++ b/.changeset/export-setup-ts-runtime.md
@@ -1,0 +1,13 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat(app-tools): export `setupTsRuntime` and `resolveTsRuntimeRegisterMode` from the public entry
+
+The server TypeScript runtime setup app-tools' own dev/build commands use
+(ts-node when the project depends on it, Node.js native TypeScript as the
+fallback, plus tsconfig-paths/alias registration) is now part of the public
+API, so frameworks composing app-tools in-process (running their own command
+actions instead of app-tools') can register the same runtime without keeping
+a private copy of the logic. Also exports the `TsRuntimeRegisterMode` and
+`TsRuntimeSetupOptions` types.

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -173,6 +173,12 @@ export { serve } from './commands/serve';
 export type { DevOptions } from './utils/types';
 export { generateWatchFiles } from './utils/generateWatchFiles';
 export {
+  resolveTsRuntimeRegisterMode,
+  setupTsRuntime,
+  type TsRuntimeRegisterMode,
+  type TsRuntimeSetupOptions,
+} from './utils/register';
+export {
   resolveModernRsbuildConfig,
   type ResolveModernRsbuildConfigOptions,
 } from './rsbuild';

--- a/packages/solutions/app-tools/src/utils/register.ts
+++ b/packages/solutions/app-tools/src/utils/register.ts
@@ -11,9 +11,9 @@ import {
 } from '@modern-js/utils';
 import type { ConfigChain } from '@rsbuild/core';
 
-type TsRuntimeRegisterMode = 'ts-node' | 'node-loader' | 'unsupported';
+export type TsRuntimeRegisterMode = 'ts-node' | 'node-loader' | 'unsupported';
 
-interface TsRuntimeSetupOptions {
+export interface TsRuntimeSetupOptions {
   moduleType?: string;
   /**
    * User-configured `server.tsconfigPath`. Forwarded into the shared


### PR DESCRIPTION
## Summary

Exports `setupTsRuntime` / `resolveTsRuntimeRegisterMode` (and the `TsRuntimeRegisterMode` / `TsRuntimeSetupOptions` types) from `@modern-js/app-tools`' public entry.

The server TypeScript runtime setup that app-tools' own `dev`/`build` command actions already use — ts-node when the project depends on it, Node.js native TypeScript support as the fallback, plus tsconfig-paths/alias registration — was internal (`src/utils/register.ts`). Frameworks that compose `appTools()` in-process but register their **own** command actions (so app-tools' command layer never runs) currently have to keep a private copy of this logic to load user server-side TS (BFF handlers, `config/mock`, server hooks) in dev. Making the existing helper public lets them call the exact same battle-tested path with `(appDir, distDir, alias?, options?)` and delete their copies.

No behavior change — export surface only (two `export` keywords added on the existing type/interface, plus the entry re-export).

## Related Links

- Follow-up to the removal of the default server ts register (#5621): this exposes the current, supported runtime-setup path as API instead of frameworks re-implementing it.

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes. (export-only change; covered by the existing app-tools suite — 89/89 locally, build + dist d.ts verified)