### PR TITLE
fix(runtime): serialize deferred resolver scripts safely

### DIFF
--- a/.changeset/safe-deferred-resolvers.md
+++ b/.changeset/safe-deferred-resolvers.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: emit streaming SSR deferred resolver scripts only at safe HTML boundaries
+
+fix: Streaming SSR 的 deferred resolver script 仅在安全的 HTML 边界输出

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
@@ -1,4 +1,5 @@
 import { PassThrough, Readable, Transform } from 'stream';
+import { StringDecoder } from 'string_decoder';
 import { storage } from '@modern-js/runtime-utils/node';
 import { SSR_HYDRATION_ID_PREFIX } from '@modern-js/utils/universal/constants';
 import type { ReactElement } from 'react';
@@ -7,6 +8,7 @@ import { RenderLevel } from '../../constants';
 import { getGlobalInternalRuntimeContext } from '../../context';
 import { getMonitors } from '../../context/monitors';
 import { enqueueFromEntries } from './deferredScript';
+import { DeferredScriptOutputCoordinator } from './deferredScriptOutputCoordinator';
 import {
   type CreateReadableStreamFromElement,
   ShellChunkStatus,
@@ -87,7 +89,20 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
               entryName,
               styledComponentsStyleTags,
             }).then(({ shellAfter, shellBefore }) => {
+              const decoder = new StringDecoder('utf8');
               const pendingScripts: string[] = [];
+              const outputState: {
+                coordinator?: DeferredScriptOutputCoordinator;
+              } = {};
+              let deferredResolversComplete = Promise.resolve();
+
+              const writeReact = (content: string) => {
+                if (!outputState.coordinator) {
+                  throw new Error('Deferred script coordinator is not ready');
+                }
+                outputState.coordinator.writeReact(content);
+              };
+
               const body = new Transform({
                 transform(chunk, _encoding, callback) {
                   try {
@@ -122,19 +137,26 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                         );
 
                         shellChunkStatus = ShellChunkStatus.FINISH;
-                        this.push(`${shellBefore}${beforeMark}${shellAfter}`);
+                        writeReact(`${shellBefore}${beforeMark}${shellAfter}`);
                         if (afterMark) {
-                          this.push(afterMark);
+                          writeReact(afterMark);
                         }
-                        // Flush any pending <script> collected before shell finished
-                        if (pendingScripts.length > 0) {
-                          for (const s of pendingScripts) {
-                            this.push(s);
+                        // FINISH retains its shell lifecycle meaning. The coordinator
+                        // becomes eligible only after this marker chunk's afterMark
+                        // bytes have been observed, preserving their original order.
+                        if (outputState.coordinator) {
+                          outputState.coordinator.markShellFinished();
+                          for (const script of pendingScripts) {
+                            outputState.coordinator.enqueueResolver(script);
                           }
+                          pendingScripts.length = 0;
                         }
                       }
                     } else {
-                      this.push(chunk);
+                      const decodedChunk = decoder.write(
+                        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+                      );
+                      writeReact(decodedChunk);
                     }
                     callback();
                   } catch (e) {
@@ -147,6 +169,52 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                     }
                   }
                 },
+                flush(callback) {
+                  try {
+                    writeReact(decoder.end());
+                  } catch (error) {
+                    callback(
+                      error instanceof Error
+                        ? error
+                        : new Error('Received unknown error when streaming'),
+                    );
+                    return;
+                  }
+
+                  deferredResolversComplete.then(
+                    () => {
+                      try {
+                        outputState.coordinator?.finish();
+                        callback();
+                      } catch (error) {
+                        callback(
+                          error instanceof Error
+                            ? error
+                            : new Error(
+                                'Received unknown error when streaming',
+                              ),
+                        );
+                      }
+                    },
+                    error => {
+                      callback(
+                        error instanceof Error
+                          ? error
+                          : new Error('Received unknown error when streaming'),
+                      );
+                    },
+                  );
+                },
+              });
+
+              const coordinator = new DeferredScriptOutputCoordinator(
+                content => {
+                  body.push(content);
+                },
+              );
+              outputState.coordinator = coordinator;
+              body.once('close', () => {
+                coordinator.abort();
               });
 
               const passThrough = new PassThrough();
@@ -162,9 +230,6 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                   processedStream = extender.processStream(processedStream);
                 }
               });
-              reactStreamingPipe(passThrough);
-
-              processedStream.pipe(body);
 
               // Inject router data scripts, enqueue until shell finished
               try {
@@ -182,21 +247,32 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
 
                 if (entries.length > 0) {
                   const enqueueScript = (s: string) => {
+                    if (!outputState.coordinator) {
+                      throw new Error(
+                        'Deferred script coordinator is not ready',
+                      );
+                    }
                     if (shellChunkStatus === ShellChunkStatus.FINISH) {
-                      body.write(s);
+                      outputState.coordinator.enqueueResolver(s);
                     } else {
                       pendingScripts.push(s);
                     }
                   };
 
-                  enqueueFromEntries(entries, config.nonce, (s: string) =>
-                    enqueueScript(s),
+                  deferredResolversComplete = enqueueFromEntries(
+                    entries,
+                    config.nonce,
+                    enqueueScript,
                   );
                 }
               } catch (err) {
                 const monitors = getMonitors();
                 monitors.error('cannot inject router data script', err);
               }
+
+              reactStreamingPipe(passThrough);
+
+              processedStream.pipe(body);
             });
           },
 

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
@@ -3,6 +3,7 @@ import { storage } from '@modern-js/runtime-utils/node';
 import { ESCAPED_SHELL_STREAM_END_MARK } from '../../../common';
 import { RenderLevel } from '../../constants';
 import { enqueueFromEntries } from './deferredScript';
+import { DeferredScriptOutputCoordinator } from './deferredScriptOutputCoordinator';
 import {
   type CreateReadableStreamFromElement,
   ShellChunkStatus,
@@ -72,11 +73,14 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
       }
 
       const reader = readableOriginal.getReader();
+      let coordinator: DeferredScriptOutputCoordinator | undefined;
 
       const stream = new ReadableStream({
         start(controller) {
+          const decoder = new TextDecoder();
           const pendingScripts: string[] = [];
           let isClosed = false;
+          let deferredResolversComplete = Promise.resolve();
 
           const safeEnqueue = (chunk: Uint8Array | unknown) => {
             if (isClosed) return;
@@ -98,20 +102,9 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
             }
           };
 
-          const flushPendingScripts = () => {
-            for (const s of pendingScripts) {
-              safeEnqueue(encodeForWebStream(s));
-            }
-            pendingScripts.length = 0;
-          };
-
-          const enqueueScript = (script: string) => {
-            if (shellChunkStatus === ShellChunkStatus.FINISH) {
-              safeEnqueue(encodeForWebStream(script));
-            } else {
-              pendingScripts.push(script);
-            }
-          };
+          coordinator = new DeferredScriptOutputCoordinator(content => {
+            safeEnqueue(encodeForWebStream(content));
+          });
 
           const storageContext = storage.useContext?.();
           const activeDeferreds = storageContext?.activeDeferreds;
@@ -125,13 +118,32 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
               : [];
 
           if (entries.length > 0) {
-            enqueueFromEntries(entries, config.nonce, enqueueScript);
+            deferredResolversComplete = enqueueFromEntries(
+              entries,
+              config.nonce,
+              script => {
+                if (!coordinator) {
+                  throw new Error('Deferred script coordinator is not ready');
+                }
+                if (shellChunkStatus === ShellChunkStatus.FINISH) {
+                  coordinator.enqueueResolver(script);
+                } else {
+                  pendingScripts.push(script);
+                }
+              },
+            );
           }
 
           async function push() {
             try {
               const { done, value } = await reader.read();
               if (done) {
+                const trailingText = decoder.decode();
+                if (trailingText) {
+                  coordinator?.writeReact(trailingText);
+                }
+                await deferredResolversComplete;
+                coordinator?.finish();
                 closeController();
                 return;
               }
@@ -139,7 +151,7 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
               if (isClosed) return;
 
               if (shellChunkStatus !== ShellChunkStatus.FINISH) {
-                chunkVec.push(new TextDecoder().decode(value));
+                chunkVec.push(decoder.decode(value, { stream: true }));
                 const concatedChunk = chunkVec.join('');
 
                 /**
@@ -161,22 +173,28 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                   );
 
                   shellChunkStatus = ShellChunkStatus.FINISH;
-                  safeEnqueue(
-                    encodeForWebStream(
-                      `${shellBefore}${beforeMark}${shellAfter}`,
-                    ),
+                  coordinator?.writeReact(
+                    `${shellBefore}${beforeMark}${shellAfter}`,
                   );
                   if (afterMark) {
-                    safeEnqueue(encodeForWebStream(afterMark));
+                    coordinator?.writeReact(afterMark);
                   }
-                  flushPendingScripts();
+                  coordinator?.markShellFinished();
+                  for (const script of pendingScripts) {
+                    coordinator?.enqueueResolver(script);
+                  }
+                  pendingScripts.length = 0;
                 }
               } else {
-                safeEnqueue(value);
+                const decodedChunk = decoder.decode(value, { stream: true });
+                if (decodedChunk) {
+                  coordinator?.writeReact(decodedChunk);
+                }
               }
 
               if (!isClosed) push();
             } catch (error) {
+              coordinator?.abort();
               if (!isClosed) {
                 isClosed = true;
                 try {
@@ -190,6 +208,7 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
           push();
         },
         cancel(reason) {
+          coordinator?.abort();
           reader.cancel(reason).catch(() => {
             // Ignore cancellation errors
           });

--- a/packages/runtime/plugin-runtime/src/core/server/stream/deferredScript.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/deferredScript.ts
@@ -64,27 +64,35 @@ export function enqueueFromEntries(
   entries: Array<[string, unknown]>,
   nonce: string | undefined,
   emit: (script: string) => void,
-): void {
+): Promise<void> {
+  const pendingResolvers: Promise<void>[] = [];
+
   entries.forEach(([routeId, value]) => {
     if (!isDeferredDataLike(value)) return;
     const pendingKeys = new Set<string>(value.pendingKeys ?? []);
     pendingKeys.forEach((key: string) => {
       const tracked = value.data?.[key];
       if (isPromiseLike(tracked)) {
-        (tracked as Promise<unknown>).then(
-          (val: unknown) =>
-            emit(buildDeferredDataScript(nonce, [routeId, key, val])),
-          (err: unknown) =>
-            emit(
-              buildDeferredDataScript(nonce, [
-                routeId,
-                key,
-                undefined,
-                toErrorInfo(err),
-              ]),
-            ),
+        pendingResolvers.push(
+          Promise.resolve(tracked).then(
+            (val: unknown) => {
+              emit(buildDeferredDataScript(nonce, [routeId, key, val]));
+            },
+            (err: unknown) => {
+              emit(
+                buildDeferredDataScript(nonce, [
+                  routeId,
+                  key,
+                  undefined,
+                  toErrorInfo(err),
+                ]),
+              );
+            },
+          ),
         );
       }
     });
   });
+
+  return Promise.all(pendingResolvers).then(() => undefined);
 }

--- a/packages/runtime/plugin-runtime/src/core/server/stream/deferredScriptOutputCoordinator.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/deferredScriptOutputCoordinator.ts
@@ -81,9 +81,33 @@ function getSuffix(value: string, pattern: string): string {
 }
 
 /**
- * Serializes deferred resolver scripts with the React output stream without
- * rewriting React HTML. Shell completion makes a resolver eligible to send;
- * this coordinator waits for a root-level HTML boundary before emitting it.
+ * Serializes the router's deferred-data resolver scripts with React's Fizz
+ * output without rewriting either producer's bytes.
+ *
+ * Why this exists:
+ * - A resolver script settles the client-side Promise created for a
+ *   `defer()` key. It must be sent when that individual server Promise
+ *   settles; waiting for the whole React stream would unnecessarily delay
+ *   hydration and interactivity behind unrelated Suspense boundaries.
+ * - React and the resolver callbacks are independent stream producers. A
+ *   direct `write()` can therefore land in a partial HTML tag, a hidden Fizz
+ *   segment container, or between that container and its continuation
+ *   instruction.
+ * - React's public streaming callbacks expose shell/all-ready lifecycle
+ *   events, not a safe byte-level insertion point. React chunk sizes and
+ *   `progressiveChunkSize` are buffering heuristics, not HTML or Fizz
+ *   boundaries.
+ *
+ * The coordinator deliberately recognizes the Fizz continuation containers
+ * and instructions used by the supported React stream format. This is a
+ * compatibility boundary: when the supported React/Fizz output protocol is
+ * changed, update this recognizer and its Node, Edge, HTML, SVG, MathML, and
+ * table continuation tests together. It is not intended to be a general HTML
+ * rewriter.
+ *
+ * Shell completion only makes a resolver eligible to send. The resolver is
+ * emitted after a root-level HTML boundary and, for a continuation segment,
+ * after React's matching continuation instruction.
  */
 export class DeferredScriptOutputCoordinator {
   private readonly pendingResolvers: string[] = [];

--- a/packages/runtime/plugin-runtime/src/core/server/stream/deferredScriptOutputCoordinator.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/deferredScriptOutputCoordinator.ts
@@ -1,0 +1,547 @@
+import { SSR_HYDRATION_ID_PREFIX } from '@modern-js/utils/universal/constants';
+
+type TokenizerState =
+  | 'data'
+  | 'tag-open'
+  | 'start-tag-name'
+  | 'before-attribute-name'
+  | 'attribute-name'
+  | 'after-attribute-name'
+  | 'before-attribute-value'
+  | 'attribute-value-double-quoted'
+  | 'attribute-value-single-quoted'
+  | 'attribute-value-unquoted'
+  | 'self-closing-start-tag'
+  | 'end-tag-name'
+  | 'after-end-tag-name'
+  | 'markup-declaration'
+  | 'declaration'
+  | 'comment'
+  | 'bogus-comment'
+  | 'raw-text'
+  | 'raw-end-tag';
+
+type OpenElement = {
+  tagName: string;
+  isContinuationContainer: boolean;
+  isSegmentTableWrapper: boolean;
+};
+
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+const RAW_TEXT_ELEMENTS = new Set([
+  'iframe',
+  'noembed',
+  'noframes',
+  'script',
+  'style',
+  'textarea',
+  'title',
+  'xmp',
+]);
+
+const REACT_SEGMENT_ID_PATTERN = new RegExp(
+  `^${SSR_HYDRATION_ID_PREFIX}S:[0-9a-f]+$`,
+);
+
+const TABLE_SEGMENT_CHILDREN = new Set(['tbody', 'tr', 'colgroup']);
+
+function isAsciiAlpha(char: string): boolean {
+  return /[A-Za-z]/.test(char);
+}
+
+function isWhitespace(char: string): boolean {
+  return /[\t\n\f\r ]/.test(char);
+}
+
+function getSuffix(value: string, pattern: string): string {
+  const start = Math.max(0, value.length - pattern.length);
+  for (let index = start; index < value.length; index++) {
+    const suffix = value.slice(index);
+    if (pattern.startsWith(suffix)) {
+      return suffix;
+    }
+  }
+  return '';
+}
+
+/**
+ * Serializes deferred resolver scripts with the React output stream without
+ * rewriting React HTML. Shell completion makes a resolver eligible to send;
+ * this coordinator waits for a root-level HTML boundary before emitting it.
+ */
+export class DeferredScriptOutputCoordinator {
+  private readonly pendingResolvers: string[] = [];
+
+  private readonly openElements: OpenElement[] = [];
+
+  private shellFinished = false;
+
+  private closed = false;
+
+  private state: TokenizerState = 'data';
+
+  private currentTagName = '';
+
+  private currentAttributes = new Map<string, string | true>();
+
+  private currentAttributeName = '';
+
+  private currentAttributeValue = '';
+
+  private currentAttributeHasValue = false;
+
+  private declarationPrefix = '';
+
+  private commentTail = '';
+
+  private rawTextElement: string | undefined;
+
+  private rawTextSearch = '';
+
+  private continuationProtocolScript = false;
+
+  private continuationProtocolTail = '';
+
+  private hasContinuationProtocolCall = false;
+
+  private awaitingContinuationProtocol = false;
+
+  public constructor(private readonly emit: (chunk: string) => void) {}
+
+  public enqueueResolver(script: string): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.pendingResolvers.push(script);
+    this.flushResolvers();
+  }
+
+  /**
+   * Keep this separate from the ShellChunkStatus assignment. The caller sets
+   * FINISH at the existing marker position, then calls this after the marker
+   * chunk's afterMark bytes have been observed.
+   */
+  public markShellFinished(): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.shellFinished = true;
+    this.flushResolvers();
+  }
+
+  public writeReact(chunk: string): void {
+    if (this.closed || !chunk) {
+      return;
+    }
+
+    this.flushResolvers();
+
+    let emittedUntil = 0;
+    for (let index = 0; index < chunk.length; index++) {
+      const wasSafe = this.isSafeBoundary();
+      this.consume(chunk[index]);
+
+      if (!wasSafe && this.isSafeBoundary() && this.pendingResolvers.length) {
+        this.emit(chunk.slice(emittedUntil, index + 1));
+        emittedUntil = index + 1;
+        this.flushResolvers();
+      }
+    }
+
+    if (emittedUntil < chunk.length) {
+      this.emit(chunk.slice(emittedUntil));
+    }
+  }
+
+  public finish(): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.flushResolvers();
+    this.closed = true;
+
+    if (this.pendingResolvers.length > 0) {
+      throw new Error(
+        'Cannot emit deferred resolver scripts because the React stream ended outside a safe HTML boundary.',
+      );
+    }
+  }
+
+  public abort(): void {
+    this.closed = true;
+    this.pendingResolvers.length = 0;
+  }
+
+  private isSafeBoundary(): boolean {
+    return (
+      this.shellFinished &&
+      this.state === 'data' &&
+      this.openElements.length === 0 &&
+      !this.awaitingContinuationProtocol
+    );
+  }
+
+  private flushResolvers(): void {
+    if (!this.isSafeBoundary() || this.pendingResolvers.length === 0) {
+      return;
+    }
+
+    while (this.pendingResolvers.length > 0) {
+      const resolver = this.pendingResolvers.shift();
+      if (resolver) {
+        this.emit(resolver);
+      }
+    }
+  }
+
+  private consume(char: string): void {
+    switch (this.state) {
+      case 'data':
+        if (char === '<') {
+          this.state = 'tag-open';
+        }
+        return;
+      case 'tag-open':
+        if (char === '/') {
+          this.currentTagName = '';
+          this.state = 'end-tag-name';
+        } else if (char === '!') {
+          this.declarationPrefix = '';
+          this.state = 'markup-declaration';
+        } else if (char === '?') {
+          this.state = 'bogus-comment';
+        } else if (isAsciiAlpha(char)) {
+          this.startTag(char);
+          this.state = 'start-tag-name';
+        } else {
+          this.state = 'data';
+        }
+        return;
+      case 'start-tag-name':
+        if (isWhitespace(char)) {
+          this.state = 'before-attribute-name';
+        } else if (char === '/') {
+          this.state = 'self-closing-start-tag';
+        } else if (char === '>') {
+          this.completeStartTag(false);
+        } else {
+          this.currentTagName += char.toLowerCase();
+        }
+        return;
+      case 'before-attribute-name':
+        if (isWhitespace(char)) {
+          return;
+        }
+        if (char === '/') {
+          this.state = 'self-closing-start-tag';
+        } else if (char === '>') {
+          this.completeStartTag(false);
+        } else {
+          this.startAttribute(char);
+          this.state = 'attribute-name';
+        }
+        return;
+      case 'attribute-name':
+        if (isWhitespace(char)) {
+          this.state = 'after-attribute-name';
+        } else if (char === '=') {
+          this.currentAttributeHasValue = true;
+          this.state = 'before-attribute-value';
+        } else if (char === '/') {
+          this.completeAttribute();
+          this.state = 'self-closing-start-tag';
+        } else if (char === '>') {
+          this.completeStartTag(false);
+        } else {
+          this.currentAttributeName += char.toLowerCase();
+        }
+        return;
+      case 'after-attribute-name':
+        if (isWhitespace(char)) {
+          return;
+        }
+        if (char === '=') {
+          this.currentAttributeHasValue = true;
+          this.state = 'before-attribute-value';
+        } else if (char === '/') {
+          this.completeAttribute();
+          this.state = 'self-closing-start-tag';
+        } else if (char === '>') {
+          this.completeStartTag(false);
+        } else {
+          this.completeAttribute();
+          this.startAttribute(char);
+          this.state = 'attribute-name';
+        }
+        return;
+      case 'before-attribute-value':
+        if (isWhitespace(char)) {
+          return;
+        }
+        if (char === '"') {
+          this.state = 'attribute-value-double-quoted';
+        } else if (char === "'") {
+          this.state = 'attribute-value-single-quoted';
+        } else if (char === '>') {
+          this.completeStartTag(false);
+        } else {
+          this.currentAttributeValue += char;
+          this.state = 'attribute-value-unquoted';
+        }
+        return;
+      case 'attribute-value-double-quoted':
+        if (char === '"') {
+          this.completeAttribute();
+          this.state = 'before-attribute-name';
+        } else {
+          this.currentAttributeValue += char;
+        }
+        return;
+      case 'attribute-value-single-quoted':
+        if (char === "'") {
+          this.completeAttribute();
+          this.state = 'before-attribute-name';
+        } else {
+          this.currentAttributeValue += char;
+        }
+        return;
+      case 'attribute-value-unquoted':
+        if (isWhitespace(char)) {
+          this.completeAttribute();
+          this.state = 'before-attribute-name';
+        } else if (char === '>') {
+          this.completeStartTag(false);
+        } else {
+          this.currentAttributeValue += char;
+        }
+        return;
+      case 'self-closing-start-tag':
+        if (char === '>') {
+          this.completeStartTag(true);
+        } else if (!isWhitespace(char)) {
+          this.startAttribute(char);
+          this.state = 'attribute-name';
+        }
+        return;
+      case 'end-tag-name':
+        if (isWhitespace(char)) {
+          this.state = 'after-end-tag-name';
+        } else if (char === '>') {
+          this.completeEndTag();
+        } else {
+          this.currentTagName += char.toLowerCase();
+        }
+        return;
+      case 'after-end-tag-name':
+        if (char === '>') {
+          this.completeEndTag();
+        }
+        return;
+      case 'markup-declaration':
+        if (this.declarationPrefix.length < 2 && char === '-') {
+          this.declarationPrefix += char;
+          if (this.declarationPrefix === '--') {
+            this.commentTail = '';
+            this.state = 'comment';
+          }
+        } else {
+          this.state = char === '>' ? 'data' : 'declaration';
+        }
+        return;
+      case 'declaration':
+        if (char === '>') {
+          this.state = 'data';
+        }
+        return;
+      case 'comment':
+        this.commentTail = `${this.commentTail}${char}`.slice(-3);
+        if (this.commentTail === '-->') {
+          this.state = 'data';
+        }
+        return;
+      case 'bogus-comment':
+        if (char === '>') {
+          this.state = 'data';
+        }
+        return;
+      case 'raw-text':
+        this.consumeRawText(char);
+        return;
+      case 'raw-end-tag':
+        if (char === '>') {
+          this.completeRawTextEndTag();
+        } else if (!isWhitespace(char)) {
+          this.state = 'raw-text';
+          this.rawTextSearch = getSuffix(
+            `${this.rawTextSearch}${char.toLowerCase()}`,
+            `</${this.rawTextElement}`,
+          );
+        }
+    }
+  }
+
+  private startTag(char: string): void {
+    this.currentTagName = char.toLowerCase();
+    this.currentAttributes = new Map();
+    this.currentAttributeName = '';
+    this.currentAttributeValue = '';
+    this.currentAttributeHasValue = false;
+  }
+
+  private startAttribute(char: string): void {
+    this.currentAttributeName = char.toLowerCase();
+    this.currentAttributeValue = '';
+    this.currentAttributeHasValue = false;
+  }
+
+  private completeAttribute(): void {
+    if (!this.currentAttributeName) {
+      return;
+    }
+
+    this.currentAttributes.set(
+      this.currentAttributeName,
+      this.currentAttributeHasValue ? this.currentAttributeValue : true,
+    );
+    this.currentAttributeName = '';
+    this.currentAttributeValue = '';
+    this.currentAttributeHasValue = false;
+  }
+
+  private completeStartTag(selfClosing: boolean): void {
+    this.completeAttribute();
+    const tagName = this.currentTagName;
+    const id = this.currentAttributes.get('id');
+    const hasReactSegmentId =
+      typeof id === 'string' && REACT_SEGMENT_ID_PATTERN.test(id);
+    const hasHiddenAttribute = this.currentAttributes.has('hidden');
+    const isHiddenSegmentTable =
+      tagName === 'table' && hasHiddenAttribute && !hasReactSegmentId;
+    const isTableSegmentChild =
+      hasReactSegmentId &&
+      TABLE_SEGMENT_CHILDREN.has(tagName) &&
+      this.openElements[this.openElements.length - 1]?.isSegmentTableWrapper ===
+        true;
+    const isContinuationContainer =
+      hasReactSegmentId &&
+      ((tagName === 'div' && hasHiddenAttribute) ||
+        ((tagName === 'svg' || tagName === 'math') &&
+          id !== undefined &&
+          this.currentAttributes.get('aria-hidden') === 'true' &&
+          this.currentAttributes.get('style') === 'display:none') ||
+        (tagName === 'table' && hasHiddenAttribute) ||
+        isTableSegmentChild);
+    this.continuationProtocolScript =
+      tagName === 'script' && this.awaitingContinuationProtocol;
+    this.continuationProtocolTail = '';
+    this.hasContinuationProtocolCall = false;
+
+    if (!selfClosing && !VOID_ELEMENTS.has(tagName)) {
+      this.openElements.push({
+        tagName,
+        isContinuationContainer,
+        isSegmentTableWrapper: isHiddenSegmentTable,
+      });
+    }
+
+    this.currentTagName = '';
+    this.currentAttributes = new Map();
+    this.currentAttributeName = '';
+    this.currentAttributeValue = '';
+    this.currentAttributeHasValue = false;
+
+    if (!selfClosing && RAW_TEXT_ELEMENTS.has(tagName)) {
+      this.rawTextElement = tagName;
+      this.rawTextSearch = '';
+      this.state = 'raw-text';
+    } else {
+      this.state = 'data';
+    }
+  }
+
+  private completeEndTag(): void {
+    this.closeOpenElement(this.currentTagName);
+    this.currentTagName = '';
+    this.state = 'data';
+  }
+
+  private consumeRawText(char: string): void {
+    const rawTextElement = this.rawTextElement;
+    if (!rawTextElement) {
+      this.state = 'data';
+      return;
+    }
+
+    const endTagPrefix = `</${rawTextElement}`;
+    if (this.continuationProtocolScript) {
+      this.continuationProtocolTail =
+        `${this.continuationProtocolTail}${char}`.slice(-4);
+      if (/\$(?:RC|RS|RX|RB)\b/.test(this.continuationProtocolTail)) {
+        this.hasContinuationProtocolCall = true;
+      }
+    }
+    this.rawTextSearch = getSuffix(
+      `${this.rawTextSearch}${char.toLowerCase()}`,
+      endTagPrefix,
+    );
+    if (this.rawTextSearch === endTagPrefix) {
+      this.state = 'raw-end-tag';
+    }
+  }
+
+  private completeRawTextEndTag(): void {
+    const rawTextElement = this.rawTextElement;
+    if (rawTextElement) {
+      this.closeOpenElement(rawTextElement);
+    }
+    if (
+      rawTextElement === 'script' &&
+      this.continuationProtocolScript &&
+      this.hasContinuationProtocolCall
+    ) {
+      this.awaitingContinuationProtocol = false;
+    }
+    this.rawTextElement = undefined;
+    this.rawTextSearch = '';
+    this.continuationProtocolScript = false;
+    this.continuationProtocolTail = '';
+    this.hasContinuationProtocolCall = false;
+    this.state = 'data';
+  }
+
+  private closeOpenElement(tagName: string): void {
+    const matchingIndex = this.openElements
+      .map(element => element.tagName)
+      .lastIndexOf(tagName);
+    if (matchingIndex === -1) {
+      return;
+    }
+
+    const closedElements = this.openElements.splice(matchingIndex);
+    const closedContinuation = closedElements.some(
+      element => element.isContinuationContainer,
+    );
+    if (closedContinuation) {
+      this.awaitingContinuationProtocol = true;
+    }
+  }
+}

--- a/packages/runtime/plugin-runtime/tests/ssr/deferredScriptOutputCoordinator.test.ts
+++ b/packages/runtime/plugin-runtime/tests/ssr/deferredScriptOutputCoordinator.test.ts
@@ -1,0 +1,226 @@
+import { enqueueFromEntries } from '../../src/core/server/stream/deferredScript';
+import { DeferredScriptOutputCoordinator } from '../../src/core/server/stream/deferredScriptOutputCoordinator';
+
+const resolver = (name: string) => `<script data-resolver="${name}"></script>`;
+
+function createCoordinator() {
+  const output: string[] = [];
+  const coordinator = new DeferredScriptOutputCoordinator(chunk => {
+    output.push(chunk);
+  });
+
+  return {
+    coordinator,
+    output: () => output.join(''),
+  };
+}
+
+describe('DeferredScriptOutputCoordinator', () => {
+  test('keeps resolvers before the shell in the pre-shell queue', () => {
+    const { coordinator, output } = createCoordinator();
+
+    coordinator.enqueueResolver(resolver('before-shell'));
+    coordinator.writeReact('<html><body>shell</body></html>');
+
+    expect(output()).toBe('<html><body>shell</body></html>');
+
+    coordinator.markShellFinished();
+
+    expect(output()).toBe(
+      '<html><body>shell</body></html><script data-resolver="before-shell"></script>',
+    );
+  });
+
+  test('observes marker-chunk afterMark bytes before releasing pre-shell resolvers', () => {
+    const { coordinator, output } = createCoordinator();
+
+    coordinator.enqueueResolver(resolver('before-shell'));
+    coordinator.writeReact('<html><body>shell</body></html><a href="/template');
+    coordinator.markShellFinished();
+
+    expect(output()).toBe('<html><body>shell</body></html><a href="/template');
+
+    coordinator.writeReact('">template</a>');
+
+    expect(output()).toBe(
+      '<html><body>shell</body></html><a href="/template">template</a><script data-resolver="before-shell"></script>',
+    );
+  });
+
+  test('waits for a quoted attribute to close and preserves UTF-8 text', () => {
+    const { coordinator, output } = createCoordinator();
+    coordinator.markShellFinished();
+
+    coordinator.writeReact('<a href="https://example.test/你好');
+    coordinator.enqueueResolver(resolver('first'));
+    coordinator.enqueueResolver(resolver('second'));
+
+    expect(output()).toBe('<a href="https://example.test/你好');
+
+    coordinator.writeReact('">链接</a>');
+
+    expect(output()).toBe(
+      '<a href="https://example.test/你好">链接</a><script data-resolver="first"></script><script data-resolver="second"></script>',
+    );
+  });
+
+  test('waits for any incomplete attribute before preserving FIFO resolver order', () => {
+    const { coordinator, output } = createCoordinator();
+    coordinator.markShellFinished();
+
+    coordinator.writeReact('<div class="skeleton');
+    coordinator.enqueueResolver(resolver('class'));
+    coordinator.writeReact('">content</div>');
+
+    expect(output()).toBe(
+      '<div class="skeleton">content</div><script data-resolver="class"></script>',
+    );
+  });
+
+  test('keeps the response open until registered resolver promises are emitted', async () => {
+    const { coordinator, output } = createCoordinator();
+    coordinator.markShellFinished();
+
+    let resolveData: (value: string) => void;
+    const data = new Promise<string>(resolve => {
+      resolveData = resolve;
+    });
+    const completed = enqueueFromEntries(
+      [
+        [
+          'route',
+          {
+            data: { templateData: data },
+            pendingKeys: ['templateData'],
+          },
+        ],
+      ],
+      undefined,
+      script => coordinator.enqueueResolver(script),
+    );
+
+    coordinator.writeReact('<a href="/template');
+    resolveData!('resolved');
+    await completed;
+
+    expect(output()).toBe('<a href="/template');
+
+    coordinator.writeReact('">template</a>');
+    coordinator.finish();
+
+    expect(output()).toMatch(
+      /^<a href="\/template">template<\/a><script async data-fn-name="r"/,
+    );
+    expect(output()).toContain('&quot;resolved&quot;');
+  });
+
+  test('does not inject into comments, templates, or raw-text elements', () => {
+    const { coordinator, output } = createCoordinator();
+    coordinator.markShellFinished();
+
+    coordinator.writeReact('<!-- deferred');
+    coordinator.enqueueResolver(resolver('comment'));
+    coordinator.writeReact(' -->');
+    coordinator.writeReact('<template><span>template</span>');
+    coordinator.enqueueResolver(resolver('template'));
+    coordinator.writeReact('</template>');
+    coordinator.writeReact(
+      '<style>.card::before { content: "<script>"; }</style>',
+    );
+    coordinator.enqueueResolver(resolver('style'));
+    coordinator.writeReact(
+      '<script>const html = "<a href=\\"/x\\">";</script>',
+    );
+    coordinator.enqueueResolver(resolver('script'));
+    coordinator.writeReact('<div>next</div>');
+
+    expect(output()).toBe(
+      '<!-- deferred --><script data-resolver="comment"></script><template><span>template</span></template><script data-resolver="template"></script><style>.card::before { content: "<script>"; }</style><script data-resolver="style"></script><script>const html = "<a href=\\"/x\\">";</script><script data-resolver="script"></script><div>next</div>',
+    );
+  });
+
+  test('waits for React continuation protocol script before injecting', () => {
+    const { coordinator, output } = createCoordinator();
+    coordinator.markShellFinished();
+
+    coordinator.writeReact(
+      '<div hidden id="modern-js-S:0"><a href="/template">template</a></div>',
+    );
+    coordinator.enqueueResolver(resolver('continuation'));
+
+    expect(output()).toBe(
+      '<div hidden id="modern-js-S:0"><a href="/template">template</a></div>',
+    );
+
+    coordinator.writeReact('<script>window.afterContinuation = true</script>');
+
+    expect(output()).toBe(
+      '<div hidden id="modern-js-S:0"><a href="/template">template</a></div><script>window.afterContinuation = true</script>',
+    );
+
+    coordinator.writeReact('<script>$RC("B:0", "modern-js-S:0")</script>');
+
+    expect(output()).toBe(
+      '<div hidden id="modern-js-S:0"><a href="/template">template</a></div><script>window.afterContinuation = true</script><script>$RC("B:0", "modern-js-S:0")</script><script data-resolver="continuation"></script>',
+    );
+  });
+
+  test.each([
+    [
+      'SVG',
+      '<svg aria-hidden="true" style="display:none" id="modern-js-S:1"><circle /></svg>',
+    ],
+    [
+      'MathML',
+      '<math aria-hidden="true" style="display:none" id="modern-js-S:2"><mi>x</mi></math>',
+    ],
+    [
+      'table',
+      '<table hidden id="modern-js-S:3"><tbody><tr><td>x</td></tr></tbody></table>',
+    ],
+    [
+      'table body',
+      '<table hidden><tbody id="modern-js-S:4"><tr><td>x</td></tr></tbody></table>',
+    ],
+    [
+      'table row',
+      '<table hidden><tr id="modern-js-S:5"><td>x</td></tr></table>',
+    ],
+    [
+      'colgroup',
+      '<table hidden><colgroup id="modern-js-S:6"><col /></colgroup></table>',
+    ],
+  ])(
+    'waits for the React %s continuation protocol script',
+    (_name, segment) => {
+      const { coordinator, output } = createCoordinator();
+      coordinator.markShellFinished();
+
+      coordinator.writeReact(segment);
+      coordinator.enqueueResolver(resolver('continuation'));
+
+      expect(output()).toBe(segment);
+
+      coordinator.writeReact('<script>$RC("B:0", "modern-js-S:0")</script>');
+
+      expect(output()).toBe(
+        `${segment}<script>$RC("B:0", "modern-js-S:0")</script><script data-resolver="continuation"></script>`,
+      );
+    },
+  );
+
+  test('does not confuse business IDs with React continuation segments', () => {
+    const { coordinator, output } = createCoordinator();
+    coordinator.markShellFinished();
+
+    coordinator.writeReact(
+      '<div hidden id="modern-js-S:business">content</div>',
+    );
+    coordinator.enqueueResolver(resolver('business'));
+    coordinator.finish();
+
+    expect(output()).toBe(
+      '<div hidden id="modern-js-S:business">content</div><script data-resolver="business"></script>',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Serialize deferred resolver scripts through a shared HTML-safe output coordinator.
- Keep `ShellChunkStatus.FINISH` as the pre-shell release gate for Node and Edge.
- Wait for React continuation-protocol completion and registered resolver promises before closing.

## Validation

- `pnpm --filter @modern-js/runtime build`
- `pnpm --filter @modern-js/runtime test`
- `pnpm --dir tests exec rstest integration/ssr/tests/streaming.test.ts`

## Review

- Independent review completed; added coverage for HTML, SVG, MathML, and table continuation wrappers.