### PR TITLE
docs: remove stale modern new/upgrade sections from commands reference

### DIFF
--- a/packages/document/docs/en/apis/app/commands.mdx
+++ b/packages/document/docs/en/apis/app/commands.mdx
@@ -80,73 +80,13 @@ Options:
   -w --watch            turn on watch mode, watch for changes and rebuild
 ```
 
-## modern new
-
-The `modern new` command is used to enable features in an existing project.
-
-For example, add application entry, enable some optional features such as BFF, micro frontend, etc.
-
-```bash
-Usage: modern new [options]
-
-Options:
-  --config-file <configFile>  specify the configuration file, which can be a relative or absolute path
-  --lang <lang>          set the language (zh or en) for the new command.
-  -d, --debug            using debug mode to log something (default: false)
-  -c, --config <config>  set default generator config(json string)
-  --dist-tag <tag>       use specified tag version for its generator
-  --registry             set npm registry url to run npm command
-  -h, --help             show command help
-```
-
-### Add Entry
-
-In the project, execute the `new` command to add entries as follows:
-
-```text
-$ npx modern new
-? Please select the operation you want: Create Element
-? Please select the type of element to create: New "entry"
-? Please fill in the entry name: entry
-```
-
-### Enable Features
-
-In the project, execute the `new` command to enable features as follows:
-
-```text
-$ npx modern new
-? Please select the operation you want: Enable Features
-? Please select the feature name: (Use arrow keys)
-❯ Enable BFF
-  Enable SSG
-  Enable Micro Frontend
-```
-
-:::tip
-The `--config` parameter needs to use a JSON string.
-
-pnpm does not support the use of JSON strings as parameter values currently. Use `npm new` to turn on.【[Relate Issue](https://github.com/pnpm/pnpm/issues/3876)】
-:::
-
 import ServeCommand from '@site-docs-en/components/serve-command';
 
 <ServeCommand />
 
-## modern upgrade
-
-Execute the command `npx modern upgrade` in the project, by default, dependencies in the `package.json` are updated to the latest version.
-
-```bash
-Usage: modern upgrade [options]
-
-Options:
-  --config <config> specify the configuration file, which can be a relative or absolute path
-  --registry <registry>  specify npm registry (default: "")
-  -d,--debug             using debug mode to log something (default: false)
-  --cwd <cwd>            app directory (default: "")
-  -h, --help             show command help
-```
+:::info
+The `modern new` and `modern upgrade` commands were removed in Modern.js 3.0. See the [upgrade guide](/guides/upgrade/other#new-and-upgrade-commands-removed) for alternatives.
+:::
 
 ## modern inspect
 

--- a/packages/document/docs/zh/apis/app/commands.mdx
+++ b/packages/document/docs/zh/apis/app/commands.mdx
@@ -80,73 +80,13 @@ Options:
   -w --watch  开启 watch 模式, 监听文件变更并重新构建
 ```
 
-## modern new
-
-`modern new` 命令用于在已有项目中添加项目元素。
-
-比如添加应用入口、启用一些可选功能如 BFF、微前端开发模式等。
-
-```bash
-Usage: modern new [options]
-
-Options:
-  --config-file <configFile>  指定配置文件路径，可以为相对路径或绝对路径
-  --lang <lang>          设置 new 命令执行语言(zh 或者 en)
-  -d, --debug            开启 Debug 模式，打印调试日志信息 (default: false)
-  -c, --config <config>  生成器运行默认配置(JSON 字符串)
-  --dist-tag <tag>       生成器使用特殊的 npm Tag 版本
-  --registry             生成器运行过程中定制 npm Registry
-  -h, --help             显示命令帮助
-```
-
-### 添加入口
-
-在 Modern.js 工程中，执行 `new` 命令添加入口的步骤如下：
-
-```bash
-$ npx modern new
-? 请选择你想要的操作 创建工程元素
-? 请选择创建元素类型 新建「应用入口」
-? 请填写入口名称 entry
-```
-
-### 启用可选功能
-
-在 Modern.js 工程中，执行 `new` 命令启用可选能力的步骤如下：
-
-```bash
-$ npx modern new
-? 请选择你想要的操作 启用可选功能
-? 请选择功能名称 (Use arrow keys)
-❯ 启用「BFF」功能
-  启用「微前端」模式
-```
-
-:::tip
-`--config` 参数对应参数值需要使用 JSON 字符串。
-
-pnpm 暂不支持使用 JSON 字符串作为参数值，可使用 `npm new` 开启相关功能。【[相关 Issue](https://github.com/pnpm/pnpm/issues/3876)】
-
-:::
-
 import ServeCommand from '@site-docs/components/serve-command';
 
 <ServeCommand />
 
-## modern upgrade
-
-在项目根目录下执行命令 `npx modern upgrade`，会默认将当前执行命令项目的 `package.json` 中的 Modern.js 相关依赖更新至最新版本。
-
-```bash
-Usage: modern upgrade [options]
-
-Options:
-  -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
-  --registry <registry>  定制 npm registry (default: "")
-  -d,--debug             开启 Debug 模式，打印调试日志信息 (default: false)
-  --cwd <cwd>            项目路径 (default: "")
-  -h, --help             display help for command
-```
+:::info
+`modern new` 和 `modern upgrade` 命令已在 Modern.js 3.0 中移除，替代方式见[升级指南](/guides/upgrade/other#new-命令和-upgrade-命令移除)。
+:::
 
 ## modern inspect
 


### PR DESCRIPTION
## Summary

`modern new` and `modern upgrade` were removed in Modern.js 3.0 (per the [upgrade guide](https://modernjs.dev/guides/upgrade/other#new-and-upgrade-commands-removed)), but `apis/app/commands.mdx` (zh & en) still documented both commands in full — teaching users/AI agents to run commands that no longer exist, and contradicting the upgrade guide inside the same docs site (this also pollutes llms-full.txt and the upcoming bundled docs with two conflicting conclusions).

This PR removes both stale sections and replaces them with an info callout linking to the upgrade guide, keeping the still-valid `<ServeCommand />` section.

## Changes
- `docs/en/apis/app/commands.mdx`: drop `## modern new` / `## modern upgrade`, add removal callout
- `docs/zh/apis/app/commands.mdx`: same

## Related
Part of the AI governance M1 work (agent knowledge supply): cleaning conflicting knowledge before bundling docs into the app-tools tarball.