### PR TITLE
test(bff): spawn pnpm through cross-spawn on Windows

### DIFF
--- a/tests/integration/bff-corss-project/tests/types-portability.test.ts
+++ b/tests/integration/bff-corss-project/tests/types-portability.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import crossSpawn from 'cross-spawn';
 import ts from 'typescript';
 import {
   createIsolatedTestApp,
@@ -9,8 +10,6 @@ import {
 } from '../../../utils/modernTestUtils';
 
 rstest.setConfig({ testTimeout: 1000 * 60 * 3, hookTimeout: 1000 * 60 * 3 });
-
-const PNPM_BIN = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
 const sourceApiAppDir = path.resolve(__dirname, '../bff-api-app');
 
@@ -52,12 +51,23 @@ describe('crossProject client type portability', () => {
       await modernBuild(apiAppDir, [], {});
 
       // 1. Pack exactly what would be published.
-      //    On Windows `pnpm` is a `.cmd` shim, which `execFileSync` cannot
-      //    execute without a shell — spawning the bare name fails with ENOENT.
-      execFileSync(PNPM_BIN, ['pack', '--pack-destination', workDir], {
-        cwd: apiAppDir,
-        stdio: 'pipe',
-      });
+      //    Spawned through cross-spawn: on Windows `pnpm` is a `.cmd` shim,
+      //    which node refuses to execute directly (ENOENT for the bare name,
+      //    EINVAL for the `.cmd` since the CVE-2024-27980 fix). cross-spawn
+      //    routes it through the shell and quotes the arguments itself.
+      const pack = crossSpawn.sync(
+        'pnpm',
+        ['pack', '--pack-destination', workDir],
+        {
+          cwd: apiAppDir,
+          stdio: 'pipe',
+        },
+      );
+      if (pack.status !== 0) {
+        throw new Error(
+          `pnpm pack failed (${pack.status ?? pack.error}): ${pack.stderr?.toString() ?? ''}`,
+        );
+      }
       const tarball = fs
         .readdirSync(workDir)
         .find(name => name.endsWith('.tgz'));

--- a/tests/integration/bff-corss-project/tests/types-portability.test.ts
+++ b/tests/integration/bff-corss-project/tests/types-portability.test.ts
@@ -10,6 +10,8 @@ import {
 
 rstest.setConfig({ testTimeout: 1000 * 60 * 3, hookTimeout: 1000 * 60 * 3 });
 
+const PNPM_BIN = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+
 const sourceApiAppDir = path.resolve(__dirname, '../bff-api-app');
 
 // Type-check `consumerDir` in isolation and return the diagnostics. An unused
@@ -50,7 +52,9 @@ describe('crossProject client type portability', () => {
       await modernBuild(apiAppDir, [], {});
 
       // 1. Pack exactly what would be published.
-      execFileSync('pnpm', ['pack', '--pack-destination', workDir], {
+      //    On Windows `pnpm` is a `.cmd` shim, which `execFileSync` cannot
+      //    execute without a shell — spawning the bare name fails with ENOENT.
+      execFileSync(PNPM_BIN, ['pack', '--pack-destination', workDir], {
         cwd: apiAppDir,
         stdio: 'pipe',
       });


### PR DESCRIPTION
## Summary

`types-portability.test.ts` packs the fixture with `execFileSync('pnpm', ...)`, which cannot run on Windows: `pnpm` is a `.cmd` shim, so the bare name fails with `spawnSync pnpm ENOENT`. This has kept `integration-test-windows` red since #8797; Linux was unaffected.

Naming the shim explicitly (`pnpm.cmd`) only trades one failure for another — node refuses to execute a `.bat`/`.cmd` directly since the CVE-2024-27980 fix, so it becomes `spawnSync pnpm.cmd EINVAL`. Both were confirmed on Windows CI.

## Fix

Spawn through `cross-spawn`, already a devDependency of the test workspace, which handles the shim and the argument quoting itself.

Also check the exit status: `execFileSync` threw on failure, but `sync()` returns a result, so without the check a failing `pnpm pack` would surface later as a misleading "tarball not found".

## Verification

Windows integration tests with this fix (plus #8819 for the ESM loader corruption): **87 passed | 4 skipped, 0 failed**. The test also passes locally on Linux.

Co-Authored-By: Riff
