### PR TITLE
test(utils): report modern command failures instead of swallowing them

### DIFF
--- a/tests/utils/checkFrameworkEsm.mjs
+++ b/tests/utils/checkFrameworkEsm.mjs
@@ -1,0 +1,59 @@
+// Parses every `.mjs` the framework publishes, without running any of it.
+//
+// A project with `"type": "module"` loads the framework from `dist/esm-node`,
+// a CommonJS one from `dist/cjs`. When only the ESM projects die at startup
+// with a syntax error the ESM build is the suspect, but the loader reports
+// neither the file nor the line, so parse the whole build and name it here.
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const repoRoot = process.argv[2];
+const files = [];
+
+const collect = dir => {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const target = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collect(target);
+    } else if (entry.name.endsWith('.mjs')) {
+      files.push(target);
+    }
+  }
+};
+
+// Packages are laid out as `packages/<category>/<package>`.
+const packagesDir = path.join(repoRoot, 'packages');
+for (const category of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!category.isDirectory()) {
+    continue;
+  }
+  const categoryDir = path.join(packagesDir, category.name);
+  for (const pkg of fs.readdirSync(categoryDir, { withFileTypes: true })) {
+    if (pkg.isDirectory()) {
+      collect(path.join(categoryDir, pkg.name, 'dist', 'esm-node'));
+    }
+  }
+}
+
+let broken = 0;
+for (const file of files) {
+  try {
+    // Constructing the module parses it; it is never linked or evaluated.
+    new vm.SourceTextModule(fs.readFileSync(file, 'utf8'), {
+      identifier: file,
+    });
+  } catch (error) {
+    broken += 1;
+    console.error(`[framework-esm] ${file} does not parse: ${error.message}`);
+  }
+}
+console.error(
+  `[framework-esm] parsed ${files.length} framework .mjs file(s), ${broken} unparsable`,
+);

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -9,6 +9,87 @@ const kModernAppTools = path.join(
   '../node_modules/@modern-js/app-tools/bin/modern.js',
 );
 
+// A syntax error raised while Node compiles a generated module names neither
+// the file nor the line once the CLI has caught and re-logged it. The generated
+// code is the only part that differs per platform, so parse what was written
+// under `.modern-js` and let node report the offending file itself.
+function reportUnparsableGeneratedCode(cwd) {
+  if (!cwd) {
+    return;
+  }
+  const fs = require('fs');
+  const os = require('os');
+  const { execFileSync } = require('child_process');
+  const root = path.join(cwd, 'node_modules', '.modern-js');
+
+  const files = [];
+  const collect = dir => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const target = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        collect(target);
+      } else if (/\.(js|jsx|mjs)$/.test(entry.name)) {
+        files.push(target);
+      }
+    }
+  };
+  collect(root);
+
+  if (!files.length) {
+    console.error(`[generated-code] nothing to parse under ${root}`);
+    return;
+  }
+
+  // `node --check` parses a `.js` file as CommonJS, which silently accepts the
+  // ESM-only breakage we are looking for. Check a `.mjs` copy instead so the
+  // parser applies module semantics, exactly like the failing loader did.
+  let isEsm = false;
+  try {
+    isEsm =
+      JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'))
+        .type === 'module';
+  } catch {}
+
+  let broken = 0;
+  for (const file of files) {
+    let target = file;
+    if (isEsm && !file.endsWith('.mjs')) {
+      target = path.join(
+        os.tmpdir(),
+        `modern-parse-${process.pid}-${broken}-${path.basename(file)}.mjs`,
+      );
+      try {
+        fs.copyFileSync(file, target);
+      } catch {
+        target = file;
+      }
+    }
+    try {
+      execFileSync(process.execPath, ['--check', target], { stdio: 'pipe' });
+    } catch (error) {
+      broken += 1;
+      console.error(
+        `[generated-code] ${file} does not parse:\n${error.stderr || error.message}`,
+      );
+    } finally {
+      if (target !== file) {
+        try {
+          fs.unlinkSync(target);
+        } catch {}
+      }
+    }
+  }
+  console.error(
+    `[generated-code] parsed ${files.length} generated file(s) under ${root}, ${broken} unparsable`,
+  );
+}
+
 function runContinuousTask(argv, stdOut, options = {}) {
   const { cwd } = options;
   const env = {
@@ -76,6 +157,7 @@ function runContinuousTask(argv, stdOut, options = {}) {
             stderrOutput ? `\n${stderrOutput}` : ''
           }`,
         );
+        reportUnparsableGeneratedCode(cwd);
         resolve();
       }
     });
@@ -155,6 +237,7 @@ function runModernCommand(argv, options = {}) {
             stdoutOutput ? `\n${stdoutOutput}` : ''
           }${stderrOutput ? `\n${stderrOutput}` : ''}`,
         );
+        reportUnparsableGeneratedCode(cwd);
       }
       resolve({
         code,

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -38,7 +38,9 @@ function reportUnparsableGeneratedCode(cwd) {
       const target = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         collect(target);
-      } else if (/\.(js|jsx|mjs)$/.test(entry.name)) {
+        // `.jsx` is deliberately absent: it carries JSX, which node cannot
+        // parse at all, so checking it reports every file as broken.
+      } else if (/\.(js|mjs)$/.test(entry.name)) {
         files.push(target);
       }
     }

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -20,7 +20,11 @@ function reportUnparsableGeneratedCode(cwd) {
   const fs = require('fs');
   const os = require('os');
   const { execFileSync } = require('child_process');
-  const root = path.join(cwd, 'node_modules', '.modern-js');
+  // Generated entries land in `.modern-js`, transpiled configs in `.cache`, so
+  // walk `node_modules` itself. Installed packages are pnpm symlinks and
+  // `isDirectory()` is false for those, so the walk stays inside what this run
+  // actually wrote instead of descending into the store.
+  const root = path.join(cwd, 'node_modules');
 
   const files = [];
   const collect = dir => {

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -24,6 +24,15 @@ function runContinuousTask(argv, stdOut, options = {}) {
 
     let didResolve = false;
 
+    // stderr is not part of the ready/error markers, but it is where a crashing
+    // app prints why it died. Without collecting it, a dev server that never
+    // boots leaves no trace and the test fails later with a misleading
+    // ERR_CONNECTION_REFUSED.
+    let stderrOutput = '';
+    instance.stderr?.on('data', data => {
+      stderrOutput += data.toString();
+    });
+
     function handleStdout(data) {
       const message = data.toString();
 
@@ -56,10 +65,17 @@ function runContinuousTask(argv, stdOut, options = {}) {
       reject(error);
     });
 
-    instance.on('close', () => {
+    instance.on('close', code => {
       instance.stdout.removeListener('data', handleStdout);
       if (!didResolve) {
         didResolve = true;
+        // Exited before it was ever ready — report it here, otherwise the only
+        // symptom is a connection refused in whatever assertion runs next.
+        console.error(
+          `[runContinuousTask] "${argv.join(' ')}" exited with code ${code} before becoming ready${
+            stderrOutput ? `\n${stderrOutput}` : ''
+          }`,
+        );
         resolve();
       }
     });
@@ -86,6 +102,10 @@ function runModernCommand(argv, options = {}) {
       options.instance(instance);
     }
 
+    // Set once the promise has been settled by a marker, so the close handler
+    // can tell an unexpected exit from an already-reported one.
+    let settled = false;
+
     let stderrOutput = '';
     if (options.stderr) {
       instance.stderr.on('data', chunk => {
@@ -110,10 +130,12 @@ function runModernCommand(argv, options = {}) {
         rejectOnCompileError &&
         compileErrorMarker.test(message)
       ) {
+        settled = true;
         reject(new Error(message));
       }
 
       if (marker?.test(message)) {
+        settled = true;
         resolve({
           code: 0,
           stdout: stdoutOutput,
@@ -124,6 +146,16 @@ function runModernCommand(argv, options = {}) {
     // }
 
     instance.on('close', code => {
+      // A non-zero exit that never printed "Compile error" resolves like a
+      // success here, and callers rarely check `code`. Report it, otherwise the
+      // only symptom is a missing-artifact assertion further down the test.
+      if (!settled && code !== 0) {
+        console.error(
+          `[runModernCommand] "${cmd}" exited with code ${code}${
+            stdoutOutput ? `\n${stdoutOutput}` : ''
+          }${stderrOutput ? `\n${stderrOutput}` : ''}`,
+        );
+      }
       resolve({
         code,
         stdout: stdoutOutput,

--- a/tests/utils/modernTestUtils.js
+++ b/tests/utils/modernTestUtils.js
@@ -96,6 +96,37 @@ function reportUnparsableGeneratedCode(cwd) {
   );
 }
 
+// Only `"type": "module"` fixtures fail, and they are the ones that resolve the
+// framework to `dist/esm-node`; CommonJS fixtures load `dist/cjs` and pass. So
+// when a command dies, check whether the ESM build itself still parses. Runs at
+// most once per worker: it is the same build for every test in the process.
+let checkedFrameworkEsm = false;
+function reportUnparsableFrameworkEsm() {
+  if (checkedFrameworkEsm) {
+    return;
+  }
+  checkedFrameworkEsm = true;
+  const { execFileSync } = require('child_process');
+  const repoRoot = path.resolve(__dirname, '../..');
+  try {
+    // Inherit so the report lands in the CI log next to the failure it explains.
+    execFileSync(
+      process.execPath,
+      [
+        '--experimental-vm-modules',
+        '--no-warnings',
+        path.join(__dirname, 'checkFrameworkEsm.mjs'),
+        repoRoot,
+      ],
+      { stdio: ['ignore', 'inherit', 'inherit'] },
+    );
+  } catch (error) {
+    console.error(
+      `[framework-esm] ${error.stderr || error.stdout || error.message}`,
+    );
+  }
+}
+
 function runContinuousTask(argv, stdOut, options = {}) {
   const { cwd } = options;
   const env = {
@@ -164,6 +195,7 @@ function runContinuousTask(argv, stdOut, options = {}) {
           }`,
         );
         reportUnparsableGeneratedCode(cwd);
+        reportUnparsableFrameworkEsm();
         resolve();
       }
     });
@@ -244,6 +276,7 @@ function runModernCommand(argv, options = {}) {
           }${stderrOutput ? `\n${stderrOutput}` : ''}`,
         );
         reportUnparsableGeneratedCode(cwd);
+        reportUnparsableFrameworkEsm();
       }
       resolve({
         code,


### PR DESCRIPTION
Both spawn helpers hide why a command died:

- runModernCommand resolves on any exit code unless stdout happened to contain 'Compile error', and callers do not check the resolved code, so a crashed `modern build` is indistinguishable from a successful one. The test then fails on a missing artifact, which points at the wrong place.
- runContinuousTask never reads stderr at all, and resolves when the app closes before printing its ready marker. A dev server that fails to boot leaves no trace; the next assertion reports a connection refused.

Report the exit code and captured output in both cases. Neither change alters control flow: the promises settle exactly as before, so tests that expect a failing build are unaffected.

## Summary


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
