### PR TITLE
feat(builder): enable Rspack native watcher by default

### DIFF
--- a/.changeset/enable-native-watcher.md
+++ b/.changeset/enable-native-watcher.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/builder': patch
+---
+
+feat(builder): enable Rspack `experiments.nativeWatcher` by default, and allow opting out via `tools.rspack`
+
+feat(builder): 默认开启 Rspack 的 `experiments.nativeWatcher`，可通过 `tools.rspack` 关闭

--- a/packages/cli/builder/src/plugins/nativeWatcher.ts
+++ b/packages/cli/builder/src/plugins/nativeWatcher.ts
@@ -1,0 +1,16 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+/**
+ * Enable Rspack's Rust native watcher by default.
+ * Users can opt out via `tools.rspack`, which is applied after this hook.
+ */
+export const pluginNativeWatcher = (): RsbuildPlugin => ({
+  name: 'builder:native-watcher',
+
+  setup(api) {
+    api.modifyRspackConfig(config => {
+      config.experiments ??= {};
+      config.experiments.nativeWatcher ??= true;
+    });
+  },
+});

--- a/packages/cli/builder/src/shared/parseCommonConfig.ts
+++ b/packages/cli/builder/src/shared/parseCommonConfig.ts
@@ -14,6 +14,7 @@ import { pluginEmitRouteFile } from '../plugins/emitRouteFile';
 import { pluginEnvironmentDefaults } from '../plugins/environmentDefaults';
 import { pluginGlobalVars } from '../plugins/globalVars';
 import { pluginHtmlMinifierTerser } from '../plugins/htmlMinify';
+import { pluginNativeWatcher } from '../plugins/nativeWatcher';
 import { pluginRuntimeChunk } from '../plugins/runtimeChunk';
 import type { BuilderConfig, CreateBuilderCommonOptions } from '../types';
 import { transformToRsbuildServerOptions } from './devServer';
@@ -230,6 +231,7 @@ export async function parseCommonConfig(
     }),
     pluginEnvironmentDefaults(distPath),
     pluginHtmlMinifierTerser(),
+    pluginNativeWatcher(),
   ];
 
   if (checkSyntax) {

--- a/packages/cli/builder/tests/__snapshots__/default.test.ts.snap
+++ b/packages/cli/builder/tests/__snapshots__/default.test.ts.snap
@@ -23,6 +23,7 @@ exports[`builder rspack > should generator rspack config correctly 1`] = `
     ],
   },
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -1491,6 +1492,7 @@ exports[`builder rspack > should generator rspack config correctly 2`] = `
   "rsbuild:less",
   "builder:environment-defaults-plugin",
   "builder:plugin-html-minifier-terser",
+  "builder:native-watcher",
   "rsbuild:type-check",
   "builder:runtime-chunk",
   "rsbuild:react",
@@ -1524,6 +1526,7 @@ exports[`builder rspack > should generator rspack config correctly when node 1`]
     ],
   },
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -2486,6 +2489,7 @@ exports[`builder rspack > should generator rspack config correctly when prod 1`]
     ],
   },
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {
@@ -3977,6 +3981,7 @@ exports[`builder rspack > should generator rspack config correctly when service-
     ],
   },
   "experiments": {
+    "nativeWatcher": true,
     "sourceImport": true,
   },
   "infrastructureLogging": {

--- a/packages/cli/builder/tests/__snapshots__/environment.test.ts.snap
+++ b/packages/cli/builder/tests/__snapshots__/environment.test.ts.snap
@@ -24,6 +24,7 @@ exports[`builder environment compat > should generator environment config correc
       ],
     },
     "experiments": {
+      "nativeWatcher": true,
       "sourceImport": true,
     },
     "infrastructureLogging": {
@@ -1502,6 +1503,7 @@ exports[`builder environment compat > should generator environment config correc
       ],
     },
     "experiments": {
+      "nativeWatcher": true,
       "sourceImport": true,
     },
     "infrastructureLogging": {
@@ -2440,6 +2442,7 @@ exports[`builder environment compat > should generator environment config correc
       ],
     },
     "experiments": {
+      "nativeWatcher": true,
       "sourceImport": true,
     },
     "infrastructureLogging": {

--- a/packages/cli/builder/tests/nativeWatcher.test.ts
+++ b/packages/cli/builder/tests/nativeWatcher.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from '@rstest/core';
+import { createBuilder } from '../src';
+import { unwrapConfig } from './helper';
+
+describe('experiments.nativeWatcher', () => {
+  it('should be enabled by default', async () => {
+    const rsbuild = await createBuilder({
+      cwd: '',
+      bundlerType: 'rspack',
+      config: {},
+    });
+
+    const config = await unwrapConfig(rsbuild);
+
+    expect(config.experiments?.nativeWatcher).toBe(true);
+  });
+
+  it('should be overridable by tools.rspack', async () => {
+    const rsbuild = await createBuilder({
+      cwd: '',
+      bundlerType: 'rspack',
+      config: {
+        tools: {
+          rspack: {
+            experiments: {
+              nativeWatcher: false,
+            },
+          },
+        },
+      },
+    });
+
+    const config = await unwrapConfig(rsbuild);
+
+    expect(config.experiments?.nativeWatcher).toBe(false);
+  });
+
+  it('should be overridable by tools.bundlerChain', async () => {
+    const rsbuild = await createBuilder({
+      cwd: '',
+      bundlerType: 'rspack',
+      config: {
+        tools: {
+          bundlerChain: chain => {
+            chain.experiments({
+              ...chain.get('experiments'),
+              nativeWatcher: false,
+            });
+          },
+        },
+      },
+    });
+
+    const config = await unwrapConfig(rsbuild);
+
+    expect(config.experiments?.nativeWatcher).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Modern.js watch mode currently falls back to Rspack's default Watchpack-based watcher. Watchpack degrades badly when a large number of files change at once ([webpack/watchpack#223](https://github.com/webpack/watchpack/issues/223)), which shows up in dev on big apps. Rspack's Rust native watcher does incremental change detection and avoids that class of problem.

Before / after (`experiments` in the generated Rspack config):

```diff
  "experiments": {
+   "nativeWatcher": true,
    "sourceImport": true,
  }
```

## What

Registers a small Rsbuild plugin in `@modern-js/builder` that sets `experiments.nativeWatcher` through `modifyRspackConfig`.

Two escape hatches, both covered by tests:

```ts
// tools.rspack runs after every modifyRspackConfig hook
tools: { rspack: { experiments: { nativeWatcher: false } } }

// tools.bundlerChain runs before it — this is why the plugin uses `??=`, not `=`
tools: { bundlerChain: chain => chain.experiments({ ...chain.get('experiments'), nativeWatcher: false }) }
```

## Notes

`NativeWatchFileSystem` rejects a function for `watchOptions.ignored` (string / array / RegExp only). The only place this repo sets it (`adapterBasic.ts`) uses a string array, so nothing here breaks — but it is a behavior difference worth calling out for anyone passing a function through `tools.rspack`.

## Verification

- `@modern-js/builder` unit tests: 46 passed, 0 failed.
- Probed Rspack directly: `nativeWatcher=undefined -> NodeWatchFileSystem`, `nativeWatcher=true -> NativeWatchFileSystem`.
- Ran `modern dev` on `tests/integration/basic-app`, edited `src/App.tsx`, confirmed the incremental rebuild fires.