### PR TITLE
feat(builder): add source.reactCompiler to enable React Compiler

### DIFF
--- a/.changeset/spicy-donkeys-attack.md
+++ b/.changeset/spicy-donkeys-attack.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': minor
+'@modern-js/app-tools': minor
+---
+
+feat(builder): add `source.reactCompiler` to enable React Compiler via Rspack's built-in SWC implementation
+feat(builder): 新增 `source.reactCompiler` 配置，基于 Rspack 内置 SWC 的 Rust 版 React Compiler 提供一键开启能力

--- a/examples/react-compiler/modern.config.ts
+++ b/examples/react-compiler/modern.config.ts
@@ -1,14 +1,9 @@
 import { appTools, defineConfig } from '@modern-js/app-tools';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 
 // https://modernjs.dev/en/configure/app/usage
 export default defineConfig({
-  builderPlugins: [
-    pluginBabel({
-      babelLoaderOptions: (_config, { addPlugins }) => {
-        addPlugins(['babel-plugin-react-compiler']);
-      },
-    }),
-  ],
+  source: {
+    reactCompiler: true,
+  },
   plugins: [appTools()],
 });

--- a/examples/react-compiler/package.json
+++ b/examples/react-compiler/package.json
@@ -22,12 +22,10 @@
     "@biomejs/biome": "1.9.4",
     "@modern-js/app-tools": "latest",
     "@modern-js/tsconfig": "latest",
-    "@rsbuild/plugin-babel": "^1.1.2",
     "@types/jest": "~29.2.4",
     "@types/node": "^20",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "babel-plugin-react-compiler": "^1.0.0",
     "eslint-plugin-react-hooks": "^6.0.0-rc.1",
     "rimraf": "^6.0.1",
     "typescript": "~5.7.3"

--- a/packages/cli/builder/package.json
+++ b/packages/cli/builder/package.json
@@ -38,7 +38,7 @@
     "@rsbuild/plugin-check-syntax": "2.0.0",
     "@rsbuild/plugin-css-minimizer": "2.0.1",
     "@rsbuild/plugin-less": "1.6.4",
-    "@rsbuild/plugin-react": "2.0.1",
+    "@rsbuild/plugin-react": "2.1.0",
     "@rsbuild/plugin-rem": "1.0.6",
     "@rsbuild/plugin-sass": "1.5.3",
     "@rsbuild/plugin-source-build": "1.0.6",

--- a/packages/cli/builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/builder/src/shared/parseCommonConfig.ts
@@ -70,7 +70,13 @@ export async function parseCommonConfig(
       ...outputConfig
     } = {},
     html: { outputStructure, appIcon, ...htmlConfig } = {},
-    source: { alias, globalVars, transformImport, ...sourceConfig } = {},
+    source: {
+      alias,
+      globalVars,
+      transformImport,
+      reactCompiler,
+      ...sourceConfig
+    } = {},
     dev = {},
     server = {},
     security: { checkSyntax, sri, ...securityConfig } = {},
@@ -269,7 +275,9 @@ export async function parseCommonConfig(
     );
   }
 
-  rsbuildPlugins.push(pluginReact());
+  rsbuildPlugins.push(
+    pluginReact(reactCompiler !== undefined ? { reactCompiler } : {}),
+  );
 
   if (!disableSvgr) {
     const { pluginSvgr } = await import('@rsbuild/plugin-svgr');

--- a/packages/cli/builder/src/types.ts
+++ b/packages/cli/builder/src/types.ts
@@ -22,6 +22,7 @@ import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import type { PluginCheckSyntaxOptions } from '@rsbuild/plugin-check-syntax';
 import type { PluginCssMinimizerOptions } from '@rsbuild/plugin-css-minimizer';
 import type { PluginLessOptions } from '@rsbuild/plugin-less';
+import type { PluginReactOptions } from '@rsbuild/plugin-react';
 import type { PluginRemOptions } from '@rsbuild/plugin-rem';
 import type { PluginSassOptions } from '@rsbuild/plugin-sass';
 import type { PluginSourceBuildOptions } from '@rsbuild/plugin-source-build';
@@ -175,6 +176,12 @@ export type BuilderExtraConfig = {
      * Define global variables. It can replace expressions like `process.env.FOO` in your code after compile.
      */
     globalVars?: ChainedGlobalVars;
+    /**
+     * Enable or configure React Compiler, powered by the Rust-based implementation
+     * built into Rspack's `builtin:swc-loader` (`jsc.transform.reactCompiler`).
+     * @default undefined (disabled)
+     */
+    reactCompiler?: PluginReactOptions['reactCompiler'];
   };
   output?: {
     /**

--- a/packages/cli/builder/tests/reactCompiler.test.ts
+++ b/packages/cli/builder/tests/reactCompiler.test.ts
@@ -1,0 +1,87 @@
+import { join } from 'path';
+import type { Rspack } from '@rsbuild/core';
+import { describe, expect, test } from '@rstest/core';
+import { createBuilder } from '../src';
+import { parseCommonConfig } from '../src/shared/parseCommonConfig';
+import type { BuilderConfig } from '../src/types';
+
+function getSwcTransformOptions(config: Rspack.Configuration) {
+  for (const rule of config.module?.rules || []) {
+    if (!rule || typeof rule !== 'object') {
+      continue;
+    }
+    const uses = Array.isArray(rule.use) ? rule.use : [rule.use];
+    for (const use of uses) {
+      if (
+        use &&
+        typeof use === 'object' &&
+        use.loader?.includes('swc-loader') &&
+        typeof use.options === 'object'
+      ) {
+        return (use.options as Rspack.SwcLoaderOptions).jsc?.transform;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function getBundlerConfig(config: BuilderConfig) {
+  const rsbuild = await createBuilder({
+    bundlerType: 'rspack',
+    config,
+    cwd: join(__dirname, '..'),
+  });
+  const {
+    origin: { bundlerConfigs },
+  } = await rsbuild.inspectConfig();
+  return bundlerConfigs[0];
+}
+
+describe('source.reactCompiler', () => {
+  test('should not enable react compiler by default', async () => {
+    const transform = getSwcTransformOptions(await getBundlerConfig({}));
+
+    expect(transform).toBeDefined();
+    expect(transform).not.toHaveProperty('reactCompiler');
+  });
+
+  test('should enable react compiler when set to true', async () => {
+    const transform = getSwcTransformOptions(
+      await getBundlerConfig({
+        source: {
+          reactCompiler: true,
+        },
+      }),
+    );
+
+    expect(transform?.reactCompiler).toEqual(true);
+  });
+
+  test('should pass through react compiler options object', async () => {
+    const transform = getSwcTransformOptions(
+      await getBundlerConfig({
+        source: {
+          reactCompiler: {
+            target: '18',
+            compilationMode: 'annotation',
+          },
+        },
+      }),
+    );
+
+    expect(transform?.reactCompiler).toEqual({
+      target: '18',
+      compilationMode: 'annotation',
+    });
+  });
+
+  test('should not leak reactCompiler into rsbuild source config', async () => {
+    const { rsbuildConfig } = await parseCommonConfig({
+      source: {
+        reactCompiler: true,
+      },
+    });
+
+    expect(rsbuildConfig.source).not.toHaveProperty('reactCompiler');
+  });
+});

--- a/packages/document/docs/en/configure/app/source/react-compiler.mdx
+++ b/packages/document/docs/en/configure/app/source/react-compiler.mdx
@@ -1,0 +1,72 @@
+---
+title: reactCompiler
+---
+
+# source.reactCompiler
+
+- **Type:** `boolean | ReactCompilerOptions`
+- **Default:** `undefined` (disabled)
+
+Whether to enable [React Compiler](https://react.dev/learn/react-compiler). React Compiler is a build-time tool that optimizes re-rendering performance of React applications through automatic memoization.
+
+Modern.js implements this capability based on the Rust-based React Compiler built into Rspack's `builtin:swc-loader` (equivalent to setting SWC's `jsc.transform.reactCompiler`), reusing Rspack's built-in SWC transform chain without introducing Babel.
+
+:::tip
+This option is disabled by default. It must be enabled explicitly for any React version, including React 19.
+:::
+
+## Example
+
+### Enable React Compiler (React 19)
+
+```ts title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: true,
+  },
+});
+```
+
+### Using with React 18
+
+The compiled output targets React 19 by default. To use it in React 18 projects, you need to:
+
+1. Install [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) as a **runtime dependency** (the compiled output references it at runtime):
+
+```bash
+npm add react-compiler-runtime
+```
+
+2. Specify the React version via `target`:
+
+```ts title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: {
+      target: '18',
+    },
+  },
+});
+```
+
+### Customize compilation behavior
+
+When passing an object, the options are the same as Rspack's `jsc.transform.reactCompiler`. For example, use `compilationMode: 'annotation'` to only compile functions annotated with the `"use memo"` directive:
+
+```ts title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: {
+      compilationMode: 'annotation',
+    },
+  },
+});
+```
+
+For the complete list of options, see [Rsbuild - reactCompiler](https://rsbuild.rs/plugins/list/plugin-react#reactcompiler) and the [React Compiler configuration docs](https://react.dev/reference/react-compiler/configuration).

--- a/packages/document/docs/en/guides/advanced-features/page-performance/react-compiler.mdx
+++ b/packages/document/docs/en/guides/advanced-features/page-performance/react-compiler.mdx
@@ -1,54 +1,69 @@
 # React Compiler
 
-The React Compiler is an experimental compiler introduced in React 19 that can automatically optimize your React code.
+React Compiler is a build-time compiler from the React team that reduces unnecessary re-renders through automatic memoization, without manually writing `useMemo`, `useCallback`, or `React.memo`.
 
-Before starting to use the React Compiler, it is recommended to read the [React Compiler documentation](https://zh-hans.react.dev/learn/react-compiler) to understand its features, current status, and usage.
+Before starting to use React Compiler, it is recommended to read the [React Compiler documentation](https://react.dev/learn/react-compiler) to understand its features, current status, and usage.
 
 ## How to Use
 
+Modern.js provides built-in support for React Compiler via the [source.reactCompiler](/configure/app/source/react-compiler) option, powered by the Rust-based React Compiler implementation in Rspack's `builtin:swc-loader`. It reuses Rspack's built-in SWC transform chain without introducing Babel (`babel-plugin-react-compiler`).
+
+This capability is **disabled by default** and must be enabled explicitly for any React version.
+
 ### React 19
 
-If you are using React 19, Modern.js has built-in support for React Compiler, and no additional configuration is required.
-
-### React 18
-
-If you are using React 18, you need to configure it as follows:
-
-1. Install `react-compiler-runtime` to allow the compiled code to run on versions before 19:
-
-```bash
-npm install react-compiler-runtime
-```
-
-2. Install `babel-plugin-react-compiler`:
-
-```bash
-npm install babel-plugin-react-compiler
-```
-
-3. Register the Babel plugin in your Modern.js configuration file:
+If you are using React 19, simply enable `source.reactCompiler` — no additional dependencies are required:
 
 ```ts title="modern.config.ts"
 import { appTools, defineConfig } from '@modern-js/app-tools';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 
 export default defineConfig({
-  builderPlugins: [
-    pluginBabel({
-      babelLoaderOptions: (config, { addPlugins }) => {
-        addPlugins([
-          [
-            'babel-plugin-react-compiler',
-          {
-            target: '18', // 或 '17'，根据你使用的 React 版本
-          },
-          ],
-        ]);
-      },
-    });
-  ];
+  source: {
+    reactCompiler: true,
+  },
   plugins: [appTools()],
 });
 ```
+
+### React 18
+
+If you are using React 18, configure it as follows:
+
+1. Install `react-compiler-runtime` as a **runtime dependency** to allow the compiled code to run on versions before React 19:
+
+```bash
+npm add react-compiler-runtime
+```
+
+2. Specify the React version via `target` in the configuration:
+
+```ts title="modern.config.ts"
+import { appTools, defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: {
+      target: '18',
+    },
+  },
+  plugins: [appTools()],
+});
+```
+
+## Customize Compilation Behavior
+
+`source.reactCompiler` accepts an object to configure the compilation behavior, with the same options as Rspack's `jsc.transform.reactCompiler`. For example, use `compilationMode: 'annotation'` to only compile functions annotated with the `"use memo"` directive, enabling React Compiler incrementally:
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  source: {
+    reactCompiler: {
+      compilationMode: 'annotation',
+    },
+  },
+});
+```
+
+For the complete list of options, see [Rsbuild - reactCompiler](https://rsbuild.rs/plugins/list/plugin-react#reactcompiler) and the [React Compiler configuration docs](https://react.dev/reference/react-compiler/configuration).
 
 > For detailed code, you can refer to the [Modern.js & React Compiler example project](https://github.com/web-infra-dev/modern.js/tree/main/examples/react-compiler)

--- a/packages/document/docs/zh/configure/app/source/react-compiler.mdx
+++ b/packages/document/docs/zh/configure/app/source/react-compiler.mdx
@@ -1,0 +1,72 @@
+---
+title: reactCompiler
+---
+
+# source.reactCompiler
+
+- **类型：** `boolean | ReactCompilerOptions`
+- **默认值：** `undefined`（不开启）
+
+是否启用 [React Compiler](https://zh-hans.react.dev/learn/react-compiler)。React Compiler 是一个构建期工具，通过自动记忆化（memoization）优化 React 应用的重渲染性能。
+
+Modern.js 基于 Rspack `builtin:swc-loader` 内置的 Rust 版 React Compiler 实现该能力（等价于设置 SWC 的 `jsc.transform.reactCompiler`），复用 Rspack 内置的 SWC 转换链，无需额外引入 Babel。
+
+:::tip
+该配置默认关闭，任何 React 版本下都需要显式开启，包括 React 19。
+:::
+
+## 示例
+
+### 开启 React Compiler（React 19）
+
+```ts title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: true,
+  },
+});
+```
+
+### 在 React 18 中使用
+
+React Compiler 编译产物默认面向 React 19。在 React 18 项目中使用时，需要：
+
+1. 将 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) 安装为**运行时依赖**（编译产物会在运行时引用它）：
+
+```bash
+npm add react-compiler-runtime
+```
+
+2. 通过 `target` 指定 React 版本：
+
+```ts title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: {
+      target: '18',
+    },
+  },
+});
+```
+
+### 自定义编译行为
+
+传入对象时，选项与 Rspack `jsc.transform.reactCompiler` 一致，例如通过 `compilationMode: 'annotation'` 仅编译带有 `"use memo"` 指令的函数：
+
+```ts title="modern.config.ts"
+import { defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: {
+      compilationMode: 'annotation',
+    },
+  },
+});
+```
+
+完整选项请参考 [Rsbuild - reactCompiler](https://rsbuild.rs/plugins/list/plugin-react#reactcompiler) 与 [React Compiler 配置文档](https://zh-hans.react.dev/reference/react-compiler/configuration)。

--- a/packages/document/docs/zh/guides/advanced-features/page-performance/react-compiler.mdx
+++ b/packages/document/docs/zh/guides/advanced-features/page-performance/react-compiler.mdx
@@ -1,54 +1,69 @@
 # React Compiler
 
-React Compiler 是 React 19 引入的一个实验性编译器，它可以自动优化你的 React 代码。
+React Compiler 是 React 官方提供的构建期编译器，通过自动记忆化（memoization）减少不必要的重渲染，无需手动编写 `useMemo`、`useCallback` 和 `React.memo`。
 
-在开始使用 React Compiler 之前，建议阅读 [React Compiler 文档](https://zh-hans.react.dev/learn/react-compiler)，以了解 React Compiler 的功能、当前状态和使用方法。
+在开始使用 React Compiler 之前，建议阅读 [React Compiler 文档](https://zh-hans.react.dev/learn/react-compiler)，以了解它的功能、当前状态和使用方法。
 
 ## 如何使用
 
+Modern.js 通过 [source.reactCompiler](/configure/app/source/react-compiler) 配置内置支持 React Compiler，底层使用 Rspack `builtin:swc-loader` 中 Rust 实现的 React Compiler，复用 Rspack 内置的 SWC 转换链，无需额外引入 Babel（`babel-plugin-react-compiler`）。
+
+该能力**默认关闭**，任何 React 版本下都需要显式开启。
+
 ### React 19
 
-如果你使用的是 React 19，Modern.js 已内置支持 React Compiler，无需额外配置即可使用。
+如果你使用的是 React 19，开启 `source.reactCompiler` 即可，无需安装任何额外依赖：
+
+```ts title="modern.config.ts"
+import { appTools, defineConfig } from '@modern-js/app-tools';
+
+export default defineConfig({
+  source: {
+    reactCompiler: true,
+  },
+  plugins: [appTools()],
+});
+```
 
 ### React 18
 
 如果你使用的是 React 18，需要按照以下步骤配置：
 
-1. 安装 `react-compiler-runtime`，以允许编译后的代码在 19 之前的版本上运行：
+1. 将 `react-compiler-runtime` 安装为**运行时依赖**，以允许编译后的代码在 React 19 之前的版本上运行：
 
 ```bash
-npm install react-compiler-runtime
+npm add react-compiler-runtime
 ```
 
-2. 安装 `babel-plugin-react-compiler`：
-
-```bash
-npm install babel-plugin-react-compiler
-```
-
-3. 在你的 Modern.js 配置文件中注册 Babel 插件：
+2. 在配置中通过 `target` 指定 React 版本：
 
 ```ts title="modern.config.ts"
 import { appTools, defineConfig } from '@modern-js/app-tools';
-import { pluginBabel } from '@rsbuild/plugin-babel';
 
 export default defineConfig({
-  builderPlugins: [
-    pluginBabel({
-      babelLoaderOptions: (config, { addPlugins }) => {
-        addPlugins([
-          [
-            'babel-plugin-react-compiler',
-          {
-            target: '18', // 或 '17'，根据你使用的 React 版本
-          },
-          ],
-        ]);
-      },
-    });
-  ];
+  source: {
+    reactCompiler: {
+      target: '18',
+    },
+  },
   plugins: [appTools()],
 });
 ```
+
+## 自定义编译行为
+
+`source.reactCompiler` 支持传入对象来配置编译行为，选项与 Rspack 的 `jsc.transform.reactCompiler` 一致。例如，通过 `compilationMode: 'annotation'` 可以只编译带有 `"use memo"` 指令的函数，渐进式地启用 React Compiler：
+
+```ts title="modern.config.ts"
+export default defineConfig({
+  source: {
+    reactCompiler: {
+      compilationMode: 'annotation',
+    },
+  },
+});
+```
+
+完整选项请参考 [Rsbuild - reactCompiler](https://rsbuild.rs/plugins/list/plugin-react#reactcompiler) 与 [React Compiler 配置文档](https://zh-hans.react.dev/reference/react-compiler/configuration)。
 
 > 详细代码可以参考：[Modern.js & React Compiler 示例项目](https://github.com/web-infra-dev/modern.js/tree/main/examples/react-compiler)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,9 +508,6 @@ importers:
       '@modern-js/tsconfig':
         specifier: latest
         version: 3.5.0
-      '@rsbuild/plugin-babel':
-        specifier: ^1.1.2
-        version: 1.2.1(@rsbuild/core@2.1.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -523,9 +520,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
-      babel-plugin-react-compiler:
-        specifier: ^1.0.0
-        version: 1.0.0
       eslint-plugin-react-hooks:
         specifier: ^6.0.0-rc.1
         version: 6.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -656,7 +650,7 @@ importers:
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@2.8.8)(react@19.2.7)(utf-8-validate@5.0.10)
       storybook-addon-modernjs:
         specifier: 3.3.4
-        version: 3.3.4(1f15a68c7937c622e8517ab474573def)
+        version: 3.3.4(48dd44a16c961995bb6c4ec2f1ea8b00)
       storybook-react-rsbuild:
         specifier: 3.3.4
         version: 3.3.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@2.8.8)(react@19.2.7)(utf-8-validate@5.0.10))(typescript@5.7.3)(vite@5.4.21(@types/node@20.19.27)(less@4.6.7)(lightningcss@1.30.2)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.16))
@@ -936,8 +930,8 @@ importers:
         specifier: 1.6.4
         version: 1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16))
       '@rsbuild/plugin-react':
-        specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+        specifier: 2.1.0
+        version: 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       '@rsbuild/plugin-rem':
         specifier: 1.0.6
         version: 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
@@ -1270,10 +1264,10 @@ importers:
         version: 1.5.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
       '@rspress/core':
         specifier: 2.0.13
-        version: 2.0.13(@module-federation/runtime-tools@2.0.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.13(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-llms':
         specifier: 2.0.2
-        version: 2.0.2(@rspress/core@2.0.13(@module-federation/runtime-tools@2.0.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 2.0.2(@rspress/core@2.0.13(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@rspress/shared':
         specifier: 2.0.2
         version: 2.0.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
@@ -2678,8 +2672,8 @@ importers:
   scripts/rslib:
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: 2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+        specifier: 2.1.0
+        version: 2.1.0(@rsbuild/core@2.1.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       '@rslib/core':
         specifier: 0.23.2
         version: 0.23.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(typescript@5.9.3)
@@ -4065,6 +4059,34 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.9.3)
+
+  tests/integration/react-compiler:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../packages/solutions/app-tools
+      '@types/node':
+        specifier: ^20
+        version: 20.19.27
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: ^5
+        version: 5.7.3
 
   tests/integration/routes:
     dependencies:
@@ -7594,6 +7616,9 @@ packages:
   '@modern-js/plugin@3.5.0':
     resolution: {integrity: sha512-VdD+qp8KtAvMpWeDG0omp9p5bAZoSlEHHDOVXje09fsNdqDCvFxQRnu3wKwELGO4rxVmCtWSmlazqArUbTV+zg==}
 
+  '@modern-js/plugin@3.6.0':
+    resolution: {integrity: sha512-ZiSVndsH3+H3gPP6kcPsf9CfG5sH5Ubu/jqISpKyQOmXoNkDyYI670+5BDeKEWO0FwYTt2B7PT6lcJJ2cAy8dQ==}
+
   '@modern-js/polyfill-lib@1.0.2':
     resolution: {integrity: sha512-UdBEpS0kwBYm43n60FEZFvZ3dUhqlzzvZkIMwiQGYHvlpXuAN/30GrWnp2WUdd5+eM5ObRCJ1bSJ7+UYouxPAQ==}
     engines: {node: '>=8'}
@@ -7614,6 +7639,17 @@ packages:
     peerDependencies:
       react: '>=17.0.2'
       react-dom: '>=17.0.2'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@modern-js/runtime-utils@3.6.0':
+    resolution: {integrity: sha512-NcRY7U625PbNbXVzvR0is/4aol6U/zgItpKLEcO/xWp7Nwx9MCQziCVclPprBVrgq0xPhPUvL0xokb2JKV7w1g==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
     peerDependenciesMeta:
       react:
         optional: true
@@ -7717,11 +7753,25 @@ packages:
   '@modern-js/types@3.5.0':
     resolution: {integrity: sha512-4DvHMk7kk5eo8460nAoUCRmnt9oa6T7y3PdH07TfPti5tqSYvmqYFCE83HDEvtBU+XlezBdpTtzvRyVJAOO5vQ==}
 
+  '@modern-js/types@3.6.0':
+    resolution: {integrity: sha512-uVKXGVTNe0SJBG4vM1xtcHTxUefkBSo6k2hlxPp8Glidpp3UDv1HiSDvuTzaZuMdoLc89IbsEAheuBa2dPOWew==}
+
   '@modern-js/utils@2.70.4':
     resolution: {integrity: sha512-LQrwyGlFhsH2BmZxStF0TPeStm6aumf4N1J+ZyObLw5URrN4o8vCyeyqrPVciICeoTqhHg2GIArJWB5PXRcUig==}
 
   '@modern-js/utils@3.5.0':
     resolution: {integrity: sha512-a3ilaEb5FArJ5VzvnQx6j0MrmoSFqBrNdJiuTB/jYYhYGYZXET5MlW3hDUG5RkeaDev9VvRwmgI79rQxlVNvKw==}
+    peerDependencies:
+      react: ^19.2.7
+      react-dom: ^19.2.7
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@modern-js/utils@3.6.0':
+    resolution: {integrity: sha512-2277qvtipOc47EPpQQTKY4S79AZse2jw0d2l4cRpkDyRQKQ5opwGXiVZY7PcpBzet7cJS9EMRfuHag7fJjjT7w==}
     peerDependencies:
       react: ^19.2.7
       react-dom: ^19.2.7
@@ -8654,6 +8704,14 @@ packages:
       '@rsbuild/core':
         optional: true
 
+  '@rsbuild/plugin-react@2.1.0':
+    resolution: {integrity: sha512-RQTIAWB/CwPjoWt9iAl+8HixeQVgZ7kEIBrWPCixfITyHdiD84h0YpUTpEUuz6kGHw1KXT9mHZ3Rwy6WG7aRDA==}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
   '@rsbuild/plugin-rem@1.0.6':
     resolution: {integrity: sha512-4PCzvGNFGBM2HDhNqOw8Z6uofePB3hokmfBrm/PkJU0wIqH5P+JIeh51/HlTiODXoita0/ei1VSqfwwo9+E8Ig==}
     peerDependencies:
@@ -8982,6 +9040,15 @@ packages:
     resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
     peerDependencies:
       '@rspack/core': ^2.0.0-0
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  '@rspack/plugin-react-refresh@2.0.2':
+    resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
+    peerDependencies:
+      '@rspack/core': ^2.0.0
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
       '@rspack/core':
@@ -10592,9 +10659,6 @@ packages:
     resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
-  babel-plugin-react-compiler@1.0.0:
-    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   babel-plugin-styled-components@2.1.4:
     resolution: {integrity: sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==}
@@ -21833,6 +21897,21 @@ snapshots:
       - react
       - react-dom
 
+  '@modern-js/plugin@3.6.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@modern-js/runtime-utils': 3.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/types': 3.6.0
+      '@modern-js/utils': 3.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@swc/helpers': 0.5.23
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - core-js
+      - react
+      - react-dom
+    optional: true
+
   '@modern-js/polyfill-lib@1.0.2':
     dependencies:
       '@financial-times/polyfill-useragent-normaliser': 1.10.2
@@ -21913,6 +21992,19 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@modern-js/runtime-utils@3.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@modern-js/types': 3.6.0
+      '@modern-js/utils': 3.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@swc/helpers': 0.5.23
+      lru-cache: 10.4.3
+      react-router: 7.15.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      serialize-javascript: 6.0.2
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optional: true
 
   '@modern-js/runtime@3.5.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-rspack@0.0.2(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -22164,6 +22256,9 @@ snapshots:
 
   '@modern-js/types@3.5.0': {}
 
+  '@modern-js/types@3.6.0':
+    optional: true
+
   '@modern-js/utils@2.70.4':
     dependencies:
       '@swc/helpers': 0.5.23
@@ -22182,6 +22277,19 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@modern-js/utils@3.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      caniuse-lite: 1.0.30001799
+      import-meta-resolve: 4.2.0
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      rslog: 1.3.2
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optional: true
 
   '@module-federation/automatic-vendor-federation@1.2.1(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
     dependencies:
@@ -23379,9 +23487,18 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.4(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
@@ -23422,7 +23539,7 @@ snapshots:
 
   '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@5.0.4)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.0.4))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.0.4))(typescript@5.0.4)
@@ -23437,7 +23554,7 @@ snapshots:
 
   '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))(typescript@5.7.3)
@@ -23452,7 +23569,7 @@ snapshots:
 
   '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
@@ -23816,6 +23933,12 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
 
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
+
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
 
@@ -23867,7 +23990,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspress/core@2.0.13(@module-federation/runtime-tools@2.0.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.13(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
@@ -23917,9 +24040,9 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-llms@2.0.2(@rspress/core@2.0.13(@module-federation/runtime-tools@2.0.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rspress/plugin-llms@2.0.2(@rspress/core@2.0.13(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2))':
     dependencies:
-      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.0.0)(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.13(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.48.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
       remark-mdx: 3.1.1
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
@@ -25804,10 +25927,6 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
-
-  babel-plugin-react-compiler@1.0.0:
-    dependencies:
-      '@babel/types': 7.29.7
 
   babel-plugin-styled-components@2.1.4(@babel/core@7.29.7)(styled-components@5.3.11(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7))(supports-color@5.5.0):
     dependencies:
@@ -33496,7 +33615,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook-addon-modernjs@3.3.4(1f15a68c7937c622e8517ab474573def):
+  storybook-addon-modernjs@3.3.4(48dd44a16c961995bb6c4ec2f1ea8b00):
     dependencies:
       '@modern-js/app-tools': 3.5.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.7(react@19.2.7))(react-server-dom-rspack@0.0.2(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.16))
       '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
@@ -33504,7 +33623,7 @@ snapshots:
       rslog: 1.3.2
       storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@2.8.8)(react@19.2.7)(utf-8-validate@5.0.10))(typescript@5.7.3)(vite@5.4.21(@types/node@20.19.27)(less@4.6.7)(lightningcss@1.30.2)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0))
     optionalDependencies:
-      '@modern-js/plugin': 3.5.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modern-js/plugin': 3.6.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       typescript: 5.7.3
 
   storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@2.8.8)(react@19.2.7)(utf-8-validate@5.0.10))(typescript@5.7.3)(vite@5.4.21(@types/node@20.19.27)(less@4.6.7)(lightningcss@1.30.2)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.48.0)):

--- a/scripts/rslib/package.json
+++ b/scripts/rslib/package.json
@@ -15,7 +15,7 @@
     }
   },
   "devDependencies": {
-    "@rsbuild/plugin-react": "2.0.1",
+    "@rsbuild/plugin-react": "2.1.0",
     "@rslib/core": "0.23.2",
     "@types/node": "^20",
     "typescript": "^5"

--- a/tests/integration/react-compiler/modern.config.ts
+++ b/tests/integration/react-compiler/modern.config.ts
@@ -1,0 +1,7 @@
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  source: {
+    reactCompiler: true,
+  },
+});

--- a/tests/integration/react-compiler/package.json
+++ b/tests/integration/react-compiler/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "name": "react-compiler-test",
+  "version": "2.66.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "serve": "modern serve"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@types/node": "^20",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5"
+  }
+}

--- a/tests/integration/react-compiler/src/App.tsx
+++ b/tests/integration/react-compiler/src/App.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+let staticChildRenderCount = 0;
+
+// StaticChild intentionally mutates a module-level variable so React Compiler
+// bails out on it; the assertions target the parent's compiler-memoized
+// `<StaticChild />` element instead.
+function StaticChild() {
+  staticChildRenderCount += 1;
+  return <span data-testid="child-render-count">{staticChildRenderCount}</span>;
+}
+
+const App = () => {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="increment"
+        onClick={() => setCount(count + 1)}
+      >
+        increment
+      </button>
+      <span data-testid="count">{count}</span>
+      <StaticChild />
+    </div>
+  );
+};
+
+export default App;

--- a/tests/integration/react-compiler/src/modern-app-env.d.ts
+++ b/tests/integration/react-compiler/src/modern-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types='@modern-js/app-tools/types' />

--- a/tests/integration/react-compiler/tests/index.test.ts
+++ b/tests/integration/react-compiler/tests/index.test.ts
@@ -1,0 +1,114 @@
+import path from 'path';
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+import {
+  getPort,
+  killApp,
+  launchApp,
+  launchOptions,
+  modernBuild,
+  modernServe,
+} from '../../../utils/modernTestUtils';
+
+const appDir = path.resolve(__dirname, '../');
+
+async function getRenderState(page: Page) {
+  const count = await page.$eval('[data-testid="count"]', el => el.textContent);
+  const childRenders = await page.$eval(
+    '[data-testid="child-render-count"]',
+    el => el.textContent,
+  );
+  return { count, childRenders };
+}
+
+/**
+ * React Compiler memoizes the `<StaticChild />` element created in the parent,
+ * so a parent state update must re-render the parent (count changes) without
+ * re-rendering the child (child render count stays the same). Without the
+ * compiler, the child re-renders on every parent update.
+ */
+async function expectChildMemoized(page: Page, url: string) {
+  await page.goto(url, { waitUntil: ['networkidle0'] });
+
+  const before = await getRenderState(page);
+  expect(before.count).toEqual('0');
+
+  await page.click('[data-testid="increment"]');
+  await page.waitForFunction(
+    () => document.querySelector('[data-testid="count"]')?.textContent === '1',
+  );
+
+  const after = await getRenderState(page);
+  expect(after.count).toEqual('1');
+  expect(after.childRenders).toEqual(before.childRenders);
+}
+
+describe('react compiler (dev)', () => {
+  let app: unknown;
+  let appPort: number;
+  let page: Page;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    appPort = await getPort();
+    app = await launchApp(appDir, appPort, {}, {});
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    await killApp(app);
+    await page.close();
+    await browser.close();
+  });
+
+  test('should skip re-rendering memoized child on parent update', async () => {
+    await expectChildMemoized(page, `http://localhost:${appPort}`);
+  });
+
+  test('should reference react compiler runtime in dev bundle', async () => {
+    const html = await (await fetch(`http://localhost:${appPort}`)).text();
+    const scriptSrcs = [...html.matchAll(/src="([^"]+\.js[^"]*)"/g)].map(
+      match => match[1],
+    );
+    expect(scriptSrcs.length).toBeGreaterThan(0);
+
+    const sources = await Promise.all(
+      scriptSrcs.map(async src => {
+        const url = src.startsWith('http')
+          ? src
+          : `http://localhost:${appPort}${src}`;
+        return (await fetch(url)).text();
+      }),
+    );
+    expect(
+      sources.some(source => source.includes('react/compiler-runtime')),
+    ).toBeTruthy();
+  });
+});
+
+describe('react compiler (build)', () => {
+  let app: unknown;
+  let port: number;
+  let page: Page;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    port = await getPort();
+    const buildRes = await modernBuild(appDir);
+    expect(buildRes.code).toEqual(0);
+
+    app = await modernServe(appDir, port, { cwd: appDir });
+    browser = await puppeteer.launch(launchOptions as any);
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    await killApp(app);
+    await page.close();
+    await browser.close();
+  });
+
+  test('should skip re-rendering memoized child on parent update', async () => {
+    await expectChildMemoized(page, `http://localhost:${port}`);
+  });
+});

--- a/tests/integration/react-compiler/tests/tsconfig.json
+++ b/tests/integration/react-compiler/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "paths": {},
+    "types": ["node", "@rstest/core/globals"]
+  }
+}

--- a/tests/integration/react-compiler/tsconfig.json
+++ b/tests/integration/react-compiler/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION

- bump @rsbuild/plugin-react 2.0.1 -> 2.1.0 in @modern-js/builder and the internal @modern-js/rslib preset (exposes top-level reactCompiler option)
- add source.reactCompiler (boolean | ReactCompilerOptions) to BuilderConfig and wire it into pluginReact registration in parseCommonConfig; the option is stripped from rsbuildConfig.source and behavior is unchanged when unset
- rewrite react-compiler guides (zh/en): the feature is opt-in for all React versions including 19; React 18 needs react-compiler-runtime as a runtime dependency plus target: '18'
- add configure/app/source/react-compiler reference docs (zh/en)
- switch examples/react-compiler from babel-plugin-react-compiler to source.reactCompiler
- add builder unit tests (true / object / unset / no source leak) and a tests/integration/react-compiler behavioral smoke (dev + prod: compiler-memoized child must not re-render on parent state update; dev bundle references react/compiler-runtime)

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
