### PR TITLE
chore(release): prepare 3.9.0 minor release

### DIFF
--- a/.changeset/prepare-minor-release.md
+++ b/.changeset/prepare-minor-release.md
@@ -1,0 +1,5 @@
+---
+'@modern-js/app-tools': minor
+---
+
+chore: prepare the 3.9.0 minor release.


### PR DESCRIPTION
## Summary

- Add a minor changeset for `@modern-js/app-tools`.
- The `@modern-js/*` fixed group will be released together as version `3.9.0`.

## Validation

- `pnpm exec changeset status`