### PR TITLE
test(bff): build the portability fixture in an isolated copy

### DIFF
--- a/tests/integration/bff-corss-project/tests/types-portability.test.ts
+++ b/tests/integration/bff-corss-project/tests/types-portability.test.ts
@@ -3,11 +3,14 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import ts from 'typescript';
-import { modernBuild } from '../../../utils/modernTestUtils';
+import {
+  createIsolatedTestApp,
+  modernBuild,
+} from '../../../utils/modernTestUtils';
 
 rstest.setConfig({ testTimeout: 1000 * 60 * 3, hookTimeout: 1000 * 60 * 3 });
 
-const apiAppDir = path.resolve(__dirname, '../bff-api-app');
+const sourceApiAppDir = path.resolve(__dirname, '../bff-api-app');
 
 // Type-check `consumerDir` in isolation and return the diagnostics. An unused
 // `@ts-expect-error` also surfaces here (TS2578), so a type that silently
@@ -32,10 +35,20 @@ describe('crossProject client type portability', () => {
   // real regression surface — "resolvable in the local dist" is not the same as
   // "resolvable from the packed tarball".
   it('a packed tarball resolves the client types from an isolated consumer', async () => {
-    await modernBuild(apiAppDir, [], {});
+    // Build and pack a copy: `index.test.ts` runs dev servers from the source
+    // fixture in a parallel test file, and a build there would empty its dist
+    // under the running server. `dist-1` is this fixture's output directory,
+    // so it must be excluded too — the copy has to start without stale (or
+    // half-written) build output.
+    const { appDir: apiAppDir, cleanup } = await createIsolatedTestApp(
+      sourceApiAppDir,
+      { exclude: ['dist-1'] },
+    );
 
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bff-portability-'));
     try {
+      await modernBuild(apiAppDir, [], {});
+
       // 1. Pack exactly what would be published.
       execFileSync('pnpm', ['pack', '--pack-destination', workDir], {
         cwd: apiAppDir,
@@ -132,6 +145,7 @@ describe('crossProject client type portability', () => {
       expect(messages).toEqual([]);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
+      await cleanup();
     }
   });
 });

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -253,6 +253,89 @@ function sleep(t) {
   return new Promise(resolve => setTimeout(resolve, t));
 }
 
+/**
+ * Copy a fixture app into a unique temporary sibling directory so test files
+ * that would otherwise share one project directory each run against their own
+ * copy. Concurrent build/dev in a single directory corrupts artifacts: the
+ * build empties `dist` under the running server.
+ *
+ * node_modules is NOT symlinked as a whole: a whole-dir link would make all
+ * copies share `node_modules/.modern-js` (generated code), re-creating the
+ * conflict. Every entry is linked individually instead, and `.cache` /
+ * `.modern-js` are left out so each copy gets its own.
+ */
+async function createIsolatedTestApp(sourceAppDir, options = {}) {
+  const fse = require('fs-extra');
+  const { prefix = `.isolated-${path.basename(sourceAppDir)}-`, exclude = [] } =
+    options;
+
+  const appDir = await fse.mkdtemp(
+    path.join(path.dirname(sourceAppDir), prefix),
+  );
+  const topLevelExcludes = [
+    'node_modules',
+    'dist',
+    'dist-deploy',
+    'dist-ssg',
+    '.output',
+    'tests',
+    'test',
+    ...exclude,
+  ];
+  await fse.copy(sourceAppDir, appDir, {
+    filter: src => {
+      const relative = path.relative(sourceAppDir, src);
+      if (!relative) {
+        return true;
+      }
+      const [firstSegment] = relative.split(path.sep);
+      return !topLevelExcludes.includes(firstSegment);
+    },
+  });
+
+  const sourceNodeModules = path.join(sourceAppDir, 'node_modules');
+  const appNodeModules = path.join(appDir, 'node_modules');
+  await fse.ensureDir(appNodeModules);
+  if (await fse.pathExists(sourceNodeModules)) {
+    for (const entry of await fse.readdir(sourceNodeModules)) {
+      if (entry === '.cache' || entry === '.modern-js') {
+        continue;
+      }
+      const target = path.join(sourceNodeModules, entry);
+      // stat (not lstat): pnpm's top-level entries are themselves symlinks,
+      // and the link type must describe what they finally point to.
+      let isDirectory = true;
+      try {
+        isDirectory = (await fse.stat(target)).isDirectory();
+      } catch {
+        continue; // dangling link in the source tree
+      }
+      await fse.ensureSymlink(
+        target,
+        path.join(appNodeModules, entry),
+        isDirectory ? 'junction' : 'file',
+      );
+    }
+  }
+
+  return {
+    appDir,
+    // Callers must kill any process using appDir before cleanup; removal is
+    // retried because Windows keeps directories busy while children exit.
+    async cleanup() {
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+          await fse.remove(appDir);
+          return;
+        } catch {
+          await sleep(500);
+        }
+      }
+      await fse.remove(appDir).catch(() => {});
+    },
+  };
+}
+
 module.exports = {
   runContinuousTask,
   runModernCommand,
@@ -265,4 +348,5 @@ module.exports = {
   getPort,
   sleep,
   launchOptions,
+  createIsolatedTestApp,
 };


### PR DESCRIPTION
`tests/integration/bff-corss-project` has two test files sharing one fixture: `index.test.ts` runs dev servers from `bff-api-app`, while `types-portability.test.ts` builds and packs the same directory. rstest runs test files in parallel, so the build empties `dist-1` under the running server — four dev assertions have been failing on Linux and Windows since #8797 landed ([Linux](https://github.com/web-infra-dev/modern.js/actions/runs/31667295291/job/94344487506), [Windows](https://github.com/web-infra-dev/modern.js/actions/runs/31667294976/job/94344486255)).

The portability test now copies the fixture into a temporary sibling directory and builds there, so the two files never touch the same directory. `dist-1` is this fixture's output directory and is excluded from the copy, otherwise a concurrent build could be copied half-written.
