### PR TITLE
feat(app-tools): add dev server lock file

### DIFF
--- a/.changeset/dev-server-lock.md
+++ b/.changeset/dev-server-lock.md
@@ -2,4 +2,4 @@
 '@modern-js/app-tools': patch
 ---
 
-feat: add a project operation lock: `dev`/`start` register a shared lock and `build`/`deploy` hold an exclusive lock, so a second `modern dev` (or a build during dev) fails fast with the running instance's URL, PID and kill command instead of silently switching ports or clobbering `dist`; opt in to multiple dev servers with `modern dev --allow-multiple`
+feat: add a project operation lock: `dev`/`start` register a shared lock and `build`/`deploy`/`inspect` hold an exclusive lock, so a second `modern dev` (or a build during dev) fails fast with the running instance's URL, PID and kill command instead of silently switching ports or clobbering `dist`. Finite builds conflicting over the same directories queue automatically instead of failing, `build --watch` stays exclusive for its lifetime, and commands whose `output.tempDir` + `output.distPath` are both distinct run in parallel. Opt in to multiple dev servers with `modern dev --allow-multiple`

--- a/.changeset/dev-server-lock.md
+++ b/.changeset/dev-server-lock.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': patch
+---
+
+feat: add a project operation lock: `dev`/`start` register a shared lock and `build`/`deploy` hold an exclusive lock, so a second `modern dev` (or a build during dev) fails fast with the running instance's URL, PID and kill command instead of silently switching ports or clobbering `dist`; opt in to multiple dev servers with `modern dev --allow-multiple`

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ playground/
 .claude
 .agents/
 .specify/
+
+# transient copies created by tests/utils createIsolatedTestApp & pure-esm tests
+tests/integration/**/.isolated-*
+tests/integration/.pure-esm-*

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare-build": "cross-env NX_DAEMON=false NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t build -p @modern-js/* --exclude=@modern-js/main-doc,@modern-js/module-tools-docs --maxParallel=4",
     "prepare": "npm run prepare-build && husky install",
     "prepare-build-continue": "cross-env NX_DAEMON=false NX_REJECT_UNKNOWN_LOCAL_CACHE=0 nx run-many -t build -p @modern-js/* --exclude=@modern-js/main-doc,@modern-js/module-tools-docs --nxBail=false --maxParallel=4 || echo 'Build completed with some failures, continuing...'",
-    "build:required": "cross-env NX_DAEMON=false nx run-many -t build -p @modern-js/builder @modern-js/bff-core @modern-js/utils @modern-js/i18n-utils @modern-js/runtime-utils",
+    "build:required": "cross-env NX_DAEMON=false nx run-many -t build -p @modern-js/builder @modern-js/bff-core @modern-js/utils @modern-js/i18n-utils @modern-js/runtime-utils @modern-js/app-tools",
     "lint": "biome check",
     "change": "changeset add",
     "bump": "changeset version",

--- a/packages/document/docs/en/apis/app/commands.mdx
+++ b/packages/document/docs/en/apis/app/commands.mdx
@@ -219,20 +219,21 @@ import DeployCommand from '@site-docs-en/components/deploy-command';
 
 ## Concurrent command protection
 
-Modern.js prevents concurrent commands from reading or writing the same generated files. The protection is scoped to the project root, so isolated copies of a project do not affect each other.
+Modern.js prevents concurrent commands from reading or writing the same generated files. Two directories decide a conflict: the generated-files directory (`output.tempDir`, default `node_modules/.modern-js`) and the build output directory (`output.distPath`, default `dist`) — sharing **either** counts as a conflict, while commands whose directories are both different never affect each other and run in parallel.
 
-For the same project root:
+When commands conflict over the same directories:
 
 | Running command | New command | Result |
 | --- | --- | --- |
 | `dev` / `start` | `dev` / `start` | Blocked by default |
-| `dev` / `start` | `build` / `deploy` | Blocked |
-| `build` / `deploy` | `dev` / `start` | Blocked |
-| `build` / `deploy` | `build` / `deploy` | Blocked |
+| `dev` / `start` | `build` / `deploy` / `inspect` | Blocked |
+| `build` / `deploy` / `inspect` | `dev` / `start` | Blocked |
+| `build --watch` | `build` / `deploy` / `inspect` | Blocked (the watcher never exits, so waiting would hang) |
+| `build` / `deploy` / `inspect` | `build` / `deploy` / `inspect` | **Queued**: waits for the running one to finish, then continues |
 
-Read-only commands such as `serve` and `inspect` do not take a lock.
+`serve` only reads the build output and does not take a lock. `inspect` recreates the generated-files directory on startup, so it holds a short exclusive lock.
 
-This also applies to `build --watch`: the exclusive lock is held until the watcher stops.
+While queued, the CLI prints the command and PID it is waiting for; Ctrl-C cancels at any time. There is no fixed waiting timeout, and the order among multiple waiters is not guaranteed.
 
 If you intentionally need multiple development servers for one project root, start the additional server with:
 
@@ -240,6 +241,8 @@ If you intentionally need multiple development servers for one project root, sta
 modern dev --allow-multiple
 ```
 
-`--allow-multiple` only permits multiple development servers. It does not allow `dev` and `build` / `deploy` to run together.
+`--allow-multiple` only permits multiple development servers — it never allows `dev` and `build` / `deploy` to run together, and only `dev` / `start` (its alias) accept it.
+
+For real parallelism (for example building each region separately), give every process its own `output.tempDir` and `output.distPath` (the config file can derive them from an environment variable): fully disjoint directories never queue.
 
 When a command is blocked, the CLI reports the conflicting operation and, when available, its URL and PID. Stop or reuse that process, then retry the command. A subsequent command automatically removes a stale lock when Modern.js can verify that its process has exited.

--- a/packages/document/docs/en/apis/app/commands.mdx
+++ b/packages/document/docs/en/apis/app/commands.mdx
@@ -21,6 +21,7 @@ Options:
   -h, --help            show command help
   --web-only            only start web service
   --api-only            only start API service
+  --allow-multiple      allow another dev server for the same project directory
 ```
 
 After running `modern dev`, Modern.js will watch source file changes and apply hot module replacement.
@@ -66,6 +67,31 @@ modern dev --entry foo,bar
 ## modern start
 
 `modern start` is an alias of `modern dev` command, the usage of the two are exactly the same.
+
+## Concurrent command protection
+
+Modern.js prevents concurrent commands from reading or writing the same generated files. The protection is scoped to the project root, so isolated copies of a project do not affect each other.
+
+For the same project root:
+
+| Running command | New command | Result |
+| --- | --- | --- |
+| `dev` / `start` | `dev` / `start` | Blocked by default |
+| `dev` / `start` | `build` / `deploy` | Blocked |
+| `build` / `deploy` | `dev` / `start` | Blocked |
+| `build` / `deploy` | `build` / `deploy` | Blocked |
+
+This also applies to `build --watch`: the exclusive lock is held until the watcher stops.
+
+If you intentionally need multiple development servers for one project root, start the additional server with:
+
+```bash
+modern dev --allow-multiple
+```
+
+`--allow-multiple` only permits multiple development servers. It does not allow `dev` and `build` / `deploy` to run together.
+
+When a command is blocked, the CLI reports the conflicting operation and, when available, its URL and PID. Stop or reuse that process, then retry the command. Locks left by exited processes are removed automatically on a subsequent command.
 
 ## modern build
 

--- a/packages/document/docs/en/apis/app/commands.mdx
+++ b/packages/document/docs/en/apis/app/commands.mdx
@@ -68,33 +68,6 @@ modern dev --entry foo,bar
 
 `modern start` is an alias of `modern dev` command, the usage of the two are exactly the same.
 
-## Concurrent command protection
-
-Modern.js prevents concurrent commands from reading or writing the same generated files. The protection is scoped to the project root, so isolated copies of a project do not affect each other.
-
-For the same project root:
-
-| Running command | New command | Result |
-| --- | --- | --- |
-| `dev` / `start` | `dev` / `start` | Blocked by default |
-| `dev` / `start` | `build` / `deploy` | Blocked |
-| `build` / `deploy` | `dev` / `start` | Blocked |
-| `build` / `deploy` | `build` / `deploy` | Blocked |
-
-Read-only commands such as `serve` and `inspect` do not take a lock.
-
-This also applies to `build --watch`: the exclusive lock is held until the watcher stops.
-
-If you intentionally need multiple development servers for one project root, start the additional server with:
-
-```bash
-modern dev --allow-multiple
-```
-
-`--allow-multiple` only permits multiple development servers. It does not allow `dev` and `build` / `deploy` to run together.
-
-When a command is blocked, the CLI reports the conflicting operation and, when available, its URL and PID. Stop or reuse that process, then retry the command. A subsequent command automatically removes a stale lock when Modern.js can verify that its process has exited.
-
 ## modern build
 
 The `modern build` command will build production-ready artifacts in the `dist/` directory by default. You can specify the output directory by modifying the configuration [`output.distPath`](/configure/app/output/dist-path).
@@ -107,6 +80,8 @@ Options:
   -h, --help            show command help
   -w --watch            turn on watch mode, watch for changes and rebuild
 ```
+
+See [Concurrent command protection](#concurrent-command-protection) for how builds interact with other running commands.
 
 ## modern new
 
@@ -241,3 +216,30 @@ Inspect config succeed, open following files to view the content:
 import DeployCommand from '@site-docs-en/components/deploy-command';
 
 <DeployCommand />
+
+## Concurrent command protection
+
+Modern.js prevents concurrent commands from reading or writing the same generated files. The protection is scoped to the project root, so isolated copies of a project do not affect each other.
+
+For the same project root:
+
+| Running command | New command | Result |
+| --- | --- | --- |
+| `dev` / `start` | `dev` / `start` | Blocked by default |
+| `dev` / `start` | `build` / `deploy` | Blocked |
+| `build` / `deploy` | `dev` / `start` | Blocked |
+| `build` / `deploy` | `build` / `deploy` | Blocked |
+
+Read-only commands such as `serve` and `inspect` do not take a lock.
+
+This also applies to `build --watch`: the exclusive lock is held until the watcher stops.
+
+If you intentionally need multiple development servers for one project root, start the additional server with:
+
+```bash
+modern dev --allow-multiple
+```
+
+`--allow-multiple` only permits multiple development servers. It does not allow `dev` and `build` / `deploy` to run together.
+
+When a command is blocked, the CLI reports the conflicting operation and, when available, its URL and PID. Stop or reuse that process, then retry the command. A subsequent command automatically removes a stale lock when Modern.js can verify that its process has exited.

--- a/packages/document/docs/en/apis/app/commands.mdx
+++ b/packages/document/docs/en/apis/app/commands.mdx
@@ -81,6 +81,8 @@ For the same project root:
 | `build` / `deploy` | `dev` / `start` | Blocked |
 | `build` / `deploy` | `build` / `deploy` | Blocked |
 
+Read-only commands such as `serve` and `inspect` do not take a lock.
+
 This also applies to `build --watch`: the exclusive lock is held until the watcher stops.
 
 If you intentionally need multiple development servers for one project root, start the additional server with:

--- a/packages/document/docs/en/apis/app/commands.mdx
+++ b/packages/document/docs/en/apis/app/commands.mdx
@@ -93,7 +93,7 @@ modern dev --allow-multiple
 
 `--allow-multiple` only permits multiple development servers. It does not allow `dev` and `build` / `deploy` to run together.
 
-When a command is blocked, the CLI reports the conflicting operation and, when available, its URL and PID. Stop or reuse that process, then retry the command. Locks left by exited processes are removed automatically on a subsequent command.
+When a command is blocked, the CLI reports the conflicting operation and, when available, its URL and PID. Stop or reuse that process, then retry the command. A subsequent command automatically removes a stale lock when Modern.js can verify that its process has exited.
 
 ## modern build
 

--- a/packages/document/docs/zh/apis/app/commands.mdx
+++ b/packages/document/docs/zh/apis/app/commands.mdx
@@ -219,20 +219,21 @@ import DeployCommand from '@site-docs/components/deploy-command';
 
 ## 并发命令保护
 
-Modern.js 会阻止多个命令并发读写同一份生成文件。保护范围是项目根目录，因此项目的不同隔离副本互不影响。
+Modern.js 会阻止多个命令并发读写同一份生成文件。判断依据是两个目录：框架生成文件目录（`output.tempDir`，默认 `node_modules/.modern-js`）与产物目录（`output.distPath`，默认 `dist`）——**任一相同即视为冲突**；两者都不同的命令组合互不影响，可自由并行。
 
-在同一项目根目录中：
+同一套目录内发生冲突时：
 
 | 已运行的命令 | 新命令 | 结果 |
 | --- | --- | --- |
 | `dev` / `start` | `dev` / `start` | 默认阻止 |
-| `dev` / `start` | `build` / `deploy` | 阻止 |
-| `build` / `deploy` | `dev` / `start` | 阻止 |
-| `build` / `deploy` | `build` / `deploy` | 阻止 |
+| `dev` / `start` | `build` / `deploy` / `inspect` | 阻止 |
+| `build` / `deploy` / `inspect` | `dev` / `start` | 阻止 |
+| `build --watch` | `build` / `deploy` / `inspect` | 阻止（监听进程长驻，无法等待） |
+| `build` / `deploy` / `inspect` | `build` / `deploy` / `inspect` | **自动排队**：等待前一个完成后继续执行 |
 
-`serve`、`inspect` 等只读命令不会加锁。
+`serve` 只读产物，不参与锁。`inspect` 启动时会重建生成文件目录，因此持有短暂的独占锁。
 
-`build --watch` 同样受此规则保护：在监听进程停止前会一直持有独占锁。
+排队期间 CLI 会打印正在等待的命令与 PID，可随时 Ctrl-C 取消；等待没有固定超时，多个等待者的先后顺序不做保证。
 
 如果确实需要在同一项目根目录中运行多个开发服务器，请使用：
 
@@ -240,8 +241,8 @@ Modern.js 会阻止多个命令并发读写同一份生成文件。保护范围�
 modern dev --allow-multiple
 ```
 
-`--allow-multiple` 只允许多个开发服务器并存，不允许 `dev` 与 `build` / `deploy` 同时运行。
+`--allow-multiple` 只允许多个开发服务器并存，不允许 `dev` 与 `build` / `deploy` 同时运行；仅 `dev` / `start`（别名）支持该参数。
 
-该参数仅 `dev` / `start`（别名）支持；`build` / `deploy` 不接受该参数（传入会提示未知参数）——独占锁对任何并发都互斥，不存在放宽的语义。
+需要真正并行（例如多区域分别构建）时，为每个进程配置独立的 `output.tempDir` 与 `output.distPath`（配置文件可读环境变量派生目录），即可完全隔离、互不排队。
 
 命令被阻止时，CLI 会显示冲突操作，并在可以确认时显示其 URL 和 PID。请停止或复用该进程后重试；Modern.js 能确认原进程已退出时，会在后续命令执行时自动清理遗留锁。

--- a/packages/document/docs/zh/apis/app/commands.mdx
+++ b/packages/document/docs/zh/apis/app/commands.mdx
@@ -21,6 +21,7 @@ Options:
   -h, --help            显示命令帮助
   --web-only            仅启动 Web 服务
   --api-only            仅启动 API 接口服务
+  --allow-multiple      允许在同一项目目录中再启动一个开发服务器
 ```
 
 运行 `modern dev` 后，Modern.js 会监听源文件变化并进行模块热更新。
@@ -66,6 +67,31 @@ modern dev --entry foo,bar
 ## modern start
 
 `modern start` 是 `modern dev` 命令的别名，两者的功能和用法完全一致。
+
+## 并发命令保护
+
+Modern.js 会阻止多个命令并发读写同一份生成文件。保护范围是项目根目录，因此项目的不同隔离副本互不影响。
+
+在同一项目根目录中：
+
+| 已运行的命令 | 新命令 | 结果 |
+| --- | --- | --- |
+| `dev` / `start` | `dev` / `start` | 默认阻止 |
+| `dev` / `start` | `build` / `deploy` | 阻止 |
+| `build` / `deploy` | `dev` / `start` | 阻止 |
+| `build` / `deploy` | `build` / `deploy` | 阻止 |
+
+`build --watch` 同样受此规则保护：在监听进程停止前会一直持有独占锁。
+
+如果确实需要在同一项目根目录中运行多个开发服务器，请使用：
+
+```bash
+modern dev --allow-multiple
+```
+
+`--allow-multiple` 只允许多个开发服务器并存，不允许 `dev` 与 `build` / `deploy` 同时运行。
+
+命令被阻止时，CLI 会显示冲突操作，并在可以确认时显示其 URL 和 PID。请停止或复用该进程后重试；已退出进程遗留的锁会在后续命令执行时自动清理。
 
 ## modern build
 

--- a/packages/document/docs/zh/apis/app/commands.mdx
+++ b/packages/document/docs/zh/apis/app/commands.mdx
@@ -93,7 +93,7 @@ modern dev --allow-multiple
 
 `--allow-multiple` 只允许多个开发服务器并存，不允许 `dev` 与 `build` / `deploy` 同时运行。
 
-命令被阻止时，CLI 会显示冲突操作，并在可以确认时显示其 URL 和 PID。请停止或复用该进程后重试；已退出进程遗留的锁会在后续命令执行时自动清理。
+命令被阻止时，CLI 会显示冲突操作，并在可以确认时显示其 URL 和 PID。请停止或复用该进程后重试；Modern.js 能确认原进程已退出时，会在后续命令执行时自动清理遗留锁。
 
 ## modern build
 

--- a/packages/document/docs/zh/apis/app/commands.mdx
+++ b/packages/document/docs/zh/apis/app/commands.mdx
@@ -81,6 +81,8 @@ Modern.js 会阻止多个命令并发读写同一份生成文件。保护范围�
 | `build` / `deploy` | `dev` / `start` | 阻止 |
 | `build` / `deploy` | `build` / `deploy` | 阻止 |
 
+`serve`、`inspect` 等只读命令不会加锁。
+
 `build --watch` 同样受此规则保护：在监听进程停止前会一直持有独占锁。
 
 如果确实需要在同一项目根目录中运行多个开发服务器，请使用：

--- a/packages/document/docs/zh/apis/app/commands.mdx
+++ b/packages/document/docs/zh/apis/app/commands.mdx
@@ -68,33 +68,6 @@ modern dev --entry foo,bar
 
 `modern start` 是 `modern dev` 命令的别名，两者的功能和用法完全一致。
 
-## 并发命令保护
-
-Modern.js 会阻止多个命令并发读写同一份生成文件。保护范围是项目根目录，因此项目的不同隔离副本互不影响。
-
-在同一项目根目录中：
-
-| 已运行的命令 | 新命令 | 结果 |
-| --- | --- | --- |
-| `dev` / `start` | `dev` / `start` | 默认阻止 |
-| `dev` / `start` | `build` / `deploy` | 阻止 |
-| `build` / `deploy` | `dev` / `start` | 阻止 |
-| `build` / `deploy` | `build` / `deploy` | 阻止 |
-
-`serve`、`inspect` 等只读命令不会加锁。
-
-`build --watch` 同样受此规则保护：在监听进程停止前会一直持有独占锁。
-
-如果确实需要在同一项目根目录中运行多个开发服务器，请使用：
-
-```bash
-modern dev --allow-multiple
-```
-
-`--allow-multiple` 只允许多个开发服务器并存，不允许 `dev` 与 `build` / `deploy` 同时运行。
-
-命令被阻止时，CLI 会显示冲突操作，并在可以确认时显示其 URL 和 PID。请停止或复用该进程后重试；Modern.js 能确认原进程已退出时，会在后续命令执行时自动清理遗留锁。
-
 ## modern build
 
 `modern build` 命令默认会在 `dist/` 目录下构建出可用于生产环境的产物。你可以通过修改配置 [`output.distPath`](/configure/app/output/dist-path) 指定产物的输出目录。
@@ -107,6 +80,8 @@ Options:
   -h, --help  显示命令帮助
   -w --watch  开启 watch 模式, 监听文件变更并重新构建
 ```
+
+构建与其他命令的并发限制见 [并发命令保护](#并发命令保护)。
 
 ## modern new
 
@@ -241,3 +216,32 @@ Inspect config succeed, open following files to view the content:
 import DeployCommand from '@site-docs/components/deploy-command';
 
 <DeployCommand />
+
+## 并发命令保护
+
+Modern.js 会阻止多个命令并发读写同一份生成文件。保护范围是项目根目录，因此项目的不同隔离副本互不影响。
+
+在同一项目根目录中：
+
+| 已运行的命令 | 新命令 | 结果 |
+| --- | --- | --- |
+| `dev` / `start` | `dev` / `start` | 默认阻止 |
+| `dev` / `start` | `build` / `deploy` | 阻止 |
+| `build` / `deploy` | `dev` / `start` | 阻止 |
+| `build` / `deploy` | `build` / `deploy` | 阻止 |
+
+`serve`、`inspect` 等只读命令不会加锁。
+
+`build --watch` 同样受此规则保护：在监听进程停止前会一直持有独占锁。
+
+如果确实需要在同一项目根目录中运行多个开发服务器，请使用：
+
+```bash
+modern dev --allow-multiple
+```
+
+`--allow-multiple` 只允许多个开发服务器并存，不允许 `dev` 与 `build` / `deploy` 同时运行。
+
+该参数仅 `dev` / `start`（别名）支持；`build` / `deploy` 不接受该参数（传入会提示未知参数）——独占锁对任何并发都互斥，不存在放宽的语义。
+
+命令被阻止时，CLI 会显示冲突操作，并在可以确认时显示其 URL 和 PID。请停止或复用该进程后重试；Modern.js 能确认原进程已退出时，会在后续命令执行时自动清理遗留锁。

--- a/packages/solutions/app-tools/bin/modern.js
+++ b/packages/solutions/app-tools/bin/modern.js
@@ -21,16 +21,28 @@ try {
   // ignore
 }
 
+// `run()` prints a friendly message for lock conflicts and re-throws the
+// typed error so its rejection semantics stay intact for programmatic
+// callers; the bin just turns that known error into a silent exit code.
+const onFatal = err => {
+  if (err && err.name === 'DevServerLockError') {
+    process.exit(process.exitCode || 1);
+  }
+  throw err;
+};
+
 if (isESM) {
   import('../dist/esm-node/run/index.mjs').then(({ run }) => {
-    run({
+    return run({
       internalPlugins: INTERNAL_RUNTIME_PLUGINS,
       version,
-    });
+    }).catch(onFatal);
   });
 } else {
-  require('../dist/cjs/run/index.js').run({
-    internalPlugins: INTERNAL_RUNTIME_PLUGINS,
-    version,
-  });
+  require('../dist/cjs/run/index.js')
+    .run({
+      internalPlugins: INTERNAL_RUNTIME_PLUGINS,
+      version,
+    })
+    .catch(onFatal);
 }

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -3,7 +3,7 @@ import type { CLIPluginAPI } from '@modern-js/plugin';
 import { fs, type Alias, logger } from '@modern-js/utils';
 import type { ConfigChain } from '@rsbuild/core';
 import type { AppTools } from '../types';
-import { releaseCommandLock } from '../utils/devLock';
+import { markLockPersistent, releaseCommandLock } from '../utils/devLock';
 import { loadServerPlugins } from '../utils/loadPlugins';
 import { setupTsRuntime } from '../utils/register';
 import { generateRoutes } from '../utils/routes';
@@ -53,6 +53,12 @@ export const build = async (
   const { appDirectory, metaName } = api.getAppContext();
   let keepLockUntilExit = false;
   try {
+    if (options?.watch) {
+      // A watcher keeps writing output for the lifetime of the process, so
+      // nobody may queue behind its lock. The flag only becomes visible in
+      // this action (after the lock was taken in `onPrepare`).
+      markLockPersistent(appDirectory, metaName);
+    }
     await runBuild(api, options);
     // In watch mode `builder.build()` resolves after the first compilation,
     // while the watcher continues to write output. Keep the exclusive lock

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -3,6 +3,7 @@ import type { CLIPluginAPI } from '@modern-js/plugin';
 import { fs, type Alias, logger } from '@modern-js/utils';
 import type { ConfigChain } from '@rsbuild/core';
 import type { AppTools } from '../types';
+import { releaseCommandLock } from '../utils/devLock';
 import { loadServerPlugins } from '../utils/loadPlugins';
 import { setupTsRuntime } from '../utils/register';
 import { generateRoutes } from '../utils/routes';
@@ -46,6 +47,21 @@ async function copyEnvFiles(
 }
 
 export const build = async (
+  api: CLIPluginAPI<AppTools>,
+  options?: BuildOptions,
+) => {
+  const { appDirectory, metaName } = api.getAppContext();
+  try {
+    await runBuild(api, options);
+  } finally {
+    // The exclusive lock is taken in `onPrepare`; a bare `deploy` runs this
+    // function while holding a 'deploy' lock, which this op-matched release
+    // leaves alone.
+    releaseCommandLock(appDirectory, metaName, 'build');
+  }
+};
+
+const runBuild = async (
   api: CLIPluginAPI<AppTools>,
   options?: BuildOptions,
 ) => {

--- a/packages/solutions/app-tools/src/commands/build.ts
+++ b/packages/solutions/app-tools/src/commands/build.ts
@@ -51,13 +51,20 @@ export const build = async (
   options?: BuildOptions,
 ) => {
   const { appDirectory, metaName } = api.getAppContext();
+  let keepLockUntilExit = false;
   try {
     await runBuild(api, options);
+    // In watch mode `builder.build()` resolves after the first compilation,
+    // while the watcher continues to write output. Keep the exclusive lock
+    // for the lifetime of the CLI process; `onBeforeExit` owns its cleanup.
+    keepLockUntilExit = Boolean(options?.watch);
   } finally {
     // The exclusive lock is taken in `onPrepare`; a bare `deploy` runs this
     // function while holding a 'deploy' lock, which this op-matched release
     // leaves alone.
-    releaseCommandLock(appDirectory, metaName, 'build');
+    if (!keepLockUntilExit) {
+      releaseCommandLock(appDirectory, metaName, 'build');
+    }
   }
 };
 

--- a/packages/solutions/app-tools/src/commands/deploy.ts
+++ b/packages/solutions/app-tools/src/commands/deploy.ts
@@ -1,5 +1,6 @@
 import type { CLIPluginAPI } from '@modern-js/plugin';
 import type { AppTools } from '../types';
+import { releaseCommandLock } from '../utils/devLock';
 import { getServerPlugins } from '../utils/loadPlugins';
 import type { DeployOptions } from '../utils/types';
 import { build } from './build';
@@ -10,16 +11,22 @@ export const deploy = async (
 ) => {
   const hooks = api.getHooks();
 
-  const { metaName } = api.getAppContext();
+  const { appDirectory, metaName } = api.getAppContext();
 
-  if (options.skipBuild) {
-    // A skipped build still needs the server plugins that register deploy hooks.
-    await getServerPlugins(api, metaName);
-  } else {
-    await build(api);
+  try {
+    if (options.skipBuild) {
+      // A skipped build still needs the server plugins that register deploy hooks.
+      await getServerPlugins(api, metaName);
+    } else {
+      await build(api);
+    }
+
+    await hooks.onBeforeDeploy.call(options);
+    await hooks.deploy.call();
+    await hooks.onAfterDeploy.call(options);
+  } finally {
+    // Deploy reads dist for its whole duration (including --skip-build), so
+    // the exclusive lock taken in `onPrepare` is held until here.
+    releaseCommandLock(appDirectory, metaName, 'deploy');
   }
-
-  await hooks.onBeforeDeploy.call(options);
-  await hooks.deploy.call();
-  await hooks.onAfterDeploy.call(options);
 };

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -16,6 +16,7 @@ import {
 import type { ConfigChain } from '@rsbuild/core';
 import type { AppNormalizedConfig, AppTools } from '../types';
 import { setServer } from '../utils/createServer';
+import { markDevLockReady } from '../utils/devLock';
 import { loadServerPlugins } from '../utils/loadPlugins';
 import { printInstructions } from '../utils/printInstructions';
 import { setupTsRuntime } from '../utils/register';
@@ -114,6 +115,10 @@ export const dev = async (
         host,
       },
       () => {
+        markDevLockReady(appContext.appDirectory, appContext.metaName, {
+          port,
+          host,
+        });
         printInstructions(
           hooks,
           appContext,
@@ -142,6 +147,11 @@ export const dev = async (
         }
 
         logger.debug('listen dev server done');
+
+        markDevLockReady(appContext.appDirectory, appContext.metaName, {
+          port,
+          host,
+        });
 
         await afterListen();
       },

--- a/packages/solutions/app-tools/src/commands/dev.ts
+++ b/packages/solutions/app-tools/src/commands/dev.ts
@@ -10,6 +10,7 @@ import {
   type Alias,
   DEFAULT_DEV_HOST,
   SERVER_DIR,
+  getAddressUrls,
   getMeta,
   logger,
 } from '@modern-js/utils';
@@ -100,6 +101,28 @@ export const dev = async (
 
   const host = normalizedConfig.dev?.host || DEFAULT_DEV_HOST;
 
+  // Same protocol/host derivation as `prettyInstructions`, so the URLs in
+  // the lock file match what the terminal prints (HTTPS, custom host, IPv6).
+  const markLockReady = () => {
+    const isHttps = Boolean(
+      normalizedConfig.dev?.https ||
+        (normalizedConfig.tools as { devServer?: { https?: unknown } })
+          ?.devServer?.https,
+    );
+    markDevLockReady(appDirectory, metaName, {
+      port,
+      host,
+      urls:
+        typeof port === 'number'
+          ? getAddressUrls(
+              isHttps ? 'https' : 'http',
+              port,
+              normalizedConfig.dev?.host,
+            ).map(({ url }) => url)
+          : undefined,
+    });
+  };
+
   if (apiOnly) {
     const { server } = await createDevServer(
       {
@@ -115,10 +138,7 @@ export const dev = async (
         host,
       },
       () => {
-        markDevLockReady(appContext.appDirectory, appContext.metaName, {
-          port,
-          host,
-        });
+        markLockReady();
         printInstructions(
           hooks,
           appContext,
@@ -144,14 +164,13 @@ export const dev = async (
       async (err?: Error) => {
         if (err) {
           logger.error('Occur error %s, when start dev server', err);
+          // Never mark the lock ready for a server that failed to listen.
+          return;
         }
 
         logger.debug('listen dev server done');
 
-        markDevLockReady(appContext.appDirectory, appContext.metaName, {
-          port,
-          host,
-        });
+        markLockReady();
 
         await afterListen();
       },

--- a/packages/solutions/app-tools/src/commands/index.ts
+++ b/packages/solutions/app-tools/src/commands/index.ts
@@ -24,6 +24,10 @@ export const devCommand = async (
     .option('--analyze', i18n.t(localeKeys.command.shared.analyze))
     .option('--api-only', i18n.t(localeKeys.command.dev.apiOnly))
     .option('--web-only', i18n.t(localeKeys.command.dev.webOnly))
+    // Consumed by the dev-lock plugin in `onPrepare` (before this action
+    // runs); registered here so it shows up in `--help` and passes
+    // Commander's unknown-option check.
+    .option('--allow-multiple', i18n.t(localeKeys.command.dev.allowMultiple))
     .action(async (options: DevOptions) => {
       const { dev } = await import('./dev.js');
       await dev(api, options);

--- a/packages/solutions/app-tools/src/commands/inspect.ts
+++ b/packages/solutions/app-tools/src/commands/inspect.ts
@@ -1,6 +1,7 @@
 import type { CLIPluginAPI } from '@modern-js/plugin';
 import type { RsbuildMode } from '@rsbuild/core';
 import type { AppTools } from '../types';
+import { releaseCommandLock } from '../utils/devLock';
 import type { InspectOptions } from '../utils/types';
 
 export const inspect = async (
@@ -8,21 +9,27 @@ export const inspect = async (
   options: InspectOptions,
 ) => {
   const appContext = api.getAppContext();
-  if (!appContext.builder) {
-    throw new Error(
-      'Expect the Builder to have been initialized, But the appContext.builder received `undefined`',
-    );
-  }
-  const metaName =
-    appContext.metaName === 'modern-js' ? 'modern.js' : appContext.metaName;
+  try {
+    if (!appContext.builder) {
+      throw new Error(
+        'Expect the Builder to have been initialized, But the appContext.builder received `undefined`',
+      );
+    }
+    const metaName =
+      appContext.metaName === 'modern-js' ? 'modern.js' : appContext.metaName;
 
-  return appContext.builder.inspectConfig({
-    mode: options.env as RsbuildMode,
-    verbose: options.verbose,
-    outputPath: options.output,
-    writeToDisk: true,
-    extraConfigs: {
-      [metaName]: api.getNormalizedConfig(),
-    },
-  });
+    return await appContext.builder.inspectConfig({
+      mode: options.env as RsbuildMode,
+      verbose: options.verbose,
+      outputPath: options.output,
+      writeToDisk: true,
+      extraConfigs: {
+        [metaName]: api.getNormalizedConfig(),
+      },
+    });
+  } finally {
+    // inspect empties internalDirectory on startup, so it holds a short
+    // exclusive lock taken in `onPrepare`.
+    releaseCommandLock(appContext.appDirectory, appContext.metaName, 'inspect');
+  }
 };

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -22,6 +22,7 @@ import { DEFAULT_RUNTIME_CONFIG_FILE } from './constants';
 import { i18n } from './locale';
 import analyzePlugin from './plugins/analyze';
 import deployPlugin from './plugins/deploy';
+import devLockPlugin from './plugins/devLock';
 import initializePlugin from './plugins/initialize';
 import serverBuildPlugin from './plugins/serverBuild';
 import serverRuntimePlugin from './plugins/serverRuntime';
@@ -47,6 +48,9 @@ export * from './defineConfig';
 export const appTools = (): CliPlugin<AppTools> => ({
   name: '@modern-js/app-tools',
   usePlugins: [
+    // Must stay first: its `onPrepare` checks the project operation lock
+    // before any plugin cleans `internalDirectory` or `dist`.
+    devLockPlugin(),
     serverRuntimePlugin(),
     compatPlugin(),
     initializePlugin(),

--- a/packages/solutions/app-tools/src/index.ts
+++ b/packages/solutions/app-tools/src/index.ts
@@ -48,7 +48,8 @@ export * from './defineConfig';
 export const appTools = (): CliPlugin<AppTools> => ({
   name: '@modern-js/app-tools',
   usePlugins: [
-    // Must stay first: its `onPrepare` checks the project operation lock
+    // Must stay first: its `modifyResolvedConfig` checks the project
+    // operation lock before the initialize plugin probes the dev port and
     // before any plugin cleans `internalDirectory` or `dist`.
     devLockPlugin(),
     serverRuntimePlugin(),

--- a/packages/solutions/app-tools/src/locale/en.ts
+++ b/packages/solutions/app-tools/src/locale/en.ts
@@ -12,6 +12,8 @@ export const EN_LOCALE = {
       entry: 'compiler by entry',
       apiOnly: 'start api server only',
       webOnly: 'start web server only',
+      allowMultiple:
+        'allow starting another dev server while one is already running for this project',
       selectEntry: 'Please select the entry that needs to be built',
       requireEntry: 'You must choose at least one entry',
     },

--- a/packages/solutions/app-tools/src/locale/zh.ts
+++ b/packages/solutions/app-tools/src/locale/zh.ts
@@ -11,6 +11,7 @@ export const ZH_LOCALE = {
       entry: '指定入口，编译特定的页面',
       apiOnly: '仅启动 API 接口服务',
       webOnly: '仅启动 Web 服务',
+      allowMultiple: '已有 dev server 运行时，允许再启动一个',
       selectEntry: '请选择需要构建的入口',
       requireEntry: '请至少选择一个入口',
     },

--- a/packages/solutions/app-tools/src/plugins/devLock.ts
+++ b/packages/solutions/app-tools/src/plugins/devLock.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { getArgv, getCommand, minimist } from '@modern-js/utils';
 import type { AppTools, CliPlugin } from '../types';
 import {
@@ -35,19 +36,37 @@ export default (): CliPlugin<AppTools> => ({
       // `RunOptions.allowMultiple` and stores a run-scoped intent; raw argv
       // is only a fallback for callers that drive `cli.init()` directly.
       const intent = getDevLockIntent(appDirectory);
+      const args = minimist(getArgv(), {
+        boolean: ['allow-multiple', 'watch'],
+        alias: { w: 'watch' },
+      });
       const allowMultiple =
-        intent?.allowMultiple ??
-        Boolean(
-          minimist(getArgv(), { boolean: ['allow-multiple'] })[
-            'allow-multiple'
-          ],
-        );
+        intent?.allowMultiple ?? Boolean(args['allow-multiple']);
+
+      // The write set this command will touch. internalDirectory is fixed at
+      // plugin-setup time (from `output.tempDir`); distDirectory follows the
+      // resolved config, computed here defensively because other plugins may
+      // not have written it onto the app context yet in this early hook.
+      const resolvedConfig = api.getNormalizedConfig() as
+        | { output?: { distPath?: { root?: string } } }
+        | undefined;
+      const distRoot = resolvedConfig?.output?.distPath?.root || 'dist';
+      const distDirectory =
+        appContext.distDirectory ||
+        (path.isAbsolute(distRoot)
+          ? distRoot
+          : path.resolve(appDirectory, distRoot));
 
       await acquireCommandLock({
         appDirectory,
         metaName,
         operation,
         allowMultiple: operation === 'dev' && allowMultiple,
+        // `build --watch` seen on argv marks the lock persistent up front;
+        // programmatic watch is upgraded in the build action itself.
+        watch: operation === 'build' && Boolean(args.watch),
+        internalDirectory: appContext.internalDirectory,
+        distDirectory,
       });
     });
 

--- a/packages/solutions/app-tools/src/plugins/devLock.ts
+++ b/packages/solutions/app-tools/src/plugins/devLock.ts
@@ -2,6 +2,7 @@ import { getArgv, getCommand, minimist } from '@modern-js/utils';
 import type { AppTools, CliPlugin } from '../types';
 import {
   acquireCommandLock,
+  getDevLockIntent,
   normalizeLockOperation,
   releaseAllLocks,
   suspendForRestart,
@@ -30,17 +31,23 @@ export default (): CliPlugin<AppTools> => ({
         return;
       }
 
-      // The flag is consumed here, before Commander parses the command
-      // action options (which happens after `onPrepare`).
-      const args = minimist(getArgv(), {
-        boolean: ['allow-multiple'],
-      });
+      // The run entry (`createRunOptions`) parses `--allow-multiple` /
+      // `RunOptions.allowMultiple` and stores a run-scoped intent; raw argv
+      // is only a fallback for callers that drive `cli.init()` directly.
+      const intent = getDevLockIntent(appDirectory);
+      const allowMultiple =
+        intent?.allowMultiple ??
+        Boolean(
+          minimist(getArgv(), { boolean: ['allow-multiple'] })[
+            'allow-multiple'
+          ],
+        );
 
       await acquireCommandLock({
         appDirectory,
         metaName,
         operation,
-        allowMultiple: operation === 'dev' && Boolean(args['allow-multiple']),
+        allowMultiple: operation === 'dev' && allowMultiple,
       });
     });
 

--- a/packages/solutions/app-tools/src/plugins/devLock.ts
+++ b/packages/solutions/app-tools/src/plugins/devLock.ts
@@ -1,0 +1,59 @@
+import { getArgv, getCommand, minimist } from '@modern-js/utils';
+import type { AppTools, CliPlugin } from '../types';
+import {
+  acquireCommandLock,
+  normalizeLockOperation,
+  releaseAllLocks,
+  suspendForRestart,
+} from '../utils/devLock';
+
+/**
+ * Registers the project operation lock. Must be the first plugin in
+ * app-tools' `usePlugins` so its `onPrepare` runs before the two destructive
+ * cleanups (`internalDirectory` in the analyze plugin, `dist` in app-tools) —
+ * a conflict must be reported before anything gets deleted.
+ */
+export default (): CliPlugin<AppTools> => ({
+  name: '@modern-js/plugin-dev-lock',
+
+  setup: api => {
+    api.onPrepare(async () => {
+      const appContext = api.getAppContext();
+      const { appDirectory, metaName } = appContext;
+
+      // CLI runs carry the command in argv; programmatic runs put it on the
+      // app context. `start` (and the worker variant) normalize to `dev`.
+      const operation = normalizeLockOperation(
+        getCommand() || (appContext as { command?: string }).command,
+      );
+      if (!operation) {
+        return;
+      }
+
+      // The flag is consumed here, before Commander parses the command
+      // action options (which happens after `onPrepare`).
+      const args = minimist(getArgv(), {
+        boolean: ['allow-multiple'],
+      });
+
+      await acquireCommandLock({
+        appDirectory,
+        metaName,
+        operation,
+        allowMultiple: operation === 'dev' && Boolean(args['allow-multiple']),
+      });
+    });
+
+    // Config hot restart re-runs the whole CLI init in the same process:
+    // keep the lock file (it is still ours), only stop the heartbeat.
+    api.onBeforeRestart(() => {
+      const { appDirectory, metaName } = api.getAppContext();
+      suspendForRestart(appDirectory, metaName);
+    });
+
+    // The CLI owns SIGINT/SIGTERM and funnels every exit through this hook.
+    api.onBeforeExit(() => {
+      releaseAllLocks();
+    });
+  },
+});

--- a/packages/solutions/app-tools/src/plugins/devLock.ts
+++ b/packages/solutions/app-tools/src/plugins/devLock.ts
@@ -11,15 +11,18 @@ import {
 
 /**
  * Registers the project operation lock. Must be the first plugin in
- * app-tools' `usePlugins` so its `onPrepare` runs before the two destructive
- * cleanups (`internalDirectory` in the analyze plugin, `dist` in app-tools) —
- * a conflict must be reported before anything gets deleted.
+ * app-tools' `usePlugins` so its `modifyResolvedConfig` runs before the
+ * initialize plugin probes the dev port (which logs "Port X is in use,
+ * using port Y" — misleading for a process that is about to be rejected)
+ * and before the two destructive cleanups in `onPrepare` (`internalDirectory`
+ * in the analyze plugin, `dist` in app-tools): a conflict must be reported
+ * before anything is printed or deleted.
  */
 export default (): CliPlugin<AppTools> => ({
   name: '@modern-js/plugin-dev-lock',
 
   setup: api => {
-    api.onPrepare(async () => {
+    api.modifyResolvedConfig(async resolved => {
       const appContext = api.getAppContext();
       const { appDirectory, metaName } = appContext;
 
@@ -29,7 +32,7 @@ export default (): CliPlugin<AppTools> => ({
         getCommand() || (appContext as { command?: string }).command,
       );
       if (!operation) {
-        return;
+        return resolved;
       }
 
       // The run entry (`createRunOptions`) parses `--allow-multiple` /
@@ -45,12 +48,9 @@ export default (): CliPlugin<AppTools> => ({
 
       // The write set this command will touch. internalDirectory is fixed at
       // plugin-setup time (from `output.tempDir`); distDirectory follows the
-      // resolved config, computed here defensively because other plugins may
-      // not have written it onto the app context yet in this early hook.
-      const resolvedConfig = api.getNormalizedConfig() as
-        | { output?: { distPath?: { root?: string } } }
-        | undefined;
-      const distRoot = resolvedConfig?.output?.distPath?.root || 'dist';
+      // resolved config passed to this hook, computed here because no plugin
+      // has written it onto the app context yet at this point.
+      const distRoot = resolved.output?.distPath?.root || 'dist';
       const distDirectory =
         appContext.distDirectory ||
         (path.isAbsolute(distRoot)
@@ -68,6 +68,7 @@ export default (): CliPlugin<AppTools> => ({
         internalDirectory: appContext.internalDirectory,
         distDirectory,
       });
+      return resolved;
     });
 
     // Config hot restart re-runs the whole CLI init in the same process:

--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -122,12 +122,12 @@ export async function run(options: RunOptions) {
     await CLIPluginRun(runOptions);
   } catch (err) {
     // Lock conflicts are expected, user-facing outcomes: print an actionable
-    // message instead of a stack trace. Programmatic callers that invoke the
-    // CLI directly (not through this wrapper) receive the typed error as-is.
+    // message instead of a stack trace, then re-throw so `run()` keeps its
+    // rejection semantics for programmatic callers (the CLI bin catches the
+    // typed error and exits without printing it a second time).
     if (isDevServerLockError(err)) {
       printDevServerLockError(err);
       process.exitCode = 1;
-      return;
     }
     throw err;
   } finally {
@@ -152,13 +152,19 @@ function printDevServerLockError(err: DevServerLockError) {
     );
   }
   const [first] = err.instances;
-  if (first) {
+  if (first?.identityVerified) {
     const killCommand =
       process.platform === 'win32'
         ? `taskkill /PID ${first.pid} /F`
         : `kill ${first.pid}`;
     console.error(
       `${chalk.red('error')}   Reuse it, or stop it first: ${chalk.cyan(killCommand)}`,
+    );
+  } else if (first) {
+    // Without a verified process identity the pid may have been reused by
+    // an unrelated process — never suggest a blind force-kill.
+    console.error(
+      `${chalk.red('error')}   Verify PID ${first.pid} before stopping it manually.`,
     );
   }
   if (err.code === 'EDEV_SERVER_RUNNING') {

--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -6,6 +6,7 @@ import { handleSetupResult } from '../compat/hooks';
 import {
   type DevServerLockError,
   isDevServerLockError,
+  setDevLockIntent,
 } from '../utils/devLock';
 import { getConfigFile } from '../utils/getConfigFile';
 import { loadInternalPlugins } from '../utils/loadPlugins';
@@ -18,6 +19,12 @@ export interface RunOptions {
   internalPlugins?: InternalPlugins;
   initialLog?: string;
   version: string;
+  /**
+   * Intentionally run this dev server alongside an already-running one
+   * (equivalent to the `--allow-multiple` CLI flag; the option wins over
+   * argv when both are present).
+   */
+  allowMultiple?: boolean;
 }
 export async function createRunOptions({
   cwd,
@@ -26,6 +33,7 @@ export async function createRunOptions({
   version,
   internalPlugins,
   configFile,
+  allowMultiple,
 }: RunOptions) {
   const nodeVersion = process.versions.node;
   const versionArr = nodeVersion.split('.').map(Number);
@@ -57,7 +65,8 @@ export async function createRunOptions({
   const cliParams = minimist<{
     c?: string;
     config?: string;
-  }>(process.argv.slice(2));
+    'allow-multiple'?: boolean;
+  }>(process.argv.slice(2), { boolean: ['allow-multiple'] });
   /**
    * Commands that support specify config files
    * `new` command need to use `--config-file` params,because `--config` is already used
@@ -87,6 +96,13 @@ export async function createRunOptions({
   const finalConfigFile: string = customConfigFile || getConfigFile(configFile);
 
   const plugins = await loadInternalPlugins(appDirectory, internalPlugins);
+
+  // Single place where the multi-dev intent is resolved: the typed run
+  // option wins over the raw `--allow-multiple` flag. Stored run-scoped
+  // (keyed by appDirectory) for the dev-lock plugin to read in `onPrepare`.
+  setDevLockIntent(appDirectory, {
+    allowMultiple: allowMultiple ?? Boolean(cliParams['allow-multiple']),
+  });
 
   return {
     cwd,

--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -3,6 +3,10 @@ import { run as CLIPluginRun } from '@modern-js/plugin/run';
 import type { InternalPlugins } from '@modern-js/types';
 import { chalk, minimist } from '@modern-js/utils';
 import { handleSetupResult } from '../compat/hooks';
+import {
+  type DevServerLockError,
+  isDevServerLockError,
+} from '../utils/devLock';
 import { getConfigFile } from '../utils/getConfigFile';
 import { loadInternalPlugins } from '../utils/loadPlugins';
 
@@ -96,5 +100,48 @@ export async function createRunOptions({
 
 export async function run(options: RunOptions) {
   const runOptions = await createRunOptions(options);
-  await CLIPluginRun(runOptions);
+  try {
+    await CLIPluginRun(runOptions);
+  } catch (err) {
+    // Lock conflicts are expected, user-facing outcomes: print an actionable
+    // message instead of a stack trace. Programmatic callers that invoke the
+    // CLI directly (not through this wrapper) receive the typed error as-is.
+    if (isDevServerLockError(err)) {
+      printDevServerLockError(err);
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+}
+
+function printDevServerLockError(err: DevServerLockError) {
+  console.error(`${chalk.red('error')}   [${err.code}] ${err.message}`);
+  for (const instance of err.instances) {
+    const url =
+      instance.urls?.[0] ??
+      (instance.port ? `http://localhost:${instance.port}` : undefined);
+    console.error(
+      `${chalk.red('error')}     ${instance.operation} (PID: ${instance.pid}${
+        url ? `, URL: ${chalk.cyan(url)}` : ''
+      })`,
+    );
+  }
+  const [first] = err.instances;
+  if (first) {
+    const killCommand =
+      process.platform === 'win32'
+        ? `taskkill /PID ${first.pid} /F`
+        : `kill ${first.pid}`;
+    console.error(
+      `${chalk.red('error')}   Reuse it, or stop it first: ${chalk.cyan(killCommand)}`,
+    );
+  }
+  if (err.code === 'EDEV_SERVER_RUNNING') {
+    console.error(
+      `${chalk.red('error')}   To intentionally run another dev server: ${chalk.cyan(
+        'modern dev --allow-multiple',
+      )}`,
+    );
+  }
 }

--- a/packages/solutions/app-tools/src/run/index.ts
+++ b/packages/solutions/app-tools/src/run/index.ts
@@ -5,6 +5,7 @@ import { chalk, minimist } from '@modern-js/utils';
 import { handleSetupResult } from '../compat/hooks';
 import {
   type DevServerLockError,
+  clearDevLockIntent,
   isDevServerLockError,
   setDevLockIntent,
 } from '../utils/devLock';
@@ -106,6 +107,7 @@ export async function createRunOptions({
 
   return {
     cwd,
+    appDirectory,
     initialLog: initialLog || `Modern.js Framework v${version}`,
     configFile: finalConfigFile,
     metaName,
@@ -115,7 +117,7 @@ export async function createRunOptions({
 }
 
 export async function run(options: RunOptions) {
-  const runOptions = await createRunOptions(options);
+  const { appDirectory, ...runOptions } = await createRunOptions(options);
   try {
     await CLIPluginRun(runOptions);
   } catch (err) {
@@ -128,6 +130,12 @@ export async function run(options: RunOptions) {
       return;
     }
     throw err;
+  } finally {
+    // The intent only belongs to this invocation. By now the dev-lock guard
+    // (which runs during CLI init, before the command action) has consumed
+    // it; hot restarts re-derive the privilege from the process's own lock
+    // file instead of this map.
+    clearDevLockIntent(appDirectory);
   }
 }
 

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -12,9 +12,13 @@ const START_TIME_TOLERANCE_MS = 5000;
 // period so we never race a writer from a different (non tmp+rename) source.
 const BAD_JSON_GRACE_MS = 5000;
 const MUTEX_WAIT_TOTAL_MS = 10_000;
+// How often a queued command re-enters the mutex to re-evaluate, and how
+// often it reminds the user it is still waiting.
+const QUEUE_POLL_MS = 1_000;
+const QUEUE_LOG_INTERVAL_MS = 10_000;
 const HEARTBEAT_INTERVAL_MS = 10_000;
 
-export type LockOperation = 'dev' | 'build' | 'deploy';
+export type LockOperation = 'dev' | 'build' | 'deploy' | 'inspect';
 export type LockMode = 'shared' | 'exclusive';
 export type LockState = 'starting' | 'ready' | 'running';
 
@@ -29,6 +33,21 @@ export interface DevLockInfo {
   host?: string;
   urls?: string[];
   appDirectory: string;
+  /**
+   * The write set of this command: the framework-generated file directory
+   * and the build output directory. Two locks conflict only when either
+   * path is shared; fully disjoint write sets run in parallel. Locks from
+   * older writers may miss these fields — the safe reading of an unknown
+   * write set is "the whole app".
+   */
+  internalDirectory?: string;
+  distDirectory?: string;
+  /**
+   * Whether the holder is a long-lived task (dev server, `build --watch`).
+   * A persistent holder can never be waited on — queuing behind it would
+   * hang forever, so a conflicting command fails fast instead.
+   */
+  persistent?: boolean;
   allowMultiple?: boolean;
   heartbeatAt?: number;
   /**
@@ -93,6 +112,12 @@ export const normalizeLockOperation = (
   }
   if (command === 'deploy') {
     return 'deploy';
+  }
+  if (command === 'inspect') {
+    // inspect empties `internalDirectory` on startup (it is in the analyze
+    // plugin's build-commands list) and dumps configs into dist — a short
+    // exclusive task.
+    return 'inspect';
   }
   return null;
 };
@@ -182,6 +207,12 @@ const mutexWaitTotalMs = () => {
   return Number.isFinite(fromEnv) && fromEnv > 0
     ? fromEnv
     : MUTEX_WAIT_TOTAL_MS;
+};
+
+// Internal override so queueing tests do not poll at one-second granularity.
+const queuePollMs = () => {
+  const fromEnv = Number(process.env.MODERN_DEV_LOCK_QUEUE_POLL_MS);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : QUEUE_POLL_MS;
 };
 
 const readMutexOwner = (mutexDir: string): MutexOwner | null => {
@@ -512,48 +543,106 @@ const collectLiveLocks = async (lockDir: string) => {
   return { others, self };
 };
 
+interface WriteSet {
+  internalDirectory?: string;
+  distDirectory?: string;
+}
+
+const writeSetsIntersect = (a: WriteSet, b: WriteSet): boolean => {
+  if (
+    !a.internalDirectory ||
+    !b.internalDirectory ||
+    !a.distDirectory ||
+    !b.distDirectory
+  ) {
+    // Unknown write set (an older writer): assume it spans the whole app.
+    return true;
+  }
+  return (
+    a.internalDirectory === b.internalDirectory ||
+    a.distDirectory === b.distDirectory
+  );
+};
+
+type ConflictDecision =
+  | { kind: 'proceed' }
+  | { kind: 'error'; error: DevServerLockError }
+  | { kind: 'wait'; holders: DevLockInfo[] };
+
+/**
+ * First step: physical conflict = write sets intersect (either directory
+ * shared). Fully disjoint commands — a per-config isolation set up through
+ * `output.tempDir` + `output.distPath` — run in parallel, whatever they are.
+ *
+ * Second step, for the conflicting ones: fail fast when the wait would be
+ * unbounded (the holder is persistent) or the intent is wrong (a second bare
+ * dev); wait when the holder is a finite build-like task.
+ */
 const decideConflict = (
   op: LockOperation,
+  mine: WriteSet,
   allowMultiple: boolean,
   others: DevLockInfo[],
-): DevServerLockError | null => {
-  const exclusive = others.filter(lock => lock.mode === 'exclusive');
-  const shared = others.filter(lock => lock.mode === 'shared');
+): ConflictDecision => {
+  const conflicting = others.filter(lock => writeSetsIntersect(mine, lock));
+  if (conflicting.length === 0) {
+    return { kind: 'proceed' };
+  }
+
+  const exclusive = conflicting.filter(lock => lock.mode === 'exclusive');
+  const shared = conflicting.filter(lock => lock.mode === 'shared');
 
   if (op === 'dev') {
     if (exclusive.length > 0) {
-      return new DevServerLockError(
-        'EDEV_BLOCKED_BY_BUILD',
-        'A build/deploy is currently writing the output of this project.',
-        exclusive.map(toInstance),
-      );
+      return {
+        kind: 'error',
+        error: new DevServerLockError(
+          'EDEV_BLOCKED_BY_BUILD',
+          'A build/deploy is currently writing the output of this project.',
+          exclusive.map(toInstance),
+        ),
+      };
     }
     if (shared.length > 0 && !allowMultiple) {
-      return new DevServerLockError(
-        'EDEV_SERVER_RUNNING',
-        'Another dev server is already running for this project.',
-        shared.map(toInstance),
-      );
+      return {
+        kind: 'error',
+        error: new DevServerLockError(
+          'EDEV_SERVER_RUNNING',
+          'Another dev server is already running for this project.',
+          shared.map(toInstance),
+        ),
+      };
     }
-    return null;
+    return { kind: 'proceed' };
   }
 
-  // build / deploy
-  if (exclusive.length > 0) {
-    return new DevServerLockError(
-      'EBUILD_IN_PROGRESS',
-      'Another build/deploy is already running for this project.',
-      exclusive.map(toInstance),
-    );
-  }
+  // build / deploy / inspect
   if (shared.length > 0) {
-    return new DevServerLockError(
-      'EBUILD_BLOCKED_BY_DEV',
-      'A dev server is running for this project; stop it before building.',
-      shared.map(toInstance),
-    );
+    return {
+      kind: 'error',
+      error: new DevServerLockError(
+        'EBUILD_BLOCKED_BY_DEV',
+        'A dev server is running for this project; stop it before building.',
+        shared.map(toInstance),
+      ),
+    };
   }
-  return null;
+  const persistentHolders = exclusive.filter(lock => lock.persistent === true);
+  if (persistentHolders.length > 0) {
+    return {
+      kind: 'error',
+      error: new DevServerLockError(
+        'EBUILD_IN_PROGRESS',
+        'A watch build is running for this project; stop it before building.',
+        persistentHolders.map(toInstance),
+      ),
+    };
+  }
+  if (exclusive.length > 0) {
+    // Finite build-like holders: queue behind them instead of failing.
+    return { kind: 'wait', holders: exclusive };
+  }
+  return { kind: 'proceed' };
 };
 
 // ---- per-process session (heartbeat + exit cleanup, hot-restart safe) ----
@@ -630,6 +719,11 @@ export interface AcquireOptions {
   metaName: string;
   operation: LockOperation;
   allowMultiple?: boolean;
+  /** `build --watch`: marks the lock persistent so nobody queues behind it. */
+  watch?: boolean;
+  /** Write set of this command; missing values fall back to app defaults. */
+  internalDirectory?: string;
+  distDirectory?: string;
 }
 
 /**
@@ -642,6 +736,9 @@ export const acquireCommandLock = async ({
   metaName,
   operation,
   allowMultiple = false,
+  watch = false,
+  internalDirectory,
+  distDirectory,
 }: AcquireOptions): Promise<void> => {
   const lockDir = getLockDirectory(appDirectory, metaName);
   fs.mkdirSync(lockDir, { recursive: true });
@@ -657,40 +754,118 @@ export const acquireCommandLock = async ({
   }
   installExitHook();
 
-  const token = await acquireMutex(lockDir);
-  try {
-    const { others, self } = await collectLiveLocks(lockDir);
+  // Fall back to the app defaults so programmatic callers that do not pass
+  // the write set still participate with the standard directories.
+  const mine: Required<WriteSet> = {
+    internalDirectory:
+      internalDirectory ??
+      path.join(appDirectory, 'node_modules', `.${metaName}`),
+    distDirectory: distDirectory ?? path.join(appDirectory, 'dist'),
+  };
+  const persistent = operation === 'dev' || (operation === 'build' && watch);
 
-    // A hot restart re-enters without the original CLI/run intent; the
-    // privilege granted at the first acquire is persisted in our own lock
-    // file, so a multi-instance dev survives config restarts.
-    const effectiveAllowMultiple =
-      allowMultiple ||
-      (self?.operation === 'dev' && self.allowMultiple === true);
+  let waitedSince: number | undefined;
+  let lastWaitLog = 0;
 
-    const conflict = decideConflict(operation, effectiveAllowMultiple, others);
-    if (conflict) {
-      throw conflict;
+  // Queue loop. Every round fully re-enters the mutex, re-cleans stale locks
+  // and re-evaluates from scratch — never "the lock is gone, write directly".
+  // The mutex is released before sleeping, so waiting holds nothing, and a
+  // persistent task that jumps in during a wait flips the next round into a
+  // fail-fast error. No in-framework deadline: a fixed timeout would kill
+  // slow-but-legitimate builds; CI's overall timeout is the final backstop.
+  for (;;) {
+    const token = await acquireMutex(lockDir);
+    let decision!: ConflictDecision;
+    try {
+      const { others, self } = await collectLiveLocks(lockDir);
+
+      // A hot restart re-enters without the original CLI/run intent; the
+      // privilege granted at the first acquire is persisted in our own lock
+      // file, so a multi-instance dev survives config restarts.
+      const effectiveAllowMultiple =
+        allowMultiple ||
+        (self?.operation === 'dev' && self.allowMultiple === true);
+
+      decision = decideConflict(
+        operation,
+        mine,
+        effectiveAllowMultiple,
+        others,
+      );
+
+      if (decision.kind === 'error') {
+        throw decision.error;
+      }
+      if (decision.kind === 'proceed') {
+        const mode: LockMode = operation === 'dev' ? 'shared' : 'exclusive';
+        const state: LockState = operation === 'dev' ? 'starting' : 'running';
+        writeLockFile(session, {
+          // Hot restart in the same process: reuse (rewrite) our existing file.
+          ...(self ?? {}),
+          schemaVersion: LOCK_SCHEMA_VERSION,
+          operation,
+          mode,
+          state,
+          persistent,
+          pid: process.pid,
+          processStartedAt: selfStartedAt(),
+          appDirectory,
+          internalDirectory: mine.internalDirectory,
+          distDirectory: mine.distDirectory,
+          allowMultiple:
+            operation === 'dev' ? effectiveAllowMultiple : undefined,
+          heartbeatAt: Date.now(),
+        });
+        startHeartbeat(session);
+        return;
+      }
+    } finally {
+      releaseMutex(lockDir, token);
     }
 
-    const mode: LockMode = operation === 'dev' ? 'shared' : 'exclusive';
-    const state: LockState = operation === 'dev' ? 'starting' : 'running';
+    if (decision.kind !== 'wait') {
+      continue;
+    }
+    const holder = decision.holders[0];
+    const now = Date.now();
+    if (waitedSince === undefined) {
+      waitedSince = now;
+      lastWaitLog = now;
+      logger.info(
+        `[dev-lock] waiting for ${holder.operation} (PID ${holder.pid}) to finish before starting ${operation}...`,
+      );
+    } else if (now - lastWaitLog >= QUEUE_LOG_INTERVAL_MS) {
+      lastWaitLog = now;
+      logger.info(
+        `[dev-lock] still waiting for ${holder.operation} (PID ${holder.pid}) after ${Math.round((now - waitedSince) / 1000)}s...`,
+      );
+    }
+    await sleep(queuePollMs());
+  }
+};
+
+/**
+ * Upgrade the current lock to persistent. `build --watch` learns about the
+ * watch flag in the command action (after the lock was taken in `onPrepare`),
+ * and a watcher that keeps writing output must never be queued behind.
+ */
+export const markLockPersistent = (
+  appDirectory: string,
+  metaName: string,
+): void => {
+  const session = sessions.get(sessionKey(appDirectory, metaName));
+  if (!session?.current || session.current.persistent) {
+    return;
+  }
+  try {
     writeLockFile(session, {
-      // Hot restart in the same process: reuse (rewrite) our existing file.
-      ...(self ?? {}),
-      schemaVersion: LOCK_SCHEMA_VERSION,
-      operation,
-      mode,
-      state,
-      pid: process.pid,
-      processStartedAt: selfStartedAt(),
-      appDirectory,
-      allowMultiple: operation === 'dev' ? effectiveAllowMultiple : undefined,
+      ...session.current,
+      persistent: true,
       heartbeatAt: Date.now(),
     });
-    startHeartbeat(session);
-  } finally {
-    releaseMutex(lockDir, token);
+  } catch {
+    // Losing the upgrade only risks a waiter queuing behind a watcher; the
+    // periodic waiting log keeps that observable.
   }
 };
 

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -33,6 +33,12 @@ export interface DevLockInfo {
   appDirectory: string;
   allowMultiple?: boolean;
   heartbeatAt?: number;
+  /**
+   * Runtime-only (never written to disk): whether the holder's identity was
+   * verified via its real process start time. When false, kill suggestions
+   * must be softened — the pid could belong to an unrelated process.
+   */
+  identityVerified?: boolean;
 }
 
 export type DevLockErrorCode =
@@ -51,6 +57,8 @@ export interface DevLockInstance {
   urls?: string[];
   startedAt: number;
   appDirectory: string;
+  /** Whether the pid's real start time confirmed the holder's identity. */
+  identityVerified: boolean;
 }
 
 export class DevServerLockError extends Error {
@@ -295,6 +303,9 @@ export const acquireRegistryMutex = async (
   cleanMutexDebris(lockDir);
 
   for (;;) {
+    // Preparing the candidate only touches paths we own — any failure here
+    // (read-only cache dir, ENOSPC, …) is a real IO error and must surface
+    // immediately instead of degenerating into a busy retry loop.
     try {
       fs.mkdirSync(candidate, { recursive: true });
       const owner: MutexOwner = {
@@ -304,13 +315,20 @@ export const acquireRegistryMutex = async (
         acquiredAt: Date.now(),
       };
       atomicWrite(path.join(candidate, 'owner.json'), JSON.stringify(owner));
+    } catch (err) {
+      fs.rmSync(candidate, { recursive: true, force: true });
+      throw err;
+    }
+
+    try {
       fs.renameSync(candidate, mutexDir);
       return token;
     } catch (err) {
       fs.rmSync(candidate, { recursive: true, force: true });
       const code = (err as NodeJS.ErrnoException).code;
-      // Occupied target reads differently per platform; anything else is a
-      // real IO error and must surface.
+      // An occupied rename target reads differently per platform
+      // (EEXIST/ENOTEMPTY on POSIX, EPERM/EACCES on Windows); anything else
+      // is a real IO error and must surface.
       if (
         code !== 'EEXIST' &&
         code !== 'ENOTEMPTY' &&
@@ -334,6 +352,8 @@ export const acquireRegistryMutex = async (
       // A published mutex always contains owner.json, so a missing or
       // unreadable one can only come from manual damage or an old layout.
       // Grace it briefly, then take it over via a deterministic tombstone.
+      // A vanished mutex (stat failure) falls through to the normal
+      // deadline/backoff path — never into a hot spin.
       try {
         const mtime = fs.statSync(mutexDir).mtimeMs;
         if (Date.now() - mtime > BAD_JSON_GRACE_MS) {
@@ -347,8 +367,7 @@ export const acquireRegistryMutex = async (
           continue;
         }
       } catch {
-        // The mutex vanished between rename failure and stat: retry now.
-        continue;
+        // fall through to deadline check + backoff
       }
     }
 
@@ -385,6 +404,7 @@ const toInstance = (lock: DevLockInfo): DevLockInstance => ({
   urls: lock.urls,
   startedAt: lock.processStartedAt,
   appDirectory: lock.appDirectory,
+  identityVerified: lock.identityVerified === true,
 });
 
 /**
@@ -444,11 +464,35 @@ const collectLiveLocks = async (lockDir: string) => {
       continue;
     }
 
-    if (!identityMatches(lock.pid, lock.processStartedAt)) {
+    if (!isProcessAlive(lock.pid)) {
       logger.debug(`[dev-lock] removing stale lock ${filePath}`);
       fs.rmSync(filePath, { force: true });
       continue;
     }
+
+    const actualStartTime = getProcessStartTime(lock.pid);
+    if (actualStartTime !== null) {
+      if (
+        Math.abs(actualStartTime - lock.processStartedAt) >
+        START_TIME_TOLERANCE_MS
+      ) {
+        // The pid was reused by an unrelated process.
+        logger.debug(`[dev-lock] removing pid-reused lock ${filePath}`);
+        fs.rmSync(filePath, { force: true });
+        continue;
+      }
+      // Identity-verified alive: never delete on a failed port probe. During
+      // a config hot restart the server is closed before CLI init re-runs,
+      // so for a short window a live dev has no listening port — deleting
+      // its lock here would let a concurrent build wipe its output.
+      lock.identityVerified = true;
+      others.push(lock);
+      continue;
+    }
+
+    // No start-time source on this platform: the port probe is the only
+    // remaining signal to tell a lingering lock from a live server.
+    lock.identityVerified = false;
     if (
       lock.operation === 'dev' &&
       lock.state === 'ready' &&

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -172,6 +172,9 @@ interface MutexOwner {
 const MUTEX_DIR_NAME = '.mutex';
 const TOMBSTONE_PREFIX = '.stale-';
 const CANDIDATE_PREFIX = '.mutex-candidate-';
+// A mutex detached by its owner on release. Unlike a tombstone it no longer
+// occupies a name any waiter can rename onto, so it is always safe to sweep.
+const RELEASE_PREFIX = '.mutex-release-';
 
 // Internal override so tests do not have to wait the full deadline.
 const mutexWaitTotalMs = () => {
@@ -219,6 +222,12 @@ const cleanMutexDebris = (lockDir: string): void => {
     return;
   }
   for (const entry of entries) {
+    if (entry.startsWith(RELEASE_PREFIX)) {
+      // Detached by a releaser that died before deleting it. Nothing can
+      // reach it any more, so it is unconditionally collectible.
+      fs.rmSync(path.join(lockDir, entry), { recursive: true, force: true });
+      continue;
+    }
     if (!entry.startsWith(CANDIDATE_PREFIX)) {
       continue;
     }
@@ -363,11 +372,35 @@ export const acquireRegistryMutex = async (
 export const releaseRegistryMutex = (lockDir: string, token: string): void => {
   const mutexDir = path.join(lockDir, MUTEX_DIR_NAME);
   const owner = readMutexOwner(mutexDir);
-  if (owner && owner.token !== token) {
-    // The mutex changed hands (we were declared dead); never delete it.
+  if (!owner || owner.token !== token) {
+    // Either the mutex changed hands (we were declared dead) or it is being
+    // handed over right now, so its owner is momentarily unreadable. Neither
+    // is ours to delete.
     return;
   }
-  fs.rmSync(mutexDir, { recursive: true, force: true });
+
+  // Detach under our own name before deleting. A recursive delete of the
+  // shared path removes `owner.json` first and only then the directory, and
+  // a waiter may rename its complete candidate onto that momentarily empty
+  // directory — the trailing rmdir would fail with ENOTEMPTY and take files
+  // from the new owner with it. A rename is atomic: either we move the whole
+  // directory out of the shared name, or we never touch it.
+  const detached = path.join(lockDir, `${RELEASE_PREFIX}${token}`);
+  try {
+    fs.renameSync(mutexDir, detached);
+  } catch {
+    // Taken over or already gone between the read and the rename; whatever
+    // occupies the shared name now belongs to someone else.
+    return;
+  }
+
+  try {
+    fs.rmSync(detached, { recursive: true, force: true });
+  } catch {
+    // The mutex is already released — the shared name is free. Failing to
+    // delete the detached copy must not surface as an error from the command
+    // that was holding it; `cleanMutexDebris` collects it on the next acquire.
+  }
 };
 
 const acquireMutex = acquireRegistryMutex;

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -1,0 +1,571 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import net from 'net';
+import path from 'path';
+import { logger } from '@modern-js/utils';
+
+export const LOCK_SCHEMA_VERSION = 1;
+
+// Identity tolerance: process start time read back from the OS and the value
+// recorded in the lock never match exactly (tick rounding, ps formatting).
+const START_TIME_TOLERANCE_MS = 5000;
+// A lock whose content is not valid JSON is corrupted, but give a short grace
+// period so we never race a writer from a different (non tmp+rename) source.
+const BAD_JSON_GRACE_MS = 5000;
+const TCP_PROBE_TIMEOUT_MS = 300;
+const MUTEX_WAIT_TOTAL_MS = 10_000;
+const HEARTBEAT_INTERVAL_MS = 10_000;
+
+export type LockOperation = 'dev' | 'build' | 'deploy';
+export type LockMode = 'shared' | 'exclusive';
+export type LockState = 'starting' | 'ready' | 'running';
+
+export interface DevLockInfo {
+  schemaVersion: number;
+  operation: LockOperation;
+  mode: LockMode;
+  state: LockState;
+  pid: number;
+  processStartedAt: number;
+  port?: number;
+  host?: string;
+  urls?: string[];
+  appDirectory: string;
+  heartbeatAt?: number;
+}
+
+export type DevLockErrorCode =
+  | 'EDEV_SERVER_RUNNING'
+  | 'EDEV_BLOCKED_BY_BUILD'
+  | 'EBUILD_BLOCKED_BY_DEV'
+  | 'EBUILD_IN_PROGRESS'
+  | 'EUNSUPPORTED_LEASE'
+  | 'EDEVLOCK_BUSY';
+
+export interface DevLockInstance {
+  pid: number;
+  operation: LockOperation;
+  mode: LockMode;
+  port?: number;
+  urls?: string[];
+  startedAt: number;
+  appDirectory: string;
+}
+
+export class DevServerLockError extends Error {
+  code: DevLockErrorCode;
+  instances: DevLockInstance[];
+
+  constructor(
+    code: DevLockErrorCode,
+    message: string,
+    instances: DevLockInstance[] = [],
+  ) {
+    super(message);
+    this.name = 'DevServerLockError';
+    this.code = code;
+    this.instances = instances;
+  }
+}
+
+export const isDevServerLockError = (err: unknown): err is DevServerLockError =>
+  err instanceof Error && err.name === 'DevServerLockError';
+
+export const getLockDirectory = (appDirectory: string, metaName: string) =>
+  path.join(appDirectory, 'node_modules', '.cache', metaName, 'locks', 'v1');
+
+/** dev|start share the dev semantics; anything else does not take a lock. */
+export const normalizeLockOperation = (
+  command: string | undefined,
+): LockOperation | null => {
+  if (command === 'dev' || command === 'start' || command === 'dev-worker') {
+    return 'dev';
+  }
+  if (command === 'build') {
+    return 'build';
+  }
+  if (command === 'deploy') {
+    return 'deploy';
+  }
+  return null;
+};
+
+const selfStartedAt = () => Date.now() - process.uptime() * 1000;
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but belongs to someone else.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+};
+
+/**
+ * Best-effort process start time for PID-reuse detection. Returns null when
+ * the platform offers no cheap way to read it (Windows), in which case the
+ * caller falls back to liveness + port probing only.
+ */
+const getProcessStartTime = (pid: number): number | null => {
+  try {
+    if (process.platform === 'linux') {
+      // /proc/<pid> is created when the process starts.
+      return fs.statSync(`/proc/${pid}`).ctimeMs;
+    }
+    if (process.platform === 'darwin') {
+      const out = execSync(`ps -o lstart= -p ${pid}`, {
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+        .toString()
+        .trim();
+      if (out) {
+        const parsed = Date.parse(out);
+        return Number.isNaN(parsed) ? null : parsed;
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+};
+
+const identityMatches = (pid: number, recordedStartedAt: number): boolean => {
+  if (!isProcessAlive(pid)) {
+    return false;
+  }
+  const actual = getProcessStartTime(pid);
+  if (actual === null) {
+    // No start-time source on this platform: liveness is all we have.
+    return true;
+  }
+  return Math.abs(actual - recordedStartedAt) <= START_TIME_TOLERANCE_MS;
+};
+
+const probePort = (port: number, host?: string): Promise<boolean> => {
+  // Probe the loopback matching the wildcard family, otherwise the real host.
+  const target =
+    !host || host === '0.0.0.0'
+      ? '127.0.0.1'
+      : host === '::' || host === '[::]'
+        ? '::1'
+        : host;
+  return new Promise(resolve => {
+    const socket = net.connect({ port, host: target });
+    const done = (result: boolean) => {
+      socket.destroy();
+      resolve(result);
+    };
+    socket.setTimeout(TCP_PROBE_TIMEOUT_MS);
+    socket.once('connect', () => done(true));
+    socket.once('timeout', () => done(false));
+    socket.once('error', () => done(false));
+  });
+};
+
+const atomicWrite = (filePath: string, data: string) => {
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, filePath);
+};
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+interface MutexOwner {
+  pid: number;
+  processStartedAt: number;
+  token: string;
+  acquiredAt: number;
+}
+
+/**
+ * Cross-process critical section: every process contends on the same
+ * `.mutex` directory (mkdir is atomic). The only condition that allows
+ * breaking someone else's mutex is proof that its owner is dead — a live
+ * owner is waited on and, past the deadline, reported as busy, never broken.
+ */
+const acquireMutex = async (lockDir: string): Promise<string> => {
+  const mutexDir = path.join(lockDir, '.mutex');
+  const ownerFile = path.join(mutexDir, 'owner.json');
+  const token = `${process.pid}-${Math.random().toString(36).slice(2)}`;
+  const deadline = Date.now() + MUTEX_WAIT_TOTAL_MS;
+  let delay = 50;
+
+  for (;;) {
+    try {
+      fs.mkdirSync(mutexDir);
+      const owner: MutexOwner = {
+        pid: process.pid,
+        processStartedAt: selfStartedAt(),
+        token,
+        acquiredAt: Date.now(),
+      };
+      atomicWrite(ownerFile, JSON.stringify(owner));
+      return token;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw err;
+      }
+    }
+
+    let owner: MutexOwner | undefined;
+    try {
+      owner = JSON.parse(fs.readFileSync(ownerFile, 'utf-8'));
+    } catch {
+      // owner.json not written yet or unreadable — treat as held.
+    }
+    if (owner && !identityMatches(owner.pid, owner.processStartedAt)) {
+      // Owner is provably dead: clear the leftover mutex and retry now.
+      fs.rmSync(mutexDir, { recursive: true, force: true });
+      continue;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new DevServerLockError(
+        'EDEVLOCK_BUSY',
+        'Another Modern.js process is checking this project, please retry shortly.',
+      );
+    }
+    await sleep(delay);
+    delay = Math.min(delay * 1.5, 500);
+  }
+};
+
+const releaseMutex = (lockDir: string, token: string) => {
+  const mutexDir = path.join(lockDir, '.mutex');
+  try {
+    const owner: MutexOwner = JSON.parse(
+      fs.readFileSync(path.join(mutexDir, 'owner.json'), 'utf-8'),
+    );
+    if (owner.token !== token) {
+      // The mutex changed hands (we were declared dead); never delete it.
+      return;
+    }
+  } catch {
+    // Missing/unreadable owner: fall through and best-effort remove.
+  }
+  fs.rmSync(mutexDir, { recursive: true, force: true });
+};
+
+const toInstance = (lock: DevLockInfo): DevLockInstance => ({
+  pid: lock.pid,
+  operation: lock.operation,
+  mode: lock.mode,
+  port: lock.port,
+  urls: lock.urls,
+  startedAt: lock.processStartedAt,
+  appDirectory: lock.appDirectory,
+});
+
+/**
+ * Enumerate lock files, delete stale ones, and return the live locks held by
+ * other processes plus (when present) our own lock for hot-restart reuse.
+ */
+const collectLiveLocks = async (lockDir: string) => {
+  const others: DevLockInfo[] = [];
+  let self: DevLockInfo | undefined;
+
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(lockDir);
+  } catch {
+    return { others, self };
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.lock')) {
+      continue;
+    }
+    const filePath = path.join(lockDir, entry);
+
+    let lock: DevLockInfo;
+    try {
+      lock = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    } catch {
+      try {
+        if (Date.now() - fs.statSync(filePath).mtimeMs > BAD_JSON_GRACE_MS) {
+          fs.rmSync(filePath, { force: true });
+        }
+      } catch {
+        // already gone
+      }
+      continue;
+    }
+
+    if (typeof lock.schemaVersion !== 'number' || !lock.pid) {
+      fs.rmSync(filePath, { force: true });
+      continue;
+    }
+    if (lock.schemaVersion > LOCK_SCHEMA_VERSION) {
+      // Written by a newer CLI: never delete what we cannot understand.
+      throw new DevServerLockError(
+        'EUNSUPPORTED_LEASE',
+        `Found a lock file written by a newer version of the CLI (${filePath}). Upgrade this CLI, or remove the file manually if you are sure no other process is running.`,
+        [toInstance(lock)],
+      );
+    }
+
+    if (
+      lock.pid === process.pid &&
+      Math.abs(lock.processStartedAt - selfStartedAt()) <=
+        START_TIME_TOLERANCE_MS
+    ) {
+      self = lock;
+      continue;
+    }
+
+    if (!identityMatches(lock.pid, lock.processStartedAt)) {
+      logger.debug(`[dev-lock] removing stale lock ${filePath}`);
+      fs.rmSync(filePath, { force: true });
+      continue;
+    }
+    if (
+      lock.operation === 'dev' &&
+      lock.state === 'ready' &&
+      typeof lock.port === 'number' &&
+      !(await probePort(lock.port, lock.host))
+    ) {
+      logger.debug(`[dev-lock] removing dead-server lock ${filePath}`);
+      fs.rmSync(filePath, { force: true });
+      continue;
+    }
+
+    others.push(lock);
+  }
+
+  return { others, self };
+};
+
+const decideConflict = (
+  op: LockOperation,
+  allowMultiple: boolean,
+  others: DevLockInfo[],
+): DevServerLockError | null => {
+  const exclusive = others.filter(lock => lock.mode === 'exclusive');
+  const shared = others.filter(lock => lock.mode === 'shared');
+
+  if (op === 'dev') {
+    if (exclusive.length > 0) {
+      return new DevServerLockError(
+        'EDEV_BLOCKED_BY_BUILD',
+        'A build/deploy is currently writing the output of this project.',
+        exclusive.map(toInstance),
+      );
+    }
+    if (shared.length > 0 && !allowMultiple) {
+      return new DevServerLockError(
+        'EDEV_SERVER_RUNNING',
+        'Another dev server is already running for this project.',
+        shared.map(toInstance),
+      );
+    }
+    return null;
+  }
+
+  // build / deploy
+  if (exclusive.length > 0) {
+    return new DevServerLockError(
+      'EBUILD_IN_PROGRESS',
+      'Another build/deploy is already running for this project.',
+      exclusive.map(toInstance),
+    );
+  }
+  if (shared.length > 0) {
+    return new DevServerLockError(
+      'EBUILD_BLOCKED_BY_DEV',
+      'A dev server is running for this project; stop it before building.',
+      shared.map(toInstance),
+    );
+  }
+  return null;
+};
+
+// ---- per-process session (heartbeat + exit cleanup, hot-restart safe) ----
+
+interface DevLockSession {
+  lockDir: string;
+  lockFile: string;
+  current?: DevLockInfo;
+  heartbeat?: ReturnType<typeof setInterval>;
+}
+
+const sessions = new Map<string, DevLockSession>();
+let exitHookInstalled = false;
+
+const sessionKey = (appDirectory: string, metaName: string) =>
+  `${appDirectory} ${metaName}`;
+
+const writeLockFile = (session: DevLockSession, lock: DevLockInfo) => {
+  session.current = lock;
+  atomicWrite(session.lockFile, JSON.stringify(lock, null, 2));
+};
+
+const removeOwnLock = (session: DevLockSession) => {
+  stopHeartbeat(session);
+  session.current = undefined;
+  try {
+    // Only ever delete our own <pid>.lock; identity re-check is implicit in
+    // the filename (pid) plus the fact that we wrote it in this process.
+    fs.rmSync(session.lockFile, { force: true });
+  } catch {
+    // best-effort
+  }
+};
+
+const stopHeartbeat = (session: DevLockSession) => {
+  if (session.heartbeat) {
+    clearInterval(session.heartbeat);
+    session.heartbeat = undefined;
+  }
+};
+
+const startHeartbeat = (session: DevLockSession) => {
+  stopHeartbeat(session);
+  session.heartbeat = setInterval(() => {
+    if (session.current) {
+      try {
+        writeLockFile(session, {
+          ...session.current,
+          heartbeatAt: Date.now(),
+        });
+      } catch {
+        // best-effort
+      }
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+  // Never keep the process alive just for the heartbeat.
+  session.heartbeat.unref?.();
+};
+
+const installExitHook = () => {
+  if (exitHookInstalled) {
+    return;
+  }
+  exitHookInstalled = true;
+  process.on('exit', () => {
+    for (const session of sessions.values()) {
+      removeOwnLock(session);
+    }
+  });
+};
+
+export interface AcquireOptions {
+  appDirectory: string;
+  metaName: string;
+  operation: LockOperation;
+  allowMultiple?: boolean;
+}
+
+/**
+ * Check existing locks and register our own, atomically (inside the registry
+ * mutex). Throws DevServerLockError on conflict. Re-entry from the same
+ * process (config hot restart) reuses the existing lock file.
+ */
+export const acquireCommandLock = async ({
+  appDirectory,
+  metaName,
+  operation,
+  allowMultiple = false,
+}: AcquireOptions): Promise<void> => {
+  const lockDir = getLockDirectory(appDirectory, metaName);
+  fs.mkdirSync(lockDir, { recursive: true });
+
+  const key = sessionKey(appDirectory, metaName);
+  let session = sessions.get(key);
+  if (!session) {
+    session = {
+      lockDir,
+      lockFile: path.join(lockDir, `${process.pid}.lock`),
+    };
+    sessions.set(key, session);
+  }
+  installExitHook();
+
+  const token = await acquireMutex(lockDir);
+  try {
+    const { others, self } = await collectLiveLocks(lockDir);
+
+    const conflict = decideConflict(operation, allowMultiple, others);
+    if (conflict) {
+      throw conflict;
+    }
+
+    const mode: LockMode = operation === 'dev' ? 'shared' : 'exclusive';
+    const state: LockState = operation === 'dev' ? 'starting' : 'running';
+    writeLockFile(session, {
+      // Hot restart in the same process: reuse (rewrite) our existing file.
+      ...(self ?? {}),
+      schemaVersion: LOCK_SCHEMA_VERSION,
+      operation,
+      mode,
+      state,
+      pid: process.pid,
+      processStartedAt: selfStartedAt(),
+      appDirectory,
+      heartbeatAt: Date.now(),
+    });
+    startHeartbeat(session);
+  } finally {
+    releaseMutex(lockDir, token);
+  }
+};
+
+/** dev only: fill in the real port/urls once `server.listen` succeeded. */
+export const markDevLockReady = (
+  appDirectory: string,
+  metaName: string,
+  info: { port?: number; host?: string; urls?: string[] },
+): void => {
+  const session = sessions.get(sessionKey(appDirectory, metaName));
+  if (!session?.current) {
+    return;
+  }
+  try {
+    writeLockFile(session, {
+      ...session.current,
+      state: 'ready',
+      port: info.port,
+      host: info.host,
+      urls: info.urls,
+      heartbeatAt: Date.now(),
+    });
+  } catch (err) {
+    // Losing the update downgrades protection but must not break dev itself.
+    logger.warn(
+      `[dev-lock] failed to update lock file, duplicate-instance protection is degraded: ${err}`,
+    );
+  }
+};
+
+/** Release the lock this process holds for the given operation, if any. */
+export const releaseCommandLock = (
+  appDirectory: string,
+  metaName: string,
+  operation?: LockOperation,
+): void => {
+  const session = sessions.get(sessionKey(appDirectory, metaName));
+  if (!session) {
+    return;
+  }
+  if (operation && session.current && session.current.operation !== operation) {
+    return;
+  }
+  removeOwnLock(session);
+};
+
+/** Hot restart: keep the lock file, only dispose process-local resources. */
+export const suspendForRestart = (
+  appDirectory: string,
+  metaName: string,
+): void => {
+  const session = sessions.get(sessionKey(appDirectory, metaName));
+  if (session) {
+    stopHeartbeat(session);
+  }
+};
+
+export const releaseAllLocks = (): void => {
+  for (const session of sessions.values()) {
+    removeOwnLock(session);
+  }
+};

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
-import net from 'net';
 import path from 'path';
 import { logger } from '@modern-js/utils';
 
@@ -12,7 +11,6 @@ const START_TIME_TOLERANCE_MS = 5000;
 // A lock whose content is not valid JSON is corrupted, but give a short grace
 // period so we never race a writer from a different (non tmp+rename) source.
 const BAD_JSON_GRACE_MS = 5000;
-const TCP_PROBE_TIMEOUT_MS = 300;
 const MUTEX_WAIT_TOTAL_MS = 10_000;
 const HEARTBEAT_INTERVAL_MS = 10_000;
 
@@ -118,8 +116,8 @@ const isProcessAlive = (pid: number): boolean => {
 
 /**
  * Best-effort process start time for PID-reuse detection. Returns null when
- * the platform offers no cheap way to read it (Windows), in which case the
- * caller falls back to liveness + port probing only.
+ * the platform offers no cheap way to read it (Windows), in which case
+ * liveness alone decides and stale-lock handling stays fail-safe.
  */
 const getProcessStartTime = (pid: number): number | null => {
   try {
@@ -154,27 +152,6 @@ const identityMatches = (pid: number, recordedStartedAt: number): boolean => {
     return true;
   }
   return Math.abs(actual - recordedStartedAt) <= START_TIME_TOLERANCE_MS;
-};
-
-const probePort = (port: number, host?: string): Promise<boolean> => {
-  // Probe the loopback matching the wildcard family, otherwise the real host.
-  const target =
-    !host || host === '0.0.0.0'
-      ? '127.0.0.1'
-      : host === '::' || host === '[::]'
-        ? '::1'
-        : host;
-  return new Promise(resolve => {
-    const socket = net.connect({ port, host: target });
-    const done = (result: boolean) => {
-      socket.destroy();
-      resolve(result);
-    };
-    socket.setTimeout(TCP_PROBE_TIMEOUT_MS);
-    socket.once('connect', () => done(true));
-    socket.once('timeout', () => done(false));
-    socket.once('error', () => done(false));
-  });
 };
 
 const atomicWrite = (filePath: string, data: string) => {
@@ -471,39 +448,26 @@ const collectLiveLocks = async (lockDir: string) => {
     }
 
     const actualStartTime = getProcessStartTime(lock.pid);
-    if (actualStartTime !== null) {
-      if (
-        Math.abs(actualStartTime - lock.processStartedAt) >
-        START_TIME_TOLERANCE_MS
-      ) {
-        // The pid was reused by an unrelated process.
-        logger.debug(`[dev-lock] removing pid-reused lock ${filePath}`);
-        fs.rmSync(filePath, { force: true });
-        continue;
-      }
-      // Identity-verified alive: never delete on a failed port probe. During
-      // a config hot restart the server is closed before CLI init re-runs,
-      // so for a short window a live dev has no listening port — deleting
-      // its lock here would let a concurrent build wipe its output.
-      lock.identityVerified = true;
-      others.push(lock);
-      continue;
-    }
-
-    // No start-time source on this platform: the port probe is the only
-    // remaining signal to tell a lingering lock from a live server.
-    lock.identityVerified = false;
     if (
-      lock.operation === 'dev' &&
-      lock.state === 'ready' &&
-      typeof lock.port === 'number' &&
-      !(await probePort(lock.port, lock.host))
+      actualStartTime !== null &&
+      Math.abs(actualStartTime - lock.processStartedAt) >
+        START_TIME_TOLERANCE_MS
     ) {
-      logger.debug(`[dev-lock] removing dead-server lock ${filePath}`);
+      // The pid was reused by an unrelated process.
+      logger.debug(`[dev-lock] removing pid-reused lock ${filePath}`);
       fs.rmSync(filePath, { force: true });
       continue;
     }
 
+    // A lock whose pid is alive is kept on every platform — fail-safe.
+    // During a config hot restart the server closes before CLI init
+    // re-runs, so for a short window a live dev has no listening port;
+    // any port-based "is it really serving" heuristic would delete the
+    // lock in exactly that window and let a concurrent build wipe the
+    // dev's output. Where no start-time source exists (Windows) this can
+    // keep a pid-reused lock around until a human checks — a conservative
+    // block, never a false green light.
+    lock.identityVerified = actualStartTime !== null;
     others.push(lock);
   }
 

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -224,8 +224,13 @@ const cleanMutexDebris = (lockDir: string): void => {
   for (const entry of entries) {
     if (entry.startsWith(RELEASE_PREFIX)) {
       // Detached by a releaser that died before deleting it. Nothing can
-      // reach it any more, so it is unconditionally collectible.
-      fs.rmSync(path.join(lockDir, entry), { recursive: true, force: true });
+      // reach it any more, so it is unconditionally collectible — and a
+      // failed sweep must never abort the acquisition that triggered it.
+      try {
+        fs.rmSync(path.join(lockDir, entry), { recursive: true, force: true });
+      } catch {
+        // Left for the next sweep.
+      }
       continue;
     }
     if (!entry.startsWith(CANDIDATE_PREFIX)) {

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -31,6 +31,7 @@ export interface DevLockInfo {
   host?: string;
   urls?: string[];
   appDirectory: string;
+  allowMultiple?: boolean;
   heartbeatAt?: number;
 }
 
@@ -186,7 +187,6 @@ interface MutexOwner {
 const MUTEX_DIR_NAME = '.mutex';
 const TOMBSTONE_PREFIX = '.stale-';
 const CANDIDATE_PREFIX = '.mutex-candidate-';
-const TOMBSTONE_GC_MS = 60_000;
 
 // Internal override so tests do not have to wait the full deadline.
 const mutexWaitTotalMs = () => {
@@ -217,7 +217,15 @@ const renameQuietly = (from: string, to: string): void => {
   }
 };
 
-/** Sweep inert debris: aged tombstones and candidates of dead processes. */
+/**
+ * Sweep candidate directories left behind by dead processes.
+ *
+ * Token tombstones (`.stale-<token>`) are deliberately never collected: a
+ * waiter suspended for an arbitrary time may still hold a pre-suspension
+ * read of a long-dead owner, and the tombstone occupying that exact target
+ * name is the only thing preventing it from renaming the *current* holder's
+ * mutex away. They are tiny and only ever created by abnormal takeovers.
+ */
 const cleanMutexDebris = (lockDir: string): void => {
   let entries: string[] = [];
   try {
@@ -226,19 +234,32 @@ const cleanMutexDebris = (lockDir: string): void => {
     return;
   }
   for (const entry of entries) {
+    if (!entry.startsWith(CANDIDATE_PREFIX)) {
+      continue;
+    }
     const full = path.join(lockDir, entry);
     try {
-      if (entry.startsWith(TOMBSTONE_PREFIX)) {
-        // A tombstone only needs to outlive in-flight waiters of the round
-        // that created it (bounded by the mutex wait deadline).
-        if (Date.now() - fs.statSync(full).mtimeMs > TOMBSTONE_GC_MS) {
+      const owner = readMutexOwner(full);
+      if (owner) {
+        if (!identityMatches(owner.pid, owner.processStartedAt)) {
           fs.rmSync(full, { recursive: true, force: true });
         }
-      } else if (entry.startsWith(CANDIDATE_PREFIX)) {
-        const owner = readMutexOwner(full);
-        if (!owner || !identityMatches(owner.pid, owner.processStartedAt)) {
+        continue;
+      }
+      // No owner.json yet: the creator may be alive between mkdir and the
+      // owner write. The candidate name embeds its creator's pid — only
+      // remove once that process is provably gone (or, for unparsable
+      // names, after a generous grace period).
+      const pidFromName = Number.parseInt(
+        entry.slice(CANDIDATE_PREFIX.length),
+        10,
+      );
+      if (Number.isInteger(pidFromName) && pidFromName > 0) {
+        if (!isProcessAlive(pidFromName)) {
           fs.rmSync(full, { recursive: true, force: true });
         }
+      } else if (Date.now() - fs.statSync(full).mtimeMs > BAD_JSON_GRACE_MS) {
+        fs.rmSync(full, { recursive: true, force: true });
       }
     } catch {
       // debris cleanup is best-effort
@@ -594,7 +615,14 @@ export const acquireCommandLock = async ({
   try {
     const { others, self } = await collectLiveLocks(lockDir);
 
-    const conflict = decideConflict(operation, allowMultiple, others);
+    // A hot restart re-enters without the original CLI/run intent; the
+    // privilege granted at the first acquire is persisted in our own lock
+    // file, so a multi-instance dev survives config restarts.
+    const effectiveAllowMultiple =
+      allowMultiple ||
+      (self?.operation === 'dev' && self.allowMultiple === true);
+
+    const conflict = decideConflict(operation, effectiveAllowMultiple, others);
     if (conflict) {
       throw conflict;
     }
@@ -611,6 +639,7 @@ export const acquireCommandLock = async ({
       pid: process.pid,
       processStartedAt: selfStartedAt(),
       appDirectory,
+      allowMultiple: operation === 'dev' ? effectiveAllowMultiple : undefined,
       heartbeatAt: Date.now(),
     });
     startHeartbeat(session);
@@ -685,11 +714,12 @@ export interface DevLockIntent {
   allowMultiple?: boolean;
 }
 
-// Keyed by appDirectory so concurrent programmatic runs against different
-// apps in one process cannot cross-pollinate. Each run overwrites its own
-// app's entry, and the entry deliberately survives the run: a config hot
-// restart re-executes CLI init in the same process and must observe the
-// original intent.
+// Keyed by appDirectory so concurrent runs against different apps in one
+// process cannot cross-pollinate. The entry lives only for the duration of
+// the `run()` invocation that set it (cleared in its `finally`), so a stale
+// `allowMultiple: true` can never leak into a later `cli.init()` for the
+// same app. Hot restarts do not need this map: the privilege is persisted
+// in the process's own lock file and re-applied on self re-entry.
 const runIntents = new Map<string, DevLockIntent>();
 
 export const setDevLockIntent = (

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -93,6 +93,11 @@ export const normalizeLockOperation = (
 const selfStartedAt = () => Date.now() - process.uptime() * 1000;
 
 const isProcessAlive = (pid: number): boolean => {
+  // A process asking about itself is alive by definition; this also keeps
+  // sandboxes that guard `process.kill` on the own pid out of the picture.
+  if (pid === process.pid) {
+    return true;
+  }
   try {
     process.kill(pid, 0);
     return true;
@@ -178,46 +183,152 @@ interface MutexOwner {
   acquiredAt: number;
 }
 
+const MUTEX_DIR_NAME = '.mutex';
+const TOMBSTONE_PREFIX = '.stale-';
+const CANDIDATE_PREFIX = '.mutex-candidate-';
+const TOMBSTONE_GC_MS = 60_000;
+
+// Internal override so tests do not have to wait the full deadline.
+const mutexWaitTotalMs = () => {
+  const fromEnv = Number(process.env.MODERN_DEV_LOCK_MUTEX_WAIT_MS);
+  return Number.isFinite(fromEnv) && fromEnv > 0
+    ? fromEnv
+    : MUTEX_WAIT_TOTAL_MS;
+};
+
+const readMutexOwner = (mutexDir: string): MutexOwner | null => {
+  try {
+    return JSON.parse(
+      fs.readFileSync(path.join(mutexDir, 'owner.json'), 'utf-8'),
+    );
+  } catch {
+    return null;
+  }
+};
+
+const renameQuietly = (from: string, to: string): void => {
+  try {
+    fs.renameSync(from, to);
+  } catch {
+    // ENOENT: another waiter already took it over. EEXIST/ENOTEMPTY: the
+    // tombstone for this owner already exists, so this late rename is the
+    // exact race the deterministic target name is there to stop — either
+    // way the current `.mutex` (with its new owner) is left untouched.
+  }
+};
+
+/** Sweep inert debris: aged tombstones and candidates of dead processes. */
+const cleanMutexDebris = (lockDir: string): void => {
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(lockDir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(lockDir, entry);
+    try {
+      if (entry.startsWith(TOMBSTONE_PREFIX)) {
+        // A tombstone only needs to outlive in-flight waiters of the round
+        // that created it (bounded by the mutex wait deadline).
+        if (Date.now() - fs.statSync(full).mtimeMs > TOMBSTONE_GC_MS) {
+          fs.rmSync(full, { recursive: true, force: true });
+        }
+      } else if (entry.startsWith(CANDIDATE_PREFIX)) {
+        const owner = readMutexOwner(full);
+        if (!owner || !identityMatches(owner.pid, owner.processStartedAt)) {
+          fs.rmSync(full, { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // debris cleanup is best-effort
+    }
+  }
+};
+
 /**
- * Cross-process critical section: every process contends on the same
- * `.mutex` directory (mkdir is atomic). The only condition that allows
- * breaking someone else's mutex is proof that its owner is dead — a live
- * owner is waited on and, past the deadline, reported as busy, never broken.
+ * Cross-process critical section. Acquisition publishes a fully-populated
+ * candidate directory and atomically renames it to the fixed `.mutex` path —
+ * a rename onto an existing non-empty directory fails, so winning the rename
+ * is winning the mutex, and a published mutex always carries a complete
+ * `owner.json` (there is no created-but-not-yet-written window).
+ *
+ * The only condition that allows taking over someone else's mutex is proof
+ * that its owner is dead; the takeover is itself an atomic rename to a
+ * tombstone whose name is derived from the dead owner's token, so among
+ * concurrent waiters exactly one wins and a late waiter cannot displace the
+ * next owner's mutex. A live owner is waited on and, past the deadline,
+ * reported as busy — never broken, no matter how long it has been holding.
+ *
+ * Exported for tests only.
  */
-const acquireMutex = async (lockDir: string): Promise<string> => {
-  const mutexDir = path.join(lockDir, '.mutex');
-  const ownerFile = path.join(mutexDir, 'owner.json');
+export const acquireRegistryMutex = async (
+  lockDir: string,
+): Promise<string> => {
+  const mutexDir = path.join(lockDir, MUTEX_DIR_NAME);
   const token = `${process.pid}-${Math.random().toString(36).slice(2)}`;
-  const deadline = Date.now() + MUTEX_WAIT_TOTAL_MS;
+  const candidate = path.join(lockDir, `${CANDIDATE_PREFIX}${token}`);
+  const deadline = Date.now() + mutexWaitTotalMs();
   let delay = 50;
+
+  cleanMutexDebris(lockDir);
 
   for (;;) {
     try {
-      fs.mkdirSync(mutexDir);
+      fs.mkdirSync(candidate, { recursive: true });
       const owner: MutexOwner = {
         pid: process.pid,
         processStartedAt: selfStartedAt(),
         token,
         acquiredAt: Date.now(),
       };
-      atomicWrite(ownerFile, JSON.stringify(owner));
+      atomicWrite(path.join(candidate, 'owner.json'), JSON.stringify(owner));
+      fs.renameSync(candidate, mutexDir);
       return token;
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+      fs.rmSync(candidate, { recursive: true, force: true });
+      const code = (err as NodeJS.ErrnoException).code;
+      // Occupied target reads differently per platform; anything else is a
+      // real IO error and must surface.
+      if (
+        code !== 'EEXIST' &&
+        code !== 'ENOTEMPTY' &&
+        code !== 'EPERM' &&
+        code !== 'EACCES'
+      ) {
         throw err;
       }
     }
 
-    let owner: MutexOwner | undefined;
-    try {
-      owner = JSON.parse(fs.readFileSync(ownerFile, 'utf-8'));
-    } catch {
-      // owner.json not written yet or unreadable — treat as held.
-    }
-    if (owner && !identityMatches(owner.pid, owner.processStartedAt)) {
-      // Owner is provably dead: clear the leftover mutex and retry now.
-      fs.rmSync(mutexDir, { recursive: true, force: true });
-      continue;
+    const owner = readMutexOwner(mutexDir);
+    if (owner) {
+      if (!identityMatches(owner.pid, owner.processStartedAt)) {
+        renameQuietly(
+          mutexDir,
+          path.join(lockDir, `${TOMBSTONE_PREFIX}${owner.token}`),
+        );
+        continue;
+      }
+    } else {
+      // A published mutex always contains owner.json, so a missing or
+      // unreadable one can only come from manual damage or an old layout.
+      // Grace it briefly, then take it over via a deterministic tombstone.
+      try {
+        const mtime = fs.statSync(mutexDir).mtimeMs;
+        if (Date.now() - mtime > BAD_JSON_GRACE_MS) {
+          renameQuietly(
+            mutexDir,
+            path.join(
+              lockDir,
+              `${TOMBSTONE_PREFIX}corrupt-${Math.floor(mtime)}`,
+            ),
+          );
+          continue;
+        }
+      } catch {
+        // The mutex vanished between rename failure and stat: retry now.
+        continue;
+      }
     }
 
     if (Date.now() >= deadline) {
@@ -231,21 +342,19 @@ const acquireMutex = async (lockDir: string): Promise<string> => {
   }
 };
 
-const releaseMutex = (lockDir: string, token: string) => {
-  const mutexDir = path.join(lockDir, '.mutex');
-  try {
-    const owner: MutexOwner = JSON.parse(
-      fs.readFileSync(path.join(mutexDir, 'owner.json'), 'utf-8'),
-    );
-    if (owner.token !== token) {
-      // The mutex changed hands (we were declared dead); never delete it.
-      return;
-    }
-  } catch {
-    // Missing/unreadable owner: fall through and best-effort remove.
+/** Exported for tests only. */
+export const releaseRegistryMutex = (lockDir: string, token: string): void => {
+  const mutexDir = path.join(lockDir, MUTEX_DIR_NAME);
+  const owner = readMutexOwner(mutexDir);
+  if (owner && owner.token !== token) {
+    // The mutex changed hands (we were declared dead); never delete it.
+    return;
   }
   fs.rmSync(mutexDir, { recursive: true, force: true });
 };
+
+const acquireMutex = acquireRegistryMutex;
+const releaseMutex = releaseRegistryMutex;
 
 const toInstance = (lock: DevLockInfo): DevLockInstance => ({
   pid: lock.pid,
@@ -568,4 +677,32 @@ export const releaseAllLocks = (): void => {
   for (const session of sessions.values()) {
     removeOwnLock(session);
   }
+};
+
+// ---- run-scoped intent (typed run options → guard plugin) ----
+
+export interface DevLockIntent {
+  allowMultiple?: boolean;
+}
+
+// Keyed by appDirectory so concurrent programmatic runs against different
+// apps in one process cannot cross-pollinate. Each run overwrites its own
+// app's entry, and the entry deliberately survives the run: a config hot
+// restart re-executes CLI init in the same process and must observe the
+// original intent.
+const runIntents = new Map<string, DevLockIntent>();
+
+export const setDevLockIntent = (
+  appDirectory: string,
+  intent: DevLockIntent,
+): void => {
+  runIntents.set(appDirectory, intent);
+};
+
+export const getDevLockIntent = (
+  appDirectory: string,
+): DevLockIntent | undefined => runIntents.get(appDirectory);
+
+export const clearDevLockIntent = (appDirectory: string): void => {
+  runIntents.delete(appDirectory);
 };

--- a/packages/solutions/app-tools/src/utils/devLock.ts
+++ b/packages/solutions/app-tools/src/utils/devLock.ts
@@ -658,7 +658,7 @@ const sessions = new Map<string, DevLockSession>();
 let exitHookInstalled = false;
 
 const sessionKey = (appDirectory: string, metaName: string) =>
-  `${appDirectory} ${metaName}`;
+  `${appDirectory}\u0000${metaName}`;
 
 const writeLockFile = (session: DevLockSession, lock: DevLockInfo) => {
   session.current = lock;

--- a/packages/solutions/app-tools/tests/commands/build.test.ts
+++ b/packages/solutions/app-tools/tests/commands/build.test.ts
@@ -1,5 +1,6 @@
 import { type Plugin, createPluginManager } from '@modern-js/plugin';
 import { build } from '../../src/commands/build';
+import { releaseAllLocks } from '../../src/utils/devLock';
 
 const mockGenerateRoutes = rstest.fn();
 const mockSetupTsRuntime = rstest.fn();
@@ -21,6 +22,10 @@ rstest.mock('../../src/utils/loadPlugins', () => ({
 }));
 
 describe('command build', () => {
+  afterEach(() => {
+    releaseAllLocks();
+  });
+
   afterAll(() => {
     rstest.resetAllMocks();
   });

--- a/packages/solutions/app-tools/tests/utils/devLock.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLock.test.ts
@@ -1,0 +1,265 @@
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DevServerLockError,
+  LOCK_SCHEMA_VERSION,
+  acquireCommandLock,
+  getLockDirectory,
+  markDevLockReady,
+  normalizeLockOperation,
+  releaseAllLocks,
+  releaseCommandLock,
+} from '../../src/utils/devLock';
+
+const META = 'modern-js';
+
+let appDirectory: string;
+let lockDir: string;
+
+const readLocks = () =>
+  fs
+    .readdirSync(lockDir)
+    .filter(f => f.endsWith('.lock'))
+    .map(f => JSON.parse(fs.readFileSync(path.join(lockDir, f), 'utf-8')));
+
+// The identity check compares the recorded start time with the real one, so
+// locks that should read as "alive" must record the pid's actual start time.
+const realStartTime = (pid: number) => {
+  try {
+    return fs.statSync(`/proc/${pid}`).ctimeMs;
+  } catch {
+    return Date.now();
+  }
+};
+
+const writeForeignLock = (overrides: Record<string, unknown> = {}) => {
+  fs.mkdirSync(lockDir, { recursive: true });
+  const lock = {
+    schemaVersion: LOCK_SCHEMA_VERSION,
+    operation: 'dev',
+    mode: 'shared',
+    state: 'starting',
+    pid: 999999,
+    appDirectory,
+    ...overrides,
+  } as Record<string, unknown> & { pid: number };
+  if (lock.processStartedAt === undefined) {
+    lock.processStartedAt = realStartTime(lock.pid);
+  }
+  fs.writeFileSync(
+    path.join(lockDir, `${lock.pid}.lock`),
+    JSON.stringify(lock),
+  );
+  return lock;
+};
+
+beforeEach(() => {
+  appDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'devlock-'));
+  lockDir = getLockDirectory(appDirectory, META);
+});
+
+afterEach(() => {
+  releaseAllLocks();
+  fs.rmSync(appDirectory, { recursive: true, force: true });
+});
+
+describe('normalizeLockOperation', () => {
+  it('treats start as an alias of dev and ignores read-only commands', () => {
+    expect(normalizeLockOperation('dev')).toBe('dev');
+    expect(normalizeLockOperation('start')).toBe('dev');
+    expect(normalizeLockOperation('build')).toBe('build');
+    expect(normalizeLockOperation('deploy')).toBe('deploy');
+    expect(normalizeLockOperation('serve')).toBeNull();
+    expect(normalizeLockOperation('inspect')).toBeNull();
+    expect(normalizeLockOperation(undefined)).toBeNull();
+  });
+});
+
+describe('acquireCommandLock', () => {
+  it('writes a shared lock for dev and removes it on release', async () => {
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+    });
+    const [lock] = readLocks();
+    expect(lock.mode).toBe('shared');
+    expect(lock.state).toBe('starting');
+    expect(lock.pid).toBe(process.pid);
+
+    releaseCommandLock(appDirectory, META, 'dev');
+    expect(readLocks()).toHaveLength(0);
+  });
+
+  it('re-entry from the same process reuses the lock (hot restart)', async () => {
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+    });
+    // Second acquire in the same process must not conflict with itself.
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+    });
+    expect(readLocks()).toHaveLength(1);
+  });
+
+  it('rejects a second dev while a live dev lock exists', async () => {
+    // Use our parent process as a genuinely alive foreign process.
+    writeForeignLock({ pid: process.ppid });
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'dev' }),
+    ).rejects.toMatchObject({ code: 'EDEV_SERVER_RUNNING' });
+  });
+
+  it('allows a second dev with allowMultiple, which also writes its lock', async () => {
+    writeForeignLock({ pid: process.ppid });
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+      allowMultiple: true,
+    });
+    expect(readLocks()).toHaveLength(2);
+  });
+
+  it('blocks build when a dev lock is alive, and dev when a build lock is alive', async () => {
+    writeForeignLock({ pid: process.ppid });
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'build' }),
+    ).rejects.toMatchObject({ code: 'EBUILD_BLOCKED_BY_DEV' });
+
+    fs.rmSync(path.join(lockDir, `${process.ppid}.lock`));
+    writeForeignLock({
+      pid: process.ppid,
+      operation: 'build',
+      mode: 'exclusive',
+      state: 'running',
+    });
+    await expect(
+      acquireCommandLock({
+        appDirectory,
+        metaName: META,
+        operation: 'dev',
+        allowMultiple: true,
+      }),
+    ).rejects.toMatchObject({ code: 'EDEV_BLOCKED_BY_BUILD' });
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'deploy' }),
+    ).rejects.toMatchObject({ code: 'EBUILD_IN_PROGRESS' });
+  });
+
+  it('cleans up a stale lock whose process is gone', async () => {
+    // A pid that is (almost certainly) not running.
+    writeForeignLock({ pid: 2 ** 22 - 3 });
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+    });
+    const locks = readLocks();
+    expect(locks).toHaveLength(1);
+    expect(locks[0].pid).toBe(process.pid);
+  });
+
+  it('cleans up a ready dev lock whose port is no longer listening', async () => {
+    writeForeignLock({
+      pid: process.ppid,
+      state: 'ready',
+      port: 65531,
+      host: '127.0.0.1',
+    });
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'build',
+    });
+    const locks = readLocks();
+    expect(locks).toHaveLength(1);
+    expect(locks[0].operation).toBe('build');
+  });
+
+  it('keeps a ready dev lock whose port is actually listening', async () => {
+    const server = net.createServer();
+    await new Promise<void>(resolve =>
+      server.listen(0, '127.0.0.1', () => resolve()),
+    );
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      writeForeignLock({
+        pid: process.ppid,
+        state: 'ready',
+        port,
+        host: '127.0.0.1',
+      });
+      await expect(
+        acquireCommandLock({
+          appDirectory,
+          metaName: META,
+          operation: 'build',
+        }),
+      ).rejects.toMatchObject({ code: 'EBUILD_BLOCKED_BY_DEV' });
+    } finally {
+      server.close();
+    }
+  });
+
+  it('never deletes a lock written by a newer CLI', async () => {
+    writeForeignLock({
+      pid: process.ppid,
+      schemaVersion: LOCK_SCHEMA_VERSION + 1,
+    });
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'dev' }),
+    ).rejects.toMatchObject({ code: 'EUNSUPPORTED_LEASE' });
+    expect(readLocks()).toHaveLength(1);
+  });
+
+  it('release is op-matched: an inner build release keeps the deploy lock', async () => {
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'deploy',
+    });
+    releaseCommandLock(appDirectory, META, 'build');
+    expect(readLocks()).toHaveLength(1);
+    releaseCommandLock(appDirectory, META, 'deploy');
+    expect(readLocks()).toHaveLength(0);
+  });
+
+  it('markDevLockReady fills in port and flips state', async () => {
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+    });
+    markDevLockReady(appDirectory, META, { port: 8080, host: 'localhost' });
+    const [lock] = readLocks();
+    expect(lock.state).toBe('ready');
+    expect(lock.port).toBe(8080);
+  });
+
+  it('errors carry structured instances for agents', async () => {
+    writeForeignLock({ pid: process.ppid, state: 'starting' });
+    try {
+      await acquireCommandLock({
+        appDirectory,
+        metaName: META,
+        operation: 'dev',
+      });
+      throw new Error('expected a DevServerLockError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DevServerLockError);
+      const lockErr = err as DevServerLockError;
+      expect(lockErr.instances[0]).toMatchObject({
+        pid: process.ppid,
+        operation: 'dev',
+        mode: 'shared',
+      });
+    }
+  });
+});

--- a/packages/solutions/app-tools/tests/utils/devLock.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLock.test.ts
@@ -183,21 +183,20 @@ describe('acquireCommandLock', () => {
     expect(locks[0].pid).toBe(process.pid);
   });
 
-  it('cleans up a ready dev lock whose port is no longer listening', async () => {
+  it('keeps an identity-verified live dev lock even when its port is closed (hot-restart window)', async () => {
+    // During a config hot restart the server closes before CLI init re-runs:
+    // the holder is alive but momentarily has no listening port. A failed
+    // port probe must NOT strip it of protection.
     writeForeignLock({
       pid: process.ppid,
       state: 'ready',
       port: 65531,
       host: '127.0.0.1',
     });
-    await acquireCommandLock({
-      appDirectory,
-      metaName: META,
-      operation: 'build',
-    });
-    const locks = readLocks();
-    expect(locks).toHaveLength(1);
-    expect(locks[0].operation).toBe('build');
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'build' }),
+    ).rejects.toMatchObject({ code: 'EBUILD_BLOCKED_BY_DEV' });
+    expect(readLocks()).toHaveLength(1);
   });
 
   it('keeps a ready dev lock whose port is actually listening', async () => {
@@ -307,6 +306,9 @@ describe('acquireCommandLock', () => {
         pid: process.ppid,
         operation: 'dev',
         mode: 'shared',
+        // ppid's real start time is readable on linux/darwin, so the kill
+        // suggestion is allowed for it.
+        identityVerified: true,
       });
     }
   });

--- a/packages/solutions/app-tools/tests/utils/devLock.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLock.test.ts
@@ -6,11 +6,14 @@ import {
   DevServerLockError,
   LOCK_SCHEMA_VERSION,
   acquireCommandLock,
+  clearDevLockIntent,
+  getDevLockIntent,
   getLockDirectory,
   markDevLockReady,
   normalizeLockOperation,
   releaseAllLocks,
   releaseCommandLock,
+  setDevLockIntent,
 } from '../../src/utils/devLock';
 
 const META = 'modern-js';
@@ -241,6 +244,17 @@ describe('acquireCommandLock', () => {
     const [lock] = readLocks();
     expect(lock.state).toBe('ready');
     expect(lock.port).toBe(8080);
+  });
+
+  it('run-scoped intent is keyed by appDirectory and does not leak across apps', () => {
+    setDevLockIntent(appDirectory, { allowMultiple: true });
+    expect(getDevLockIntent(appDirectory)).toEqual({ allowMultiple: true });
+    expect(getDevLockIntent('/some/other/app')).toBeUndefined();
+    // A later run for the same app overwrites the previous intent.
+    setDevLockIntent(appDirectory, { allowMultiple: false });
+    expect(getDevLockIntent(appDirectory)).toEqual({ allowMultiple: false });
+    clearDevLockIntent(appDirectory);
+    expect(getDevLockIntent(appDirectory)).toBeUndefined();
   });
 
   it('errors carry structured instances for agents', async () => {

--- a/packages/solutions/app-tools/tests/utils/devLock.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLock.test.ts
@@ -60,6 +60,10 @@ const writeForeignLock = (overrides: Record<string, unknown> = {}) => {
     state: 'starting',
     pid: 999999,
     appDirectory,
+    // Same write set as the app defaults, so foreign locks conflict unless a
+    // test opts into isolation explicitly.
+    internalDirectory: path.join(appDirectory, 'node_modules', '.modern-js'),
+    distDirectory: path.join(appDirectory, 'dist'),
     ...overrides,
   } as Record<string, unknown> & { pid: number };
   if (lock.processStartedAt === undefined) {
@@ -89,7 +93,7 @@ describe('normalizeLockOperation', () => {
     expect(normalizeLockOperation('build')).toBe('build');
     expect(normalizeLockOperation('deploy')).toBe('deploy');
     expect(normalizeLockOperation('serve')).toBeNull();
-    expect(normalizeLockOperation('inspect')).toBeNull();
+    expect(normalizeLockOperation('inspect')).toBe('inspect');
     expect(normalizeLockOperation(undefined)).toBeNull();
   });
 });
@@ -156,6 +160,9 @@ describe('acquireCommandLock', () => {
       operation: 'build',
       mode: 'exclusive',
       state: 'running',
+      // watch build: persistent, so a conflicting build fails fast instead
+      // of queueing behind an unbounded holder.
+      persistent: true,
     });
     await expect(
       acquireCommandLock({
@@ -269,6 +276,144 @@ describe('acquireCommandLock', () => {
     const [lock] = readLocks();
     expect(lock.state).toBe('ready');
     expect(lock.port).toBe(8080);
+  });
+
+  it('queues behind a finite build and proceeds once it releases', async () => {
+    process.env.MODERN_DEV_LOCK_QUEUE_POLL_MS = '50';
+    try {
+      const foreign = writeForeignLock({
+        pid: process.ppid,
+        operation: 'build',
+        mode: 'exclusive',
+        state: 'running',
+      });
+      const pending = acquireCommandLock({
+        appDirectory,
+        metaName: META,
+        operation: 'build',
+      });
+      // Simulate the holder finishing while we wait.
+      await new Promise(resolve => setTimeout(resolve, 200));
+      fs.rmSync(path.join(lockDir, `${foreign.pid}.lock`));
+      await pending;
+      const locks = readLocks();
+      expect(locks).toHaveLength(1);
+      expect(locks[0].pid).toBe(process.pid);
+    } finally {
+      delete process.env.MODERN_DEV_LOCK_QUEUE_POLL_MS;
+    }
+  });
+
+  it('a waiter preempted by a persistent task fails fast instead of waiting forever', async () => {
+    process.env.MODERN_DEV_LOCK_QUEUE_POLL_MS = '50';
+    try {
+      const foreign = writeForeignLock({
+        pid: process.ppid,
+        operation: 'build',
+        mode: 'exclusive',
+        state: 'running',
+      });
+      const pending = acquireCommandLock({
+        appDirectory,
+        metaName: META,
+        operation: 'build',
+      });
+      await new Promise(resolve => setTimeout(resolve, 150));
+      // The finite build ends, but a dev server grabs the project first.
+      fs.rmSync(path.join(lockDir, `${foreign.pid}.lock`));
+      writeForeignLock({ pid: process.ppid });
+      await expect(pending).rejects.toMatchObject({
+        code: 'EBUILD_BLOCKED_BY_DEV',
+      });
+    } finally {
+      delete process.env.MODERN_DEV_LOCK_QUEUE_POLL_MS;
+    }
+  });
+
+  it('fully disjoint write sets run in parallel, whatever the commands are', async () => {
+    // A build over an isolated write set (per-config tempDir + distPath).
+    writeForeignLock({
+      pid: process.ppid,
+      operation: 'build',
+      mode: 'exclusive',
+      state: 'running',
+      internalDirectory: path.join(appDirectory, 'node_modules', '.iso-a'),
+      distDirectory: path.join(appDirectory, 'dist-a'),
+    });
+    // Our own build against the default directories: no shared path, no wait.
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'build',
+    });
+    expect(readLocks()).toHaveLength(2);
+
+    releaseCommandLock(appDirectory, META, 'build');
+
+    // Even a bare dev coexists with an isolated dev — no flag needed.
+    fs.rmSync(path.join(lockDir, `${process.ppid}.lock`));
+    writeForeignLock({
+      pid: process.ppid,
+      internalDirectory: path.join(appDirectory, 'node_modules', '.iso-b'),
+      distDirectory: path.join(appDirectory, 'dist-b'),
+    });
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+    });
+    expect(readLocks()).toHaveLength(2);
+  });
+
+  it('sharing either directory alone still conflicts', async () => {
+    // Same internalDirectory, different dist: the generated-code dir is
+    // enough to collide (a watcher holder makes it fail fast, observable).
+    writeForeignLock({
+      pid: process.ppid,
+      operation: 'build',
+      mode: 'exclusive',
+      state: 'running',
+      persistent: true,
+      distDirectory: path.join(appDirectory, 'dist-other'),
+    });
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'build' }),
+    ).rejects.toMatchObject({ code: 'EBUILD_IN_PROGRESS' });
+  });
+
+  it('locks from older writers without write-set fields conflict conservatively', async () => {
+    writeForeignLock({
+      pid: process.ppid,
+      internalDirectory: undefined,
+      distDirectory: undefined,
+    });
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'dev' }),
+    ).rejects.toMatchObject({ code: 'EDEV_SERVER_RUNNING' });
+  });
+
+  it('inspect takes a short exclusive lock', async () => {
+    expect(normalizeLockOperation('inspect')).toBe('inspect');
+
+    writeForeignLock({ pid: process.ppid });
+    await expect(
+      acquireCommandLock({
+        appDirectory,
+        metaName: META,
+        operation: 'inspect',
+      }),
+    ).rejects.toMatchObject({ code: 'EBUILD_BLOCKED_BY_DEV' });
+
+    fs.rmSync(path.join(lockDir, `${process.ppid}.lock`));
+    writeForeignLock({
+      pid: process.ppid,
+      operation: 'inspect',
+      mode: 'exclusive',
+      state: 'running',
+    });
+    await expect(
+      acquireCommandLock({ appDirectory, metaName: META, operation: 'dev' }),
+    ).rejects.toMatchObject({ code: 'EDEV_BLOCKED_BY_BUILD' });
   });
 
   it('hot-restart re-entry inherits allowMultiple from its own lock file', async () => {

--- a/packages/solutions/app-tools/tests/utils/devLock.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLock.test.ts
@@ -28,13 +28,27 @@ const readLocks = () =>
     .map(f => JSON.parse(fs.readFileSync(path.join(lockDir, f), 'utf-8')));
 
 // The identity check compares the recorded start time with the real one, so
-// locks that should read as "alive" must record the pid's actual start time.
+// locks that should read as "alive" must record the pid's actual start time
+// — mirroring the platform sources the implementation itself uses.
 const realStartTime = (pid: number) => {
   try {
-    return fs.statSync(`/proc/${pid}`).ctimeMs;
+    if (process.platform === 'linux') {
+      return fs.statSync(`/proc/${pid}`).ctimeMs;
+    }
+    if (process.platform === 'darwin') {
+      const out = require('node:child_process')
+        .execSync(`ps -o lstart= -p ${pid}`)
+        .toString()
+        .trim();
+      const parsed = Date.parse(out);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
   } catch {
-    return Date.now();
+    // fall through
   }
+  return Date.now();
 };
 
 const writeForeignLock = (overrides: Record<string, unknown> = {}) => {
@@ -244,6 +258,26 @@ describe('acquireCommandLock', () => {
     const [lock] = readLocks();
     expect(lock.state).toBe('ready');
     expect(lock.port).toBe(8080);
+  });
+
+  it('hot-restart re-entry inherits allowMultiple from its own lock file', async () => {
+    // First acquire opted in to multi-instance mode alongside a live dev.
+    writeForeignLock({ pid: process.ppid });
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+      allowMultiple: true,
+    });
+    // Config hot restart re-enters WITHOUT the original intent; the
+    // privilege persisted in our own lock file must keep it passing.
+    await acquireCommandLock({
+      appDirectory,
+      metaName: META,
+      operation: 'dev',
+    });
+    const own = readLocks().find(lock => lock.pid === process.pid);
+    expect(own.allowMultiple).toBe(true);
   });
 
   it('run-scoped intent is keyed by appDirectory and does not leak across apps', () => {

--- a/packages/solutions/app-tools/tests/utils/devLock.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLock.test.ts
@@ -183,19 +183,31 @@ describe('acquireCommandLock', () => {
     expect(locks[0].pid).toBe(process.pid);
   });
 
-  it('keeps an identity-verified live dev lock even when its port is closed (hot-restart window)', async () => {
+  it('keeps a live dev lock even when its port is closed (hot-restart window), on every platform', async () => {
     // During a config hot restart the server closes before CLI init re-runs:
-    // the holder is alive but momentarily has no listening port. A failed
-    // port probe must NOT strip it of protection.
+    // the holder is alive but momentarily has no listening port. A live pid
+    // must keep its lock on every platform — including Windows, where the
+    // start time cannot be read and identityVerified stays false.
     writeForeignLock({
       pid: process.ppid,
       state: 'ready',
       port: 65531,
       host: '127.0.0.1',
     });
-    await expect(
-      acquireCommandLock({ appDirectory, metaName: META, operation: 'build' }),
-    ).rejects.toMatchObject({ code: 'EBUILD_BLOCKED_BY_DEV' });
+    try {
+      await acquireCommandLock({
+        appDirectory,
+        metaName: META,
+        operation: 'build',
+      });
+      throw new Error('expected EBUILD_BLOCKED_BY_DEV');
+    } catch (err) {
+      const lockErr = err as DevServerLockError;
+      expect(lockErr.code).toBe('EBUILD_BLOCKED_BY_DEV');
+      expect(lockErr.instances[0].identityVerified).toBe(
+        process.platform !== 'win32',
+      );
+    }
     expect(readLocks()).toHaveLength(1);
   });
 
@@ -306,9 +318,9 @@ describe('acquireCommandLock', () => {
         pid: process.ppid,
         operation: 'dev',
         mode: 'shared',
-        // ppid's real start time is readable on linux/darwin, so the kill
-        // suggestion is allowed for it.
-        identityVerified: true,
+        // ppid's real start time is readable on linux/darwin (not Windows),
+        // and only a verified identity may receive a kill suggestion.
+        identityVerified: process.platform !== 'win32',
       });
     }
   });

--- a/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
@@ -180,12 +180,55 @@ describe('registry mutex', () => {
 
   it('releasing detaches the mutex instead of emptying the shared path', async () => {
     const token = await acquireRegistryMutex(lockDir);
+    const renameSpy = rstest.spyOn(fs, 'renameSync');
+    const rmSpy = rstest.spyOn(fs, 'rmSync');
+
     releaseRegistryMutex(lockDir, token);
-    // Emptying `.mutex` in place would let a waiter rename its candidate onto
-    // the momentarily empty directory, and the trailing rmdir would then fail
-    // with ENOTEMPTY on the new owner's files.
+
+    // The shared path must leave in one atomic move. Deleting it recursively
+    // empties it first, and a waiter can rename its candidate onto the
+    // momentarily empty directory — the trailing rmdir then fails with
+    // ENOTEMPTY and takes the new owner's files with it.
+    expect(renameSpy).toHaveBeenCalledWith(
+      mutexPath(),
+      path.join(lockDir, `.mutex-release-${token}`),
+    );
+    for (const [target] of rmSpy.mock.calls) {
+      expect(target).not.toBe(mutexPath());
+    }
+
+    renameSpy.mockRestore();
+    rmSpy.mockRestore();
     expect(fs.existsSync(mutexPath())).toBe(false);
     expect(listEntries('.mutex-release-')).toHaveLength(0);
+  });
+
+  it('a failing release-debris sweep does not block acquire', async () => {
+    const debris = path.join(lockDir, '.mutex-release-stuck');
+    fs.mkdirSync(debris, { recursive: true });
+    const realRmSync = fs.rmSync;
+    const rmSpy = rstest.spyOn(fs, 'rmSync').mockImplementation(((
+      target: fs.PathLike,
+      options?: unknown,
+    ) => {
+      if (target === debris) {
+        throw Object.assign(new Error('EACCES: permission denied'), {
+          code: 'EACCES',
+        });
+      }
+      return realRmSync(target, options as fs.RmOptions);
+    }) as typeof fs.rmSync);
+
+    try {
+      // Sweeping debris is best-effort: the acquisition it runs inside must
+      // still succeed, and must not surface the raw filesystem error.
+      const token = await acquireRegistryMutex(lockDir);
+      expect(token).toBeTruthy();
+      releaseRegistryMutex(lockDir, token);
+    } finally {
+      rmSpy.mockRestore();
+      fs.rmSync(debris, { recursive: true, force: true });
+    }
   });
 
   it('a release racing a takeover leaves the new holder untouched', async () => {

--- a/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
@@ -20,12 +20,27 @@ const ownerPath = () => path.join(mutexPath(), 'owner.json');
 const listEntries = (prefix: string) =>
   fs.readdirSync(lockDir).filter(entry => entry.startsWith(prefix));
 
+// Mirrors the platform sources the implementation itself uses, so a fake
+// owner backed by a live pid reads as genuinely alive on every OS.
 const realStartTime = (pid: number) => {
   try {
-    return fs.statSync(`/proc/${pid}`).ctimeMs;
+    if (process.platform === 'linux') {
+      return fs.statSync(`/proc/${pid}`).ctimeMs;
+    }
+    if (process.platform === 'darwin') {
+      const out = require('node:child_process')
+        .execSync(`ps -o lstart= -p ${pid}`)
+        .toString()
+        .trim();
+      const parsed = Date.parse(out);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
   } catch {
-    return Date.now();
+    // fall through
   }
+  return Date.now();
 };
 
 // Publish a mutex exactly like the implementation does, on behalf of a fake
@@ -137,6 +152,32 @@ describe('registry mutex', () => {
     releaseRegistryMutex(lockDir, token);
   });
 
+  it('token tombstones are never garbage-collected by age', async () => {
+    const tombstone = path.join(lockDir, '.stale-some-old-token');
+    fs.mkdirSync(tombstone, { recursive: true });
+    fs.writeFileSync(path.join(tombstone, 'owner.json'), '{}');
+    const past = new Date(Date.now() - 3_600_000);
+    fs.utimesSync(tombstone, past, past);
+    const token = await acquireRegistryMutex(lockDir);
+    releaseRegistryMutex(lockDir, token);
+    // An hour-old tombstone must still be there: it may be the only thing
+    // stopping a long-suspended waiter from renaming the current mutex away.
+    expect(fs.existsSync(tombstone)).toBe(true);
+  });
+
+  it('keeps an ownerless candidate whose creator is still alive', async () => {
+    // Simulates a process paused between mkdir(candidate) and writing
+    // owner.json — the candidate name embeds the (live) creator pid.
+    const candidate = path.join(
+      lockDir,
+      `.mutex-candidate-${process.ppid}-paused`,
+    );
+    fs.mkdirSync(candidate, { recursive: true });
+    const token = await acquireRegistryMutex(lockDir);
+    releaseRegistryMutex(lockDir, token);
+    expect(fs.existsSync(candidate)).toBe(true);
+  });
+
   it('cleans candidate debris left by a crash between create and rename', async () => {
     const debris = path.join(lockDir, '.mutex-candidate-4194301-crashed');
     fs.mkdirSync(debris, { recursive: true });
@@ -155,16 +196,26 @@ describe('registry mutex', () => {
   });
 });
 
-// Real multi-process contention over the built CJS artifact. Skipped when
-// the package has not been built (`nx build @modern-js/app-tools`).
+// Real multi-process contention over the built CJS artifact. Locally the
+// suite is skipped when the package has not been built yet; in CI a missing
+// artifact is a hard failure so this coverage can never silently drop out
+// (`build:required` builds @modern-js/app-tools before unit tests run).
 const testDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
 const distDevLock = path.resolve(testDir, '../../dist/cjs/utils/devLock.js');
-const describeWithDist = fs.existsSync(distDevLock) ? describe : describe.skip;
+const distExists = fs.existsSync(distDevLock);
+const inCI = Boolean(process.env.CI && process.env.CI !== 'false');
+const describeWithDist = distExists || inCI ? describe : describe.skip;
 
 describeWithDist('registry mutex across real processes', () => {
-  it('exclusive build locks never overlap between processes', async () => {
-    const logFile = path.join(appDirectory, 'sections.log');
-    const childScript = `
+  it('built artifact is present (required for the multi-process suite)', () => {
+    expect(distExists).toBe(true);
+  });
+
+  (distExists ? it : it.skip)(
+    'exclusive build locks never overlap between processes',
+    async () => {
+      const logFile = path.join(appDirectory, 'sections.log');
+      const childScript = `
         const fs = require('fs');
         const { acquireCommandLock, releaseCommandLock } =
           require(${JSON.stringify(distDevLock)});
@@ -186,41 +237,43 @@ describeWithDist('registry mutex across real processes', () => {
           process.exit(3);
         });
       `;
-    const children = Array.from({ length: 4 }, () =>
-      execFileAsync(
-        process.execPath,
-        ['-e', childScript, appDirectory, logFile],
-        { env: { ...process.env, MODERN_DEV_LOCK_MUTEX_WAIT_MS: '8000' } },
-      ).catch(err => err),
-    );
-    await Promise.all(children);
+      const children = Array.from({ length: 4 }, () =>
+        execFileAsync(
+          process.execPath,
+          ['-e', childScript, appDirectory, logFile],
+          { env: { ...process.env, MODERN_DEV_LOCK_MUTEX_WAIT_MS: '8000' } },
+        ).catch(err => err),
+      );
+      await Promise.all(children);
 
-    const lines = fs
-      .readFileSync(logFile, 'utf-8')
-      .trim()
-      .split('\n')
-      .filter(Boolean);
-    // Replay the log: at no point may two processes be inside the
-    // exclusive section simultaneously.
-    let inside = 0;
-    let winners = 0;
-    for (const line of lines) {
-      const [kind] = line.split(' ');
-      if (kind === 'enter') {
-        inside += 1;
-        winners += 1;
-        expect(inside).toBe(1);
-      } else if (kind === 'exit') {
-        inside -= 1;
+      const lines = fs
+        .readFileSync(logFile, 'utf-8')
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      // Replay the log: at no point may two processes be inside the
+      // exclusive section simultaneously.
+      let inside = 0;
+      let winners = 0;
+      for (const line of lines) {
+        const [kind] = line.split(' ');
+        if (kind === 'enter') {
+          inside += 1;
+          winners += 1;
+          expect(inside).toBe(1);
+        } else if (kind === 'exit') {
+          inside -= 1;
+        }
       }
-    }
-    // At least one process must have made it through; the rest either
-    // queued (also fine) or were rejected with a typed conflict.
-    expect(winners).toBeGreaterThanOrEqual(1);
-    for (const line of lines) {
-      if (line.startsWith('blocked')) {
-        expect(line).toMatch(/EBUILD_IN_PROGRESS|EDEVLOCK_BUSY/);
+      // At least one process must have made it through; the rest either
+      // queued (also fine) or were rejected with a typed conflict.
+      expect(winners).toBeGreaterThanOrEqual(1);
+      for (const line of lines) {
+        if (line.startsWith('blocked')) {
+          expect(line).toMatch(/EBUILD_IN_PROGRESS|EDEVLOCK_BUSY/);
+        }
       }
-    }
-  }, 30_000);
+    },
+    30_000,
+  );
 });

--- a/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
@@ -1,0 +1,226 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import {
+  acquireRegistryMutex,
+  getLockDirectory,
+  releaseRegistryMutex,
+} from '../../src/utils/devLock';
+
+const execFileAsync = promisify(execFile);
+
+let lockDir: string;
+let appDirectory: string;
+
+const mutexPath = () => path.join(lockDir, '.mutex');
+const ownerPath = () => path.join(mutexPath(), 'owner.json');
+
+const listEntries = (prefix: string) =>
+  fs.readdirSync(lockDir).filter(entry => entry.startsWith(prefix));
+
+const realStartTime = (pid: number) => {
+  try {
+    return fs.statSync(`/proc/${pid}`).ctimeMs;
+  } catch {
+    return Date.now();
+  }
+};
+
+// Publish a mutex exactly like the implementation does, on behalf of a fake
+// owner (dead pid or a live foreign process).
+const publishForeignMutex = (owner: {
+  pid: number;
+  processStartedAt?: number;
+  token?: string;
+}) => {
+  fs.mkdirSync(mutexPath(), { recursive: true });
+  fs.writeFileSync(
+    ownerPath(),
+    JSON.stringify({
+      token: `foreign-${owner.pid}`,
+      acquiredAt: Date.now(),
+      processStartedAt: realStartTime(owner.pid),
+      ...owner,
+    }),
+  );
+};
+
+beforeEach(() => {
+  appDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'devlock-mutex-'));
+  lockDir = getLockDirectory(appDirectory, 'modern-js');
+  fs.mkdirSync(lockDir, { recursive: true });
+  process.env.MODERN_DEV_LOCK_MUTEX_WAIT_MS = '1500';
+});
+
+afterEach(() => {
+  delete process.env.MODERN_DEV_LOCK_MUTEX_WAIT_MS;
+  fs.rmSync(appDirectory, { recursive: true, force: true });
+});
+
+describe('registry mutex', () => {
+  it('published mutex always carries a complete owner.json', async () => {
+    const token = await acquireRegistryMutex(lockDir);
+    const owner = JSON.parse(fs.readFileSync(ownerPath(), 'utf-8'));
+    expect(owner.pid).toBe(process.pid);
+    expect(owner.token).toBe(token);
+    releaseRegistryMutex(lockDir, token);
+    expect(fs.existsSync(mutexPath())).toBe(false);
+  });
+
+  it('a second acquire waits for a live holder and reports busy, never breaks it', async () => {
+    const token = await acquireRegistryMutex(lockDir);
+    await expect(acquireRegistryMutex(lockDir)).rejects.toMatchObject({
+      code: 'EDEVLOCK_BUSY',
+    });
+    // The live holder's mutex must be fully intact after the failed attempt.
+    expect(JSON.parse(fs.readFileSync(ownerPath(), 'utf-8')).token).toBe(token);
+    releaseRegistryMutex(lockDir, token);
+  });
+
+  it('a queued acquire succeeds once the holder releases', async () => {
+    const first = await acquireRegistryMutex(lockDir);
+    const pending = acquireRegistryMutex(lockDir);
+    await new Promise(resolve => setTimeout(resolve, 120));
+    releaseRegistryMutex(lockDir, first);
+    const second = await pending;
+    expect(second).not.toBe(first);
+    releaseRegistryMutex(lockDir, second);
+  });
+
+  it('takes over a dead owner via a tombstone rename', async () => {
+    publishForeignMutex({ pid: 2 ** 22 - 3, processStartedAt: Date.now() });
+    const token = await acquireRegistryMutex(lockDir);
+    expect(JSON.parse(fs.readFileSync(ownerPath(), 'utf-8')).token).toBe(token);
+    // The dead owner's mutex was moved aside, not deleted in place.
+    expect(listEntries('.stale-')).toHaveLength(1);
+    releaseRegistryMutex(lockDir, token);
+  });
+
+  it('concurrent waiters taking over the same dead owner produce exactly one new holder', async () => {
+    publishForeignMutex({ pid: 2 ** 22 - 3, processStartedAt: Date.now() });
+    // Both contenders race the tombstone rename and then the acquisition;
+    // the loser of the acquisition must queue, so release the winner ASAP.
+    const contenders = [
+      acquireRegistryMutex(lockDir).then(token => {
+        releaseRegistryMutex(lockDir, token);
+        return token;
+      }),
+      acquireRegistryMutex(lockDir).then(token => {
+        releaseRegistryMutex(lockDir, token);
+        return token;
+      }),
+    ];
+    const tokens = await Promise.all(contenders);
+    expect(new Set(tokens).size).toBe(2);
+    // Exactly one tombstone for the single dead owner.
+    expect(listEntries('.stale-')).toHaveLength(1);
+  });
+
+  it('recovers from a damaged mutex (no owner.json) after the grace period', async () => {
+    fs.mkdirSync(mutexPath(), { recursive: true });
+    // Backdate the damaged mutex beyond the 5s grace window.
+    const past = new Date(Date.now() - 10_000);
+    fs.utimesSync(mutexPath(), past, past);
+    const token = await acquireRegistryMutex(lockDir);
+    expect(JSON.parse(fs.readFileSync(ownerPath(), 'utf-8')).token).toBe(token);
+    releaseRegistryMutex(lockDir, token);
+  });
+
+  it('a stale release from a displaced owner never deletes the new mutex', async () => {
+    publishForeignMutex({ pid: 2 ** 22 - 3, processStartedAt: Date.now() });
+    const token = await acquireRegistryMutex(lockDir);
+    // The displaced (dead) owner's release must be a no-op.
+    releaseRegistryMutex(lockDir, `foreign-${2 ** 22 - 3}`);
+    expect(fs.existsSync(mutexPath())).toBe(true);
+    releaseRegistryMutex(lockDir, token);
+  });
+
+  it('cleans candidate debris left by a crash between create and rename', async () => {
+    const debris = path.join(lockDir, '.mutex-candidate-4194301-crashed');
+    fs.mkdirSync(debris, { recursive: true });
+    fs.writeFileSync(
+      path.join(debris, 'owner.json'),
+      JSON.stringify({
+        pid: 2 ** 22 - 3,
+        processStartedAt: Date.now(),
+        token: 'crashed',
+        acquiredAt: Date.now(),
+      }),
+    );
+    const token = await acquireRegistryMutex(lockDir);
+    releaseRegistryMutex(lockDir, token);
+    expect(listEntries('.mutex-candidate-')).toHaveLength(0);
+  });
+});
+
+// Real multi-process contention over the built CJS artifact. Skipped when
+// the package has not been built (`nx build @modern-js/app-tools`).
+const testDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+const distDevLock = path.resolve(testDir, '../../dist/cjs/utils/devLock.js');
+const describeWithDist = fs.existsSync(distDevLock) ? describe : describe.skip;
+
+describeWithDist('registry mutex across real processes', () => {
+  it('exclusive build locks never overlap between processes', async () => {
+    const logFile = path.join(appDirectory, 'sections.log');
+    const childScript = `
+        const fs = require('fs');
+        const { acquireCommandLock, releaseCommandLock } =
+          require(${JSON.stringify(distDevLock)});
+        const appDirectory = process.argv[1];
+        const logFile = process.argv[2];
+        (async () => {
+          await acquireCommandLock({
+            appDirectory,
+            metaName: 'modern-js',
+            operation: 'build',
+          });
+          fs.appendFileSync(logFile, 'enter ' + Date.now() + '\\n');
+          await new Promise(r => setTimeout(r, 150));
+          fs.appendFileSync(logFile, 'exit ' + Date.now() + '\\n');
+          releaseCommandLock(appDirectory, 'modern-js', 'build');
+          process.exit(0);
+        })().catch(err => {
+          fs.appendFileSync(logFile, 'blocked ' + (err.code || err) + '\\n');
+          process.exit(3);
+        });
+      `;
+    const children = Array.from({ length: 4 }, () =>
+      execFileAsync(
+        process.execPath,
+        ['-e', childScript, appDirectory, logFile],
+        { env: { ...process.env, MODERN_DEV_LOCK_MUTEX_WAIT_MS: '8000' } },
+      ).catch(err => err),
+    );
+    await Promise.all(children);
+
+    const lines = fs
+      .readFileSync(logFile, 'utf-8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    // Replay the log: at no point may two processes be inside the
+    // exclusive section simultaneously.
+    let inside = 0;
+    let winners = 0;
+    for (const line of lines) {
+      const [kind] = line.split(' ');
+      if (kind === 'enter') {
+        inside += 1;
+        winners += 1;
+        expect(inside).toBe(1);
+      } else if (kind === 'exit') {
+        inside -= 1;
+      }
+    }
+    // At least one process must have made it through; the rest either
+    // queued (also fine) or were rejected with a typed conflict.
+    expect(winners).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      if (line.startsWith('blocked')) {
+        expect(line).toMatch(/EBUILD_IN_PROGRESS|EDEVLOCK_BUSY/);
+      }
+    }
+  }, 30_000);
+});

--- a/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
+++ b/packages/solutions/app-tools/tests/utils/devLockMutex.test.ts
@@ -178,6 +178,50 @@ describe('registry mutex', () => {
     expect(fs.existsSync(candidate)).toBe(true);
   });
 
+  it('releasing detaches the mutex instead of emptying the shared path', async () => {
+    const token = await acquireRegistryMutex(lockDir);
+    releaseRegistryMutex(lockDir, token);
+    // Emptying `.mutex` in place would let a waiter rename its candidate onto
+    // the momentarily empty directory, and the trailing rmdir would then fail
+    // with ENOTEMPTY on the new owner's files.
+    expect(fs.existsSync(mutexPath())).toBe(false);
+    expect(listEntries('.mutex-release-')).toHaveLength(0);
+  });
+
+  it('a release racing a takeover leaves the new holder untouched', async () => {
+    const token = await acquireRegistryMutex(lockDir);
+    // Simulates the window between our owner read and our rename: another
+    // process has already replaced the mutex. Releasing must not touch it,
+    // and must not throw.
+    fs.rmSync(mutexPath(), { recursive: true, force: true });
+    publishForeignMutex({ pid: process.pid, token: 'new-holder' });
+    expect(() => releaseRegistryMutex(lockDir, token)).not.toThrow();
+    expect(JSON.parse(fs.readFileSync(ownerPath(), 'utf-8')).token).toBe(
+      'new-holder',
+    );
+    fs.rmSync(mutexPath(), { recursive: true, force: true });
+  });
+
+  it('a release with an unreadable owner is a no-op', async () => {
+    const token = await acquireRegistryMutex(lockDir);
+    // Mid-handover the owner file can be missing; nothing may be deleted on
+    // the strength of a guess.
+    fs.rmSync(ownerPath(), { force: true });
+    expect(() => releaseRegistryMutex(lockDir, token)).not.toThrow();
+    expect(fs.existsSync(mutexPath())).toBe(true);
+    fs.rmSync(mutexPath(), { recursive: true, force: true });
+  });
+
+  it('collects release debris left by a crash between detach and delete', async () => {
+    const debris = path.join(lockDir, '.mutex-release-crashed');
+    fs.mkdirSync(debris, { recursive: true });
+    fs.writeFileSync(path.join(debris, 'owner.json'), '{}');
+    const token = await acquireRegistryMutex(lockDir);
+    releaseRegistryMutex(lockDir, token);
+    // A detached mutex is unreachable, so it is always safe to sweep.
+    expect(listEntries('.mutex-release-')).toHaveLength(0);
+  });
+
   it('cleans candidate debris left by a crash between create and rename', async () => {
     const debris = path.join(lockDir, '.mutex-candidate-4194301-crashed');
     fs.mkdirSync(debris, { recursive: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,10 +120,10 @@ importers:
     dependencies:
       '@modern-js/plugin-ssg':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@types/express@4.17.25)(@types/node@20.19.27)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@types/express@4.17.25)(@types/node@20.19.27)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -132,20 +132,20 @@ importers:
         version: 19.2.8(react@19.2.8)
       zephyr-modernjs-plugin:
         specifier: 1.1.0
-        version: 1.1.0(@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))))(zephyr-rspack-plugin@1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))))
+        version: 1.1.0(@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)))(zephyr-rspack-plugin@1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)))
       zephyr-rspack-plugin:
         specifier: 1.1.0
-        version: 1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.5.14
         version: 29.5.14
@@ -169,7 +169,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@types/koa':
         specifier: ^2.15.0
         version: 2.15.2
@@ -191,10 +191,10 @@ importers:
         version: 1.8.3
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -218,7 +218,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -231,10 +231,10 @@ importers:
         version: 1.9.4
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -261,7 +261,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -274,10 +274,10 @@ importers:
         version: 1.9.4
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -301,10 +301,10 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@module-federation/modern-js-v3':
         specifier: 2.0.0
-        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -323,10 +323,10 @@ importers:
         version: 1.8.3
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -350,10 +350,10 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@module-federation/modern-js-v3':
         specifier: 2.0.0
-        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -366,10 +366,10 @@ importers:
         version: 1.8.3
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -393,10 +393,10 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@module-federation/modern-js-v3':
         specifier: 2.0.0
-        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@module-federation/runtime':
         specifier: 2.0.0
         version: 2.0.0
@@ -415,10 +415,10 @@ importers:
         version: 1.8.3
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -442,10 +442,10 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@module-federation/modern-js-v3':
         specifier: 2.0.0
-        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -458,10 +458,10 @@ importers:
         version: 1.8.3
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -491,7 +491,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -504,10 +504,10 @@ importers:
         version: 1.9.4
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -534,13 +534,13 @@ importers:
     dependencies:
       '@modern-js/plugin-bff':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))(zod@3.25.76)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))(zod@3.25.76)
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@modern-js/server-runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -553,10 +553,10 @@ importers:
         version: 1.9.4
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -586,13 +586,13 @@ importers:
     dependencies:
       '@modern-js/plugin-bff':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))(zod@3.25.76)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))(zod@3.25.76)
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@modern-js/server-runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       antd:
         specifier: ^5.29.3
         version: 5.29.3(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -617,10 +617,10 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@rsbuild/core':
         specifier: 2.2.0-rc.0
         version: 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
@@ -650,7 +650,7 @@ importers:
         version: 10.5.10(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@2.8.8)(react@19.2.8)(utf-8-validate@5.0.10)
       storybook-addon-modernjs:
         specifier: 3.3.4
-        version: 3.3.4(10f51c43bf113b9a63bc334b1cc71e2d)
+        version: 3.3.4(7bda0656b576b6af43a6642e31cc3849)
       storybook-react-rsbuild:
         specifier: 3.4.2
         version: 3.4.2(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(storybook@10.5.10(@types/react@19.2.17)(bufferutil@4.1.0)(prettier@2.8.8)(react@19.2.8)(utf-8-validate@5.0.10))(typescript@5.7.3)(vite@5.4.21(@types/node@20.19.27)(less@4.6.7)(lightningcss@1.30.2)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.50.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
@@ -662,7 +662,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -672,10 +672,10 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@types/jest':
         specifier: ~29.2.4
         version: 29.2.6
@@ -705,7 +705,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -730,10 +730,10 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -778,7 +778,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -788,10 +788,10 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.61.1
@@ -821,7 +821,7 @@ importers:
     dependencies:
       '@modern-js/runtime':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -831,10 +831,10 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: latest
-        version: 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))
+        version: 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))
       '@modern-js/tsconfig':
         specifier: latest
-        version: 3.8.2
+        version: 3.9.0
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -3462,6 +3462,21 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+
+  tests/integration/dev-server-lock:
+    dependencies:
+      '@modern-js/app-tools':
+        specifier: workspace:*
+        version: link:../../../packages/solutions/app-tools
+      '@modern-js/runtime':
+        specifier: workspace:*
+        version: link:../../../packages/runtime/plugin-runtime
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
 
   tests/integration/disable-html:
     dependencies:
@@ -7592,8 +7607,8 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@modern-js/app-tools@3.8.2':
-    resolution: {integrity: sha512-CZA215IvuT+bHNdNTQrppVozIOlzDn/M7ryzQ2sL9DrOb1XSbZVQLXg61X55HOdkQ1kT2n6oSzXAkfGVSW1tyQ==}
+  '@modern-js/app-tools@3.9.0':
+    resolution: {integrity: sha512-RYJzeX/PnmbWSbvuGMlTvMPf5JCV3duobeXoW4QTTscmKG4QAbTT19zQln+bvXCZ+/2iMtLq0hw/M1jryaQhqw==}
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
@@ -7605,8 +7620,8 @@ packages:
       tsconfig-paths:
         optional: true
 
-  '@modern-js/bff-core@3.8.2':
-    resolution: {integrity: sha512-ckkQoJFLu+dLEJJv4wtDZpZXNLle+xrS8wtHclcOCVnUmctOdB+FqnlN/tFPh9ZiAaVI0+SwwUIvpdPhH9u1tg==}
+  '@modern-js/bff-core@3.9.0':
+    resolution: {integrity: sha512-dVqo3excnnMS2IWwDtRsFBsQGTOiBA9Mk1mhm8bhekZPk55CA5LNBKKvEzSTJf47cGHa1iSBYTpi2w28ny0l6A==}
     peerDependencies:
       ts-node: ^10.9.2
       tsconfig-paths: ^4.2.0
@@ -7615,8 +7630,8 @@ packages:
       zod:
         optional: true
 
-  '@modern-js/builder@3.8.2':
-    resolution: {integrity: sha512-ow+BvEQfnY0nsXKb622Xr7Knip/+PRmlMr803Hz31QhTGBIYj986+WSoYjMVDljx5gk3/pu3eK1FWfu2WJWZFw==}
+  '@modern-js/builder@3.9.0':
+    resolution: {integrity: sha512-9wxV8K3aF3HVOQTk6UwNo+J/iWQmVwXtb6/m7Z98Jy0Wxf/zPWTsnDdECPaqCkzEuoDi69W9r5/KCbHo64Cldw==}
 
   '@modern-js/codesmith-api-handlebars@2.6.9':
     resolution: {integrity: sha512-wfTJ1vHr7aq2xMrja03xjy1JQ5gTQDUK+degP9kFdU5iGpw3AwIBZOLq6gyDtDBJYj2bk2KSaoXlFOQl1UYGzQ==}
@@ -7635,11 +7650,11 @@ packages:
   '@modern-js/core@2.70.4':
     resolution: {integrity: sha512-VdhyTkCn7EJyWs1FkoDG/6/rjb6OehLboDH12hwMcfyLcItahbAsVh9pX+yMC1YXkL7NpUbtO81pURF/pLacPA==}
 
-  '@modern-js/create-request@3.8.2':
-    resolution: {integrity: sha512-Ill1MCG16fwGjnuA/jGb2RTBpmwZy0oIUh96McWoSkqyWYcqxvTusfxhrfUW13v6rTOjs5mlK2cS6pCYYC7sAw==}
+  '@modern-js/create-request@3.9.0':
+    resolution: {integrity: sha512-y2k8P3TYu9F1Eg+6Rab3Kdk78KG9qRJiwpfHz+ctydlq8KwCoRSTPYHVOtmnxnSPL1X8ZuzN6TBPJpWZMXPbtQ==}
 
-  '@modern-js/i18n-utils@3.8.2':
-    resolution: {integrity: sha512-rAS0bvrG5ep3zSByZB55MmTSM5ZRy85td+LG+KaCnawld3T8QO+Y7oCRiqnGJMK89pb7VMduUle+jXfXcgWI8g==}
+  '@modern-js/i18n-utils@3.9.0':
+    resolution: {integrity: sha512-ZxE+p3/sfb6UtNf3WL6HfFnyr6Q6vTagA5jOpTDPUesnZkMgZamEOcdOA5LgqDPDCbVDyLY9gr+sBhNmc7m+Mw==}
 
   '@modern-js/module-tools@2.70.4':
     resolution: {integrity: sha512-2zFwwZ3gP9Yl2Ly21HLi7k2pi/CF1UrfDBM7uDcBiUCV1EqSw11zBjDxy53xlv97NatJBq7SAdinKL07BMEo+A==}
@@ -7654,23 +7669,23 @@ packages:
   '@modern-js/node-bundle-require@2.70.4':
     resolution: {integrity: sha512-xCriWRLEEDHsrVMtkt6P5kfXljUQVT/GHpJTrJWIgptcwcGrfAfb8nAUAmkqkyTIqSrNxoNXegyI9w+sFPO+TA==}
 
-  '@modern-js/plugin-bff@3.8.2':
-    resolution: {integrity: sha512-8GapEdOqKPphB9zyRxrrUoKz3bGzmJps7diHzbwsCvSpLgTlpZRBuxizqhuRhu19enVSHi8jReMoYNsBRd5G6A==}
+  '@modern-js/plugin-bff@3.9.0':
+    resolution: {integrity: sha512-csryFiUafroKkG4w3G5TGymorAp6vDiKw9hEeLgSEyv3XHQFl9Bg44mvAGL02CqLiRDYAh/IYAm7dIyNMlpwKw==}
 
   '@modern-js/plugin-changeset@2.70.4':
     resolution: {integrity: sha512-ut71UMoeMXJUTfo/IYPdzqCdsqSve7+uQf60kCEVqszX6ofFVv4y4+aGlB3EMAqt7KqcJaOH+TCyRM9Ww/HLsw==}
 
-  '@modern-js/plugin-data-loader@3.8.2':
-    resolution: {integrity: sha512-/RnUxI9hxBuYnszLqN48sH/MBG5q5MYBwYQ5B0uRLiiSruNGSDju7tC1n/+nUBFIOvNorx95yhb6efM8AfP5xA==}
+  '@modern-js/plugin-data-loader@3.9.0':
+    resolution: {integrity: sha512-ExxgNxzxGLPNdnT0NVJqkwm0vwFnRyyn/mAj/LPob/alzuMqp9U5PbaGXaQ/W2IrfvqC73FwQnVFjKNMDFhw8g==}
     engines: {node: '>=20'}
     peerDependencies:
-      react: '>=18.0.0'
+      react: '>=18.3.1'
 
   '@modern-js/plugin-i18n@2.70.4':
     resolution: {integrity: sha512-pRKl4u8ZyfianS/R1M8JXHXrxTXoUgySo4laFrB3rZ8crl2RFdgBruqY2KceTIcUL9qZ0IgWLjTLKO7MGFzwvw==}
 
-  '@modern-js/plugin-ssg@3.8.2':
-    resolution: {integrity: sha512-Phe+aslukRI8F5jiqAK4t0FY50I3A5OJzVxZkZa3bUKwJEbqMhOb+k9vX6YMUg/2HbZOhWi8DJ9Gn1kImBFmIQ==}
+  '@modern-js/plugin-ssg@3.9.0':
+    resolution: {integrity: sha512-Q76EjwadurjGZnNWArTUs3t+Vm4cPv9+W8swoGI3Z9NFTE/gFu/M68rXCxqKQUKfR8vTSYHIZfX5asPKirBS0g==}
     peerDependencies:
       react-router-dom: '>=7.13.1'
     peerDependenciesMeta:
@@ -7680,9 +7695,6 @@ packages:
   '@modern-js/plugin@2.70.4':
     resolution: {integrity: sha512-vqoioz6JbU+fIirmTMmbvHTYrWNM6IhMyOgZJ6kjHHeu/EdXyaYSp8X1DzPW7IXPWQavr0VuLq0E+Sav+G6HYg==}
 
-  '@modern-js/plugin@3.8.2':
-    resolution: {integrity: sha512-kiaGdn22Vb/Y//w+8nyqC3GDU7qMK2yzTHOCZHZyd3fcK/EXRS/swJlR3Qv2rJVmr9fnwCdpR41B5A9F/pMs0Q==}
-
   '@modern-js/plugin@3.9.0':
     resolution: {integrity: sha512-n3AA2K4117MaBl7GHIroQlsoKlHB1654Ym0VfvMGye+oOohkDzMWmZh3fITXUbItwddWzlzNPsjtqSE5ODAKKA==}
 
@@ -7690,27 +7702,16 @@ packages:
     resolution: {integrity: sha512-UdBEpS0kwBYm43n60FEZFvZ3dUhqlzzvZkIMwiQGYHvlpXuAN/30GrWnp2WUdd5+eM5ObRCJ1bSJ7+UYouxPAQ==}
     engines: {node: '>=8'}
 
-  '@modern-js/prod-server@3.8.2':
-    resolution: {integrity: sha512-5/0jmj9CLTjbF8TGlqqwnu9bYQsrqMTIdG8RbHsgJFU+7d74GtaJED0WoxsjkxwxJO3BzSQI1FJpmFvloe9w0Q==}
+  '@modern-js/prod-server@3.9.0':
+    resolution: {integrity: sha512-AwDUDS+Z+74lDdgmJVXNZV6pZWeXhtjbDLPjesUADGEhtThIKADag7Ijxp239s5uYXDuaQcRoz3CNmVw9VD8gg==}
     engines: {node: '>=20'}
 
-  '@modern-js/render@3.8.2':
-    resolution: {integrity: sha512-CnDN167f0hBAc+ZN/2HrBqiYtADABcE6gvCHzCPEbQaKPkO82NsZ+wtrENx/jpuhOgpyBs4OjR6xtBCJkcuSGQ==}
+  '@modern-js/render@3.9.0':
+    resolution: {integrity: sha512-zbhPU4rzWE64MHE2N6skWH6C8I4gag/Mo3I3c8VQKc8rF6b2JWRaYGQuY3rrn4SMOgeILsy2cKtLL1gxblu1PQ==}
     peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-      react-server-dom-rspack: 0.0.2
-
-  '@modern-js/runtime-utils@3.8.2':
-    resolution: {integrity: sha512-++QGHNESs/J2Ns3lKDlVOnI6Tx3zEdXjpZZZol6PWiUQ8PZmFwJNZT1fVzOXfSS58mcAA+QFojAT2wWFpNkpSA==}
-    peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
+      react: '>=18.3.1'
+      react-dom: '>=18.3.1'
+      react-server-dom-rspack: 0.1.0
 
   '@modern-js/runtime-utils@3.9.0':
     resolution: {integrity: sha512-KM20objjcL5y1FFjONTMrne9M1iprawj+Rmn0mFbawjSWdQmbHyWmbPF0IaT1TBILAXrZUKfLl2jeR4VEx+4jA==}
@@ -7723,25 +7724,25 @@ packages:
       react-dom:
         optional: true
 
-  '@modern-js/runtime@3.8.2':
-    resolution: {integrity: sha512-uJVVEww8IfgjOI171hQNqS8o7lJNZUKQABWhFJFpspUVJvHZfmnGL9l9CtFnu/vo5GxIxCAhgO2uYDz95nmvzg==}
+  '@modern-js/runtime@3.9.0':
+    resolution: {integrity: sha512-8DO61J6KW8QHtcQ2G9JtDBy3im6Oy/68L+xxg6N9LPX3zpGZh6f8UiwktonMRHkODV4U0pueEWQuiEHxDEUV6A==}
     engines: {node: '>=20'}
     peerDependencies:
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
+      react: '>=18.3.1'
+      react-dom: '>=18.3.1'
 
-  '@modern-js/server-core@3.8.2':
-    resolution: {integrity: sha512-VKJq20q571VtnSKCiao7obtB97Bllo0u2LCdyEBQcpSi29bh2DXJywNvIJB1Bqzkk+ezd+GhzIp4vR4mcWkrIw==}
+  '@modern-js/server-core@3.9.0':
+    resolution: {integrity: sha512-h9MVm1nFMT0fydTNKLuwIGG8PRHeI9kSN4gkp8gX84co/p6Z0siM+VnmKI6IfVmZ6orJhj+m7jNboWKBcURBew==}
     engines: {node: '>=20'}
 
-  '@modern-js/server-runtime@3.8.2':
-    resolution: {integrity: sha512-3bN4oQQM4kZ7+XcQuTCgjiRM8JD0U4O7gMOB9/yL7ELzXJLqv2dzDbRyqslVA8IdT7JAvAAeh1vHe0qkBdiwnQ==}
+  '@modern-js/server-runtime@3.9.0':
+    resolution: {integrity: sha512-r7ZQw1oJezLX+5/6SHO85Pwl0PLyftToAW/vwMGyRfhe+mBojSwi1hPG5w16CCY9hREG9wLH9FXBnKHRko+Ghg==}
 
-  '@modern-js/server-utils@3.8.2':
-    resolution: {integrity: sha512-4XtOuQu0KPb8QNjQs4PbduUJNTGfIVntzpWEu+devpeow9SCsRwKROVz+8ruveY7bTA+6peaOcKr0Zun/aJbjQ==}
+  '@modern-js/server-utils@3.9.0':
+    resolution: {integrity: sha512-KeC+05matkpFdnada4Mc1Gu1guBfYI/JLKpByC6Ilifcx/cVyGqPm28UumGwo5s7Cjgyor7ZACy/0t2aTWPJTg==}
 
-  '@modern-js/server@3.8.2':
-    resolution: {integrity: sha512-ZmnPOi+pkkS92s1ZqUYqGQBJLAZue0I3p/rexxl//zDhVkYBhMa/DZRNovgfXhE/2AGdepnxJnKxrgdywQfFCw==}
+  '@modern-js/server@3.9.0':
+    resolution: {integrity: sha512-izQQLpCTKpUsGceSJSQEKrhf7lG+a5m8OakvxaJZMVZGbiIhxy2VK+3lF/KgkiepigCKlnVqoNrBUNkzEu98uQ==}
     peerDependencies:
       devcert: ^1.2.3
       ts-node: ^10.9.2
@@ -7811,31 +7812,17 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@modern-js/tsconfig@3.8.2':
-    resolution: {integrity: sha512-6KOyg5Fd/ihYlKkC1H7aezJctfOd+EIRZL3mZXovNu0oocz4tvaWwIRDyMI+1FbDFW0kJrGE0rCAvY/rqIzDJg==}
+  '@modern-js/tsconfig@3.9.0':
+    resolution: {integrity: sha512-eD3Zgax0HmRXm4To7P3FEIskMISt/RIsTuXcnnYLHxRshZr+PJqmbNZS3nWCI7yynqxvgBt1cp3KtaoC2k8/CQ==}
 
   '@modern-js/types@2.70.4':
     resolution: {integrity: sha512-P3Pe6S34GwJMQOYOHQx/mkcu8oEPwLU+Y3LwKslMNa43ooIgx0NEUzwl/N93bapw3LnoCQpwAOK0qQALaXnd9A==}
-
-  '@modern-js/types@3.8.2':
-    resolution: {integrity: sha512-+vQ4IP+kvhJImH4LJ09TH3aB9tjZVTpIgtTlQvJdQTPpRVHpNh8D66JNl6/c7eAwH7+hIWfbrWKGEK9rNmXEXA==}
 
   '@modern-js/types@3.9.0':
     resolution: {integrity: sha512-hOULXVcv+ertn3FSWOuwRwVXr/bLDT00WghZk8UUsCNlB/DuBs81oFES2Hy2wDAGmEqJdMa3LkZ3NdRELkJixQ==}
 
   '@modern-js/utils@2.70.4':
     resolution: {integrity: sha512-LQrwyGlFhsH2BmZxStF0TPeStm6aumf4N1J+ZyObLw5URrN4o8vCyeyqrPVciICeoTqhHg2GIArJWB5PXRcUig==}
-
-  '@modern-js/utils@3.8.2':
-    resolution: {integrity: sha512-wZD5JJATh+g4CNPHMA3iqvyAlz9hmhbUBffYGhT7+bqXHxYp8IxRm8G30+Fe/LhaXWEf1Hl7hRiMjwNOL/zWOg==}
-    peerDependencies:
-      react: ^19.2.7
-      react-dom: ^19.2.7
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@modern-js/utils@3.9.0':
     resolution: {integrity: sha512-oFltYfm1cEAtMs6mKiZt9mNBywil6cIy1FLLKLMvt1pmv1b0Qv2l6KpUzGhrb3aPgjNZEhWH+qPGC75h1msaCw==}
@@ -8690,16 +8677,6 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.1.0':
-    resolution: {integrity: sha512-BNOp22xLGA+L8zvZ12Qg/3zhFhWFZCvZ7OcQRoGLSTw1pB9q/XDLK+WGey9SFPOtsRD3CRPXheXApxwvneH6uA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.1.13':
     resolution: {integrity: sha512-Z+6MzmjOio4+bFZQ24k+7ge/oNCOdXIunAssrswTNE8AIf6mcyXpJZevRXRiOEMZasRPA8VNyh+9JngQLg729Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8730,14 +8707,6 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/plugin-assets-retry@2.0.1':
-    resolution: {integrity: sha512-eI3VA+Wi8dNnPkpuQPDnqJXTtOVdGNa2JtjbNWg2raJ9si/M4/MPealfZHvkRK2XlrM0L1Mw3EeGqS3bufn0Yg==}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
-
   '@rsbuild/plugin-assets-retry@2.0.2':
     resolution: {integrity: sha512-MPB0P5cIGn4F9kZRriMQjTDxi8k1OLpA2aYiP73xp4Gu2IbPZaxYgFlETZmUGiYv+tx/oYS3YIUGcIsr6qlohg==}
     peerDependencies:
@@ -8762,14 +8731,6 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-check-syntax@2.0.0':
-    resolution: {integrity: sha512-rNc7J1DTwR+t2N/scaCsnKe1mCGc6SEky0gV+gaoLC+CP/VO6e9SxMxv0dHQJgNEzO0i+xQ9O1cU9p+dCo9xSQ==}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
-
   '@rsbuild/plugin-check-syntax@2.0.1':
     resolution: {integrity: sha512-z+NMAUXEbM4fhoQlKJNgTjsf+O1tknBihsXj4JnSFlwpfoY5uDjKC6D+StATATvUilSKXFrk4WDhcIyoxkj1gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8783,14 +8744,6 @@ packages:
     resolution: {integrity: sha512-QZUEBLTYXwtCUVziK3XHaPv+3wLLGvO6X27sIwt12eyuIMSA5WbeuLD9y1hwsXu27jZBofP6s/mdV5H5bA/FOg==}
     peerDependencies:
       '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
-
-  '@rsbuild/plugin-less@1.6.4':
-    resolution: {integrity: sha512-cDlxi6Ne0K8ZK4PrTy/wSli5RyGkT8I55j/e0R7ZBvriHM7JL0MaA28ceiKAqy70Hy/eZ/btHTB35Sl1FAor1g==}
-    peerDependencies:
-      '@rsbuild/core': ^1.3.0 || ^2.0.0-0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -8835,14 +8788,6 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-sass@1.5.3':
-    resolution: {integrity: sha512-NViSITZF3J3i96GfemWfTZBZ43CNZUgTaaKgfti0I7odwy36Qlo8MIAbGjOy8pBSygIYn7Xl4+Jw8qAbTysCBw==}
-    peerDependencies:
-      '@rsbuild/core': ^1.3.0 || ^2.0.0-0
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
-
   '@rsbuild/plugin-sass@2.0.1':
     resolution: {integrity: sha512-BZRpVTZW+za+sv84nYYdIjR7XwVqyS8+1wAha/7BvQ1igdzlmT6xPd6h4jTWfNzdHuzIHZsuWY7kPS/ybzcndA==}
     peerDependencies:
@@ -8867,31 +8812,12 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-svgr@2.0.3':
-    resolution: {integrity: sha512-k2dMtyscm6mZI/OuWPtrQ4AL2y2SphM3cYkLD9qQlFd8FufnCOP9bmgI4fisZNhyWsdN0WSmlkosGJxqltRf1A==}
-    peerDependencies:
-      '@rsbuild/core': ^2.0.0-0
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
-
   '@rsbuild/plugin-svgr@2.0.5':
     resolution: {integrity: sha512-Ee7HWjxz6Ockv4EtLQn5rFhsVKNPGmAKG3PLHJ4yg3ePYqFMdwHfshcF3HEOVyt67HsNRYpdK2POHE3qv52Dkg==}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
     peerDependenciesMeta:
       '@rsbuild/core':
-        optional: true
-
-  '@rsbuild/plugin-type-check@1.5.0':
-    resolution: {integrity: sha512-UgIwUG3ttTj6mtusutfQhhVy3CcZwTsseYJ/vH2/7q4cEOfypbO3CFUCnV7EtovFaIHukLu+H9JD/ocwmKEpQA==}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': ^7.0.0-0
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
-      '@typescript/native-preview':
         optional: true
 
   '@rsbuild/plugin-type-check@1.6.0':
@@ -8903,14 +8829,6 @@ packages:
       '@rsbuild/core':
         optional: true
       '@typescript/native-preview':
-        optional: true
-
-  '@rsbuild/plugin-typed-css-modules@1.2.3':
-    resolution: {integrity: sha512-J/3VkCa+mFkffGWLhie+QkPlWBfnS6k/25m2b/AGkzSET5co44OjjD09F445eY3gm+uwaLgabdB7NpiUiAsl8g==}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-    peerDependenciesMeta:
-      '@rsbuild/core':
         optional: true
 
   '@rsbuild/plugin-typed-css-modules@1.2.4':
@@ -9758,9 +9676,6 @@ packages:
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
-
-  '@swc/plugin-loadable-components@11.12.0':
-    resolution: {integrity: sha512-zZr0KLZRBQKe88WgigSyE7qH+8CYIcQf9SaBTmShaly7NwZlfC8LrbdTu5bocc00Cb3ulzTcJixqAnSTfBDcOA==}
 
   '@swc/plugin-loadable-components@12.0.0':
     resolution: {integrity: sha512-3vdbr0k5NQ0W4KgIx6LrFvjKwDyMPWbeHBncfFT7Fo2IKyo7513CXMCkx6KEUEsPzTJZRhHx0pFyt2hPWnfpEA==}
@@ -11017,11 +10932,6 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  baseline-browser-mapping@2.10.42:
-    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.11.18:
     resolution: {integrity: sha512-1iEmLEYSiE1SeBoAfPo/Mnx3PzfzHUkDK61ASkCpuk3YXugYLH5DYK1SzqV55F8FMI6s0F+/tCP7Polz1QRjxw==}
     engines: {node: '>=6.0.0'}
@@ -11119,11 +11029,6 @@ packages:
 
   browserslist-to-es-version@1.4.2:
     resolution: {integrity: sha512-3NV13pCv0wmPxxZZcekHAG6vt8rQ94w2c4/UBe3ZU3NDUm5TP+QFK3rjS6XeKWSHWpnPYNfQzlhnljka0BrEOA==}
-    hasBin: true
-
-  browserslist@4.28.4:
-    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
   browserslist@4.28.8:
@@ -11706,6 +11611,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -12358,9 +12264,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.387:
-    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
-
   electron-to-chromium@1.5.412:
     resolution: {integrity: sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==}
 
@@ -12908,9 +12811,6 @@ packages:
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
-
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
@@ -15063,10 +14963,6 @@ packages:
   node-persist@4.0.4:
     resolution: {integrity: sha512-8sPAz/7tw1mCCc8xBG4f0wi+flHkSSgQeX998iQ75Pu27evA6UUWCjSE7xnrYTg2q33oU5leJ061EKPDv6BocQ==}
     engines: {node: '>=10.12.0'}
-
-  node-releases@2.0.50:
-    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
-    engines: {node: '>=18'}
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -18206,12 +18102,6 @@ packages:
     resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
     engines: {node: '>=4'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
   update-browserslist-db@1.3.1:
     resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
     hasBin: true
@@ -21327,26 +21217,26 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
+  '@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
-      '@modern-js/i18n-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin-data-loader': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/prod-server': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server': 3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(utf-8-validate@5.0.10)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+      '@modern-js/i18n-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin-data-loader': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/prod-server': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server': 3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(utf-8-validate@5.0.10)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       es-module-lexer: 1.7.0
-      flatted: 3.4.2
+      flatted: 3.4.4
       import-meta-resolve: 4.2.0
       mlly: 1.8.2
       ndepe: 0.1.13(rollup@4.62.2)
@@ -21379,26 +21269,26 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))':
+  '@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))
-      '@modern-js/i18n-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin-data-loader': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/prod-server': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server': 3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))
+      '@modern-js/i18n-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin-data-loader': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/prod-server': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server': 3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       es-module-lexer: 1.7.0
-      flatted: 3.4.2
+      flatted: 3.4.4
       import-meta-resolve: 4.2.0
       mlly: 1.8.2
       ndepe: 0.1.13
@@ -21431,26 +21321,26 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@modern-js/i18n-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin-data-loader': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/prod-server': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server': 3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@modern-js/i18n-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin-data-loader': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/prod-server': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server': 3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       es-module-lexer: 1.7.0
-      flatted: 3.4.2
+      flatted: 3.4.4
       import-meta-resolve: 4.2.0
       mlly: 1.8.2
       ndepe: 0.1.13
@@ -21483,26 +21373,26 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@modern-js/i18n-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin-data-loader': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/prod-server': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server': 3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@modern-js/i18n-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin-data-loader': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/prod-server': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server': 3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       es-module-lexer: 1.7.0
-      flatted: 3.4.2
+      flatted: 3.4.4
       import-meta-resolve: 4.2.0
       mlly: 1.8.2
       ndepe: 0.1.13
@@ -21535,26 +21425,26 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@modern-js/i18n-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin-data-loader': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/prod-server': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server': 3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@modern-js/i18n-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin-data-loader': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/prod-server': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server': 3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       es-module-lexer: 1.7.0
-      flatted: 3.4.2
+      flatted: 3.4.4
       import-meta-resolve: 4.2.0
       mlly: 1.8.2
       ndepe: 0.1.13
@@ -21587,26 +21477,26 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@modern-js/i18n-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin-data-loader': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/prod-server': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server': 3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@modern-js/i18n-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin-data-loader': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/prod-server': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server': 3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       es-module-lexer: 1.7.0
-      flatted: 3.4.2
+      flatted: 3.4.4
       import-meta-resolve: 4.2.0
       mlly: 1.8.2
       ndepe: 0.1.13
@@ -21639,9 +21529,9 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@modern-js/bff-core@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(zod@3.25.76)':
+  '@modern-js/bff-core@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(zod@3.25.76)':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       koa-compose: 4.1.0
       reflect-metadata: 0.2.2
@@ -21654,9 +21544,9 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/bff-core@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(zod@3.25.76)':
+  '@modern-js/bff-core@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(zod@3.25.76)':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       koa-compose: 4.1.0
       reflect-metadata: 0.2.2
@@ -21669,25 +21559,25 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/builder@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
+  '@modern-js/builder@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-      '@rsbuild/plugin-assets-retry': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-check-syntax': 2.0.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(esbuild@0.27.2)(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
-      '@rsbuild/plugin-less': 1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
-      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-sass': 1.5.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-svgr': 2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
-      '@rsbuild/plugin-type-check': 1.5.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
-      '@rsbuild/plugin-typed-css-modules': 1.2.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/plugin-assets-retry': 2.0.2(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-check-syntax': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(esbuild@0.27.2)(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+      '@rsbuild/plugin-less': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-sass': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-svgr': 2.0.5(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
+      '@rsbuild/plugin-typed-css-modules': 1.2.4(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       autoprefixer: 10.4.27(postcss@8.5.26)
-      browserslist: 4.28.4
+      browserslist: 4.28.8
       core-js: 3.48.0
       cssnano: 6.1.2(postcss@8.5.26)
       html-minifier-terser: 7.2.0
@@ -21700,7 +21590,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.26)
       postcss-nesting: 12.1.5(postcss@8.5.26)
       postcss-page-break: 3.0.4(postcss@8.5.26)
-      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       rspack-manifest-plugin: 5.2.2(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
@@ -21720,25 +21610,25 @@ snapshots:
       - typescript
       - webpack
 
-  '@modern-js/builder@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))':
+  '@modern-js/builder@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-      '@rsbuild/plugin-assets-retry': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-check-syntax': 2.0.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))
-      '@rsbuild/plugin-less': 1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
-      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-sass': 1.5.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-svgr': 2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
-      '@rsbuild/plugin-type-check': 1.5.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
-      '@rsbuild/plugin-typed-css-modules': 1.2.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/plugin-assets-retry': 2.0.2(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-check-syntax': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))
+      '@rsbuild/plugin-less': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-sass': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-svgr': 2.0.5(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
+      '@rsbuild/plugin-typed-css-modules': 1.2.4(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       autoprefixer: 10.4.27(postcss@8.5.26)
-      browserslist: 4.28.4
+      browserslist: 4.28.8
       core-js: 3.48.0
       cssnano: 6.1.2(postcss@8.5.26)
       html-minifier-terser: 7.2.0
@@ -21751,7 +21641,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.26)
       postcss-nesting: 12.1.5(postcss@8.5.26)
       postcss-page-break: 3.0.4(postcss@8.5.26)
-      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       rspack-manifest-plugin: 5.2.2(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
@@ -21771,25 +21661,25 @@ snapshots:
       - typescript
       - webpack
 
-  '@modern-js/builder@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@modern-js/builder@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-      '@rsbuild/plugin-assets-retry': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-check-syntax': 2.0.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@rsbuild/plugin-less': 1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
-      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-sass': 1.5.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-svgr': 2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
-      '@rsbuild/plugin-type-check': 1.5.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
-      '@rsbuild/plugin-typed-css-modules': 1.2.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/plugin-assets-retry': 2.0.2(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-check-syntax': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@rsbuild/plugin-less': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-sass': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-svgr': 2.0.5(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
+      '@rsbuild/plugin-typed-css-modules': 1.2.4(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       autoprefixer: 10.4.27(postcss@8.5.26)
-      browserslist: 4.28.4
+      browserslist: 4.28.8
       core-js: 3.48.0
       cssnano: 6.1.2(postcss@8.5.26)
       html-minifier-terser: 7.2.0
@@ -21802,7 +21692,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.26)
       postcss-nesting: 12.1.5(postcss@8.5.26)
       postcss-page-break: 3.0.4(postcss@8.5.26)
-      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       rspack-manifest-plugin: 5.2.2(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
@@ -21822,25 +21712,25 @@ snapshots:
       - typescript
       - webpack
 
-  '@modern-js/builder@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@modern-js/builder@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-      '@rsbuild/plugin-assets-retry': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-check-syntax': 2.0.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@rsbuild/plugin-less': 1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
-      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-sass': 1.5.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
-      '@rsbuild/plugin-svgr': 2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
-      '@rsbuild/plugin-type-check': 1.5.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
-      '@rsbuild/plugin-typed-css-modules': 1.2.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/plugin-assets-retry': 2.0.2(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-check-syntax': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-css-minimizer': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@rsbuild/plugin-less': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-rem': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-sass': 2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-source-build': 1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+      '@rsbuild/plugin-svgr': 2.0.5(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
+      '@rsbuild/plugin-type-check': 1.6.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
+      '@rsbuild/plugin-typed-css-modules': 1.2.4(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
       autoprefixer: 10.4.27(postcss@8.5.26)
-      browserslist: 4.28.4
+      browserslist: 4.28.8
       core-js: 3.48.0
       cssnano: 6.1.2(postcss@8.5.26)
       html-minifier-terser: 7.2.0
@@ -21853,7 +21743,7 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.26)
       postcss-nesting: 12.1.5(postcss@8.5.26)
       postcss-page-break: 3.0.4(postcss@8.5.26)
-      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      rsbuild-plugin-rsc: 0.1.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       rspack-manifest-plugin: 5.2.2(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
@@ -21928,10 +21818,10 @@ snapshots:
       '@modern-js/utils': 2.70.4
       '@swc/helpers': 0.5.23
 
-  '@modern-js/create-request@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@modern-js/create-request@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       encoding: 0.1.13
       path-to-regexp: 6.3.0
@@ -21940,9 +21830,9 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/i18n-utils@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@modern-js/i18n-utils@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - react
@@ -21989,14 +21879,14 @@ snapshots:
       '@swc/helpers': 0.5.23
       esbuild: 0.27.2
 
-  '@modern-js/plugin-bff@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))(zod@3.25.76)':
+  '@modern-js/plugin-bff@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))(zod@3.25.76)':
     dependencies:
-      '@modern-js/bff-core': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(zod@3.25.76)
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
-      '@modern-js/create-request': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/bff-core': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(zod@3.25.76)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+      '@modern-js/create-request': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       qs: 6.15.3
       type-is: 1.6.18
@@ -22021,14 +21911,14 @@ snapshots:
       - webpack
       - zod
 
-  '@modern-js/plugin-bff@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))(zod@3.25.76)':
+  '@modern-js/plugin-bff@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))(zod@3.25.76)':
     dependencies:
-      '@modern-js/bff-core': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(zod@3.25.76)
-      '@modern-js/builder': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@modern-js/create-request': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/bff-core': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(zod@3.25.76)
+      '@modern-js/builder': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.7.3)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@modern-js/create-request': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       qs: 6.15.3
       type-is: 1.6.18
@@ -22068,10 +21958,10 @@ snapshots:
       - debug
       - supports-color
 
-  '@modern-js/plugin-data-loader@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@modern-js/plugin-data-loader@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       path-to-regexp: 6.3.0
       react: 19.2.8
@@ -22083,10 +21973,10 @@ snapshots:
       '@modern-js/utils': 2.70.4
       '@swc/helpers': 0.5.23
 
-  '@modern-js/plugin-ssg@3.8.2(@module-federation/runtime-tools@2.0.0)(@types/express@4.17.25)(@types/node@20.19.27)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@modern-js/plugin-ssg@3.9.0(@module-federation/runtime-tools@2.0.0)(@types/express@4.17.25)(@types/node@20.19.27)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/prod-server': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/prod-server': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       node-mocks-http: 1.17.2(@types/express@4.17.25)(@types/node@20.19.27)
       normalize-path: 3.0.0
@@ -22105,20 +21995,6 @@ snapshots:
       '@modern-js/utils': 2.70.4
       '@swc/helpers': 0.5.23
 
-  '@modern-js/plugin@3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-      '@swc/helpers': 0.5.23
-      jiti: 2.7.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-      - core-js
-      - react
-      - react-dom
-
   '@modern-js/plugin@3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -22132,7 +22008,6 @@ snapshots:
       - core-js
       - react
       - react-dom
-    optional: true
 
   '@modern-js/polyfill-lib@1.0.2':
     dependencies:
@@ -22182,11 +22057,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modern-js/prod-server@3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@modern-js/prod-server@3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -22194,26 +22069,14 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/render@3.8.2(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@modern-js/render@3.9.0(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-server-dom-rspack: 0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
-  '@modern-js/runtime-utils@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@swc/helpers': 0.5.23
-      lru-cache: 10.4.3
-      react-router: 7.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      serialize-javascript: 6.0.2
-    optionalDependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   '@modern-js/runtime-utils@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -22226,21 +22089,20 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-    optional: true
 
-  '@modern-js/runtime@3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@modern-js/runtime@3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@loadable/component': 5.16.7(react@19.2.8)
       '@loadable/server': 5.16.7(@loadable/component@5.16.7(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/plugin-data-loader': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/render': 3.8.2(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin-data-loader': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/render': 3.9.0(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
-      '@swc/plugin-loadable-components': 11.12.0
+      '@swc/plugin-loadable-components': 12.0.0
       '@types/loadable__component': 5.13.10
       '@types/react-helmet': 6.1.11
       cookie: 0.7.2
@@ -22257,11 +22119,11 @@ snapshots:
       - core-js
       - react-server-dom-rspack
 
-  '@modern-js/server-core@3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@modern-js/server-core@3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/plugin': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/plugin': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       '@web-std/fetch': 4.2.1
       '@web-std/file': 3.0.3
@@ -22276,11 +22138,11 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/server-runtime@3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@modern-js/server-runtime@3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -22288,21 +22150,21 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/server-utils@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@modern-js/server-utils@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@modern-js/server@3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)':
+  '@modern-js/server@3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       axios: 1.19.0(debug@4.4.3)
       connect-history-api-fallback: 2.0.0
@@ -22324,13 +22186,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/server@3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)':
+  '@modern-js/server@3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.8.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.14.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       axios: 1.19.0(debug@4.4.3)
       connect-history-api-fallback: 2.0.0
@@ -22352,13 +22214,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/server@3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)':
+  '@modern-js/server@3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.0.4))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       axios: 1.19.0(debug@4.4.3)
       connect-history-api-fallback: 2.0.0
@@ -22380,13 +22242,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/server@3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(utf-8-validate@5.0.10)':
+  '@modern-js/server@3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(utf-8-validate@5.0.10)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       axios: 1.19.0(debug@4.4.3)
       connect-history-api-fallback: 2.0.0
@@ -22408,13 +22270,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modern-js/server@3.8.2(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)':
+  '@modern-js/server@3.9.0(@module-federation/runtime-tools@2.0.0)(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(utf-8-validate@5.0.10)':
     dependencies:
-      '@modern-js/runtime-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-core': 3.8.2(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/server-utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@modern-js/types': 3.8.2
-      '@modern-js/utils': 3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/runtime-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-core': 3.9.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/server-utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modern-js/types': 3.9.0
+      '@modern-js/utils': 3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@swc/helpers': 0.5.23
       axios: 1.19.0(debug@4.4.3)
       connect-history-api-fallback: 2.0.0
@@ -22472,14 +22334,11 @@ snapshots:
       '@modern-js/swc-plugins-win32-x64-msvc': 0.6.11
       '@swc/helpers': 0.5.23
 
-  '@modern-js/tsconfig@3.8.2': {}
+  '@modern-js/tsconfig@3.9.0': {}
 
   '@modern-js/types@2.70.4': {}
 
-  '@modern-js/types@3.8.2': {}
-
-  '@modern-js/types@3.9.0':
-    optional: true
+  '@modern-js/types@3.9.0': {}
 
   '@modern-js/utils@2.70.4':
     dependencies:
@@ -22487,18 +22346,6 @@ snapshots:
       caniuse-lite: 1.0.30001782
       lodash: 4.18.1
       rslog: 1.3.2
-
-  '@modern-js/utils@3.8.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@swc/helpers': 0.5.23
-      caniuse-lite: 1.0.30001809
-      import-meta-resolve: 4.2.0
-      lodash: 4.18.1
-      lodash-es: 4.18.1
-      rslog: 1.3.2
-    optionalDependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   '@modern-js/utils@3.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -22511,12 +22358,11 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-    optional: true
 
-  '@module-federation/automatic-vendor-federation@1.2.1(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@module-federation/automatic-vendor-federation@1.2.1(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       find-package-json: 1.2.0
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)
 
   '@module-federation/bridge-react-webpack-plugin@2.0.0':
     dependencies:
@@ -22639,7 +22485,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@module-federation/enhanced@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.0
       '@module-federation/cli': 2.0.0(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
@@ -22657,7 +22503,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.0.4
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -22737,13 +22583,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/modern-js-v3@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@module-federation/modern-js-v3@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       '@module-federation/bridge-react': 2.0.0(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.15.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@module-federation/cli': 2.0.0(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
-      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@module-federation/node': 2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@module-federation/rsbuild-plugin': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@module-federation/node': 2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@module-federation/rsbuild-plugin': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@module-federation/runtime': 2.0.0
       '@module-federation/sdk': 2.0.0
       '@swc/helpers': 0.5.23
@@ -22767,13 +22613,13 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@module-federation/modern-js-v3@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@module-federation/modern-js-v3@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
       '@module-federation/bridge-react': 2.0.0(react-dom@19.2.8(react@19.2.8))(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@module-federation/cli': 2.0.0(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
-      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@module-federation/node': 2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@module-federation/rsbuild-plugin': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@module-federation/node': 2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@module-federation/rsbuild-plugin': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@module-federation/runtime': 2.0.0
       '@module-federation/sdk': 2.0.0
       '@swc/helpers': 0.5.23
@@ -22827,16 +22673,16 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@module-federation/node@2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@module-federation/node@2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
-      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@module-federation/runtime': 2.0.0
       '@module-federation/sdk': 2.0.0
       btoa: 1.2.1
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -22869,10 +22715,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
+  '@module-federation/rsbuild-plugin@2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
-      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      '@module-federation/node': 2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      '@module-federation/enhanced': 2.0.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
+      '@module-federation/node': 2.7.31(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.0.4)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       '@module-federation/sdk': 2.0.0
       fs-extra: 11.3.0
     transitivePeerDependencies:
@@ -23544,15 +23390,6 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)':
-    dependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    optionalDependencies:
-      core-js: 3.48.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)':
     dependencies:
       '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
@@ -23579,10 +23416,6 @@ snapshots:
       core-js: 3.48.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
-
-  '@rsbuild/plugin-assets-retry@2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
   '@rsbuild/plugin-assets-retry@2.0.2(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
     optionalDependencies:
@@ -23614,16 +23447,6 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.3(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
-  '@rsbuild/plugin-check-syntax@2.0.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
-    dependencies:
-      acorn: 8.18.0
-      browserslist-to-es-version: 1.4.2
-      htmlparser2: 12.0.0
-      picocolors: 1.1.1
-      source-map: 0.7.6
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-
   '@rsbuild/plugin-check-syntax@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
     dependencies:
       acorn: 8.17.0
@@ -23633,12 +23456,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
-  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(esbuild@0.27.2)(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
+  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(esbuild@0.27.2)(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
     dependencies:
       css-minimizer-webpack-plugin: 8.0.0(esbuild@0.27.2)(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -23648,27 +23471,12 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))':
+  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))':
     dependencies:
-      css-minimizer-webpack-plugin: 8.0.0(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))
+      css-minimizer-webpack-plugin: 8.0.0(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@swc/css'
-      - clean-css
-      - csso
-      - esbuild
-      - lightningcss
-      - webpack
-
-  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
-    dependencies:
-      css-minimizer-webpack-plugin: 8.0.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      reduce-configs: 1.1.2
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -23693,40 +23501,19 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
+  '@rsbuild/plugin-css-minimizer@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
     dependencies:
-      deepmerge: 4.3.1
-      less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+      css-minimizer-webpack-plugin: 8.0.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
     transitivePeerDependencies:
-      - '@rspack/core'
-      - webpack
-
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))':
-    dependencies:
-      deepmerge: 4.3.1
-      less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))
-      reduce-configs: 1.1.2
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - webpack
-
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))':
-    dependencies:
-      deepmerge: 4.3.1
-      less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
-      reduce-configs: 1.1.2
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
+      - '@parcel/css'
+      - '@swc/css'
+      - clean-css
+      - csso
+      - esbuild
+      - lightningcss
       - webpack
 
   '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26))':
@@ -23734,6 +23521,42 @@ snapshots:
       deepmerge: 4.3.1
       less: 4.6.7
       less-loader: 12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26))
+      reduce-configs: 2.0.1
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))':
+    dependencies:
+      deepmerge: 4.3.1
+      less: 4.6.7
+      less-loader: 12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+      reduce-configs: 2.0.1
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))':
+    dependencies:
+      deepmerge: 4.3.1
+      less: 4.6.7
+      less-loader: 12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))
+      reduce-configs: 2.0.1
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@rsbuild/plugin-less@2.0.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))':
+    dependencies:
+      deepmerge: 4.3.1
+      less: 4.6.7
+      less-loader: 12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       reduce-configs: 2.0.1
     optionalDependencies:
       '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
@@ -23778,15 +23601,6 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-
   '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
@@ -23805,29 +23619,12 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-rem@1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      terser: 5.48.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-
   '@rsbuild/plugin-rem@1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
     dependencies:
       deepmerge: 4.3.1
       terser: 5.48.0
     optionalDependencies:
       '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.26
-      reduce-configs: 1.1.2
-      sass-embedded: 1.100.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
   '@rsbuild/plugin-sass@2.0.1(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
     dependencies:
@@ -23849,14 +23646,6 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
-  '@rsbuild/plugin-source-build@1.0.6(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
-    dependencies:
-      fast-glob: 3.3.3
-      json5: 2.2.3
-      yaml: 2.9.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-
   '@rsbuild/plugin-source-build@1.0.6(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
     dependencies:
       fast-glob: 3.3.3
@@ -23872,31 +23661,31 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.3(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
-  '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@5.0.4)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.0.4))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.0.4))(typescript@5.0.4)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))(typescript@5.7.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
@@ -23917,26 +23706,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)':
+  '@rsbuild/plugin-type-check@1.6.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.6.1(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)
     optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - typescript
-
-  '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)':
-    dependencies:
-      deepmerge: 4.3.1
-      json5: 2.2.3
-      reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.6.1(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.7.3)
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
@@ -23964,10 +23741,6 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
       - typescript
-
-  '@rsbuild/plugin-typed-css-modules@1.2.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
-    optionalDependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
   '@rsbuild/plugin-typed-css-modules@1.2.4(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
     optionalDependencies:
@@ -24941,10 +24714,6 @@ snapshots:
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
-
-  '@swc/plugin-loadable-components@11.12.0':
-    dependencies:
-      '@swc/counter': 0.1.3
 
   '@swc/plugin-loadable-components@12.0.0':
     dependencies:
@@ -26475,8 +26244,6 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  baseline-browser-mapping@2.10.42: {}
-
   baseline-browser-mapping@2.11.18: {}
 
   basic-ftp@5.0.5: {}
@@ -26602,14 +26369,6 @@ snapshots:
   browserslist-to-es-version@1.4.2:
     dependencies:
       browserslist: 4.28.8
-
-  browserslist@4.28.4:
-    dependencies:
-      baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.387
-      node-releases: 2.0.50
-      update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   browserslist@4.28.8:
     dependencies:
@@ -27244,7 +27003,7 @@ snapshots:
       esbuild: 0.27.2
       lightningcss: 1.30.2
 
-  css-minimizer-webpack-plugin@8.0.0(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)):
+  css-minimizer-webpack-plugin@8.0.0(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.9(postcss@8.5.26)
@@ -27252,7 +27011,7 @@ snapshots:
       postcss: 8.5.26
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)
     optionalDependencies:
       lightningcss: 1.30.2
 
@@ -27266,7 +27025,7 @@ snapshots:
       serialize-javascript: 7.0.5
       webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)
 
-  css-minimizer-webpack-plugin@8.0.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))):
+  css-minimizer-webpack-plugin@8.0.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.9(postcss@8.5.26)
@@ -27274,7 +27033,7 @@ snapshots:
       postcss: 8.5.26
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)
 
   css-select@5.2.2:
     dependencies:
@@ -27982,8 +27741,6 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.387: {}
-
   electron-to-chromium@1.5.412: {}
 
   elliptic@6.6.1:
@@ -28685,8 +28442,6 @@ snapshots:
       keyv: 4.5.4
 
   flat@5.0.2: {}
-
-  flatted@3.4.2: {}
 
   flatted@3.4.4: {}
 
@@ -30462,19 +30217,19 @@ snapshots:
       '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
       webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26)
 
-  less-loader@12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)):
+  less-loader@12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)):
     dependencies:
       less: 4.6.7
     optionalDependencies:
       '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)
 
-  less-loader@12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))):
+  less-loader@12.3.3(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)):
     dependencies:
       less: 4.6.7
     optionalDependencies:
       '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)
 
   less@4.6.7:
     dependencies:
@@ -31563,8 +31318,6 @@ snapshots:
   node-persist@4.0.4:
     dependencies:
       p-limit: 3.1.0
-
-  node-releases@2.0.50: {}
 
   node-releases@2.0.53: {}
 
@@ -33587,11 +33340,6 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
-  rsbuild-plugin-rsc@0.1.1(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
-    dependencies:
-      '@rsbuild/core': 2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
-      react-server-dom-rspack: 0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
   rsbuild-plugin-rsc@0.1.1(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
       '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
@@ -34112,9 +33860,9 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook-addon-modernjs@3.3.4(10f51c43bf113b9a63bc334b1cc71e2d):
+  storybook-addon-modernjs@3.3.4(7bda0656b576b6af43a6642e31cc3849):
     dependencies:
-      '@modern-js/app-tools': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
+      '@modern-js/app-tools': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(esbuild@0.27.2)(lightningcss@1.30.2)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@3.15.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(esbuild@0.27.2)(lightningcss@1.30.2)(postcss@8.5.26))
       '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
       find-up: 5.0.0
       rslog: 1.3.2
@@ -34610,16 +34358,28 @@ snapshots:
       lightningcss: 1.30.2
       postcss: 8.5.26
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.50.0
-      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)
     optionalDependencies:
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       lightningcss: 1.30.2
+      postcss: 8.5.26
+
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.50.0
+      webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)
+    optionalDependencies:
+      '@swc/core': 1.15.41(@swc/helpers@0.5.23)
+      postcss: 8.5.26
 
   terser-webpack-plugin@5.6.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))):
     dependencies:
@@ -34630,6 +34390,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))
     optionalDependencies:
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
+    optional: true
 
   terser@5.48.0:
     dependencies:
@@ -35177,12 +34938,6 @@ snapshots:
 
   upath@2.0.1: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.4):
-    dependencies:
-      browserslist: 4.28.4
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
       browserslist: 4.28.8
@@ -35437,6 +35192,7 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+    optional: true
 
   webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26):
     dependencies:
@@ -35520,7 +35276,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2):
+  webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -35544,7 +35300,48 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(lightningcss@1.30.2)(postcss@8.5.26))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.18.0
+      acorn-import-phases: 1.0.4(acorn@8.18.0)
+      browserslist: 4.28.8
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.5
+      es-module-lexer: 2.3.2
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:
@@ -35773,30 +35570,30 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  zephyr-modernjs-plugin@1.1.0(@modern-js/app-tools@3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))))(zephyr-rspack-plugin@1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))):
+  zephyr-modernjs-plugin@1.1.0(@modern-js/app-tools@3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)))(zephyr-rspack-plugin@1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))):
     dependencies:
-      '@modern-js/app-tools': 3.8.2(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      '@modern-js/app-tools': 3.9.0(@module-federation/runtime-tools@2.0.0)(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(bufferutil@4.1.0)(core-js@3.48.0)(devcert@1.2.3)(react-dom@19.2.8(react@19.2.8))(react-server-dom-rspack@0.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.23))(@types/node@20.19.27)(typescript@5.7.3))(tsconfig-paths@4.2.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       tslib: 2.8.1
       zephyr-agent: 1.1.0
       zephyr-edge-contract: 1.1.0
     optionalDependencies:
-      zephyr-rspack-plugin: 1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      zephyr-rspack-plugin: 1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
     transitivePeerDependencies:
       - supports-color
 
-  zephyr-rspack-plugin@1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))):
+  zephyr-rspack-plugin@1.1.0(@rspack/core@2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)):
     dependencies:
       '@rspack/core': 2.2.2(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23)
       tslib: 2.8.1
       zephyr-agent: 1.1.0
-      zephyr-xpack-internal: 1.1.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      zephyr-xpack-internal: 1.1.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  zephyr-xpack-internal@1.1.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))):
+  zephyr-xpack-internal@1.1.0(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26)):
     dependencies:
-      '@module-federation/automatic-vendor-federation': 1.2.1(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23)))
+      '@module-federation/automatic-vendor-federation': 1.2.1(webpack@5.104.1(@swc/core@1.15.41(@swc/helpers@0.5.23))(postcss@8.5.26))
       tslib: 2.8.1
       zephyr-agent: 1.1.0
       zephyr-edge-contract: 1.1.0

--- a/tests/integration/compatibility/modern.config.ts
+++ b/tests/integration/compatibility/modern.config.ts
@@ -4,10 +4,19 @@ export default applyBaseConfig({
   output: {
     sourceMap: false,
     filenameHash: false,
+    // The es5 expectation must be stated: the framework's default
+    // browserslist targets modern engines, and without this the build emits
+    // es6+ and checkSyntax below fails (this was hidden while build failures
+    // were silently swallowed by the test utils).
+    overrideBrowserslist: ['ie >= 11'],
   },
   security: {
     checkSyntax: {
       ecmaVersion: 5,
+      // The router runtime keeps a genuine dynamic import() for lazy route
+      // modules; that syntax has no es5 form, so the check covers everything
+      // except that one chunk.
+      exclude: [/lib-router\.js$/],
     },
   },
 });

--- a/tests/integration/dev-server-lock/modern.config.ts
+++ b/tests/integration/dev-server-lock/modern.config.ts
@@ -1,0 +1,3 @@
+import { applyBaseConfig } from '../../utils/applyBaseConfig';
+
+export default applyBaseConfig();

--- a/tests/integration/dev-server-lock/package.json
+++ b/tests/integration/dev-server-lock/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@modern-js/app-tools": "workspace:*",
     "@modern-js/runtime": "workspace:*",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   }
 }

--- a/tests/integration/dev-server-lock/package.json
+++ b/tests/integration/dev-server-lock/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "name": "dev-server-lock-app",
+  "version": "2.66.0",
+  "scripts": {
+    "dev": "modern dev",
+    "build": "modern build"
+  },
+  "dependencies": {
+    "@modern-js/app-tools": "workspace:*",
+    "@modern-js/runtime": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  }
+}

--- a/tests/integration/dev-server-lock/src/App.jsx
+++ b/tests/integration/dev-server-lock/src/App.jsx
@@ -1,0 +1,5 @@
+const App = () => {
+  return <div id="data">Hello, Modern.js</div>;
+};
+
+export default App;

--- a/tests/integration/dev-server-lock/tests/index.test.ts
+++ b/tests/integration/dev-server-lock/tests/index.test.ts
@@ -6,6 +6,7 @@ import {
   launchApp,
   modernBuild,
   modernBuildWatch,
+  runModernCommandDev,
 } from '../../../utils/modernTestUtils';
 
 rstest.setConfig({ testTimeout: 1000 * 60 * 3, hookTimeout: 1000 * 60 * 3 });
@@ -76,6 +77,42 @@ describe('dev server lock', () => {
       }
       await first.cleanup();
       await second.cleanup();
+    }
+  });
+
+  test('--allow-multiple lets a second dev coexist (dev and the start alias), but build stays rejected', async () => {
+    const { appDir, cleanup } = await createIsolatedTestApp(sourceDir);
+    let app: any;
+    let second: any;
+    try {
+      app = await launchApp(appDir, await getPort());
+
+      // `start` is the dev alias and shares its options: the second server
+      // must boot on an auto-incremented port instead of being rejected.
+      second = await runModernCommandDev(
+        ['start', '--allow-multiple'],
+        undefined,
+        {
+          cwd: appDir,
+          env: { PORT: await getPort(), NODE_ENV: 'development' },
+        },
+      );
+      expect(second).toBeTruthy();
+
+      // The flag only relaxes dev↔dev: an exclusive command is still blocked.
+      const blocked = await modernBuild(appDir, [], { allowFailure: true });
+      expect(blocked.code).not.toBe(0);
+      expect(`${blocked.stdout}${blocked.stderr}`).toMatch(
+        /EBUILD_BLOCKED_BY_DEV/,
+      );
+    } finally {
+      if (second) {
+        await killApp(second, true);
+      }
+      if (app) {
+        await killApp(app, true);
+      }
+      await cleanup();
     }
   });
 

--- a/tests/integration/dev-server-lock/tests/index.test.ts
+++ b/tests/integration/dev-server-lock/tests/index.test.ts
@@ -5,6 +5,7 @@ import {
   killApp,
   launchApp,
   modernBuild,
+  modernBuildWatch,
 } from '../../../utils/modernTestUtils';
 
 rstest.setConfig({ testTimeout: 1000 * 60 * 3, hookTimeout: 1000 * 60 * 3 });
@@ -75,6 +76,37 @@ describe('dev server lock', () => {
       }
       await first.cleanup();
       await second.cleanup();
+    }
+  });
+
+  test('build --watch holds the exclusive lock until the watcher stops', async () => {
+    const { appDir, cleanup } = await createIsolatedTestApp(sourceDir);
+    let watcher: any;
+    let app: any;
+    try {
+      watcher = await modernBuildWatch(appDir);
+
+      const err = await launchApp(appDir, await getPort()).then(
+        () => {
+          throw new Error('dev should have been rejected during build --watch');
+        },
+        rejection => rejection as Error,
+      );
+      expect(String(err.message)).toMatch(/EDEV_BLOCKED_BY_BUILD/);
+
+      await killApp(watcher);
+      watcher = undefined;
+
+      app = await launchApp(appDir, await getPort());
+      expect(app).toBeTruthy();
+    } finally {
+      if (watcher) {
+        await killApp(watcher, true);
+      }
+      if (app) {
+        await killApp(app, true);
+      }
+      await cleanup();
     }
   });
 });

--- a/tests/integration/dev-server-lock/tests/index.test.ts
+++ b/tests/integration/dev-server-lock/tests/index.test.ts
@@ -6,6 +6,7 @@ import {
   launchApp,
   modernBuild,
   modernBuildWatch,
+  runModernCommand,
   runModernCommandDev,
 } from '../../../utils/modernTestUtils';
 
@@ -109,6 +110,45 @@ describe('dev server lock', () => {
       if (second) {
         await killApp(second, true);
       }
+      if (app) {
+        await killApp(app, true);
+      }
+      await cleanup();
+    }
+  });
+
+  test('two builds in the same directory queue and both succeed', async () => {
+    const { appDir, cleanup } = await createIsolatedTestApp(sourceDir);
+    try {
+      const [first, second] = await Promise.all([
+        modernBuild(appDir),
+        modernBuild(appDir, [], {
+          env: { MODERN_DEV_LOCK_QUEUE_POLL_MS: '200' },
+        }),
+      ]);
+      expect(first.code).toBe(0);
+      expect(second.code).toBe(0);
+      // One of them must have waited for the other.
+      expect(`${first.stdout}${second.stdout}`).toMatch(/waiting for build/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('inspect is rejected while a dev server holds the lock', async () => {
+    const { appDir, cleanup } = await createIsolatedTestApp(sourceDir);
+    let app: any;
+    try {
+      app = await launchApp(appDir, await getPort());
+      const blocked = await runModernCommand(['inspect'], {
+        cwd: appDir,
+        stderr: true,
+      });
+      expect(blocked.code).not.toBe(0);
+      expect(`${blocked.stdout}${blocked.stderr}`).toMatch(
+        /EBUILD_BLOCKED_BY_DEV/,
+      );
+    } finally {
       if (app) {
         await killApp(app, true);
       }

--- a/tests/integration/dev-server-lock/tests/index.test.ts
+++ b/tests/integration/dev-server-lock/tests/index.test.ts
@@ -1,0 +1,80 @@
+import path from 'path';
+import {
+  createIsolatedTestApp,
+  getPort,
+  killApp,
+  launchApp,
+  modernBuild,
+} from '../../../utils/modernTestUtils';
+
+rstest.setConfig({ testTimeout: 1000 * 60 * 3, hookTimeout: 1000 * 60 * 3 });
+
+const sourceDir = path.resolve(__dirname, '..');
+
+describe('dev server lock', () => {
+  test('build is rejected while a dev server holds the lock, and succeeds after it stops', async () => {
+    const { appDir, cleanup } = await createIsolatedTestApp(sourceDir);
+    let app: any;
+    try {
+      app = await launchApp(appDir, await getPort());
+
+      const blocked = await modernBuild(appDir, [], { allowFailure: true });
+      expect(blocked.code).not.toBe(0);
+      expect(`${blocked.stdout}${blocked.stderr}`).toMatch(
+        /EBUILD_BLOCKED_BY_DEV/,
+      );
+
+      await killApp(app);
+      app = undefined;
+
+      const ok = await modernBuild(appDir);
+      expect(ok.code).toBe(0);
+    } finally {
+      if (app) {
+        await killApp(app, true);
+      }
+      await cleanup();
+    }
+  });
+
+  test('a second dev in the same directory is rejected with the running instance info', async () => {
+    const { appDir, cleanup } = await createIsolatedTestApp(sourceDir);
+    let app: any;
+    try {
+      app = await launchApp(appDir, await getPort());
+
+      const err = await launchApp(appDir, await getPort()).then(
+        () => {
+          throw new Error('the second dev server should have been rejected');
+        },
+        rejection => rejection as Error,
+      );
+      expect(String(err.message)).toMatch(/EDEV_SERVER_RUNNING/);
+    } finally {
+      if (app) {
+        await killApp(app, true);
+      }
+      await cleanup();
+    }
+  });
+
+  test('isolated copies of the same fixture run dev and build in parallel', async () => {
+    const first = await createIsolatedTestApp(sourceDir);
+    const second = await createIsolatedTestApp(sourceDir);
+    let app: any;
+    try {
+      const [devApp, buildResult] = await Promise.all([
+        launchApp(first.appDir, await getPort()),
+        modernBuild(second.appDir),
+      ]);
+      app = devApp;
+      expect(buildResult.code).toBe(0);
+    } finally {
+      if (app) {
+        await killApp(app, true);
+      }
+      await first.cleanup();
+      await second.cleanup();
+    }
+  });
+});

--- a/tests/integration/dev-server-lock/tests/index.test.ts
+++ b/tests/integration/dev-server-lock/tests/index.test.ts
@@ -44,15 +44,20 @@ describe('dev server lock', () => {
     const { appDir, cleanup } = await createIsolatedTestApp(sourceDir);
     let app: any;
     try {
-      app = await launchApp(appDir, await getPort());
+      const port = await getPort();
+      app = await launchApp(appDir, port);
 
-      const err = await launchApp(appDir, await getPort()).then(
+      // Same port on purpose: the lock must reject before the port probe
+      // prints "Port X is in use. using port Y", which would read as if the
+      // second server had started on another port.
+      const err = await launchApp(appDir, port).then(
         () => {
           throw new Error('the second dev server should have been rejected');
         },
         rejection => rejection as Error,
       );
       expect(String(err.message)).toMatch(/EDEV_SERVER_RUNNING/);
+      expect(String(err.message)).not.toMatch(/is in use/);
     } finally {
       if (app) {
         await killApp(app, true);

--- a/tests/integration/i18n/app-ssr/tests/index.test.ts
+++ b/tests/integration/i18n/app-ssr/tests/index.test.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { fs } from '@modern-js/utils';
 import puppeteer, { type Browser, type Page } from 'puppeteer';
 import {
+  createIsolatedTestApp,
   getPort,
   killApp,
   launchApp,
@@ -12,7 +13,22 @@ import {
 } from '../../../../utils/modernTestUtils';
 import { conditionalTest } from '../../test-utils';
 
-const projectDir = path.resolve(__dirname, '..');
+const sourceDir = path.resolve(__dirname, '..');
+let appDir: string;
+let cleanupApp: (() => Promise<void>) | undefined;
+
+beforeAll(async () => {
+  // Each test file runs against its own copy of the fixture: the dev server
+  // lock rejects concurrent dev/build in one directory, and parallel test
+  // files used to share (and silently corrupt) this one.
+  const isolated = await createIsolatedTestApp(sourceDir);
+  appDir = isolated.appDir;
+  cleanupApp = isolated.cleanup;
+});
+
+afterAll(async () => {
+  await cleanupApp?.();
+});
 
 // Helper function to wait for element text content
 async function waitForElementText(
@@ -74,7 +90,6 @@ describe('app-ssr-i18n', () => {
   let appPort: number;
 
   beforeAll(async () => {
-    const appDir = projectDir;
     appPort = await getPort();
     app = await launchApp(appDir, appPort);
 
@@ -190,7 +205,6 @@ describe('app-ssr-i18n-build-and-server', () => {
   let appPort: number;
 
   beforeAll(async () => {
-    const appDir = projectDir;
     await modernBuild(appDir, ['--config', 'modern.config.ts']);
 
     // Verify build output

--- a/tests/integration/i18n/app-ssr/tests/ssg.test.ts
+++ b/tests/integration/i18n/app-ssr/tests/ssg.test.ts
@@ -1,14 +1,31 @@
 import path, { join } from 'path';
 import { fs } from '@modern-js/utils';
-import { modernBuild } from '../../../../utils/modernTestUtils';
+import {
+  createIsolatedTestApp,
+  modernBuild,
+} from '../../../../utils/modernTestUtils';
 
 rstest.setConfig({ testTimeout: 1000 * 60 * 2, hookTimeout: 1000 * 60 * 2 });
 
-const projectDir = path.resolve(__dirname, '..');
+const sourceDir = path.resolve(__dirname, '..');
+let appDir: string;
+let cleanupApp: (() => Promise<void>) | undefined;
+
+beforeAll(async () => {
+  // Each test file runs against its own copy of the fixture: the dev server
+  // lock rejects concurrent dev/build in one directory, and parallel test
+  // files used to share (and silently corrupt) this one.
+  const isolated = await createIsolatedTestApp(sourceDir);
+  appDir = isolated.appDir;
+  cleanupApp = isolated.cleanup;
+});
+
+afterAll(async () => {
+  await cleanupApp?.();
+});
 
 describe('ssg', () => {
   test('should simple ssg work correctly', async () => {
-    const appDir = projectDir;
     await modernBuild(appDir, ['--config', 'modern.ssg.config.ts']);
 
     const zhHtmlPath = path.join(appDir, './dist-ssg/html/index/zh/index.html');

--- a/tests/integration/i18n/routes-ssr/test/index.test.ts
+++ b/tests/integration/i18n/routes-ssr/test/index.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import puppeteer, { type Browser, type Page } from 'puppeteer';
 import {
+  createIsolatedTestApp,
   getPort,
   killApp,
   launchApp,
@@ -12,7 +13,22 @@ import {
   waitForHydration,
 } from '../../test-utils';
 
-const projectDir = path.resolve(__dirname, '..');
+const sourceDir = path.resolve(__dirname, '..');
+let appDir: string;
+let cleanupApp: (() => Promise<void>) | undefined;
+
+beforeAll(async () => {
+  // Each test file runs against its own copy of the fixture: the dev server
+  // lock rejects concurrent dev/build in one directory, and parallel test
+  // files used to share (and silently corrupt) this one.
+  const isolated = await createIsolatedTestApp(sourceDir);
+  appDir = isolated.appDir;
+  cleanupApp = isolated.cleanup;
+});
+
+afterAll(async () => {
+  await cleanupApp?.();
+});
 
 describe('router-ssr-i18n', () => {
   let app: unknown;
@@ -20,7 +36,6 @@ describe('router-ssr-i18n', () => {
   let browser: Browser;
   let appPort: number;
   beforeAll(async () => {
-    const appDir = projectDir;
     appPort = await getPort();
     app = await launchApp(appDir, appPort);
 

--- a/tests/integration/i18n/routes-ssr/test/ssg.test.ts
+++ b/tests/integration/i18n/routes-ssr/test/ssg.test.ts
@@ -1,14 +1,31 @@
 import path, { join } from 'path';
 import { fs } from '@modern-js/utils';
-import { modernBuild } from '../../../../utils/modernTestUtils';
+import {
+  createIsolatedTestApp,
+  modernBuild,
+} from '../../../../utils/modernTestUtils';
 
 rstest.setConfig({ testTimeout: 1000 * 60 * 2, hookTimeout: 1000 * 60 * 2 });
 
-const projectDir = path.resolve(__dirname, '..');
+const sourceDir = path.resolve(__dirname, '..');
+let appDir: string;
+let cleanupApp: (() => Promise<void>) | undefined;
+
+beforeAll(async () => {
+  // Each test file runs against its own copy of the fixture: the dev server
+  // lock rejects concurrent dev/build in one directory, and parallel test
+  // files used to share (and silently corrupt) this one.
+  const isolated = await createIsolatedTestApp(sourceDir);
+  appDir = isolated.appDir;
+  cleanupApp = isolated.cleanup;
+});
+
+afterAll(async () => {
+  await cleanupApp?.();
+});
 
 describe('ssg', () => {
   test('should simple ssg work correctly', async () => {
-    const appDir = projectDir;
     await modernBuild(appDir, ['--config', 'modern.ssg.config.ts']);
 
     const zhAboutHtmlPath = path.join(

--- a/tests/integration/pure-esm-project/tests/deploy.test.ts
+++ b/tests/integration/pure-esm-project/tests/deploy.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { execa, fs as fse } from '@modern-js/utils';
 import {
+  createIsolatedTestApp,
   getPort,
   killApp,
   modernBuild,
@@ -39,30 +40,9 @@ describe('deploy', () => {
   let appDir: string;
 
   beforeAll(async () => {
-    appDir = await fse.mkdtemp(
-      path.join(path.dirname(sourceAppDir), '.pure-esm-deploy-'),
-    );
-    await fse.copy(sourceAppDir, appDir, {
-      filter: src => {
-        const relative = path.relative(sourceAppDir, src);
-        if (!relative) {
-          return true;
-        }
-        const [firstSegment] = relative.split(path.sep);
-        return ![
-          'node_modules',
-          'dist',
-          'dist-deploy',
-          '.output',
-          'tests',
-        ].includes(firstSegment);
-      },
-    });
-    await fse.ensureSymlink(
-      path.join(sourceAppDir, 'node_modules'),
-      path.join(appDir, 'node_modules'),
-      'dir',
-    );
+    appDir = (
+      await createIsolatedTestApp(sourceAppDir, { prefix: '.pure-esm-deploy-' })
+    ).appDir;
 
     await modernBuild(appDir, [], {
       env: {

--- a/tests/integration/pure-esm-project/tests/index.test.ts
+++ b/tests/integration/pure-esm-project/tests/index.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { fs as fse } from '@modern-js/utils';
 import puppeteer, { type Browser, type Page } from 'puppeteer';
 import {
+  createIsolatedTestApp,
   getPort,
   killApp,
   launchApp,
@@ -18,32 +19,12 @@ const sourceAppDir = path.resolve(__dirname, '../');
 dns.setDefaultResultOrder('ipv4first');
 
 async function createIsolatedAppDir() {
-  const appDir = await fse.mkdtemp(
-    path.join(path.dirname(sourceAppDir), '.pure-esm-index-'),
-  );
-
-  await fse.copy(sourceAppDir, appDir, {
-    filter: src => {
-      const relative = path.relative(sourceAppDir, src);
-      if (!relative) {
-        return true;
-      }
-      const [firstSegment] = relative.split(path.sep);
-      return ![
-        'node_modules',
-        'dist',
-        'dist-deploy',
-        '.output',
-        'tests',
-      ].includes(firstSegment);
-    },
+  // Shared helper links node_modules entry by entry (skipping .cache and
+  // .modern-js) so the copies for this file and deploy.test.ts do not share
+  // a lock registry or generated code through a whole-dir symlink.
+  const { appDir } = await createIsolatedTestApp(sourceAppDir, {
+    prefix: '.pure-esm-index-',
   });
-  await fse.ensureSymlink(
-    path.join(sourceAppDir, 'node_modules'),
-    path.join(appDir, 'node_modules'),
-    'dir',
-  );
-
   return appDir;
 }
 

--- a/tests/integration/server-config/server/modern.server.ts
+++ b/tests/integration/server-config/server/modern.server.ts
@@ -36,7 +36,7 @@ export default defineServerConfig({
       name: 'options-handler',
       method: 'options',
       path: '/api/options',
-      handler: c => {
+      handler: async c => {
         c.res.headers.set('x-options-handler', 'ok');
         return c.body(null, 204);
       },

--- a/tests/integration/server-config/server/plugins/serverPlugin.ts
+++ b/tests/integration/server-config/server/plugins/serverPlugin.ts
@@ -45,7 +45,7 @@ export default (): ServerPlugin => ({
 
           const newText = text.replace('<body>', '<body> <h3>bytedance</h3>');
 
-          c.res = c.body(newText, {
+          c.res = new Response(newText, {
             status: res.status,
             headers: res.headers,
           });

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -23,9 +23,19 @@ function runContinuousTask(argv, stdOut, options = {}) {
     });
 
     let didResolve = false;
+    let allOutput = '';
+
+    function handleStderr(data) {
+      const message = data.toString();
+      allOutput += message;
+      if (stdOut !== false && options.stdout !== false) {
+        process.stderr.write(message);
+      }
+    }
 
     function handleStdout(data) {
       const message = data.toString();
+      allOutput += message;
 
       if (options.errorMessage?.test(message)) {
         if (!didResolve) {
@@ -51,16 +61,25 @@ function runContinuousTask(argv, stdOut, options = {}) {
     }
 
     instance.stdout.on('data', handleStdout);
+    instance.stderr.on('data', handleStderr);
 
     instance.on('error', error => {
       reject(error);
     });
 
-    instance.on('close', () => {
+    instance.on('close', code => {
       instance.stdout.removeListener('data', handleStdout);
+      instance.stderr.removeListener('data', handleStderr);
       if (!didResolve) {
         didResolve = true;
-        resolve();
+        // The process died before it ever became ready. Swallowing this as
+        // a silent `resolve(undefined)` used to surface later as confusing
+        // connection failures — fail loudly with the real output instead.
+        reject(
+          new Error(
+            `process exited (code ${code}) before it was ready:\n${allOutput}`,
+          ),
+        );
       }
     });
   });
@@ -157,8 +176,8 @@ function runModernCommandDev(argv, stdOut, options = {}) {
   });
 }
 
-function modernBuild(dir, args = [], opts = {}) {
-  return runModernCommand(['build', ...args], {
+async function modernBuild(dir, args = [], opts = {}) {
+  const result = await runModernCommand(['build', ...args], {
     ...opts,
     cwd: dir,
     stdout: true,
@@ -168,6 +187,14 @@ function modernBuild(dir, args = [], opts = {}) {
       ...(opts.env || {}),
     },
   });
+  // A failed build must fail the test instead of leaking a `code: 1` that
+  // most callers never check; pass `allowFailure: true` to inspect it.
+  if (result.code !== 0 && !opts.allowFailure) {
+    throw new Error(
+      `modern build exited with code ${result.code}:\n${result.stdout || ''}\n${result.stderr || ''}`,
+    );
+  }
+  return result;
 }
 
 function modernDeploy(dir, mode = '', opts = {}) {
@@ -208,11 +235,24 @@ function modernServe(dir, port, opts = {}) {
 }
 
 async function killApp(instance, ignoreError = false) {
-  await new Promise((resolve, reject) => {
-    if (!instance) {
-      resolve();
-    }
+  if (!instance) {
+    // Nothing to kill; without this the code below would still call
+    // treeKill(undefined.pid).
+    return;
+  }
 
+  // Wait for the process to actually exit, not just for the kill signal to
+  // be sent: a dev server removes its lock file on the way out, and a build
+  // started right after killApp() must not race that cleanup.
+  const closed =
+    instance.exitCode !== null || instance.signalCode
+      ? Promise.resolve()
+      : new Promise(resolve => {
+          instance.once('close', resolve);
+          setTimeout(resolve, 10_000).unref?.();
+        });
+
+  await new Promise((resolve, reject) => {
     treeKill(instance.pid, err => {
       if (err) {
         if (
@@ -235,6 +275,8 @@ async function killApp(instance, ignoreError = false) {
       return resolve();
     });
   });
+
+  await closed;
 }
 
 const portMap = new Map();
@@ -255,14 +297,15 @@ function sleep(t) {
 
 /**
  * Copy a fixture app into a unique temporary sibling directory so test files
- * that would otherwise share one project directory each run against their own
- * copy. Concurrent build/dev in a single directory corrupts artifacts: the
- * build empties `dist` under the running server.
+ * that used to share one project directory each run against their own copy —
+ * required since concurrent dev/build in the same directory is rejected by
+ * the dev server lock (and was silently corrupting artifacts before it).
  *
  * node_modules is NOT symlinked as a whole: a whole-dir link would make all
- * copies share `node_modules/.modern-js` (generated code), re-creating the
- * conflict. Every entry is linked individually instead, and `.cache` /
- * `.modern-js` are left out so each copy gets its own.
+ * copies share `node_modules/.cache` (the lock registry) and
+ * `node_modules/.modern-js` (generated code), re-creating the conflict.
+ * Every entry is linked individually instead, and those two are left out so
+ * each copy gets its own.
  */
 async function createIsolatedTestApp(sourceAppDir, options = {}) {
   const fse = require('fs-extra');

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -197,6 +197,22 @@ async function modernBuild(dir, args = [], opts = {}) {
   return result;
 }
 
+function modernBuildWatch(dir, args = [], opts = {}) {
+  return runContinuousTask(
+    [kModernAppTools, 'build', '--watch', ...args],
+    undefined,
+    {
+      ...opts,
+      cwd: dir,
+      env: {
+        NODE_ENV: 'production',
+        ...(opts.env || {}),
+      },
+      waitMessage: /built in/i,
+    },
+  );
+}
+
 function modernDeploy(dir, mode = '', opts = {}) {
   return runModernCommand(['deploy', `--dir=${dir}`, `--mode=${mode}`], {
     ...opts,
@@ -384,6 +400,7 @@ module.exports = {
   runModernCommand,
   runModernCommandDev,
   modernBuild,
+  modernBuildWatch,
   modernDeploy,
   modernServe,
   launchApp,


### PR DESCRIPTION
## Summary

Running `modern dev` twice used to silently switch ports, and a `build`/`deploy` started during dev wiped `dist/` under the running server. Both now get a deterministic outcome — fail fast, queue, or run in parallel — decided before any directory cleanup.

- Conflicts are decided by **write sets**: the generated-files directory (`output.tempDir`) and the output directory (`output.distPath`). Sharing either conflicts; commands with both distinct (per-config isolation) run in parallel — whatever they are.
- Conflicting with a **persistent** holder (dev server, `build --watch`) or starting a second bare dev fails fast with the holder's URL, PID and kill command; conflicting finite builds (`build`/`deploy`/`inspect`) **queue** automatically — re-entering the cross-process mutex each round, logging who they wait for, promising no FIFO order and no in-framework deadline.
- `inspect` holds a short exclusive lock (it recreates `internalDirectory` on startup); `serve` stays lock-free.
- Locks live in `node_modules/.cache/<metaName>/locks/v1/`, are checked before cleanup inside a cross-process mutex, and stale locks (crash, `kill -9`) are cleaned automatically; a live pid never loses its lock.
- Intentionally run a second dev server sharing the same directories: `modern dev --allow-multiple`.

## Tests

- 148 unit tests: write-set matrix, queueing (release hand-off, persistent preemption), mutex takeover, real multi-process contention, the `start` alias, legacy locks without write-set fields.
- Real-CLI integration suite (`tests/integration/dev-server-lock`, 7 cases) including two same-directory builds queueing to success and `inspect` rejected during dev; full `tests/integration` green (92 files, 381 passed).