### PR TITLE
fix(server-core): share hono context storage across duplicated module copies

### DIFF
--- a/.changeset/server-core-global-context-storage.md
+++ b/.changeset/server-core-global-context-storage.md
@@ -1,0 +1,6 @@
+---
+'@modern-js/server-core': patch
+---
+
+fix(server-core): share the hono request context storage across duplicated module copies via a process-global AsyncLocalStorage, so BFF handlers no longer fail with "Can't call useContext out of server scope" when the host and plugin resolve different server-core instances
+fix(server-core): 通过进程级 AsyncLocalStorage 让 hono 请求上下文在重复加载的模块副本间共享，宿主与插件解析到不同 server-core 实例时 BFF 不再报 "Can't call useContext out of server scope"

--- a/packages/server/core/src/context.ts
+++ b/packages/server/core/src/context.ts
@@ -1,6 +1,10 @@
 import type { Context } from 'hono';
 import { createStorage } from './utils/storage';
 
-const { run, useHonoContext } = createStorage<Context>();
+// Keyed globally so every loaded copy of @modern-js/server-core shares the
+// same request context (see utils/storage.ts).
+const { run, useHonoContext } = createStorage<Context>(
+  '@modern-js/server-core/hono-context',
+);
 
 export { run, useHonoContext };

--- a/packages/server/core/src/utils/storage.ts
+++ b/packages/server/core/src/utils/storage.ts
@@ -1,10 +1,31 @@
 import * as ah from 'async_hooks';
 
-const createStorage = <T>() => {
+const getGlobalStorage = (globalKey: string): ah.AsyncLocalStorage<any> => {
+  // Share one AsyncLocalStorage per process for this key, even when several
+  // copies of this module are loaded at once (e.g. pnpm peer-variant
+  // duplication resolving two @modern-js/server-core instances). The context
+  // written through one copy must stay visible to the others; a module-scoped
+  // instance would silently split the store per copy.
+  const registry = globalThis as unknown as Record<
+    symbol,
+    ah.AsyncLocalStorage<any> | undefined
+  >;
+  const key = Symbol.for(globalKey);
+  let storage = registry[key];
+  if (!storage) {
+    storage = new ah.AsyncLocalStorage();
+    registry[key] = storage;
+  }
+  return storage;
+};
+
+const createStorage = <T>(globalKey?: string) => {
   let storage: ah.AsyncLocalStorage<any>;
 
   if (typeof ah.AsyncLocalStorage !== 'undefined') {
-    storage = new ah.AsyncLocalStorage();
+    storage = globalKey
+      ? getGlobalStorage(globalKey)
+      : new ah.AsyncLocalStorage();
   }
 
   const run = <O>(context: T, cb: () => O | Promise<O>): Promise<O> => {

--- a/packages/server/core/tests/utils/storage.test.ts
+++ b/packages/server/core/tests/utils/storage.test.ts
@@ -1,0 +1,44 @@
+import { createStorage } from '../../src/utils/storage';
+
+describe('test utils.storage', () => {
+  it('should keep context inside run scope', async () => {
+    const { run, useHonoContext } = createStorage<{ id: number }>();
+
+    await run({ id: 1 }, () => {
+      expect(useHonoContext()).toEqual({ id: 1 });
+    });
+  });
+
+  it('should throw when reading outside of run scope', () => {
+    const { useHonoContext } = createStorage<{ id: number }>();
+
+    expect(() => useHonoContext()).toThrowError(
+      "Can't call useContext out of server scope",
+    );
+  });
+
+  it('should not share context between independent storages', async () => {
+    const a = createStorage<{ id: number }>();
+    const b = createStorage<{ id: number }>();
+
+    await a.run({ id: 1 }, () => {
+      expect(() => b.useHonoContext()).toThrowError(
+        "Can't call useContext out of server scope",
+      );
+    });
+  });
+
+  it('should share context across module copies via the same global key', async () => {
+    // Each createStorage call with the same key models one loaded copy of
+    // @modern-js/server-core (pnpm peer-variant duplication can load two).
+    // The context written through one copy must be readable from the other,
+    // otherwise BFF handlers resolve to the second copy and fail with
+    // "Can't call useContext out of server scope".
+    const hostCopy = createStorage<{ id: number }>('modern-js/test-storage');
+    const pluginCopy = createStorage<{ id: number }>('modern-js/test-storage');
+
+    await hostCopy.run({ id: 42 }, () => {
+      expect(pluginCopy.useHonoContext()).toEqual({ id: 42 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

pnpm peer-variant duplication can load two copies of `@modern-js/server-core` in one process. Since the hono request context lives in a **module-scoped** `AsyncLocalStorage`, the host writes the context through one copy while `@modern-js/plugin-bff`'s decorators read through the other, failing with:

```
Can't call useContext out of server scope
```

This PR keys the request-context storage on `globalThis` via `Symbol.for`, so every loaded copy shares one `AsyncLocalStorage`:

- `createStorage` gains an optional `globalKey` parameter — without it the behavior is byte-for-byte unchanged (other/generic uses unaffected; `context.ts` is the only call site today);
- request isolation is untouched: ALS isolates by async call chain, not by instance count — single-copy processes already shared one module-level instance;
- transition note: a process mixing a fixed copy with an **older** copy still splits for the old copy (no worse than today); downstreams keeping their own scope-bridge workarounds should drop them only after all resolved server-core copies include this fix.

## Related Links

- Root cause of the downstream scope-bridge workaround in the EdenX fusion branch (internal).

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
