### PR TITLE
fix(deps): upgrade styled-components plugin to v1.7.0

### DIFF
--- a/.changeset/tidy-pandas-style.md
+++ b/.changeset/tidy-pandas-style.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/plugin-styled-components': patch
+---
+
+fix: upgrade @rsbuild/plugin-styled-components to v1.7.0 for Rsbuild 2.2 compatibility
+
+fix: 将 @rsbuild/plugin-styled-components 升级至 v1.7.0，以兼容 Rsbuild 2.2

--- a/packages/cli/plugin-styled-components/package.json
+++ b/packages/cli/plugin-styled-components/package.json
@@ -30,7 +30,7 @@
     "build": "rslib build"
   },
   "dependencies": {
-    "@rsbuild/plugin-styled-components": "1.6.3",
+    "@rsbuild/plugin-styled-components": "1.7.0",
     "@swc/helpers": "^0.5.17"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1219,8 +1219,8 @@ importers:
   packages/cli/plugin-styled-components:
     dependencies:
       '@rsbuild/plugin-styled-components':
-        specifier: 1.6.3
-        version: 1.6.3(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
+        specifier: 1.7.0
+        version: 1.7.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.23
@@ -8821,10 +8821,10 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-styled-components@1.6.3':
-    resolution: {integrity: sha512-6uDo8OPBHFjLRVvlzR1fJ9hFlTrX2sc0WJDHjMiGryco060r1JHKI7HCOQXhirtXhCuhDvOFdUIGdf3Bp1uCaw==}
+  '@rsbuild/plugin-styled-components@1.7.0':
+    resolution: {integrity: sha512-pCt225V1HPjjTh8lT1gvdzFSoe3tULWBFEe8Rh3GmnXkqv1Tv03+s42a6kS8f99hYMRzn0kuAv+yLL/+ZtjkWg==}
     peerDependencies:
-      '@rsbuild/core': ^1.7.0 || ^2.0.0
+      '@rsbuild/core': ^2.2.0-0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -9643,8 +9643,8 @@ packages:
   '@swc/plugin-loadable-components@12.0.0':
     resolution: {integrity: sha512-3vdbr0k5NQ0W4KgIx6LrFvjKwDyMPWbeHBncfFT7Fo2IKyo7513CXMCkx6KEUEsPzTJZRhHx0pFyt2hPWnfpEA==}
 
-  '@swc/plugin-styled-components@12.12.1':
-    resolution: {integrity: sha512-2QyISNeE501HvH9QcFOFvRMOnueWuulfJJxWadLoHtCAiTySCdWnCyLfErz2erXZUv9BDJO46/oeiiKlYiAiUQ==}
+  '@swc/plugin-styled-components@13.0.0':
+    resolution: {integrity: sha512-9kWagP4qtU4XZ7iyVrR2Nlw4/NMrbRpPCsCims15tKPHiWDI2FdL9+2ocOqB+uDwNCv3wGc8P/Eagbh3+zY/3Q==}
 
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
@@ -10908,6 +10908,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -12998,6 +12999,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -23690,12 +23692,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
-  '@rsbuild/plugin-styled-components@1.6.3(@rsbuild/core@2.1.13(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
+  '@rsbuild/plugin-styled-components@1.7.0(@rsbuild/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))':
     dependencies:
-      '@swc/plugin-styled-components': 12.12.1
+      '@swc/plugin-styled-components': 13.0.0
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
+      '@rsbuild/core': 2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0)
 
   '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.1.0(@module-federation/runtime-tools@2.0.0)(core-js@3.48.0))(@rspack/core@2.2.0-rc.0(@module-federation/runtime-tools@2.0.0)(@swc/helpers@0.5.23))(typescript@5.0.4)':
     dependencies:
@@ -24712,7 +24714,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-styled-components@12.12.1':
+  '@swc/plugin-styled-components@13.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 


### PR DESCRIPTION
## Summary

This fixes styled-components compilation with Rsbuild 2.2 by upgrading `@rsbuild/plugin-styled-components` from `1.6.3` to `1.7.0`. The new release uses `@swc/plugin-styled-components@13.0.0`, matching the SWC core embedded in Rspack 2.2.

## Related Links

- https://github.com/rstackjs/rsbuild-plugin-styled-components/releases/tag/v1.7.0

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.