### PR TITLE
feat(app-tools): support deploy.traceOptions for dependency tracing

### DIFF
--- a/.changeset/deploy-trace-options.md
+++ b/.changeset/deploy-trace-options.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': minor
+---
+
+feat: support `deploy.traceOptions` to configure server-side dependency tracing
+
+feat: 支持 `deploy.traceOptions` 配置服务端依赖追踪

--- a/packages/solutions/app-tools/src/plugins/deploy/platforms/netlify.ts
+++ b/packages/solutions/app-tools/src/plugins/deploy/platforms/netlify.ts
@@ -127,6 +127,7 @@ export const createNetlifyPreset: CreatePreset = ({
         appDir: appDirectory,
         sourceDir: funcsDirectory,
         includeEntries: [entry, netlifyEntry],
+        traceOptions: modernConfig.deploy?.traceOptions,
         copyWholePackage(pkgName) {
           return pkgName === '@modern-js/utils';
         },

--- a/packages/solutions/app-tools/src/plugins/deploy/platforms/node.ts
+++ b/packages/solutions/app-tools/src/plugins/deploy/platforms/node.ts
@@ -58,6 +58,7 @@ export const createNodePreset: CreatePreset = ({
         appDir: appDirectory,
         sourceDir: outputDirectory,
         includeEntries: [entry],
+        traceOptions: modernConfig.deploy?.traceOptions,
         copyWholePackage(pkgName) {
           return pkgName === '@modern-js/utils';
         },

--- a/packages/solutions/app-tools/src/plugins/deploy/platforms/vercel.ts
+++ b/packages/solutions/app-tools/src/plugins/deploy/platforms/vercel.ts
@@ -129,6 +129,7 @@ export const createVercelPreset: CreatePreset = ({
         appDir: appDirectory,
         sourceDir: funcsDirectory,
         includeEntries: [entry],
+        traceOptions: modernConfig.deploy?.traceOptions,
         copyWholePackage(pkgName) {
           return pkgName === '@modern-js/utils';
         },

--- a/packages/solutions/app-tools/src/types/config/deploy.ts
+++ b/packages/solutions/app-tools/src/types/config/deploy.ts
@@ -1,3 +1,5 @@
+import type { NodeFileTraceOptions } from 'ndepe';
+
 export interface MicroFrontend {
   /**
    * Specifies whether to enable the HTML entry.
@@ -22,4 +24,24 @@ export interface DeployUserConfig {
   worker?: {
     ssr?: boolean;
   };
+  /**
+   * Options forwarded to `@vercel/nft` when tracing server-side dependencies.
+   *
+   * Tracing runs with the filesystem root as its base, so static analysis of
+   * `__dirname`-based patterns in the server bundle can reach directories that
+   * are unrelated to the application and may be unreadable on the build
+   * machine. Use `ignore` to exclude them.
+   *
+   * @example
+   * ```ts
+   * export default defineConfig({
+   *   deploy: {
+   *     traceOptions: {
+   *       ignore: ['etc/**', 'private/etc/**'],
+   *     },
+   *   },
+   * });
+   * ```
+   */
+  traceOptions?: NodeFileTraceOptions;
 }

--- a/packages/solutions/app-tools/tests/deploy/trace-options.test.ts
+++ b/packages/solutions/app-tools/tests/deploy/trace-options.test.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+
+const mockNodeDepEmit = rstest.fn();
+
+rstest.mock('ndepe', () => ({
+  nodeDepEmit: (...args: unknown[]) => mockNodeDepEmit(...args),
+}));
+
+rstest.mock('@modern-js/utils', () => ({
+  chalk: { blue: (v: string) => v },
+  fs: {
+    remove: rstest.fn(),
+    copy: rstest.fn(),
+    writeFile: rstest.fn(),
+  },
+  removeModuleSyncFromExports: (v: unknown) => v,
+}));
+
+rstest.mock('../../src/plugins/deploy/utils', () => ({
+  readTemplate: rstest.fn(async () => ''),
+  resolveESMDependency: rstest.fn(async () => '/entry.js'),
+}));
+
+const createParams = (deploy?: Record<string, unknown>) =>
+  ({
+    appContext: {
+      appDirectory: path.join('/', 'app'),
+      distDirectory: path.join('/', 'app', 'dist'),
+      moduleType: 'module',
+    },
+    modernConfig: { deploy },
+    api: {},
+  }) as any;
+
+describe('deploy traceOptions', () => {
+  beforeEach(() => {
+    mockNodeDepEmit.mockClear();
+  });
+
+  it('should forward deploy.traceOptions to the dependency tracer', async () => {
+    const { createNodePreset } = await import(
+      '../../src/plugins/deploy/platforms/node'
+    );
+    const traceOptions = { ignore: ['etc/**'] };
+
+    await createNodePreset(createParams({ traceOptions })).end!();
+
+    expect(mockNodeDepEmit).toHaveBeenCalledTimes(1);
+    expect(mockNodeDepEmit.mock.calls[0][0]).toMatchObject({ traceOptions });
+  });
+
+  it('should pass undefined when deploy.traceOptions is not configured', async () => {
+    const { createNodePreset } = await import(
+      '../../src/plugins/deploy/platforms/node'
+    );
+
+    await createNodePreset(createParams()).end!();
+
+    expect(mockNodeDepEmit).toHaveBeenCalledTimes(1);
+    expect(mockNodeDepEmit.mock.calls[0][0].traceOptions).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Forward a user-configurable `deploy.traceOptions` to ndepe -> @vercel/nft when tracing server-side dependencies.

Tracing runs with the filesystem root as its base, so static analysis of __dirname-based patterns in the server bundle can reach unrelated system directories and abort the build when they are unreadable:

  EACCES: permission denied, open '/etc/sudoers'

There was previously no way to influence tracing from user config, since no deploy preset forwarded ndepe's traceOptions passthrough.

Applied to the node, vercel and netlify presets. No defaults are added, so behavior is unchanged when the option is omitted.

Refs #8779

## Summary

Forward a user-configurable `deploy.traceOptions` to `ndepe` → `@vercel/nft`
when tracing server-side dependencies.

Tracing runs with the filesystem root as its base, so static analysis of
`__dirname`-based patterns in the server bundle can reach unrelated system
directories and abort the build when they are unreadable:

EACCES: permission denied, open '/etc/sudoers'


In my case `@sentry/node-core`'s Context integration does a `readdir('/etc')` to
detect the Linux distribution, which is enough to pull `/etc/*` into the trace.
On Linux CI with stale symlinks the same root cause surfaces as
`ENOENT: stat '/etc/alternatives/which.sl1.gz'`. `.output/static` is produced
correctly — only the tracing step fails, so `node_modules` is never emitted into
`.output`.

There was previously no way to influence tracing from user config, since no
deploy preset forwarded `ndepe`'s `traceOptions` passthrough. The only
workarounds were patching `ndepe` or vendoring the deploy plugin.

Applied to the `node`, `vercel` and `netlify` presets. No defaults are added, so
behavior is unchanged when the option is omitted.

**Usage**

```ts
export default defineConfig({
  deploy: {
    traceOptions: {
      ignore: ['etc/**', 'private/etc/**'],
    },
  },
});
```
ignore patterns resolve against nft's base (/), so etc/** matches /etc/sudoers. nft evaluates ignoreFn before globbing in emitAssetDirectory, so ignored directories are never walked.

Why not traceRoot

A deploy.traceRoot option was suggested in #8779, passed to nft as the tracing base. I prototyped it and it does not work as a passthrough: base in ndepe is not only nft's tracing root but also the root that ndepe resolves nft's results against, and it is hardcoded to "/". nft returns paths relative to base, so narrowing it makes resolveTracedPath("/", "global/my-app/...") produce /global/my-app/... and the trace dies one step later with ENOENT: lstat '/global'. Making traceRoot work requires threading one root through nodeFileTrace, resolveTracedPath and the isSubPath checks, and reconciling it with the separate dependencySearchRoot in the same function — a change to ndepe's path semantics, not an app-tools passthrough.

Why no built-in ignore defaults

Shipping a default system-directory list would fix this with zero config, but those paths are platform-specific (/etc vs /private/etc on macOS, /proc and /sys on Linux, arbitrary mount points in containers), so any built-in list is both incomplete and a silent policy decision made for the user. For the record, ignoring them loses nothing: with base: '/' and no ignore, 228 files under /etc enter nft's fileList, but zero can be attributed by ndepe to an npm package, so none were ever emitted.


## Related Links
Refs #8779
Related: vercel/nft#601

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.

> I left the documentation box unchecked: I couldn't find an existing config reference page for `deploy` (neither `microFrontend` nor `worker` appears to be documented). Happy to add one wherever you'd prefer it to live.  

