### PR TITLE
fix(runtime): propagate SSR abort signal to loaders

### DIFF
--- a/.changeset/quiet-loaders-abort.md
+++ b/.changeset/quiet-loaders-abort.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/runtime': patch
+---
+
+fix: preserve the SSR request abort signal when creating the router loader request
+
+fix: 构造路由 loader 请求时保留 SSR 请求的取消信号

--- a/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
+++ b/packages/runtime/plugin-runtime/src/router/runtime/plugin.node.tsx
@@ -43,12 +43,11 @@ import { createRouteObjectsFromConfig, renderRoutes, urlJoin } from './utils';
 function createRemixRequest(request: Request) {
   const method = 'GET';
   const { headers } = request;
-  const controller = new AbortController();
 
   return new Request(request.url, {
     method,
     headers,
-    signal: controller.signal,
+    signal: request.signal,
   });
 }
 

--- a/tests/integration/ssr/fixtures/base/src/routes/abort/page.loader.ts
+++ b/tests/integration/ssr/fixtures/base/src/routes/abort/page.loader.ts
@@ -1,0 +1,28 @@
+import type { LoaderFunctionArgs } from '@modern-js/runtime/router';
+
+export default async ({ request }: LoaderFunctionArgs) => {
+  const id = new URL(request.url).searchParams.get('id');
+
+  if (id) {
+    await new Promise<void>(resolve => {
+      const onAbort = () => {
+        clearTimeout(timer);
+        console.log(`loader-aborted:${id}:${request.signal.aborted}`);
+        resolve();
+      };
+      // Bound the fixture's lifetime even when cancellation is broken.
+      const timer = setTimeout(() => {
+        request.signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, 10_000);
+      request.signal.addEventListener('abort', onAbort, { once: true });
+      console.log(`loader-started:${id}:${request.signal.aborted}`);
+    });
+  }
+
+  return {
+    method: request.method,
+    header: request.headers.get('x-loader-test'),
+    aborted: request.signal.aborted,
+  };
+};

--- a/tests/integration/ssr/fixtures/base/src/routes/abort/page.tsx
+++ b/tests/integration/ssr/fixtures/base/src/routes/abort/page.tsx
@@ -1,0 +1,13 @@
+import { useLoaderData } from '@modern-js/runtime/router';
+
+export default function Page() {
+  const data = useLoaderData() as {
+    method: string;
+    header: string | null;
+    aborted: boolean;
+  };
+
+  return (
+    <div>{`loader-result:${data.method}:${data.header}:${data.aborted}`}</div>
+  );
+}

--- a/tests/integration/ssr/tests/base.test.ts
+++ b/tests/integration/ssr/tests/base.test.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from 'node:crypto';
 import dns from 'node:dns';
+import { get } from 'node:http';
 import path, { join } from 'path';
 import { fs } from '@modern-js/utils';
 import axios from 'axios';
@@ -67,11 +69,16 @@ describe('Traditional SSR', () => {
   let appPort: number;
   let page: Page;
   let browser: Browser;
+  let serverOutput = '';
 
   beforeAll(async () => {
     const appDir = join(fixtureDir, 'base');
     appPort = await getPort();
-    app = await launchApp(appDir, appPort);
+    app = await launchApp(appDir, appPort, {
+      onStdout: (message: string) => {
+        serverOutput += message;
+      },
+    });
 
     browser = await puppeteer.launch(launchOptions as any);
     page = await browser.newPage();
@@ -88,6 +95,49 @@ describe('Traditional SSR', () => {
 
   test(`basic usage`, async () => {
     await basicUsage(page, appPort);
+  });
+
+  test.each(['GET', 'POST'])(
+    '%s SSR preserves loader headers and GET method',
+    async method => {
+      const response = await fetch(
+        `http://localhost:${appPort}/abort?no-cache=1`,
+        { method, headers: { 'x-loader-test': 'preserved' } },
+      );
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain(
+        'loader-result:GET:preserved:false',
+      );
+    },
+  );
+
+  test('aborts the loader signal when the SSR client disconnects', async () => {
+    const id = randomUUID();
+    const request = get(
+      `http://localhost:${appPort}/abort?no-cache=1&id=${id}`,
+      response => response.resume(),
+    );
+    const closed = new Promise<void>(resolve => request.once('close', resolve));
+    // Destroying an unfinished HTTP request emits ECONNRESET.
+    const errors: Error[] = [];
+    request.on('error', error => errors.push(error));
+
+    try {
+      await expect
+        .poll(() => serverOutput, { timeout: 5000 })
+        .toContain(`loader-started:${id}:false`);
+      request.destroy();
+      await closed;
+      await expect
+        .poll(() => serverOutput, { timeout: 5000 })
+        .toContain(`loader-aborted:${id}:true`);
+      expect(
+        errors.every(error => 'code' in error && error.code === 'ECONNRESET'),
+      ).toBe(true);
+    } finally {
+      request.destroy();
+      await closed;
+    }
   });
 
   // We will not add chunkLoadingGlobal to entry(index.jsx)


### PR DESCRIPTION
## Summary

When an SSR client disconnects while a route loader is running, the Node adapter aborts the original request, but the loader cannot observe cancellation because `createRemixRequest` replaces its signal with an unrelated `AbortController` signal. Pass through `request.signal` so the router and loaders can observe cancellation, while preserving the existing GET method and request headers. Loaders remain responsible for passing the signal to downstream operations such as fetch.

Add an SSR e2e regression that waits for the loader to start, disconnects a real HTTP client, and checks that the loader receives the abort event. Also cover normal GET/POST SSR requests and include a runtime patch changeset.

## Validation

- Before the fix: the disconnect regression failed; both GET/POST cases passed.
- After the fix: `pnpm test:framework integration/ssr/tests/base.test.ts --retry 0` passed (10 passed, 2 pre-existing skipped).
- `pnpm --filter @modern-js/runtime build` passed.
- Biome checks for the changed TypeScript files and `git diff --check` passed.

## Related Links

None.

## Checklist

- [x] I have added a changeset.
- [ ] I have updated the documentation (not needed for this bug fix).
- [x] I have added tests to cover my changes.
