### PR TITLE
docs: fix contributing guide test commands

### DIFF
--- a/packages/document/docs/en/community/contributing-guide.mdx
+++ b/packages/document/docs/en/community/contributing-guide.mdx
@@ -132,7 +132,7 @@ Modern.js uses [Rstest](https://rstest.rs/) for unit tests across the repository
 Before submitting a pull request, it's important to make sure that the changes haven't introduced any regressions or bugs. You can run the unit tests for the project by executing the following command:
 
 ```sh
-pnpm run test
+pnpm run test:ut
 ```
 
 Alternatively, you can run the unit tests of single package using the `--filter` option:
@@ -145,10 +145,11 @@ pnpm run --filter @modern-js/some-package test
 
 In addition to the unit tests, the Modern.js also includes end-to-end (E2E) tests, which checks the functionality of the application as a whole.
 
-You can run the `test:e2e` command to run the E2E tests:
+Run the framework integration tests and Builder E2E tests with the following commands:
 
 ```sh
-pnpm run test:e2e
+pnpm run test:framework
+pnpm run test:builder
 ```
 
 If you need to run a specified test, you can add keywords to filter:
@@ -160,7 +161,7 @@ npx rstest copy-assets
 
 ## Linting
 
-To help maintain consistency and readability of the codebase, we use a ESLint to lint the codes.
+To help maintain consistency and readability across the codebase, we use Biome for linting and formatting.
 
 You can run the Linter by executing the following command:
 

--- a/packages/document/docs/zh/community/contributing-guide.mdx
+++ b/packages/document/docs/zh/community/contributing-guide.mdx
@@ -131,7 +131,7 @@ Modern.js 仓库的单元测试统一使用 [Rstest](https://rstest.rs/)。你�
 在提交 pull request 之前，为了确保本次变更没有引入缺陷，你可以通过执行以下命令运行单元测试：
 
 ```sh
-pnpm run test
+pnpm run test:ut
 ```
 
 你也可以使用 `--filter` 选项运行单个包的单元测试：
@@ -144,10 +144,11 @@ pnpm run --filter @modern-js/some-package test
 
 除了单元测试之外，Modern.js 仓库还包括端到端 (E2E) 测试，用于检查整个应用程序的功能。
 
-你可以执行 `test:e2e` 命令来运行 E2E 测试：
+使用以下命令运行框架集成测试和 Builder E2E 测试：
 
 ```sh
-pnpm run test:e2e
+pnpm run test:framework
+pnpm run test:builder
 ```
 
 如果需要运行指定的测试，可以添加关键字进行过滤：
@@ -159,7 +160,7 @@ npx rstest copy-assets
 
 ## Linting
 
-为了帮助保持代码风格的一致性和可读性，我们使用 ESLint 对代码进行校验。
+为了帮助保持代码风格的一致性和可读性，我们使用 Biome 对代码进行校验和格式化。
 
 你可以执行以下命令来运行 Linter：
 


### PR DESCRIPTION
## Summary

- replace the missing root `test` and `test:e2e` commands with `test:ut`, `test:framework`, and `test:builder`
- update the linting description from ESLint to the repository's current Biome setup
- keep the English and Chinese contributing guides aligned

## Related Links

None

## Validation

- `pnpm --filter @modern-js/main-doc... build`
- `pnpm run check-dependencies`
- `pnpm run lint:package-json`
- `pnpm exec biome check --formatter-enabled=false`

## Checklist

- [ ] I have added changeset via `pnpm run change`. (Not applicable: documentation-only change.)
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes. (Not applicable: documentation-only change.)