### PR TITLE
fix(app-tools): stop writing the ESM loader files twice

### DIFF
--- a/.changeset/spotty-loaders-copy.md
+++ b/.changeset/spotty-loaders-copy.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/app-tools': patch
+---
+
+fix: stop writing the ESM loader files twice
+
+fix: 修复 ESM loader 文件被重复写入的问题

--- a/packages/solutions/app-tools/rslib.config.mts
+++ b/packages/solutions/app-tools/rslib.config.mts
@@ -19,11 +19,22 @@ export default defineConfig({
       },
       output: {
         ...libConfig.output,
+        // `src/esm` is also matched by the `./src/**` entry, so the bundler
+        // emits these files itself. The ESM outputs keep the `.mjs` extension,
+        // which means bundle and copy write the very same paths — two writers
+        // for one file, occasionally leaving it truncated and unparsable, which
+        // takes down every `"type": "module"` project. The CJS output emits
+        // `.js`, so there the copy is the only thing providing the `.mjs`
+        // loaders that `register()` resolves by name; keep it for that alone.
         copy: [
-          {
-            from: './src/esm',
-            to: './esm',
-          },
+          ...(libConfig.format === 'esm'
+            ? []
+            : [
+                {
+                  from: './src/esm',
+                  to: './esm',
+                },
+              ]),
           {
             from: 'plugins/deploy/platforms/templates/*.cjs',
             context: path.join(__dirname, 'src'),


### PR DESCRIPTION
## Summary

`src/esm` is matched by the `./src/**` entry, so the bundler emits those files itself. It also sits in `output.copy`, and in the ESM outputs both land on the same `.mjs` paths — two writers for one file. When the writes interleave the file is left truncated.

`bin/modern.js` loads `dist/esm-node` for any project with `"type": "module"`, so a corrupt loader takes the whole project down at startup:

```
SyntaxError: Unexpected token '}'
    at compileSourceTextModule (node:internal/modules/esm/utils)
```

## Evidence

Windows CI had been red since Aug 13. Every failing fixture was `"type": "module"`; every passing one was CommonJS — including tailwind v2/v3 passing in the same suite where v4 failed. Parsing the published ESM build during a failing run named the files:

```
dist/esm-node/esm/register-esm.mjs   does not parse: Unexpected token '}'
dist/esm-node/esm/ts-node-loader.mjs does not parse: Unexpected token ','
parsed 566 framework .mjs file(s), 2 unparsable
```

The CJS output emits `.js`, so nothing collides there — which is why CommonJS projects were never affected.

## Fix

Keep the copy only for the CJS output, where it is the sole source of the `.mjs` loaders `register()` resolves by name. Removing it entirely breaks CJS; excluding `src/esm` from the entry breaks CJS too, because `dist/cjs/utils/register.js` imports `../esm/register-esm.js`, which only exists as a bundled entry.

Rebuilding with this change produces a **byte-identical dist** (`diff -rq` before/after: 0 differences), so the duplicate write was the only thing removed.

The deploy templates are already excluded from the entry for exactly this reason; `src/esm` was missed.

## Verification

Windows integration tests on this fix (plus #8816 for an unrelated test-side failure): **87 passed | 4 skipped, 0 failed** — `SyntaxError`, `compileSourceTextModule` and `ERR_CONNECTION_REFUSED` all gone.

Note this is not test-only: these files ship inside the npm package, and a release build runs the same racy config. `@modern-js/app-tools@3.8.2` on the registry is currently clean (all 100 `esm-node` `.mjs` parse), but a release that loses the race would publish a broken loader and break every `"type": "module"` user project at startup.

Co-Authored-By: Riff
