### PR TITLE
fix(server): add CORS headers to the lazy-compilation trigger endpoint

### DIFF
--- a/.changeset/lazy-compilation-cors.md
+++ b/.changeset/lazy-compilation-cors.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server': patch
+---
+
+fix(server): add CORS headers to the lazy-compilation trigger endpoint so proxied domains (Whistle / Eden Proxy) can reach it cross-origin
+
+fix(server): 为 lazy-compilation trigger 端点补充 CORS 响应头，使代理域名（Whistle / Eden Proxy）场景可跨源访问

--- a/packages/server/server/src/dev.ts
+++ b/packages/server/server/src/dev.ts
@@ -15,7 +15,9 @@ import type { RequestHandler } from '@modern-js/types';
 import { API_DIR, SHARED_DIR, logger } from '@modern-js/utils';
 import type { WatchEvent } from './dev-tools/watcher';
 import {
+  createLazyCompilationCorsMiddleware,
   getDevOptions,
+  getLazyCompilationPrefixes,
   getMockMiddleware,
   initFileReader,
   onRepack,
@@ -39,6 +41,7 @@ export type DevPluginOptions = ModernDevServerOptions<ServerBaseOptions> & {
  * into the current server's middleware list:
  * - user `dev.setupMiddlewares` (before / after)
  * - the mock middleware
+ * - the lazy-compilation CORS middleware (only when lazy compilation is on)
  * - the rsbuild/builder dev middleware (a stable reference, just re-registered)
  * - the file-reader middleware
  */
@@ -90,11 +93,25 @@ export const devRuntimeMiddlewarePlugin = (
         handler: mockMiddleware,
       });
 
-      builderMiddlewares &&
+      if (builderMiddlewares) {
+        // Must run before `rsbuild-dev`: rspack's lazy-compilation middleware
+        // lives inside the builder middlewares and writes to the raw node
+        // response, so the CORS headers have to be in place beforehand.
+        const lazyCompilationPrefixes = getLazyCompilationPrefixes(compiler);
+        if (lazyCompilationPrefixes.length > 0) {
+          middlewares.push({
+            name: 'lazy-compilation-cors',
+            handler: createLazyCompilationCorsMiddleware(
+              lazyCompilationPrefixes,
+            ),
+          });
+        }
+
         middlewares.push({
           name: 'rsbuild-dev',
           handler: connectMid2HonoMid(builderMiddlewares as any),
         });
+      }
 
       after.forEach((middleware, index) => {
         middlewares.push({

--- a/packages/server/server/src/helpers/index.ts
+++ b/packages/server/server/src/helpers/index.ts
@@ -13,6 +13,7 @@ import Watcher, {
 export * from './repack';
 export * from './devOptions';
 export * from './fileReader';
+export * from './lazyCompilationCors';
 export * from './mock';
 
 export function startWatcher({

--- a/packages/server/server/src/helpers/lazyCompilationCors.ts
+++ b/packages/server/server/src/helpers/lazyCompilationCors.ts
@@ -1,0 +1,100 @@
+import type { Rspack } from '@modern-js/builder';
+import type { Middleware } from '@modern-js/server-core';
+
+/** Keep in sync with rspack's LAZY_COMPILATION_PREFIX. */
+const DEFAULT_LAZY_COMPILATION_PREFIX = '/_rspack/lazy/trigger';
+
+/**
+ * Collect the lazy-compilation endpoint prefixes actually configured on the
+ * (multi-)compiler, so the CORS middleware only ever touches those paths.
+ */
+export const getLazyCompilationPrefixes = (
+  compiler: Rspack.Compiler | Rspack.MultiCompiler | null,
+): string[] => {
+  if (!compiler) {
+    return [];
+  }
+  const compilers = 'compilers' in compiler ? compiler.compilers : [compiler];
+  const prefixes = new Set<string>();
+  for (const { options } of compilers) {
+    const { lazyCompilation } = options;
+    if (!lazyCompilation) {
+      continue;
+    }
+    prefixes.add(
+      (typeof lazyCompilation === 'object' && lazyCompilation.prefix) ||
+        DEFAULT_LAZY_COMPILATION_PREFIX,
+    );
+  }
+  return [...prefixes];
+};
+
+/**
+ * Rspack's lazy-compilation client triggers module compilation with a
+ * `text/plain` POST to `lazyCompilation.serverUrl` + prefix. When the page is
+ * served from a proxied domain (Whistle / Eden Proxy mapping an online domain
+ * to the local dev server) while `serverUrl` points at `127.0.0.1` (derived
+ * from `dev.client`), that POST is cross-origin, and rspack's middleware
+ * replies without any CORS headers: the request still reaches the compiler
+ * (simple request) and invalidates the build, but the browser blocks the
+ * response, so dynamic imports fail and the page reload-loops.
+ *
+ * Reflecting the Origin here keeps the direct-connect setup working — the same
+ * reason the HMR WebSocket connects straight to 127.0.0.1, except WebSockets
+ * are exempt from CORS while XHR is not. Only the lazy-compilation prefixes
+ * are opened up: the endpoint merely triggers compilation and never returns
+ * source, and the global `server.cors` config stays untouched.
+ *
+ * This middleware is a stopgap for rspack's lazyCompilationMiddleware lacking
+ * CORS handling. If a bundled rspack ships native CORS for this endpoint,
+ * verify its semantics cover the proxied-domain case and remove (or
+ * capability-gate) this layer in the same dependency bump — answering the
+ * preflight here would otherwise mask the native policy.
+ */
+export const createLazyCompilationCorsMiddleware = (
+  prefixes: string[],
+): Middleware => {
+  return async (ctx, next) => {
+    const { path } = ctx.req;
+    if (!prefixes.some(prefix => path.startsWith(prefix))) {
+      return next();
+    }
+
+    const origin = ctx.req.header('origin');
+    if (!origin) {
+      return next();
+    }
+
+    if (
+      ctx.req.method === 'OPTIONS' &&
+      ctx.req.header('access-control-request-method')
+    ) {
+      // CORS preflight. The Private-Network-Access response header is kept
+      // for compatibility with browsers that still send the request header —
+      // Chrome's PNA preflight rollout is paused (superseded by the
+      // user-permission Local Network Access model in Chrome 142), so this
+      // does NOT claim to satisfy any future local-network gating.
+      const headers: Record<string, string> = {
+        'Access-Control-Allow-Origin': origin,
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers':
+          ctx.req.header('access-control-request-headers') || 'content-type',
+        Vary: 'Origin',
+      };
+      if (ctx.req.header('access-control-request-private-network') === 'true') {
+        headers['Access-Control-Allow-Private-Network'] = 'true';
+      }
+      return ctx.body(null, 204, headers);
+    }
+
+    // The rspack middleware behind `rsbuild-dev` writes straight to the raw
+    // node response (`res.writeHead(200)`), bypassing hono's header handling,
+    // so the reflected headers must be set on the raw response too.
+    const nodeRes = ctx.env?.node?.res;
+    if (nodeRes && !nodeRes.headersSent) {
+      nodeRes.setHeader('Access-Control-Allow-Origin', origin);
+      nodeRes.setHeader('Vary', 'Origin');
+    }
+    return next();
+  };
+};

--- a/packages/server/server/tests/lazyCompilationCors.test.ts
+++ b/packages/server/server/tests/lazyCompilationCors.test.ts
@@ -1,0 +1,271 @@
+import {
+  type ServerPlugin,
+  compatPlugin,
+  createServerBase,
+} from '@modern-js/server-core';
+
+import { devRuntimeMiddlewarePlugin } from '../src/dev';
+import {
+  createLazyCompilationCorsMiddleware,
+  getLazyCompilationPrefixes,
+} from '../src/helpers';
+
+const TRIGGER = '/_rspack/lazy/trigger';
+const PROXIED_ORIGIN = 'https://www.example.com';
+
+function getDefaultConfig() {
+  return {
+    html: {},
+    output: {},
+    source: {},
+    tools: {},
+    server: {},
+    bff: {},
+    dev: {},
+    security: {},
+  } as any;
+}
+
+function getDefaultAppContext() {
+  return { apiDirectory: '', lambdaDirectory: '' } as any;
+}
+
+function makeCompiler(lazyCompilation: unknown) {
+  return { options: { lazyCompilation } } as any;
+}
+
+describe('getLazyCompilationPrefixes', () => {
+  it('returns nothing without a compiler or with lazy compilation off', () => {
+    expect(getLazyCompilationPrefixes(null)).toEqual([]);
+    expect(getLazyCompilationPrefixes(makeCompiler(undefined))).toEqual([]);
+    expect(getLazyCompilationPrefixes(makeCompiler(false))).toEqual([]);
+  });
+
+  it('resolves the default rspack prefix and custom prefixes', () => {
+    expect(getLazyCompilationPrefixes(makeCompiler({ imports: true }))).toEqual(
+      [TRIGGER],
+    );
+    expect(
+      getLazyCompilationPrefixes(makeCompiler({ prefix: '/custom/lazy' })),
+    ).toEqual(['/custom/lazy']);
+  });
+
+  it('dedupes prefixes across a multi compiler', () => {
+    const multi = {
+      compilers: [
+        makeCompiler({ imports: true }),
+        makeCompiler({ imports: true, entries: false }),
+        makeCompiler(false),
+      ],
+    } as any;
+    expect(getLazyCompilationPrefixes(multi)).toEqual([TRIGGER]);
+  });
+});
+
+describe('lazy-compilation CORS middleware (behavior)', () => {
+  // Stand-in for rspack's lazyCompilationMiddleware: replies over the RAW
+  // node response exactly like the real one (`writeHead(200)` without any
+  // CORS header), so the tests exercise the same header-merging path.
+  function makeRawRes() {
+    const headers: Record<string, string> = {};
+    return {
+      headers,
+      headersSent: false,
+      setHeader(name: string, value: string) {
+        headers[name.toLowerCase()] = value;
+      },
+    };
+  }
+
+  async function buildServer(compiler: any, onTrigger: () => void) {
+    const server = createServerBase({
+      config: getDefaultConfig(),
+      appContext: getDefaultAppContext(),
+      pwd: '',
+    });
+    const rspackLikeMiddleware = (req: any, res: any, next: () => void) => {
+      if (req.url?.startsWith(TRIGGER) && req.method === 'POST') {
+        onTrigger();
+        // The real middleware ends the raw response here; replying via a
+        // terminal hono route below keeps the assertion on the same headers.
+      }
+      next();
+    };
+    const terminal: ServerPlugin = {
+      name: 'terminal',
+      setup(api) {
+        api.onPrepare(() => {
+          const { middlewares } = api.getServerContext();
+          middlewares.push({
+            name: 'terminal-200',
+            handler: async c => c.text('ok', 200),
+          });
+        });
+      },
+    };
+    server.addPlugins([
+      compatPlugin(),
+      devRuntimeMiddlewarePlugin(
+        {
+          pwd: '',
+          dev: {},
+          builderDevServer: { middlewares: rspackLikeMiddleware },
+        } as any,
+        compiler,
+      ),
+      terminal,
+    ]);
+    await server.init();
+    return server;
+  }
+
+  it('registers only when lazy compilation is enabled on the compiler', async () => {
+    let names: string[] = [];
+    const probe: ServerPlugin = {
+      name: 'probe',
+      setup(api) {
+        api.onPrepare(() => {
+          names = api.getServerContext().middlewares.map(m => m.name);
+        });
+      },
+    };
+    const build = async (compiler: any) => {
+      const server = createServerBase({
+        config: getDefaultConfig(),
+        appContext: getDefaultAppContext(),
+        pwd: '',
+      });
+      server.addPlugins([
+        compatPlugin(),
+        devRuntimeMiddlewarePlugin(
+          {
+            pwd: '',
+            dev: {},
+            builderDevServer: {
+              middlewares: (_r: any, _s: any, n: any) => n(),
+            },
+          } as any,
+          compiler,
+        ),
+        probe,
+      ]);
+      await server.init();
+      return names;
+    };
+
+    expect(await build(makeCompiler({ imports: true }))).toContain(
+      'lazy-compilation-cors',
+    );
+    // Registered before rsbuild-dev so the headers land first.
+    const withLazy = await build(makeCompiler({ imports: true }));
+    expect(withLazy.indexOf('lazy-compilation-cors')).toBeLessThan(
+      withLazy.indexOf('rsbuild-dev'),
+    );
+    expect(await build(makeCompiler(false))).not.toContain(
+      'lazy-compilation-cors',
+    );
+    expect(await build(null)).not.toContain('lazy-compilation-cors');
+  });
+
+  it('reflects the Origin onto the raw node response for cross-origin trigger POSTs', async () => {
+    let triggered = 0;
+    const server = await buildServer(makeCompiler({ imports: true }), () => {
+      triggered += 1;
+    });
+    const rawRes = makeRawRes();
+
+    const res = await server.request(
+      TRIGGER,
+      {
+        method: 'POST',
+        headers: { origin: PROXIED_ORIGIN, 'content-type': 'text/plain' },
+        body: 'some-module-id',
+      },
+      { node: { req: { url: TRIGGER, method: 'POST' }, res: rawRes } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(triggered).toBe(1);
+    expect(rawRes.headers['access-control-allow-origin']).toBe(PROXIED_ORIGIN);
+    expect(rawRes.headers.vary).toBe('Origin');
+  });
+
+  it('answers CORS preflight with 204, allow headers and the PNA header', async () => {
+    const server = await buildServer(makeCompiler({ imports: true }), () => {
+      throw new Error('preflight must not reach the rspack middleware');
+    });
+
+    const res = await server.request(
+      TRIGGER,
+      {
+        method: 'OPTIONS',
+        headers: {
+          origin: PROXIED_ORIGIN,
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': 'content-type',
+          'access-control-request-private-network': 'true',
+        },
+      },
+      { node: { req: { url: TRIGGER, method: 'OPTIONS' }, res: makeRawRes() } },
+    );
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe(PROXIED_ORIGIN);
+    expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(res.headers.get('access-control-allow-headers')).toBe(
+      'content-type',
+    );
+    expect(res.headers.get('access-control-allow-private-network')).toBe(
+      'true',
+    );
+    expect(res.headers.get('vary')).toBe('Origin');
+  });
+
+  it('stays silent for same-origin requests and unrelated paths', async () => {
+    const server = await buildServer(makeCompiler({ imports: true }), () => {
+      // trigger may fire; headers are what matters here
+    });
+
+    // Same-origin: no Origin header -> no CORS headers added.
+    const sameOriginRes = makeRawRes();
+    await server.request(
+      TRIGGER,
+      { method: 'POST', body: 'id' },
+      { node: { req: { url: TRIGGER, method: 'POST' }, res: sameOriginRes } },
+    );
+    expect(
+      sameOriginRes.headers['access-control-allow-origin'],
+    ).toBeUndefined();
+
+    // Unrelated path: cross-origin but not the lazy endpoint.
+    const otherRes = makeRawRes();
+    await server.request(
+      '/some/asset.js',
+      { method: 'GET', headers: { origin: PROXIED_ORIGIN } },
+      {
+        node: { req: { url: '/some/asset.js', method: 'GET' }, res: otherRes },
+      },
+    );
+    expect(otherRes.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('honors a custom lazy compilation prefix', async () => {
+    const middleware = createLazyCompilationCorsMiddleware(['/custom/lazy']);
+    const rawRes = makeRawRes();
+    const ctx = {
+      req: {
+        path: '/custom/lazy',
+        method: 'POST',
+        header: (name: string) =>
+          name === 'origin' ? PROXIED_ORIGIN : undefined,
+      },
+      env: { node: { res: rawRes } },
+    } as any;
+    const next = rstest.fn();
+
+    await middleware(ctx, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(rawRes.headers['access-control-allow-origin']).toBe(PROXIED_ORIGIN);
+  });
+});


### PR DESCRIPTION
When a page is served from a proxied domain (Whistle / Eden Proxy mapping an online domain to the local dev server) while lazyCompilation.serverUrl points at 127.0.0.1 (derived from dev.client), the lazy trigger POST is cross-origin. Rspack's middleware replies without CORS headers: the request still reaches the compiler and invalidates the build, but the browser blocks the response, so dynamic imports fail and the page reload-loops.

Register a scoped middleware before rsbuild-dev that reflects the Origin for the lazy-compilation prefixes only (resolved from the compiler options) and answers CORS/PNA preflights. The endpoint only triggers compilation and never returns source; the global server.cors config stays untouched.

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
