### PR TITLE
refactor(server-core): report CSR fallbacks through monitors

### DIFF
--- a/.changeset/remove-server-fallback-hook.md
+++ b/.changeset/remove-server-fallback-hook.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/server-core': patch
+---
+
+Remove the server plugin `fallback` hook. SSR-to-CSR fallback events are now reported directly through request monitors as a warning and an `ssr-fallback` counter.

--- a/packages/server/core/src/plugins/compat/hooks.ts
+++ b/packages/server/core/src/plugins/compat/hooks.ts
@@ -6,7 +6,6 @@ import type {
 } from '@modern-js/types';
 import type {
   APIServerStartInput,
-  FallbackInput,
   ServerConfig,
   ServerPluginExtends,
   WebServerStartInput,
@@ -29,9 +28,6 @@ export function getHookRunners(
       event: ResetEvent;
     }) => {
       return hooks.onReset.call(params);
-    },
-    fallback: (input: FallbackInput) => {
-      return hooks.fallback.call(input);
     },
     prepareWebServer: (input: WebServerStartInput) => {
       return hooks.prepareWebServer.call(input);

--- a/packages/server/core/src/plugins/compat/index.ts
+++ b/packages/server/core/src/plugins/compat/index.ts
@@ -1,9 +1,8 @@
-import { createAsyncHook, createAsyncPipelineHook } from '@modern-js/plugin';
+import { createAsyncPipelineHook } from '@modern-js/plugin';
 import type {
   AfterMatchFn,
   AfterRenderFn,
   AfterStreamingRenderContextFn,
-  FallbackFn,
   PrepareApiServerFn,
   PrepareWebServerFn,
   ServerPlugin,
@@ -14,7 +13,6 @@ export { handleSetupResult } from './hooks';
 export const compatPlugin = (): ServerPlugin => ({
   name: '@modern-js/server-compat',
   registryHooks: {
-    fallback: createAsyncHook<FallbackFn>(),
     prepareWebServer: createAsyncPipelineHook<PrepareWebServerFn>(),
     prepareApiServer: createAsyncPipelineHook<PrepareApiServerFn>(),
     afterMatch: createAsyncPipelineHook<AfterMatchFn>(),

--- a/packages/server/core/src/plugins/render/inject.ts
+++ b/packages/server/core/src/plugins/render/inject.ts
@@ -1,7 +1,6 @@
 import type {
   CacheConfig,
   GetRenderHandlerOptions,
-  OnFallback,
   Render,
   ServerPlugin,
 } from '../../types';
@@ -22,21 +21,9 @@ export const injectRenderHandlerPlugin = ({
       const { distDirectory: pwd, routes, metaName } = api.getServerContext();
 
       const config = api.getServerConfig();
-
-      const hooks = api.getHooks();
-
       if (!routes) {
         return;
       }
-
-      const onFallback: OnFallback = async (reason, error, context) => {
-        // For other framework can report ssr fallback reason & error.
-        await hooks.fallback.call({
-          reason,
-          error,
-          context,
-        });
-      };
 
       const getRenderHandlerOptions: GetRenderHandlerOptions = {
         pwd: pwd!,
@@ -46,7 +33,6 @@ export const injectRenderHandlerPlugin = ({
         // TODO: support modern.server.ts cache config
         cacheConfig: cacheConfig,
         staticGenerate,
-        onFallback,
       };
 
       const render = await getRenderHandler(getRenderHandlerOptions);
@@ -66,7 +52,6 @@ export async function getRenderHandler({
   cacheConfig,
   metaName,
   staticGenerate,
-  onFallback,
 }: GetRenderHandlerOptions): Promise<Render> {
   const ssrConfig = config.server?.ssr;
   const ssrByEntries = config.server?.ssrByEntries;
@@ -91,7 +76,6 @@ export async function getRenderHandler({
     forceCSRMap,
     nonce: config.security?.nonce,
     metaName: metaName || 'modern-js',
-    onFallback,
   });
 
   return render;

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -4,13 +4,7 @@ import { cutNameByHyphen } from '@modern-js/utils/universal';
 import type { Router } from 'hono/router';
 import { TrieRouter } from 'hono/router/trie-router';
 import { X_MODERNJS_RENDER } from '../../constants';
-import type {
-  CacheConfig,
-  FallbackContext,
-  FallbackReason,
-  OnFallback,
-  UserConfig,
-} from '../../types';
+import type { CacheConfig, UserConfig } from '../../types';
 import type { Render } from '../../types';
 import type { Params } from '../../types/requestHandler';
 import { uniqueKeyByRoute } from '../../utils';
@@ -35,17 +29,15 @@ interface CreateRenderOptions {
   config: UserConfig;
   cacheConfig?: CacheConfig;
   staticGenerate?: boolean;
-  onFallback?: OnFallback;
   metaName?: string;
   forceCSR?: boolean;
   forceCSRMap?: Map<string, boolean>;
   nonce?: string;
 }
 
-type FallbackWrapper = (
-  reason: FallbackReason,
-  err?: unknown,
-) => ReturnType<OnFallback>;
+type FallbackReason = 'error' | 'header' | 'query' | `header,${string}`;
+
+type FallbackWrapper = (reason: FallbackReason) => void;
 
 const DYNAMIC_ROUTE_REG = /\/:./;
 
@@ -129,7 +121,6 @@ export async function createRender({
   forceCSR,
   forceCSRMap,
   config,
-  onFallback,
 }: CreateRenderOptions): Promise<Render> {
   const router = getRouter(routes);
 
@@ -160,14 +151,11 @@ export async function createRender({
     const framework = cutNameByHyphen(metaName || 'modern-js');
     const fallbackHeader = `x-${framework}-ssr-fallback`;
     let fallbackReason = null;
-    const fallbackContext: FallbackContext = {
-      request: req,
-      monitors,
-    };
 
-    const fallbackWrapper: FallbackWrapper = async (reason, error?) => {
+    const fallbackWrapper: FallbackWrapper = reason => {
       fallbackReason = reason;
-      return onFallback?.(reason, error, fallbackContext);
+      monitors?.warn('fallback to CSR reason: %o', { type: reason });
+      monitors?.counter('ssr-fallback', { type: reason });
     };
 
     if (!routeInfo) {
@@ -346,7 +334,7 @@ async function renderHandler(
       response = await ssrRender(request, options);
     } catch (e) {
       options.onError(e as Error, ErrorDigest.ERENDER);
-      await fallbackWrapper('error', e);
+      fallbackWrapper('error');
 
       response = await csrRender(request, {
         ...options,

--- a/packages/server/core/src/types/plugins/base.ts
+++ b/packages/server/core/src/types/plugins/base.ts
@@ -5,7 +5,6 @@ import type {
   Logger,
   Metrics,
   MiddlewareContext,
-  Monitors,
   Reporter,
   ServerRoute,
 } from '@modern-js/types';
@@ -15,24 +14,6 @@ import type { Render } from '../render';
 import type { ServerPlugin } from './plugin';
 
 export type { FileChangeEvent, ResetEvent } from '@modern-js/plugin';
-export type FallbackReason = 'error' | 'header' | 'query' | `header,${string}`;
-
-export type FallbackContext = {
-  request: Request;
-  monitors?: Monitors;
-};
-
-export type FallbackInput = {
-  reason: FallbackReason;
-  error: unknown;
-  context?: FallbackContext;
-};
-
-export type OnFallback = (
-  reason: FallbackReason,
-  error?: unknown,
-  context?: FallbackContext,
-) => Promise<void>;
 
 export type APIServerStartInput = {
   pwd: string;
@@ -74,7 +55,6 @@ export interface GetRenderHandlerOptions {
   pwd: string;
   routes: ServerRoute[];
   config: UserConfig;
-  onFallback?: OnFallback;
   cacheConfig?: CacheConfig;
   staticGenerate?: boolean;
   metaName?: string;

--- a/packages/server/core/src/types/plugins/index.ts
+++ b/packages/server/core/src/types/plugins/index.ts
@@ -2,12 +2,8 @@ export * from './plugin';
 export type {
   ServerConfig,
   CacheConfig,
-  OnFallback,
-  FallbackReason,
-  FallbackContext,
   GetRenderHandlerOptions,
   FileChangeEvent,
-  FallbackInput,
   WebServerStartInput,
   APIServerStartInput,
   ServerMiddleware,

--- a/packages/server/core/src/types/plugins/plugin.ts
+++ b/packages/server/core/src/types/plugins/plugin.ts
@@ -1,5 +1,4 @@
 import type {
-  AsyncHook,
   AsyncPipelineHook,
   ServerContext as BaseServerContext,
   ServerPlugin as BaseServerPlugin,
@@ -16,13 +15,11 @@ import type { MiddlewareHandler } from 'hono';
 import type { MiddlewareObj } from './base';
 import type {
   APIServerStartInput,
-  FallbackInput,
   ServerConfig,
   WebAdapter,
   WebServerStartInput,
 } from './base';
 
-export type FallbackFn = (input: FallbackInput) => Promise<FallbackInput>;
 export type PrepareWebServerFn = (
   input: WebServerStartInput,
 ) => Promise<WebAdapter | null>;
@@ -44,7 +41,6 @@ export interface ServerPluginExtends extends BaseServerPluginExtends {
   };
   extendHooks: {
     prepareWebServer: AsyncPipelineHook<PrepareWebServerFn>;
-    fallback: AsyncHook<FallbackFn>;
     prepareApiServer: AsyncPipelineHook<PrepareApiServerFn>;
     afterMatch: AsyncPipelineHook<AfterMatchFn>;
     afterRender: AsyncPipelineHook<AfterRenderFn>;

--- a/packages/server/core/tests/plugins/render.test.ts
+++ b/packages/server/core/tests/plugins/render.test.ts
@@ -1,15 +1,11 @@
 import path from 'path';
-import type { Logger, ServerRoute } from '@modern-js/types';
+import type { Logger, MonitorEvent, ServerRoute } from '@modern-js/types';
 import { TrieRouter } from 'hono/router/trie-router';
 import { injectResourcePlugin } from '../../src/adapters/node/plugins';
 import { createDefaultPlugins, renderPlugin } from '../../src/plugins';
 import { matchRoute } from '../../src/plugins/render/render';
 import { createServerBase } from '../../src/serverBase';
-import type {
-  FallbackInput,
-  ServerPlugin,
-  ServerUserConfig,
-} from '../../src/types';
+import type { ServerPlugin, ServerUserConfig } from '../../src/types';
 import { getDefaultAppContext, getDefaultConfig } from '../helpers';
 
 const logger: Logger = {
@@ -59,16 +55,44 @@ async function createSSRServer(
   return server;
 }
 
-function createFallbackCapturePlugin(inputs: FallbackInput[]): ServerPlugin {
+function createMonitorCapturePlugin(events: MonitorEvent[]): ServerPlugin {
   return {
-    name: 'fallback-capture',
+    name: 'monitor-capture',
     setup(api) {
-      api.fallback(async input => {
-        inputs.push(input);
-        return input;
+      api.onPrepare(() => {
+        const { middlewares } = api.getServerContext();
+        middlewares.push({
+          name: 'monitor-capture',
+          handler: async (c, next) => {
+            c.get('monitors')?.push(event => events.push(event));
+            return next();
+          },
+        });
       });
     },
   };
+}
+
+function expectFallbackReport(events: MonitorEvent[], reason: string) {
+  expect(events).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: 'log',
+        payload: expect.objectContaining({
+          level: 'warn',
+          message: 'fallback to CSR reason: %o',
+          args: [{ type: reason }],
+        }),
+      }),
+      expect.objectContaining({
+        type: 'counter',
+        payload: expect.objectContaining({
+          name: 'ssr-fallback',
+          tags: { type: reason },
+        }),
+      }),
+    ]),
+  );
 }
 
 describe('should render html correctly', () => {
@@ -209,9 +233,9 @@ describe('should render html correctly', () => {
     expect(html4).toMatch(/Hello Modern/);
   });
 
-  it('should pass request and monitors when forcing csr fallback', async () => {
+  it('should report monitor events when forcing csr fallback', async () => {
     const ssrPwd = path.join(pwd, 'ssr');
-    const fallbackInputs: FallbackInput[] = [];
+    const monitorEvents: MonitorEvent[] = [];
     const server = await createSSRServer(
       ssrPwd,
       {
@@ -219,7 +243,7 @@ describe('should render html correctly', () => {
           forceCSR: true,
         },
       },
-      [createFallbackCapturePlugin(fallbackInputs)],
+      [createMonitorCapturePlugin(monitorEvents)],
     );
 
     let fallbackHeader;
@@ -237,17 +261,7 @@ describe('should render html correctly', () => {
         `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"query"}</script>`,
       ),
     ).toBe(true);
-    expect(fallbackInputs).toHaveLength(1);
-    const fallbackInput = fallbackInputs[0]!;
-    expect(fallbackInput.reason).toBe('query');
-    expect(fallbackInput.context?.request).toBeInstanceOf(Request);
-    expect(fallbackInput.context?.request.url).toContain('/?csr=1');
-    expect(fallbackInput.context?.monitors?.counter).toEqual(
-      expect.any(Function),
-    );
-    expect(fallbackInput.context?.monitors?.error).toEqual(
-      expect.any(Function),
-    );
+    expectFallbackReport(monitorEvents, 'query');
   });
 
   it('support serve data', async () => {
@@ -296,9 +310,9 @@ describe('should render html correctly', () => {
     ).toBe(true);
   });
 
-  it('should pass request and monitors when render error fallback', async () => {
+  it('should report monitor events when render error triggers csr fallback', async () => {
     const ssrPwd = path.join(pwd, 'ssr');
-    const fallbackInputs: FallbackInput[] = [];
+    const monitorEvents: MonitorEvent[] = [];
     const server = await createSSRServer(
       ssrPwd,
       {
@@ -306,7 +320,7 @@ describe('should render html correctly', () => {
           forceCSR: true,
         },
       },
-      [createFallbackCapturePlugin(fallbackInputs)],
+      [createMonitorCapturePlugin(monitorEvents)],
     );
 
     let fallbackHeader;
@@ -331,17 +345,6 @@ describe('should render html correctly', () => {
         `<script id="__modern_ssr_fallback_reason__" type="application/json">{"reason":"error"}</script>`,
       ),
     ).toBe(true);
-    expect(fallbackInputs).toHaveLength(1);
-    const fallbackInput = fallbackInputs[0]!;
-    expect(fallbackInput.reason).toBe('error');
-    expect(fallbackInput.error).toBeInstanceOf(Error);
-    expect(fallbackInput.context?.request).toBeInstanceOf(Request);
-    expect(fallbackInput.context?.request.url).toContain('/');
-    expect(fallbackInput.context?.monitors?.counter).toEqual(
-      expect.any(Function),
-    );
-    expect(fallbackInput.context?.monitors?.error).toEqual(
-      expect.any(Function),
-    );
+    expectFallbackReport(monitorEvents, 'error');
   });
 });


### PR DESCRIPTION
## Summary
- Remove the server plugin `fallback` hook, its compatibility runner, and related type exports.
- Report SSR-to-CSR fallback events directly through request monitors.
- Preserve existing fallback response headers and HTML reason injection.

## Breaking change
Consumers must remove `api.fallback(...)`. Fallback reporting is available through the request monitor warning and `ssr-fallback` counter events.

## Verification
- `pnpm --filter @modern-js/server-core test -- tests/plugins/render.test.ts`
- `pnpm --filter @modern-js/server-core build`