### PR TITLE
chore(ci): speed up Playwright browser setup

### DIFF
--- a/.github/workflows/test-builder-e2e.yml
+++ b/.github/workflows/test-builder-e2e.yml
@@ -40,8 +40,5 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Install playwright
-        run: cd ./tests/e2e/builder && pnpm exec playwright install
-
       - name: Test
         run: pnpm run test:builder

--- a/examples/test-playwright/package.json
+++ b/examples/test-playwright/package.json
@@ -8,7 +8,7 @@
     "build": "modern build",
     "start": "modern start",
     "serve": "modern serve",
-    "prepare": "playwright install",
+    "prepare": "playwright install chromium",
     "test": "npx playwright test"
   },
   "engines": {

--- a/examples/test-playwright/playwright.config.ts
+++ b/examples/test-playwright/playwright.config.ts
@@ -31,22 +31,22 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
 
-  /* Configure projects for major browsers */
+  /* Configure the Chromium project */
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/tests/e2e/builder/playwright.config.ts
+++ b/tests/e2e/builder/playwright.config.ts
@@ -1,3 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
-export default defineConfig({});
+const isCI = Boolean(process.env.CI);
+
+export default defineConfig({
+  use: {
+    // Use the built-in Chrome browser to speed up CI tests
+    channel: isCI ? 'chrome' : undefined,
+  },
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,7 +11,7 @@
     "test:rstest-adapter": "rstest -c rstest.adapter.config.mts",
     "test:builder": "cd e2e/builder && pnpm test",
     "prepare": "node node_modules/puppeteer/install.mjs",
-    "pretest:rstest-adapter": "pnpm --dir integration/rstest/basic-app-rstest-browser exec playwright install"
+    "pretest:rstest-adapter": "pnpm --dir integration/rstest/basic-app-rstest-browser exec playwright install chromium"
   },
   "devDependencies": {
     "@modern-js/app-tools": "workspace:*",


### PR DESCRIPTION
## Summary

Use the Chrome browser preinstalled on GitHub Actions runners and remove the redundant Playwright browser installation step to reduce builder e2e CI setup time.

Limit the remaining Playwright install scripts and example projects to Chromium so unused Firefox and WebKit binaries are not downloaded or run.

## Related Links

- https://github.com/web-infra-dev/rslib/pull/1531

## Checklist

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.