### PR TITLE
fix(runtime-utils): add router cjs export

### DIFF
--- a/.changeset/router-cjs-export.md
+++ b/.changeset/router-cjs-export.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/runtime-utils': patch
+---
+
+fix: add CJS and ESM export conditions for runtime-utils router subpath
+fix: 为 runtime-utils router 子路径补充 CJS 和 ESM 导出条件

--- a/packages/toolkit/runtime-utils/package.json
+++ b/packages/toolkit/runtime-utils/package.json
@@ -21,6 +21,8 @@
     "./router": {
       "types": "./dist/types/router.d.ts",
       "modern:source": "./src/router.ts",
+      "import": "./dist/esm/router.mjs",
+      "require": "./dist/cjs/router.js",
       "default": "./dist/esm/router.mjs"
     },
     "./router/rsc": {

--- a/packages/toolkit/runtime-utils/tests/package-exports.test.ts
+++ b/packages/toolkit/runtime-utils/tests/package-exports.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+
+const pkg = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
+);
+
+describe('package exports', () => {
+  test('should expose router to both ESM import and CJS require', () => {
+    const routerExport = pkg.exports['./router'];
+
+    expect(routerExport).toMatchObject({
+      types: './dist/types/router.d.ts',
+      import: './dist/esm/router.mjs',
+      require: './dist/cjs/router.js',
+      default: './dist/esm/router.mjs',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit import conditions for runtime-utils router subpath exports
- keep CJS require entries for router subpaths so server-core SSR can require @modern-js/runtime-utils/router
- add a package exports regression test and changeset

## Test
- node static package export validation
- not run: pnpm --filter @modern-js/runtime-utils test (node_modules/rstest missing in this environment)
