### PR TITLE
fix(builder): handle stricter chain getter types

### DIFF
--- a/packages/cli/builder/src/plugins/environmentDefaults.ts
+++ b/packages/cli/builder/src/plugins/environmentDefaults.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildConfig, RsbuildPlugin, Rspack } from '@rsbuild/core';
 import {
   SERVICE_WORKER_ENVIRONMENT_NAME,
   getBrowserslistWithDefault,
@@ -84,15 +84,18 @@ export const pluginEnvironmentDefaults = (
     api.modifyBundlerChain(async (chain, { environment }) => {
       const isServiceWorker =
         environment.name === SERVICE_WORKER_ENVIRONMENT_NAME;
+      const library = chain.output.get('library') as
+        | Rspack.LibraryOptions
+        | undefined;
 
       if (isServiceWorker && chain.output.get('module') === true) {
         chain.output.library({
-          ...(chain.output.get('library') || {}),
+          ...library,
           type: 'module',
         });
       } else if (isServiceWorker) {
         chain.output.library({
-          ...(chain.output.get('library') || {}),
+          ...library,
           type: 'commonjs2',
         });
       }

--- a/packages/cli/builder/src/plugins/manifest.ts
+++ b/packages/cli/builder/src/plugins/manifest.ts
@@ -7,7 +7,7 @@ export const pluginManifest = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain(async (chain, { target, CHAIN_ID }) => {
       const { RspackManifestPlugin } = await import('rspack-manifest-plugin');
-      const publicPath = chain.output.get('publicPath');
+      const publicPath = chain.output.get('publicPath') as string | undefined;
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(RspackManifestPlugin, [
         {


### PR DESCRIPTION
## Summary

- narrow `rspack-chain` getter values before spreading them or passing them to manifest options
- keep the generated JavaScript behavior unchanged while supporting Rsbuild's stricter exported chain types

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8437
- https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/34098918430/job/101668637294

## Validation

- `pnpm exec biome check packages/cli/builder/src/plugins/environmentDefaults.ts packages/cli/builder/src/plugins/manifest.ts`
- `pnpm --filter @modern-js/builder build` with all `@rsbuild/*` overrides pointed at Rsbuild main (`35e3a2dbdf3d37b41aa6e80067c77744fbc0eb6d`)
- `pnpm --filter @modern-js/builder test` (43 passed)

## Checklist

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.

No changeset, docs, or new tests are needed because this is a type-only compatibility fix with unchanged emitted behavior; the existing builder tests pass.
