### PR TITLE
fix(server-utils): respect configured TypeScript compiler

### DIFF
--- a/.changeset/tidy-compilers-load.md
+++ b/.changeset/tidy-compilers-load.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server-utils': patch
+---
+
+fix: respect the TypeScript compiler configured by ts-node
+
+fix: 使用 ts-node 配置中指定的 TypeScript 编译器

--- a/packages/server/utils/src/compilers/typescript/index.ts
+++ b/packages/server/utils/src/compilers/typescript/index.ts
@@ -1,5 +1,10 @@
 import path from 'path';
-import { fs, getAliasConfig, logger } from '@modern-js/utils';
+import {
+  fs,
+  getAliasConfig,
+  logger,
+  readTsConfigByFile as readRawTsConfigByFile,
+} from '@modern-js/utils';
 import type { ParseConfigFileHost, Program } from 'typescript';
 import type ts from 'typescript';
 import type { CompileFunc } from '../../common';
@@ -42,8 +47,10 @@ export const compileByTs: CompileFunc = async (
     return;
   }
 
+  const tsConfig = readRawTsConfigByFile(tsconfigPath);
   const ts = new TypescriptLoader({
     appDirectory,
+    compiler: tsConfig['ts-node']?.compiler,
   }).load();
 
   const createProgram = ts.createIncrementalProgram || ts.createProgram;

--- a/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
+++ b/packages/server/utils/src/compilers/typescript/tsconfigPathsPlugin.ts
@@ -3,7 +3,7 @@ import path, { dirname, posix } from 'path';
 import { findMatchedSourcePath, findSourceEntry } from '@modern-js/utils';
 import type { MatchPath } from '@modern-js/utils/tsconfig-paths';
 import { createMatchPath } from '@modern-js/utils/tsconfig-paths';
-import * as ts from 'typescript';
+import type * as ts from 'typescript';
 
 // Extensions that TypeScript compiles into a `.js` file. Everything else
 // (`.json`, `.mjs`, `.cjs`, assets) keeps whatever extension it already has,
@@ -96,7 +96,7 @@ const isDynamicImport = (
 ): node is ts.CallExpression => {
   return (
     tsBinary.isCallExpression(node) &&
-    node.expression.kind === ts.SyntaxKind.ImportKeyword
+    node.expression.kind === tsBinary.SyntaxKind.ImportKeyword
   );
 };
 

--- a/packages/server/utils/src/compilers/typescript/typescriptLoader.ts
+++ b/packages/server/utils/src/compilers/typescript/typescriptLoader.ts
@@ -5,8 +5,17 @@ export class TypescriptLoader {
 
   private appDirectory?: string;
 
-  constructor({ appDirectory }: { appDirectory: string }) {
+  private compiler?: string;
+
+  constructor({
+    appDirectory,
+    compiler,
+  }: {
+    appDirectory: string;
+    compiler?: string;
+  }) {
     this.appDirectory = appDirectory;
+    this.compiler = compiler;
   }
 
   public load(): typeof ts {
@@ -15,7 +24,7 @@ export class TypescriptLoader {
     }
 
     try {
-      const tsPath = require.resolve('typescript', {
+      const tsPath = require.resolve(this.compiler || 'typescript', {
         paths: [this.appDirectory || process.cwd()],
       });
 

--- a/packages/server/utils/tests/ts.test.ts
+++ b/packages/server/utils/tests/ts.test.ts
@@ -1,8 +1,19 @@
 import path from 'path';
 import { fs } from '@modern-js/utils';
 import { compile } from '../src';
+import { TypescriptLoader } from '../src/compilers/typescript/typescriptLoader';
 
 describe('typescript', () => {
+  it('loads the configured compiler', () => {
+    const compiler = require.resolve('typescript');
+    const ts = new TypescriptLoader({
+      appDirectory: path.parse(process.cwd()).root,
+      compiler,
+    }).load();
+
+    expect(ts).toBe(require(compiler));
+  });
+
   it('compile typescript', async () => {
     const example = path.join(__dirname, './fixtures', './ts-example');
     const tsconfigPath = path.join(example, './tsconfig.json');


### PR DESCRIPTION
## Summary

Respect the TypeScript compiler configured via ts-node.compiler during server compilation.

## Related Links

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
