### PR TITLE
fix(server): make custom server output runnable under native ESM

### DIFF
--- a/.changeset/server-esm-module-resolution.md
+++ b/.changeset/server-esm-module-resolution.md
@@ -1,0 +1,9 @@
+---
+'@modern-js/app-tools': patch
+'@modern-js/server-utils': patch
+'@modern-js/utils': patch
+---
+
+fix: make custom server output runnable under native ESM (pass `moduleType`, resolve `.tsx` / `.jsx` entries, transform JSX)
+
+fix: 修复自定义 Server 在原生 ESM 下的产物不可运行问题（透传 `moduleType`、支持 `.tsx` / `.jsx` 入口解析、编译 JSX）

--- a/packages/server/utils/src/compilers/typescript/index.ts
+++ b/packages/server/utils/src/compilers/typescript/index.ts
@@ -22,7 +22,7 @@ const copyFiles = async (from: string, to: string, appDirectory: string) => {
     const targetDir = path.join(to, relativePath);
     await fs.copy(from, targetDir, {
       filter: src =>
-        !['.ts', '.js'].includes(path.extname(src)) &&
+        !['.ts', '.tsx', '.js', '.jsx'].includes(path.extname(src)) &&
         !src.endsWith('tsconfig.json'),
     });
   }
@@ -76,6 +76,13 @@ export const compileByTs: CompileFunc = async (
       ...options,
       rootDir: appDirectory,
       outDir: distDir,
+      // `jsx: preserve` emits `.jsx` files, which Node cannot execute and which
+      // the emitted specifiers (always `.js`) would not point at. Server output
+      // has to run in Node directly, so JSX must be transformed here.
+      jsx:
+        options.jsx === undefined || options.jsx === ts.JsxEmit.Preserve
+          ? ts.JsxEmit.ReactJSX
+          : options.jsx,
     },
   });
 
@@ -87,7 +94,7 @@ export const compileByTs: CompileFunc = async (
   );
 
   const emitResult = program.emit(undefined, undefined, undefined, undefined, {
-    before: [tsconfigPathsPlugin!],
+    before: tsconfigPathsPlugin ? [tsconfigPathsPlugin] : [],
   });
 
   const allDiagnostics = ts

--- a/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
+++ b/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
@@ -5,13 +5,26 @@ import type { MatchPath } from '@modern-js/utils/tsconfig-paths';
 import { createMatchPath } from '@modern-js/utils/tsconfig-paths';
 import * as ts from 'typescript';
 
+// Extensions that TypeScript compiles into a `.js` file. Everything else
+// (`.json`, `.mjs`, `.cjs`, assets) keeps whatever extension it already has,
+// because it is copied to the output directory untouched.
+const COMPILED_TO_JS_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
 // Convert a resolved source path into the specifier that native ESM output
-// should reference at runtime, which is always the emitted `.js` file.
+// should reference at runtime.
 const toEsmOutputPath = (resolvedPath: string) => {
   const sourcePath = findSourceEntry(resolvedPath) || resolvedPath;
   const ext = path.extname(sourcePath);
 
-  return ext ? `${sourcePath.slice(0, -ext.length)}.js` : `${sourcePath}.js`;
+  if (!ext) {
+    return `${sourcePath}.js`;
+  }
+
+  if (!COMPILED_TO_JS_EXTENSIONS.has(ext)) {
+    return sourcePath;
+  }
+
+  return `${sourcePath.slice(0, -ext.length)}.js`;
 };
 
 const resolveRelativeEsmSpecifier = (sf: ts.SourceFile, text: string) => {
@@ -131,12 +144,25 @@ export function tsconfigPathsBeforeHookFactory(
     return (sf: ts.SourceFile) => {
       const visitNode = (node: ts.Node): ts.Node => {
         if (isDynamicImport(tsBinary, node)) {
-          const importPathWithQuotes = node.arguments[0].getText(sf);
-          const text = importPathWithQuotes.slice(
-            1,
-            importPathWithQuotes.length - 1,
+          const [specifier] = node.arguments;
+          // Only a literal specifier is known at compile time. Template
+          // interpolation or concatenation has to be resolved at runtime, so
+          // those calls are left untouched.
+          if (
+            !specifier ||
+            !(
+              tsBinary.isStringLiteral(specifier) ||
+              tsBinary.isNoSubstitutionTemplateLiteral(specifier)
+            )
+          ) {
+            return tsBinary.visitEachChild(node, visitNode, ctx);
+          }
+          const result = getNotAliasedPath(
+            sf,
+            matchPath,
+            specifier.text,
+            moduleType,
           );
-          const result = getNotAliasedPath(sf, matchPath, text, moduleType);
           if (!result) {
             return node;
           }
@@ -146,6 +172,9 @@ export function tsconfigPathsBeforeHookFactory(
             node.typeArguments,
             tsBinary.factory.createNodeArray([
               tsBinary.factory.createStringLiteral(result),
+              // `import(specifier, { with: { type: 'json' } })` carries its
+              // options in the second argument, which must survive the rewrite.
+              ...node.arguments.slice(1),
             ]),
           );
         }
@@ -154,16 +183,19 @@ export function tsconfigPathsBeforeHookFactory(
           (tsBinary.isExportDeclaration(node) && node.moduleSpecifier)
         ) {
           try {
-            const importPathWithQuotes = node?.moduleSpecifier?.getText();
+            const { moduleSpecifier: specifier } = node;
 
-            if (!importPathWithQuotes) {
+            // A non-literal module specifier is a grammar error; skip it
+            // instead of slicing quotes off arbitrary text.
+            if (!specifier || !tsBinary.isStringLiteral(specifier)) {
               return node;
             }
-            const text = importPathWithQuotes.substring(
-              1,
-              importPathWithQuotes.length - 1,
+            const result = getNotAliasedPath(
+              sf,
+              matchPath,
+              specifier.text,
+              moduleType,
             );
-            const result = getNotAliasedPath(sf, matchPath, text, moduleType);
             if (!result) {
               return node;
             }
@@ -173,6 +205,11 @@ export function tsconfigPathsBeforeHookFactory(
               node as any
             ).moduleSpecifier.parent;
 
+            // `with { type: 'json' }` is parsed into `attributes`; the legacy
+            // `assert { ... }` syntax into `assertClause`. Keep whichever the
+            // source used, otherwise the clause is dropped on rewrite.
+            const importAttributes = node.attributes ?? node.assertClause;
+
             let newNode;
             if (tsBinary.isImportDeclaration(node)) {
               newNode = tsBinary.factory.updateImportDeclaration(
@@ -180,7 +217,7 @@ export function tsconfigPathsBeforeHookFactory(
                 node.modifiers,
                 node.importClause,
                 moduleSpecifier,
-                node.assertClause,
+                importAttributes,
               );
             } else {
               newNode = tsBinary.factory.updateExportDeclaration(
@@ -189,7 +226,7 @@ export function tsconfigPathsBeforeHookFactory(
                 node.isTypeOnly,
                 node.exportClause,
                 moduleSpecifier,
-                node.assertClause,
+                importAttributes,
               );
             }
             (newNode as any).flags = node.flags;

--- a/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
+++ b/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
@@ -13,7 +13,12 @@ const COMPILED_TO_JS_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
 // Convert a resolved source path into the specifier that native ESM output
 // should reference at runtime.
 const toEsmOutputPath = (resolvedPath: string) => {
-  const sourcePath = findSourceEntry(resolvedPath) || resolvedPath;
+  // A directory match is joined with the platform separator, so on Windows the
+  // result comes back with backslashes. Emitted specifiers are always posix.
+  const sourcePath = (findSourceEntry(resolvedPath) || resolvedPath).replace(
+    /\\/g,
+    '/',
+  );
   const ext = path.extname(sourcePath);
 
   if (!ext) {

--- a/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
+++ b/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
@@ -121,7 +121,9 @@ export function tsconfigPathsBeforeHookFactory(
     return matchAliasPath(requestedModule);
   };
 
-  if (Object.keys(paths).length === 0) {
+  // Native ESM output still needs relative specifiers rewritten to their
+  // emitted `.js` counterparts, even when the project declares no path alias.
+  if (Object.keys(paths).length === 0 && moduleType !== 'module') {
     return undefined;
   }
 

--- a/packages/server/utils/tests/fixtures/tsx-example/server/foo/index.tsx
+++ b/packages/server/utils/tests/fixtures/tsx-example/server/foo/index.tsx
@@ -1,0 +1,1 @@
+export const Foo = () => 'foo';

--- a/packages/server/utils/tests/fixtures/tsx-example/server/helper.mjs
+++ b/packages/server/utils/tests/fixtures/tsx-example/server/helper.mjs
@@ -1,0 +1,1 @@
+export const helperName = 'helper-mjs';

--- a/packages/server/utils/tests/fixtures/tsx-example/server/index.ts
+++ b/packages/server/utils/tests/fixtures/tsx-example/server/index.ts
@@ -1,8 +1,25 @@
 import { bar } from '../shared/bar';
+import data from '../shared/data.json' with { type: 'json' };
 import { Foo } from './foo';
+// A hand-written ESM file: it is copied as-is, so the specifier must keep `.mjs`.
+import { helperName } from './helper.mjs';
+// Same for CommonJS files that are copied instead of compiled.
+import legacy from './legacy.cjs';
+
+export const loadData = () =>
+  import('../shared/data.json', { with: { type: 'json' } });
+
+// Non-literal specifiers can only be resolved at runtime and must be emitted
+// exactly as written.
+export const loadLocaleTemplate = (lang: string) =>
+  import(`./locales/${lang}.js`);
+
+export const loadLocaleConcat = (lang: string) =>
+  // biome-ignore lint/style/useTemplate: the concatenated specifier is the case under test
+  import('./locales/' + lang + '.js');
 
 const server = () => {
-  return `${Foo()}-${bar}`;
+  return `${Foo()}-${bar}-${helperName}-${legacy.legacyName}-${data.name}`;
 };
 
 export default server;

--- a/packages/server/utils/tests/fixtures/tsx-example/server/index.ts
+++ b/packages/server/utils/tests/fixtures/tsx-example/server/index.ts
@@ -1,0 +1,8 @@
+import { bar } from '../shared/bar';
+import { Foo } from './foo';
+
+const server = () => {
+  return `${Foo()}-${bar}`;
+};
+
+export default server;

--- a/packages/server/utils/tests/fixtures/tsx-example/server/legacy.cjs
+++ b/packages/server/utils/tests/fixtures/tsx-example/server/legacy.cjs
@@ -1,0 +1,1 @@
+module.exports = { legacyName: 'legacy-cjs' };

--- a/packages/server/utils/tests/fixtures/tsx-example/server/locales/en.ts
+++ b/packages/server/utils/tests/fixtures/tsx-example/server/locales/en.ts
@@ -1,0 +1,1 @@
+export const locale = 'en';

--- a/packages/server/utils/tests/fixtures/tsx-example/shared/bar.ts
+++ b/packages/server/utils/tests/fixtures/tsx-example/shared/bar.ts
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/packages/server/utils/tests/fixtures/tsx-example/shared/data.json
+++ b/packages/server/utils/tests/fixtures/tsx-example/shared/data.json
@@ -1,0 +1,1 @@
+{ "name": "data-json" }

--- a/packages/server/utils/tests/fixtures/tsx-example/tsconfig.esm.json
+++ b/packages/server/utils/tests/fixtures/tsx-example/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "module": "ESNext",
+    "noEmitOnError": false
+  },
+  "include": ["shared", "server"]
+}

--- a/packages/server/utils/tests/fixtures/tsx-example/tsconfig.esm.json
+++ b/packages/server/utils/tests/fixtures/tsx-example/tsconfig.esm.json
@@ -5,6 +5,9 @@
     "jsx": "preserve",
     "baseUrl": "./",
     "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
     "noEmitOnError": false
   },
   "include": ["shared", "server"]

--- a/packages/server/utils/tests/ts.test.ts
+++ b/packages/server/utils/tests/ts.test.ts
@@ -100,4 +100,46 @@ describe('typescript', () => {
       await fs.remove(distDir);
     }
   });
+
+  it('should resolve tsx directory entries and emit runnable js in esm output', async () => {
+    const example = path.join(__dirname, './fixtures', './tsx-example');
+    const tsconfigPath = path.join(example, './tsconfig.esm.json');
+    const distDir = path.join(example, './dist-esm');
+    const sharedDir = path.join(example, './shared');
+    const serverDir = path.join(example, './server');
+
+    try {
+      // No alias and no tsconfig `paths`: relative specifiers still have to be
+      // rewritten for native ESM.
+      await compile(example, { alias: {} } as any, {
+        sourceDirs: [sharedDir, serverDir],
+        distDir,
+        tsconfigPath,
+        moduleType: 'module',
+      });
+
+      const serverContent = (
+        await fs.readFile(path.join(distDir, './server/index.js'))
+      ).toString();
+
+      // `./foo` points at `foo/index.tsx`, so it must not become `./foo.js`.
+      expect(serverContent).toContain(`from "./foo/index.js"`);
+      expect(serverContent).toContain(`from "../shared/bar.js"`);
+
+      // `jsx: preserve` would emit `foo/index.jsx`, which Node cannot load.
+      expect(
+        await fs.pathExists(path.join(distDir, './server/foo/index.js')),
+      ).toBeTruthy();
+      expect(
+        await fs.pathExists(path.join(distDir, './server/foo/index.jsx')),
+      ).toBeFalsy();
+
+      // Source files must not be copied next to their compiled output.
+      expect(
+        await fs.pathExists(path.join(distDir, './server/foo/index.tsx')),
+      ).toBeFalsy();
+    } finally {
+      await fs.remove(distDir);
+    }
+  });
 });

--- a/packages/server/utils/tests/ts.test.ts
+++ b/packages/server/utils/tests/ts.test.ts
@@ -142,4 +142,57 @@ describe('typescript', () => {
       await fs.remove(distDir);
     }
   });
+
+  it('should keep specifiers that are not compiled to js in esm output', async () => {
+    const example = path.join(__dirname, './fixtures', './tsx-example');
+    const tsconfigPath = path.join(example, './tsconfig.esm.json');
+    const distDir = path.join(example, './dist-esm-assets');
+    const sharedDir = path.join(example, './shared');
+    const serverDir = path.join(example, './server');
+
+    try {
+      await compile(example, { alias: {} } as any, {
+        sourceDirs: [sharedDir, serverDir],
+        distDir,
+        tsconfigPath,
+        moduleType: 'module',
+      });
+
+      const serverContent = (
+        await fs.readFile(path.join(distDir, './server/index.js'))
+      ).toString();
+
+      // `.json` and `.mjs` are copied verbatim, so their extensions must stay.
+      expect(serverContent).toContain(`"../shared/data.json"`);
+      expect(serverContent).not.toContain(`../shared/data.js"`);
+      expect(serverContent).toContain(`"./helper.mjs"`);
+      expect(serverContent).not.toContain(`"./helper.js"`);
+
+      // Import attributes must survive the specifier rewrite.
+      expect(serverContent).toMatch(/type:\s*['"]json['"]/);
+
+      // The options argument of a dynamic import must not be dropped.
+      expect(serverContent).toMatch(
+        /import\(\s*"\.\.\/shared\/data\.json"\s*,\s*\{/,
+      );
+
+      expect(serverContent).toContain(`"./legacy.cjs"`);
+
+      // Non-literal specifiers are resolved at runtime and must be untouched.
+      expect(serverContent).toContain('import(`./locales/${lang}.js`)');
+      expect(serverContent).toContain(`import('./locales/' + lang + '.js')`);
+
+      expect(
+        await fs.pathExists(path.join(distDir, './shared/data.json')),
+      ).toBeTruthy();
+      expect(
+        await fs.pathExists(path.join(distDir, './server/helper.mjs')),
+      ).toBeTruthy();
+      expect(
+        await fs.pathExists(path.join(distDir, './server/legacy.cjs')),
+      ).toBeTruthy();
+    } finally {
+      await fs.remove(distDir);
+    }
+  });
 });

--- a/packages/solutions/app-tools/src/plugins/serverBuild.ts
+++ b/packages/solutions/app-tools/src/plugins/serverBuild.ts
@@ -30,7 +30,8 @@ export default (): CliPlugin<AppTools> => ({
 
   setup(api) {
     api.onAfterBuild(async () => {
-      const { appDirectory, distDirectory, metaName } = api.getAppContext();
+      const { appDirectory, distDirectory, metaName, moduleType } =
+        api.getAppContext();
       if (
         !checkHasCache(appDirectory) &&
         !checkHasConfig(appDirectory, metaName)
@@ -71,6 +72,7 @@ export default (): CliPlugin<AppTools> => ({
             sourceDirs,
             distDir,
             tsconfigPath,
+            moduleType,
           },
         );
       }

--- a/packages/toolkit/utils/src/cli/modulePath.ts
+++ b/packages/toolkit/utils/src/cli/modulePath.ts
@@ -2,7 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { MatchPath } from '../../compiled/tsconfig-paths';
 
-export const SOURCE_EXTENSIONS = ['.ts', '.js'];
+// Keep the same order as TypeScript's own module resolution so that a
+// directory import like `./foo` resolves to the file `tsc` actually compiles.
+export const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+const TS_EXTENSIONS = ['.ts', '.tsx'];
 export const JS_LIKE_EXTENSION_RE = /\.(?:c|m)?js$/;
 
 const isFile = (filepath: string) =>
@@ -19,10 +22,14 @@ export const findSourceEntry = (resolvedPath: string) => {
     }
 
     if (JS_LIKE_EXTENSION_RE.test(resolvedPath)) {
-      const tsPath = `${resolvedPath.slice(0, -ext.length)}.ts`;
+      const withoutExt = resolvedPath.slice(0, -ext.length);
 
-      if (isFile(tsPath)) {
-        return tsPath;
+      for (const candidateExt of TS_EXTENSIONS) {
+        const tsPath = `${withoutExt}${candidateExt}`;
+
+        if (isFile(tsPath)) {
+          return tsPath;
+        }
       }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4564,6 +4564,40 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  tests/integration/server-esm-tsx:
+    dependencies:
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime/plugin-runtime
+      '@modern-js/server-runtime':
+        specifier: workspace:*
+        version: link:../../../packages/server/server-runtime
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../packages/solutions/app-tools
+      '@types/node':
+        specifier: ^20
+        version: 20.19.27
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3)
+      typescript:
+        specifier: ^5
+        version: 5.7.3
+
   tests/integration/server-json-script:
     dependencies:
       '@modern-js/runtime':

--- a/tests/integration/server-esm-tsx/modern.config.ts
+++ b/tests/integration/server-esm-tsx/modern.config.ts
@@ -1,0 +1,7 @@
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
+
+export default applyBaseConfig({
+  server: {
+    ssr: { forceCSR: true, mode: 'string' },
+  },
+});

--- a/tests/integration/server-esm-tsx/package.json
+++ b/tests/integration/server-esm-tsx/package.json
@@ -1,0 +1,25 @@
+{
+  "private": true,
+  "name": "server-esm-tsx",
+  "version": "2.66.0",
+  "type": "module",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build",
+    "serve": "modern serve"
+  },
+  "dependencies": {
+    "@modern-js/runtime": "workspace:*",
+    "@modern-js/server-runtime": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@types/node": "^20",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5"
+  }
+}

--- a/tests/integration/server-esm-tsx/server/foo/index.tsx
+++ b/tests/integration/server-esm-tsx/server/foo/index.tsx
@@ -1,0 +1,5 @@
+// A directory entry backed by `.tsx`: `tsc` resolves `./foo` to this file, so
+// the emitted specifier has to point at `foo/index.js`, not `foo.js`.
+export const Badge = () => <span>badge</span>;
+
+export const badgeName = 'foo-tsx';

--- a/tests/integration/server-esm-tsx/server/modern.server.ts
+++ b/tests/integration/server-esm-tsx/server/modern.server.ts
@@ -1,0 +1,16 @@
+import { defineServerConfig } from '@modern-js/server-runtime';
+import { message } from '../shared/message';
+// Extension-less directory import, resolved to `./foo/index.tsx`.
+import { badgeName } from './foo';
+
+export default defineServerConfig({
+  middlewares: [
+    {
+      name: 'esm-tsx-probe',
+      handler: async (c, next) => {
+        await next();
+        c.res.headers.set('x-esm-tsx', `${badgeName}-${message}`);
+      },
+    },
+  ],
+});

--- a/tests/integration/server-esm-tsx/shared/message.ts
+++ b/tests/integration/server-esm-tsx/shared/message.ts
@@ -1,0 +1,1 @@
+export const message = 'shared-message';

--- a/tests/integration/server-esm-tsx/src/App.tsx
+++ b/tests/integration/server-esm-tsx/src/App.tsx
@@ -1,0 +1,5 @@
+const App = () => {
+  return <div>hello</div>;
+};
+
+export default App;

--- a/tests/integration/server-esm-tsx/src/modern-app-env.d.ts
+++ b/tests/integration/server-esm-tsx/src/modern-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types='@modern-js/app-tools/types' />

--- a/tests/integration/server-esm-tsx/tests/index.test.ts
+++ b/tests/integration/server-esm-tsx/tests/index.test.ts
@@ -1,0 +1,73 @@
+import dns from 'node:dns';
+import path from 'path';
+import { fs as fse } from '@modern-js/utils';
+import {
+  getPort,
+  killApp,
+  modernBuild,
+  modernServe,
+} from '../../../utils/modernTestUtils';
+
+rstest.setConfig({ testTimeout: 1000 * 60 * 2, hookTimeout: 1000 * 60 * 2 });
+
+dns.setDefaultResultOrder('ipv4first');
+
+const appDir = path.resolve(__dirname, '../');
+const serverDistDir = path.join(appDir, 'dist', 'server');
+
+describe('custom server under native esm', () => {
+  beforeAll(async () => {
+    await fse.remove(path.join(appDir, 'dist'));
+    await modernBuild(appDir);
+  });
+
+  afterAll(async () => {
+    await fse.remove(path.join(appDir, 'dist'));
+  });
+
+  it('should rewrite specifiers to the files that are actually emitted', async () => {
+    const serverEntry = (
+      await fse.readFile(path.join(serverDistDir, 'modern.server.js'))
+    ).toString();
+
+    // `./foo` is backed by `foo/index.tsx`, so it must not collapse to `./foo.js`.
+    expect(serverEntry).toContain('./foo/index.js');
+    expect(serverEntry).not.toContain('"./foo.js"');
+    expect(serverEntry).toContain('../shared/message.js');
+  });
+
+  it('should emit js for tsx entries and keep sources out of dist', async () => {
+    // `jsx: preserve` would emit `foo/index.jsx`, which Node cannot load.
+    expect(
+      await fse.pathExists(path.join(serverDistDir, 'foo', 'index.js')),
+    ).toBeTruthy();
+    expect(
+      await fse.pathExists(path.join(serverDistDir, 'foo', 'index.jsx')),
+    ).toBeFalsy();
+    expect(
+      await fse.pathExists(path.join(serverDistDir, 'foo', 'index.tsx')),
+    ).toBeFalsy();
+  });
+
+  it('should be loadable by node', async () => {
+    // The strongest check: Node itself resolves the emitted specifiers.
+    const mod = await import(
+      path.join(serverDistDir, 'modern.server.js').replace(/\\/g, '/')
+    );
+
+    expect(mod.default).toBeDefined();
+  });
+
+  it('should serve requests with the custom server applied', async () => {
+    const port = await getPort();
+    const app = await modernServe(appDir, port);
+
+    try {
+      const res = await fetch(`http://localhost:${port}`);
+
+      expect(res.headers.get('x-esm-tsx')).toBe('foo-tsx-shared-message');
+    } finally {
+      await killApp(app);
+    }
+  });
+});

--- a/tests/integration/server-esm-tsx/tests/index.test.ts
+++ b/tests/integration/server-esm-tsx/tests/index.test.ts
@@ -1,4 +1,5 @@
 import dns from 'node:dns';
+import { pathToFileURL } from 'node:url';
 import path from 'path';
 import { fs as fse } from '@modern-js/utils';
 import {
@@ -52,7 +53,7 @@ describe('custom server under native esm', () => {
   it('should be loadable by node', async () => {
     // The strongest check: Node itself resolves the emitted specifiers.
     const mod = await import(
-      path.join(serverDistDir, 'modern.server.js').replace(/\\/g, '/')
+      pathToFileURL(path.join(serverDistDir, 'modern.server.js')).href
     );
 
     expect(mod.default).toBeDefined();

--- a/tests/integration/server-esm-tsx/tests/tsconfig.json
+++ b/tests/integration/server-esm-tsx/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "paths": {},
+    "types": ["node", "@rstest/core/globals"]
+  }
+}

--- a/tests/integration/server-esm-tsx/tsconfig.json
+++ b/tests/integration/server-esm-tsx/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["src", "shared", "config", "server"]
+}


### PR DESCRIPTION
A custom server in a `"type": "module"` project builds fine but fails to start with `ERR_MODULE_NOT_FOUND`, because the emitted import specifiers point at files that were never emitted.

`serverBuild` now passes `moduleType` to the compiler, module resolution follows TypeScript's extension order (`.ts` → `.tsx` → `.js` → `.jsx`), server output transforms JSX instead of emitting `.jsx`, and only sources that compile to `.js` get their extension rewritten.
