### PR TITLE
fix(bff): make published crossProject client declarations portable

### DIFF
--- a/.changeset/bff-crossproject-portable-declarations.md
+++ b/.changeset/bff-crossproject-portable-declarations.md
@@ -1,0 +1,8 @@
+---
+'@modern-js/server-utils': patch
+'@modern-js/plugin-bff': patch
+---
+
+fix: make published crossProject BFF client declarations resolvable in consumers
+
+fix: 修复发布后的 crossProject BFF 客户端声明在消费方项目中无法解析类型的问题

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -78,7 +78,7 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
     };
 
     const generator = async () => {
-      const { appDirectory, apiDirectory, lambdaDirectory, port } =
+      const { appDirectory, apiDirectory, lambdaDirectory, port, moduleType } =
         api.getAppContext();
 
       const modernConfig = api.getNormalizedConfig();
@@ -122,6 +122,7 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
         httpMethodDecider,
         relativeDistPath,
         relativeApiPath,
+        moduleType,
         apiFiles: apiRouter.getApiFiles(),
       });
       await runtimeGenerator({

--- a/packages/cli/plugin-bff/src/cli.ts
+++ b/packages/cli/plugin-bff/src/cli.ts
@@ -122,6 +122,7 @@ export const bffPlugin = (): CliPlugin<AppTools> => ({
         httpMethodDecider,
         relativeDistPath,
         relativeApiPath,
+        apiFiles: apiRouter.getApiFiles(),
       });
       await runtimeGenerator({
         runtime,

--- a/packages/cli/plugin-bff/src/utils/clientGenerator.ts
+++ b/packages/cli/plugin-bff/src/utils/clientGenerator.ts
@@ -15,6 +15,12 @@ export type APILoaderOptions = {
   relativeDistPath: string;
   relativeApiPath: string;
   /**
+   * `'module'` for native ESM output (`package.json#type: "module"`); the
+   * generated facade then re-exports with an explicit `.js` extension so
+   * `node16`/`nodenext` consumers resolve it.
+   */
+  moduleType?: 'module' | 'commonjs';
+  /**
    * Absolute paths of the valid API files, resolved by ApiRouter with the same
    * `API_FILE_RULES` the runtime router uses. Passing them in keeps the client
    * generator and the router in agreement about what an API module is, so stray
@@ -58,6 +64,7 @@ export function buildClientTypeFacade(
   clientTypesFile: string,
   originTypesFile: string,
   hasDefaultExport: boolean,
+  esm = false,
 ): string {
   const originNoExt = originTypesFile.replace(/\.d\.ts$/, '');
   let specifier = toPosixPath(
@@ -65,6 +72,12 @@ export function buildClientTypeFacade(
   );
   if (!specifier.startsWith('.')) {
     specifier = `./${specifier}`;
+  }
+  // Native ESM (`node16`/`nodenext`) requires an explicit extension in the
+  // re-export specifier, matching the `.js` the declaration emit produces; TS
+  // resolves `./x.js` back to `./x.d.ts`.
+  if (esm) {
+    specifier = `${specifier}.js`;
   }
 
   const lines: string[] = [];
@@ -302,6 +315,7 @@ async function clientGenerator(draftOptions: APILoaderOptions) {
             clientTypesFile,
             source.relativeTargetDistDir,
             DEFAULT_EXPORT_RE.test(code.value),
+            draftOptions.moduleType === 'module',
           ),
         );
       }

--- a/packages/cli/plugin-bff/src/utils/clientGenerator.ts
+++ b/packages/cli/plugin-bff/src/utils/clientGenerator.ts
@@ -14,6 +14,14 @@ export type APILoaderOptions = {
   httpMethodDecider?: HttpMethodDecider;
   relativeDistPath: string;
   relativeApiPath: string;
+  /**
+   * Absolute paths of the valid API files, resolved by ApiRouter with the same
+   * `API_FILE_RULES` the runtime router uses. Passing them in keeps the client
+   * generator and the router in agreement about what an API module is, so stray
+   * artifacts next to the sources (compiled `.d.ts`/`.js`, tests, private files)
+   * never reach `generateClient`.
+   */
+  apiFiles: string[];
 };
 
 interface FileDetails {
@@ -36,61 +44,82 @@ const TYPE_PREFIX = `${API_DIR}/`;
 const toPosixPath = (p: string) => p.replace(/\\/g, '/');
 const posixJoin = (...args: string[]) => toPosixPath(path.join(...args));
 
+// `generateClient` emits `export default createRequest(...)` only when the
+// handler declares a default export, so the generated client `.js` is an exact
+// signal for whether the facade needs a `default` re-export.
+const DEFAULT_EXPORT_RE = /(^|[\s;])export\s+default\b/;
+
+// The published client re-exports the handler's own declaration instead of
+// copying it. A verbatim copy landed the `.d.ts` one directory shallower than
+// tsc emitted it (`dist/client/*` vs `dist/<lambda>/*`), breaking every
+// relative specifier inside. A facade leaves the original declarations in place
+// (relative refs intact, and published via `**/*.d.ts`) and only points at them.
+export function buildClientTypeFacade(
+  clientTypesFile: string,
+  originTypesFile: string,
+  hasDefaultExport: boolean,
+): string {
+  const originNoExt = originTypesFile.replace(/\.d\.ts$/, '');
+  let specifier = toPosixPath(
+    path.relative(path.dirname(clientTypesFile), originNoExt),
+  );
+  if (!specifier.startsWith('.')) {
+    specifier = `./${specifier}`;
+  }
+
+  const lines: string[] = [];
+  // `export *` never carries the default binding, so re-export it explicitly.
+  if (hasDefaultExport) {
+    lines.push(`export { default } from '${specifier}';`);
+  }
+  lines.push(`export * from '${specifier}';`);
+  return `${lines.join('\n')}\n`;
+}
+
 export async function readDirectoryFiles(
   appDirectory: string,
   directory: string,
   relativeDistPath: string,
+  apiFiles: string[],
 ): Promise<FileDetails[]> {
   const filesList: FileDetails[] = [];
 
-  async function readFiles(currentPath: string): Promise<void> {
-    const entries = await fs.readdir(currentPath, { withFileTypes: true });
+  for (const resourcePath of apiFiles) {
+    const source = await fs.readFile(resourcePath, 'utf8');
+    const currentPath = path.dirname(resourcePath);
+    const relativePath = path.relative(directory, resourcePath);
+    const parsedPath = path.parse(relativePath);
 
-    for (const entry of entries) {
-      if (entry.name === '_app.ts') continue;
+    const targetDir = posixJoin(
+      `./${relativeDistPath}/${CLIENT_DIR}`,
+      parsedPath.dir,
+      `${parsedPath.name}.js`,
+    );
+    const name = parsedPath.name;
+    const absTargetDir = path.resolve(targetDir);
+    const relativePathFromAppDirectory = path.relative(
+      appDirectory,
+      currentPath,
+    );
+    const typesFilePath = posixJoin(
+      `./${relativeDistPath}`,
+      relativePathFromAppDirectory,
+      `${name}.d.ts`,
+    );
+    const relativeTargetDistDir = `./${typesFilePath}`;
+    const exportKey = toPosixPath(path.join(parsedPath.dir, name));
 
-      const resourcePath = path.join(currentPath, entry.name);
-
-      if (entry.isDirectory()) {
-        await readFiles(resourcePath);
-      } else {
-        const source = await fs.readFile(resourcePath, 'utf8');
-        const relativePath = path.relative(directory, resourcePath);
-        const parsedPath = path.parse(relativePath);
-
-        const targetDir = posixJoin(
-          `./${relativeDistPath}/${CLIENT_DIR}`,
-          parsedPath.dir,
-          `${parsedPath.name}.js`,
-        );
-        const name = parsedPath.name;
-        const absTargetDir = path.resolve(targetDir);
-        const relativePathFromAppDirectory = path.relative(
-          appDirectory,
-          currentPath,
-        );
-        const typesFilePath = posixJoin(
-          `./${relativeDistPath}`,
-          relativePathFromAppDirectory,
-          `${name}.d.ts`,
-        );
-        const relativeTargetDistDir = `./${typesFilePath}`;
-        const exportKey = toPosixPath(path.join(parsedPath.dir, name));
-
-        filesList.push({
-          resourcePath,
-          source,
-          targetDir,
-          name,
-          absTargetDir,
-          relativeTargetDistDir,
-          exportKey,
-        });
-      }
-    }
+    filesList.push({
+      resourcePath,
+      source,
+      targetDir,
+      name,
+      absTargetDir,
+      relativeTargetDistDir,
+      exportKey,
+    });
   }
 
-  await readFiles(directory);
   return filesList;
 }
 
@@ -142,6 +171,10 @@ async function setPackage(
       posixJoin(relativeDistPath, CLIENT_DIR, '**', '*'),
       posixJoin(relativeDistPath, RUNTIME_DIR, '**', '*'),
       posixJoin(relativeDistPath, PLUGIN_DIR, '**', '*'),
+      // The client facade re-exports declarations that stay in their original
+      // `dist/<lambda>` / `dist/shared` locations, so every emitted `.d.ts`
+      // must ship or consumers resolve the facade to a missing file (TS2307).
+      posixJoin(relativeDistPath, '**', '*.d.ts'),
     ];
 
     const typesVersions = {
@@ -215,17 +248,12 @@ async function setPackage(
   }
 }
 
-export async function copyFiles(from: string, to: string) {
-  if (await fs.pathExists(from)) {
-    await fs.copy(toPosixPath(from), toPosixPath(to));
-  }
-}
-
 async function clientGenerator(draftOptions: APILoaderOptions) {
   const sourceList = await readDirectoryFiles(
     draftOptions.appDir,
     draftOptions.lambdaDir,
     draftOptions.relativeDistPath,
+    draftOptions.apiFiles,
   );
 
   const getClitentCode = async (resourcePath: string, source: string) => {
@@ -267,9 +295,14 @@ async function clientGenerator(draftOptions: APILoaderOptions) {
       const code = await getClitentCode(source.resourcePath, source.source);
       if (code?.value) {
         await writeTargetFile(source.absTargetDir, code.value);
-        await copyFiles(
-          source.relativeTargetDistDir,
-          source.targetDir.replace(`js`, 'd.ts'),
+        const clientTypesFile = source.targetDir.replace(/\.js$/, '.d.ts');
+        await writeTargetFile(
+          path.resolve(clientTypesFile),
+          buildClientTypeFacade(
+            clientTypesFile,
+            source.relativeTargetDistDir,
+            DEFAULT_EXPORT_RE.test(code.value),
+          ),
         );
       }
     }

--- a/packages/cli/plugin-bff/tests/clientGenerator.test.ts
+++ b/packages/cli/plugin-bff/tests/clientGenerator.test.ts
@@ -130,6 +130,21 @@ describe('clientGenerator', () => {
       expect(withoutDefault).toContain(`export * from '../api/lambda/upload';`);
     });
 
+    it('appends a .js extension to the re-export in esm output', () => {
+      const facade = buildClientTypeFacade(
+        './dist/client/index.d.ts',
+        './dist/api/lambda/index.d.ts',
+        true,
+        true,
+      );
+      // node16/nodenext consumers need the explicit extension; TS maps
+      // `./x.js` back to `./x.d.ts`.
+      expect(facade).toContain(
+        `export { default } from '../api/lambda/index.js';`,
+      );
+      expect(facade).toContain(`export * from '../api/lambda/index.js';`);
+    });
+
     it('resolves the specifier from nested client locations', () => {
       const facade = buildClientTypeFacade(
         './dist/client/user/index.d.ts',

--- a/packages/cli/plugin-bff/tests/clientGenerator.test.ts
+++ b/packages/cli/plugin-bff/tests/clientGenerator.test.ts
@@ -1,7 +1,10 @@
 import os from 'os';
 import path from 'path';
 import { fs } from '@modern-js/utils';
-import clientGenerator from '../src/utils/clientGenerator';
+import clientGenerator, {
+  buildClientTypeFacade,
+  readDirectoryFiles,
+} from '../src/utils/clientGenerator';
 
 describe('clientGenerator', () => {
   it('writes package.json with a trailing newline', async () => {
@@ -27,6 +30,7 @@ describe('clientGenerator', () => {
         existLambda: false,
         relativeDistPath: 'dist',
         relativeApiPath: 'api',
+        apiFiles: [path.join(lambdaDir, 'user.ts')],
       });
 
       const packageContent = await fs.readFile(
@@ -39,5 +43,100 @@ describe('clientGenerator', () => {
     } finally {
       await fs.remove(appDir);
     }
+  });
+
+  it('publishes every declaration under the configured distPath', async () => {
+    // A non-default distPath guards against the glob being hardcoded to `dist`.
+    const relativeDistPath = 'dist-1';
+    const appDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bff-client-gen-'));
+    const lambdaDir = path.join(appDir, 'api', 'lambda');
+
+    try {
+      await fs.mkdir(lambdaDir, { recursive: true });
+      await fs.writeFile(
+        path.join(lambdaDir, 'user.ts'),
+        'export default function handler() {}',
+      );
+      await fs.writeFile(
+        path.join(appDir, 'package.json'),
+        JSON.stringify({ name: 'test-app' }, null, 2),
+      );
+
+      await clientGenerator({
+        prefix: '/api',
+        appDir,
+        apiDir: path.join(appDir, 'api'),
+        lambdaDir,
+        existLambda: false,
+        relativeDistPath,
+        relativeApiPath: 'api',
+        apiFiles: [path.join(lambdaDir, 'user.ts')],
+      });
+
+      const packageJson = JSON.parse(
+        await fs.readFile(path.join(appDir, 'package.json'), 'utf8'),
+      );
+
+      expect(packageJson.files).toContain(`${relativeDistPath}/**/*.d.ts`);
+    } finally {
+      await fs.remove(appDir);
+    }
+  });
+
+  describe('readDirectoryFiles', () => {
+    it('only processes the API files it is handed, ignoring stray artifacts', async () => {
+      const appDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bff-read-dir-'));
+      const lambdaDir = path.join(appDir, 'api', 'lambda');
+
+      try {
+        await fs.mkdir(lambdaDir, { recursive: true });
+        const apiFile = path.join(lambdaDir, 'index.ts');
+        await fs.writeFile(apiFile, 'export default () => {};');
+        // Stray artifacts a bare readdir would have swept in.
+        await fs.writeFile(path.join(lambdaDir, 'index.d.ts'), '');
+        await fs.writeFile(path.join(lambdaDir, 'index.test.ts'), '');
+
+        const files = await readDirectoryFiles(appDir, lambdaDir, 'dist', [
+          apiFile,
+        ]);
+
+        expect(files).toHaveLength(1);
+        expect(files[0].resourcePath).toBe(apiFile);
+      } finally {
+        await fs.remove(appDir);
+      }
+    });
+  });
+
+  describe('buildClientTypeFacade', () => {
+    it('re-exports the default binding only when the module has one', () => {
+      const withDefault = buildClientTypeFacade(
+        './dist/client/index.d.ts',
+        './dist/api/lambda/index.d.ts',
+        true,
+      );
+      // Relative, POSIX, and no `.d.ts` suffix.
+      expect(withDefault).toContain(
+        `export { default } from '../api/lambda/index';`,
+      );
+      expect(withDefault).toContain(`export * from '../api/lambda/index';`);
+
+      const withoutDefault = buildClientTypeFacade(
+        './dist/client/upload.d.ts',
+        './dist/api/lambda/upload.d.ts',
+        false,
+      );
+      expect(withoutDefault).not.toContain('export { default }');
+      expect(withoutDefault).toContain(`export * from '../api/lambda/upload';`);
+    });
+
+    it('resolves the specifier from nested client locations', () => {
+      const facade = buildClientTypeFacade(
+        './dist/client/user/index.d.ts',
+        './dist/api/lambda/user/index.d.ts',
+        false,
+      );
+      expect(facade).toContain(`export * from '../../api/lambda/user/index';`);
+    });
   });
 });

--- a/packages/server/utils/src/compilers/typescript/index.ts
+++ b/packages/server/utils/src/compilers/typescript/index.ts
@@ -3,7 +3,10 @@ import { fs, getAliasConfig, logger } from '@modern-js/utils';
 import type { ParseConfigFileHost, Program } from 'typescript';
 import type ts from 'typescript';
 import type { CompileFunc } from '../../common';
-import { tsconfigPathsBeforeHookFactory } from './tsconfigPathsPlugin';
+import {
+  tsconfigPathsAfterDeclarationsHookFactory,
+  tsconfigPathsBeforeHookFactory,
+} from './tsconfigPathsPlugin';
 import { TypescriptLoader } from './typescriptLoader';
 
 const readTsConfigByFile = (tsConfigFile: string, tsInstance: typeof ts) => {
@@ -93,8 +96,16 @@ export const compileByTs: CompileFunc = async (
     compileOptions.moduleType,
   );
 
+  // tsc keeps path aliases verbatim in `.d.ts` output, so the same rewrite has
+  // to run on declaration emit or aliased specifiers leak to consumers.
+  const tsconfigPathsDeclarationPlugin =
+    tsconfigPathsAfterDeclarationsHookFactory(ts, absoluteBaseUrl, paths);
+
   const emitResult = program.emit(undefined, undefined, undefined, undefined, {
     before: tsconfigPathsPlugin ? [tsconfigPathsPlugin] : [],
+    afterDeclarations: tsconfigPathsDeclarationPlugin
+      ? [tsconfigPathsDeclarationPlugin]
+      : [],
   });
 
   const allDiagnostics = ts

--- a/packages/server/utils/src/compilers/typescript/index.ts
+++ b/packages/server/utils/src/compilers/typescript/index.ts
@@ -99,7 +99,12 @@ export const compileByTs: CompileFunc = async (
   // tsc keeps path aliases verbatim in `.d.ts` output, so the same rewrite has
   // to run on declaration emit or aliased specifiers leak to consumers.
   const tsconfigPathsDeclarationPlugin =
-    tsconfigPathsAfterDeclarationsHookFactory(ts, absoluteBaseUrl, paths);
+    tsconfigPathsAfterDeclarationsHookFactory(
+      ts,
+      absoluteBaseUrl,
+      paths,
+      compileOptions.moduleType,
+    );
 
   const emitResult = program.emit(undefined, undefined, undefined, undefined, {
     before: tsconfigPathsPlugin ? [tsconfigPathsPlugin] : [],

--- a/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
+++ b/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
@@ -255,22 +255,27 @@ export function tsconfigPathsBeforeHookFactory(
 // declaration nodes are synthesized without source positions (specifiers are
 // read via `.text`), inline `import("...")` types appear as `ImportTypeNode`,
 // and `import x = require("...")` keeps its specifier in an
-// `ExternalModuleReference`. `moduleType` is intentionally not forwarded:
-// declaration specifiers stay extensionless.
+// `ExternalModuleReference`. `moduleType` is forwarded so ESM declarations
+// carry the same `.js` specifier as the JS output — `node16`/`nodenext`
+// consumers require explicit extensions in `.d.ts` too (TS emits `./x.js` and
+// resolves it back to `./x.d.ts`); mismatching JS and `.d.ts` here reproduces
+// the very TS2835 failure this rewrite exists to prevent.
 export function tsconfigPathsAfterDeclarationsHookFactory(
   tsBinary: typeof ts,
   baseUrl: string,
   paths: Record<string, string[] | string>,
+  moduleType?: 'module' | 'commonjs',
 ) {
-  // Declarations only need rewriting when the project declares path aliases;
-  // there is no ESM `.js`-extension concern here, unlike the `before` hook.
-  if (Object.keys(paths).length === 0) {
+  // Native ESM declarations still need relative specifiers rewritten to their
+  // emitted `.js` counterparts even without path aliases, matching the `before`
+  // hook's guard.
+  if (Object.keys(paths).length === 0 && moduleType !== 'module') {
     return undefined;
   }
 
   const matchPath = createTsMatchPath(baseUrl, paths);
   const rewrite = (sf: ts.SourceFile, text: string) =>
-    getNotAliasedPath(sf, matchPath, text);
+    getNotAliasedPath(sf, matchPath, text, moduleType);
 
   return (
     ctx: ts.TransformationContext,

--- a/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
+++ b/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
@@ -100,12 +100,10 @@ const isDynamicImport = (
   );
 };
 
-export function tsconfigPathsBeforeHookFactory(
-  tsBinary: typeof ts,
+const createTsMatchPath = (
   baseUrl: string,
   paths: Record<string, string[] | string>,
-  moduleType?: 'module' | 'commonjs',
-) {
+): MatchPath => {
   const tsPaths: Record<string, string[]> = {};
   const alias: Record<string, string> = {};
 
@@ -121,12 +119,7 @@ export function tsconfigPathsBeforeHookFactory(
 
   const matchTsPath = createMatchPath(baseUrl, tsPaths, ['main']);
 
-  const matchPath: MatchPath = (
-    requestedModule,
-    readJSONSync,
-    fileExists,
-    extensions,
-  ) => {
+  return (requestedModule, readJSONSync, fileExists, extensions) => {
     const result = matchTsPath(
       requestedModule,
       readJSONSync,
@@ -138,6 +131,15 @@ export function tsconfigPathsBeforeHookFactory(
     }
     return matchAliasPath(requestedModule);
   };
+};
+
+export function tsconfigPathsBeforeHookFactory(
+  tsBinary: typeof ts,
+  baseUrl: string,
+  paths: Record<string, string[] | string>,
+  moduleType?: 'module' | 'commonjs',
+) {
+  const matchPath = createTsMatchPath(baseUrl, paths);
 
   // Native ESM output still needs relative specifiers rewritten to their
   // emitted `.js` counterparts, even when the project declares no path alias.
@@ -243,6 +245,125 @@ export function tsconfigPathsBeforeHookFactory(
         return tsBinary.visitEachChild(node, visitNode, ctx);
       };
       return tsBinary.visitNode(sf, visitNode);
+    };
+  };
+}
+
+// TypeScript never resolves tsconfig `paths` in declaration output
+// (microsoft/TypeScript#30952), so the alias rewrite that runs on JS emit must
+// run again on the declaration AST. Differences from the `before` transform:
+// declaration nodes are synthesized without source positions (specifiers are
+// read via `.text`), inline `import("...")` types appear as `ImportTypeNode`,
+// and `import x = require("...")` keeps its specifier in an
+// `ExternalModuleReference`. `moduleType` is intentionally not forwarded:
+// declaration specifiers stay extensionless.
+export function tsconfigPathsAfterDeclarationsHookFactory(
+  tsBinary: typeof ts,
+  baseUrl: string,
+  paths: Record<string, string[] | string>,
+) {
+  // Declarations only need rewriting when the project declares path aliases;
+  // there is no ESM `.js`-extension concern here, unlike the `before` hook.
+  if (Object.keys(paths).length === 0) {
+    return undefined;
+  }
+
+  const matchPath = createTsMatchPath(baseUrl, paths);
+  const rewrite = (sf: ts.SourceFile, text: string) =>
+    getNotAliasedPath(sf, matchPath, text);
+
+  return (
+    ctx: ts.TransformationContext,
+  ): ts.Transformer<ts.SourceFile | ts.Bundle> => {
+    const { factory } = ctx;
+    return sourceFile => {
+      if (!tsBinary.isSourceFile(sourceFile)) {
+        return sourceFile;
+      }
+      const visitNode = (node: ts.Node): ts.Node => {
+        if (tsBinary.isImportTypeNode(node)) {
+          const { argument } = node;
+          if (
+            tsBinary.isLiteralTypeNode(argument) &&
+            tsBinary.isStringLiteral(argument.literal)
+          ) {
+            const result = rewrite(sourceFile, argument.literal.text);
+            if (result) {
+              const updated = factory.updateImportTypeNode(
+                node,
+                factory.createLiteralTypeNode(
+                  factory.createStringLiteral(result),
+                ),
+                // TS >= 5.3 names this `attributes`; earlier 5.x `assertions`.
+                (node as any).attributes ?? (node as any).assertions,
+                node.qualifier,
+                node.typeArguments,
+                node.isTypeOf,
+              );
+              return tsBinary.visitEachChild(updated, visitNode, ctx);
+            }
+          }
+          return tsBinary.visitEachChild(node, visitNode, ctx);
+        }
+
+        if (
+          (tsBinary.isImportDeclaration(node) ||
+            tsBinary.isExportDeclaration(node)) &&
+          node.moduleSpecifier &&
+          tsBinary.isStringLiteral(node.moduleSpecifier)
+        ) {
+          const result = rewrite(sourceFile, node.moduleSpecifier.text);
+          if (!result) {
+            return node;
+          }
+          const moduleSpecifier = factory.createStringLiteral(result);
+          const importAttributes =
+            (node as any).attributes ?? node.assertClause;
+          if (tsBinary.isImportDeclaration(node)) {
+            return factory.updateImportDeclaration(
+              node,
+              node.modifiers,
+              node.importClause,
+              moduleSpecifier,
+              importAttributes,
+            );
+          }
+          return factory.updateExportDeclaration(
+            node,
+            node.modifiers,
+            node.isTypeOnly,
+            node.exportClause,
+            moduleSpecifier,
+            importAttributes,
+          );
+        }
+
+        if (
+          tsBinary.isImportEqualsDeclaration(node) &&
+          tsBinary.isExternalModuleReference(node.moduleReference) &&
+          tsBinary.isStringLiteral(node.moduleReference.expression)
+        ) {
+          const result = rewrite(
+            sourceFile,
+            node.moduleReference.expression.text,
+          );
+          if (!result) {
+            return node;
+          }
+          return factory.updateImportEqualsDeclaration(
+            node,
+            node.modifiers,
+            node.isTypeOnly,
+            node.name,
+            factory.createExternalModuleReference(
+              factory.createStringLiteral(result),
+            ),
+          );
+        }
+
+        return tsBinary.visitEachChild(node, visitNode, ctx);
+      };
+      return tsBinary.visitEachChild(sourceFile, visitNode, ctx);
     };
   };
 }

--- a/packages/server/utils/tests/fixtures/ts-declaration-esm/api/helper.ts
+++ b/packages/server/utils/tests/fixtures/ts-declaration-esm/api/helper.ts
@@ -1,0 +1,1 @@
+export const relativeHelper = 1;

--- a/packages/server/utils/tests/fixtures/ts-declaration-esm/api/index.ts
+++ b/packages/server/utils/tests/fixtures/ts-declaration-esm/api/index.ts
@@ -1,0 +1,6 @@
+import type { SharedUser } from '@shared/types';
+import { relativeHelper } from './helper';
+
+export type { SharedUser };
+export declare function getUser(): import('@shared/types').SharedUser;
+export const h: number = relativeHelper;

--- a/packages/server/utils/tests/fixtures/ts-declaration-esm/shared/types.ts
+++ b/packages/server/utils/tests/fixtures/ts-declaration-esm/shared/types.ts
@@ -1,0 +1,4 @@
+export interface SharedUser {
+  id: string;
+  name: string;
+}

--- a/packages/server/utils/tests/fixtures/ts-declaration-esm/tsconfig.json
+++ b/packages/server/utils/tests/fixtures/ts-declaration-esm/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": "./",
+    "paths": { "@shared/*": ["./shared/*"] }
+  },
+  "include": ["shared", "api"]
+}

--- a/packages/server/utils/tests/fixtures/ts-declaration/api/declaration.ts
+++ b/packages/server/utils/tests/fixtures/ts-declaration/api/declaration.ts
@@ -1,0 +1,14 @@
+// Top-level `import type` → ImportDeclaration specifier in the emitted d.ts.
+import type { SharedUser } from '@shared/types';
+// `import x = require(...)` → ImportEqualsDeclaration specifier.
+import shared = require('@shared/types');
+
+export type ReExportedUser = SharedUser;
+
+// Re-export declaration whose module specifier is an alias.
+export type { SharedResult } from '@shared/types';
+
+// Inline `import("...")` type → ImportTypeNode specifier.
+export declare function getUser(): import('@shared/types').SharedUser;
+
+export const sharedNamespace = shared;

--- a/packages/server/utils/tests/fixtures/ts-declaration/shared/types.ts
+++ b/packages/server/utils/tests/fixtures/ts-declaration/shared/types.ts
@@ -1,0 +1,8 @@
+export interface SharedUser {
+  id: string;
+  name: string;
+}
+
+export type SharedResult = {
+  ok: boolean;
+};

--- a/packages/server/utils/tests/fixtures/ts-declaration/tsconfig.json
+++ b/packages/server/utils/tests/fixtures/ts-declaration/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@modern-js/tsconfig/base",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": false,
+    "isolatedModules": false,
+    "baseUrl": "./",
+    "paths": {
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": ["shared", "api"]
+}

--- a/packages/server/utils/tests/ts.test.ts
+++ b/packages/server/utils/tests/ts.test.ts
@@ -91,6 +91,36 @@ describe('typescript', () => {
     }
   });
 
+  it('appends .js to declaration specifiers in esm output', async () => {
+    const example = path.join(__dirname, './fixtures', './ts-declaration-esm');
+    const tsconfigPath = path.join(example, './tsconfig.json');
+    const distDir = path.join(example, './dist');
+    const sharedDir = path.join(example, './shared');
+    const apiDir = path.join(example, './api');
+
+    try {
+      await compile(example, { alias: {} } as any, {
+        sourceDirs: [sharedDir, apiDir],
+        distDir,
+        tsconfigPath,
+        moduleType: 'module',
+      });
+
+      const dts = (
+        await fs.readFile(path.join(distDir, './api/index.d.ts'))
+      ).toString();
+
+      // In ESM output the declaration specifier must carry the emitted `.js`
+      // extension just like the JS output, or `node16`/`nodenext` consumers
+      // fail with TS2835. TS resolves `./x.js` back to `./x.d.ts`.
+      expect(dts).not.toContain('@shared');
+      expect(dts).toContain('from "../shared/types.js"');
+      expect(dts).toContain('import("../shared/types.js")');
+    } finally {
+      await fs.remove(distDir);
+    }
+  });
+
   it('should keep .js suffix for aliased imports in esm output', async () => {
     const example = path.join(__dirname, './fixtures', './ts-example');
     const tsconfigPath = path.join(example, './tsconfig.esm.json');

--- a/packages/server/utils/tests/ts.test.ts
+++ b/packages/server/utils/tests/ts.test.ts
@@ -56,6 +56,41 @@ describe('typescript', () => {
     await fs.remove(distDir);
   });
 
+  it('rewrites tsconfig path aliases in emitted declarations', async () => {
+    const example = path.join(__dirname, './fixtures', './ts-declaration');
+    const tsconfigPath = path.join(example, './tsconfig.json');
+    const distDir = path.join(example, './dist');
+    const sharedDir = path.join(example, './shared');
+    const apiDir = path.join(example, './api');
+
+    try {
+      // tsc never resolves `paths` in `.d.ts` output, so the alias must be
+      // rewritten by our `afterDeclarations` transformer.
+      await compile(example, { alias: {} } as any, {
+        sourceDirs: [sharedDir, apiDir],
+        distDir,
+        tsconfigPath,
+      });
+
+      const dts = (
+        await fs.readFile(path.join(distDir, './api/declaration.d.ts'))
+      ).toString();
+
+      // No alias may leak to consumers.
+      expect(dts).not.toContain('@shared/types');
+
+      // Every specifier kind is rebased to a relative, extensionless path.
+      // ImportDeclaration / ExportDeclaration
+      expect(dts).toMatch(/from ["']\.\.\/shared\/types["']/);
+      // ImportTypeNode (inline `import("...")` type)
+      expect(dts).toContain('import("../shared/types")');
+      // ImportEqualsDeclaration (`import x = require("...")`)
+      expect(dts).toContain('require("../shared/types")');
+    } finally {
+      await fs.remove(distDir);
+    }
+  });
+
   it('should keep .js suffix for aliased imports in esm output', async () => {
     const example = path.join(__dirname, './fixtures', './ts-example');
     const tsconfigPath = path.join(example, './tsconfig.esm.json');

--- a/tests/integration/bff-corss-project/bff-api-app/api/lambda/portable.ts
+++ b/tests/integration/bff-corss-project/bff-api-app/api/lambda/portable.ts
@@ -1,0 +1,10 @@
+import type { ApiMessage } from '@shared/types';
+
+// The return type is imported through the `@shared/*` tsconfig alias, so its
+// declaration references the alias. Consumers of the published client can only
+// resolve it once the alias is rewritten to a relative path (afterDeclarations)
+// and the shared declaration ships (files: `**/*.d.ts`).
+export default async (): Promise<ApiMessage> => ({
+  message: 'Hello portable bff-api-app',
+  from: 'bff-api-app',
+});

--- a/tests/integration/bff-corss-project/bff-api-app/package.json
+++ b/tests/integration/bff-corss-project/bff-api-app/package.json
@@ -45,17 +45,21 @@
       "import": "./dist-1/client/*.js",
       "types": "./dist-1/client/*.d.ts"
     },
-    "./api/context/index": {
-      "import": "./dist-1/client/context/index.js",
-      "types": "./dist-1/client/context/index.d.ts"
-    },
     "./api/index": {
       "import": "./dist-1/client/index.js",
       "types": "./dist-1/client/index.d.ts"
     },
+    "./api/portable": {
+      "import": "./dist-1/client/portable.js",
+      "types": "./dist-1/client/portable.d.ts"
+    },
     "./api/upload": {
       "import": "./dist-1/client/upload.js",
       "types": "./dist-1/client/upload.d.ts"
+    },
+    "./api/context/index": {
+      "import": "./dist-1/client/context/index.js",
+      "types": "./dist-1/client/context/index.d.ts"
     },
     "./api/user/[id]": {
       "import": "./dist-1/client/user/[id].js",
@@ -77,14 +81,17 @@
       "api/*": [
         "./dist-1/client/*.d.ts"
       ],
-      "api/context/index": [
-        "./dist-1/client/context/index.d.ts"
-      ],
       "api/index": [
         "./dist-1/client/index.d.ts"
       ],
+      "api/portable": [
+        "./dist-1/client/portable.d.ts"
+      ],
       "api/upload": [
         "./dist-1/client/upload.d.ts"
+      ],
+      "api/context/index": [
+        "./dist-1/client/context/index.d.ts"
       ],
       "api/user/[id]": [
         "./dist-1/client/user/[id].d.ts"
@@ -97,6 +104,7 @@
   "files": [
     "dist-1/client/**/*",
     "dist-1/runtime/**/*",
-    "dist-1/plugin/**/*"
+    "dist-1/plugin/**/*",
+    "dist-1/**/*.d.ts"
   ]
 }

--- a/tests/integration/bff-corss-project/bff-api-app/shared/types.ts
+++ b/tests/integration/bff-corss-project/bff-api-app/shared/types.ts
@@ -1,0 +1,4 @@
+export interface ApiMessage {
+  message: string;
+  from: string;
+}

--- a/tests/integration/bff-corss-project/tests/types-portability.test.ts
+++ b/tests/integration/bff-corss-project/tests/types-portability.test.ts
@@ -1,0 +1,137 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import ts from 'typescript';
+import { modernBuild } from '../../../utils/modernTestUtils';
+
+rstest.setConfig({ testTimeout: 1000 * 60 * 3, hookTimeout: 1000 * 60 * 3 });
+
+const apiAppDir = path.resolve(__dirname, '../bff-api-app');
+
+// Type-check `consumerDir` in isolation and return the diagnostics. An unused
+// `@ts-expect-error` also surfaces here (TS2578), so a type that silently
+// degraded to `any` fails the check just like a missing declaration would.
+function typeCheck(consumerDir: string): ts.Diagnostic[] {
+  const configPath = path.join(consumerDir, 'tsconfig.json');
+  const parsed = ts.getParsedCommandLineOfConfigFile(
+    configPath,
+    {},
+    ts.sys as unknown as ts.ParseConfigFileHost,
+  )!;
+  const program = ts.createProgram({
+    rootNames: parsed.fileNames,
+    options: parsed.options,
+  });
+  return [...ts.getPreEmitDiagnostics(program)];
+}
+
+describe('crossProject client type portability', () => {
+  // The published package must type-check for a consumer that has no access to
+  // the source workspace: no path aliases, no symlinks, no stubs. This is the
+  // real regression surface — "resolvable in the local dist" is not the same as
+  // "resolvable from the packed tarball".
+  it('a packed tarball resolves the client types from an isolated consumer', async () => {
+    await modernBuild(apiAppDir, [], {});
+
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bff-portability-'));
+    try {
+      // 1. Pack exactly what would be published.
+      execFileSync('pnpm', ['pack', '--pack-destination', workDir], {
+        cwd: apiAppDir,
+        stdio: 'pipe',
+      });
+      const tarball = fs
+        .readdirSync(workDir)
+        .find(name => name.endsWith('.tgz'));
+      expect(tarball).toBeTruthy();
+
+      // 2. Install by extracting the tarball into an isolated node_modules —
+      //    no workspace symlink, no dependency hoisting.
+      const consumerDir = path.join(workDir, 'consumer');
+      const pkgDir = path.join(consumerDir, 'node_modules', 'bff-api-app');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      execFileSync(
+        'tar',
+        [
+          '-xzf',
+          path.join(workDir, tarball!),
+          '-C',
+          pkgDir,
+          '--strip-components=1',
+        ],
+        { stdio: 'pipe' },
+      );
+
+      // 3. The declaration closure the client re-exports must actually ship.
+      const shippedShared = path.join(pkgDir, 'dist-1', 'shared', 'types.d.ts');
+      const shippedOrigin = path.join(
+        pkgDir,
+        'dist-1',
+        'api',
+        'lambda',
+        'portable.d.ts',
+      );
+      const shippedFacade = path.join(
+        pkgDir,
+        'dist-1',
+        'client',
+        'portable.d.ts',
+      );
+      expect(fs.existsSync(shippedShared)).toBe(true);
+      expect(fs.existsSync(shippedOrigin)).toBe(true);
+      expect(fs.existsSync(shippedFacade)).toBe(true);
+
+      // No tsconfig path alias may leak into the published declarations.
+      expect(fs.readFileSync(shippedOrigin, 'utf8')).not.toContain('@shared');
+      // The facade re-exports the in-place declaration, it does not copy it.
+      expect(fs.readFileSync(shippedFacade, 'utf8')).toContain(
+        `from '../api/lambda/portable'`,
+      );
+
+      // 4. Isolated consumer that exercises the resolved type.
+      fs.writeFileSync(
+        path.join(consumerDir, 'index.ts'),
+        [
+          `import portable from 'bff-api-app/api/portable';`,
+          ``,
+          `export async function check() {`,
+          `  const msg = await portable();`,
+          `  const from: string = msg.from;`,
+          `  // @ts-expect-error 'message' is a string, so this must error. If the`,
+          `  // type had degraded to any/unknown the directive would be unused (TS2578).`,
+          `  const bad: number = msg.message;`,
+          `  return { from, bad };`,
+          `}`,
+          ``,
+        ].join('\n'),
+      );
+      fs.writeFileSync(
+        path.join(consumerDir, 'tsconfig.json'),
+        JSON.stringify(
+          {
+            compilerOptions: {
+              noEmit: true,
+              strict: true,
+              skipLibCheck: false,
+              module: 'esnext',
+              moduleResolution: 'bundler',
+              types: [],
+            },
+            include: ['index.ts'],
+          },
+          null,
+          2,
+        ),
+      );
+
+      const diagnostics = typeCheck(consumerDir);
+      const messages = diagnostics.map(d =>
+        ts.flattenDiagnosticMessageText(d.messageText, '\n'),
+      );
+      expect(messages).toEqual([]);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`bff.crossProject` client `.d.ts` resolve locally but break once **published** (fixes #8739, supersedes #8735): consumers hit `TS2307` or the type degrades to `any`. Three causes:

1. **Alias leak** — tsc keeps tsconfig `paths` verbatim in `.d.ts` ([TS#30952](https://github.com/microsoft/TypeScript/issues/30952)), so `@shared/*` reaches consumers unresolved.
2. **Broken relative specifiers** — the client `.d.ts` is copied one directory shallower than tsc emitted it, mispointing every relative import.
3. **Missing files** — `dist/shared` / `dist/api` are never added to `package.json#files`, so they're absent from the tarball.

## Changes

- **server-utils**: rewrite tsconfig aliases on declaration emit via a new `afterDeclarations` transformer (Import/Export/ImportType/ImportEquals), keeping specifiers relative and extensionless. No public API change.
- **plugin-bff**: the client re-exports the handler declaration in place via a facade instead of copying it; publish every `.d.ts` (`<distPath>/**/*.d.ts`); and drive `readDirectoryFiles` from `ApiRouter.getApiFiles()` so stray files never reach `generateClient`.

## Testing

Unit (alias rewrite, facade, file filtering) + an out-of-repo tarball consumer that `tsc`s the published client with `skipLibCheck: false` and asserts no leak and no `any` degradation.

Co-Authored-By: Riff
