### PR TITLE
feat(server-core): coordinate SSR requests and producer lifecycles

### DIFF
--- a/.changeset/ssr-request-coordination.md
+++ b/.changeset/ssr-request-coordination.md
@@ -1,7 +1,13 @@
 ---
 '@modern-js/server-core': minor
+'@modern-js/runtime': patch
+'@modern-js/runtime-utils': patch
 ---
 
 feat(server-core): add an opt-in Node SSR request coordinator with bounded admission, explicit work tracking, drain-before-update sequencing and failed-publication recovery. Default renderer integration is not enabled.
 
 feat(server-core): 新增可选的 Node SSR 请求协调原语，支持有界等待、显式工作计数、更新前排空及发布失败恢复；尚未启用默认 renderer 接入。
+
+fix(runtime): propagate streaming cancellation and track renderer, template, deferred, route preload and SSR cache work through completion. Forward an optional request work context through the render pipeline.
+
+fix(runtime): 传播流式渲染取消信号，等待 renderer、模板、deferred、路由预加载和 SSR 缓存任务真正结束，并在渲染链路传递可选请求工作上下文。

--- a/.changeset/ssr-request-coordination.md
+++ b/.changeset/ssr-request-coordination.md
@@ -1,0 +1,7 @@
+---
+'@modern-js/server-core': minor
+---
+
+feat(server-core): add an opt-in Node SSR request coordinator with bounded admission, explicit work tracking, drain-before-update sequencing and failed-publication recovery. Default renderer integration is not enabled.
+
+feat(server-core): 新增可选的 Node SSR 请求协调原语，支持有界等待、显式工作计数、更新前排空及发布失败恢复；尚未启用默认 renderer 接入。

--- a/packages/runtime/plugin-runtime/rstest.config.mts
+++ b/packages/runtime/plugin-runtime/rstest.config.mts
@@ -1,9 +1,18 @@
+import path from 'node:path';
 import type { ProjectConfig } from '@rstest/core';
 import { withTestPreset } from '@scripts/rstest-config';
 
 const commonConfig: ProjectConfig = {
   setupFiles: ['@scripts/rstest-config/setup.ts'],
   globals: true,
+  resolve: {
+    alias: {
+      '@modern-js/render/ssr': path.resolve(
+        __dirname,
+        'tests/ssr/fixtures/renderSSRStream.ts',
+      ),
+    },
+  },
   tools: {
     swc: {
       jsc: {

--- a/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
+++ b/packages/runtime/plugin-runtime/src/core/server/requestHandler.tsx
@@ -235,6 +235,7 @@ export const createRequestHandler: CreateRequestHandler = async (
         monitors: options.monitors,
         responseProxy,
         activeDeferreds,
+        work: options.work,
         serverPayload: undefined,
       },
       async () => {

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts
@@ -1,4 +1,4 @@
-import { PassThrough, Readable, Transform } from 'stream';
+import { PassThrough, Readable, Transform, finished } from 'stream';
 import { storage } from '@modern-js/runtime-utils/node';
 import { SSR_HYDRATION_ID_PREFIX } from '@modern-js/utils/universal/constants';
 import type { ReactElement } from 'react';
@@ -23,7 +23,9 @@ const defaultExtender = {
 
 export const createReadableStreamFromElement: CreateReadableStreamFromElement =
   async (request, rootElement, options) => {
+    request.signal.throwIfAborted();
     const { renderToPipeableStream } = await import('react-dom/server');
+    request.signal.throwIfAborted();
     const { runtimeContext, htmlTemplate, config, ssrConfig, entryName } =
       options;
     let shellChunkStatus = ShellChunkStatus.START;
@@ -62,147 +64,225 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
 
     const chunkVec: Buffer[] = [];
 
-    return new Promise(resolve => {
-      const { pipe: reactStreamingPipe } = renderToPipeableStream(
+    return new Promise((resolve, reject) => {
+      const cancellation = new AbortController();
+      const streams = new Set<NodeJS.ReadWriteStream>();
+      let stopped = false;
+      let abortReact: (reason?: unknown) => void = () => {};
+      let renderingDone!: () => void;
+      const rendering = new Promise<void>(done => {
+        renderingDone = done;
+      });
+      options.work?.track(rendering);
+      const stop = (reason: unknown) => {
+        if (stopped) return;
+        stopped = true;
+        cancellation.abort(reason);
+        request.signal.removeEventListener('abort', onAbort);
+        abortReact(reason);
+        for (const stream of streams) {
+          if ('destroy' in stream && typeof stream.destroy === 'function')
+            stream.destroy();
+        }
+        reject(reason);
+      };
+      const onAbort = () => stop(request.signal.reason);
+      const watch = (stream: NodeJS.ReadWriteStream) => {
+        if (streams.has(stream)) return;
+        streams.add(stream);
+        const completion = new Promise<void>(done => {
+          const cleanup = finished(stream, error => {
+            cleanup();
+            if (error) stop(error);
+            done();
+          });
+        });
+        options.work?.track(completion);
+      };
+      const { pipe: reactStreamingPipe, abort } = renderToPipeableStream(
         processedRootElement,
         {
           nonce: config.nonce,
           identifierPrefix: SSR_HYDRATION_ID_PREFIX,
-          [onReady]() {
-            let styledComponentsStyleTags = '';
-            extenders.forEach(extender => {
-              if (extender.getStyleTags) {
-                styledComponentsStyleTags += extender.getStyleTags();
+          onAllReady() {
+            renderingDone();
+            if (!stopped) {
+              try {
+                options.onAllReady?.();
+              } catch (error) {
+                stop(error);
               }
-            });
+            }
+          },
+          [onReady]() {
+            if (onReady === 'onAllReady') renderingDone();
+            if (stopped) return;
+            const templateWork = Promise.resolve().then(async () => {
+              let styledComponentsStyleTags = '';
+              extenders.forEach(extender => {
+                if (extender.getStyleTags) {
+                  styledComponentsStyleTags += extender.getStyleTags();
+                }
+              });
 
-            options[onReady]?.();
+              options[onReady]?.();
 
-            getTemplates(htmlTemplate, {
-              request,
-              ssrConfig,
-              renderLevel,
-              runtimeContext,
-              config,
-              entryName,
-              styledComponentsStyleTags,
-            }).then(({ shellAfter, shellBefore }) => {
-              const pendingScripts: string[] = [];
-              const body = new Transform({
-                transform(chunk, _encoding, callback) {
-                  try {
-                    if (shellChunkStatus !== ShellChunkStatus.FINISH) {
-                      chunkVec.push(
-                        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
-                      );
-                      /**
-                       * The shell content of App may be splitted by multiple chunks to transform,
-                       * when any node value's size is larger than the React limitation, refer to:
-                       * https://github.com/facebook/react/blob/v18.2.0/packages/react-server/src/ReactServerStreamConfigNode.js#L53.
-                       * So we use the `SHELL_STREAM_END_MARK` to mark the shell content' tail.
-                       *
-                       * The marker can also land in the middle of a chunk that already carries
-                       * suspense-boundary content emitted right after the shell (React's chunk
-                       * boundaries are byte-driven, not render-phase-driven). Concat first so
-                       * we also catch markers that straddle two chunks, then split the buffered
-                       * content at the marker: everything before goes between shellBefore and
-                       * shellAfter; everything after goes out as-is so it lands past the
-                       * closing `</html>` instead of being swallowed inside it.
-                       */
-                      const concatedChunk = Buffer.concat(
-                        chunkVec as any,
-                      ).toString('utf-8');
-                      const markerIndex = concatedChunk.indexOf(
-                        ESCAPED_SHELL_STREAM_END_MARK,
-                      );
-                      if (markerIndex !== -1) {
-                        const beforeMark = concatedChunk.slice(0, markerIndex);
-                        const afterMark = concatedChunk.slice(
-                          markerIndex + ESCAPED_SHELL_STREAM_END_MARK.length,
+              return getTemplates(htmlTemplate, {
+                request,
+                ssrConfig,
+                renderLevel,
+                runtimeContext,
+                config,
+                entryName,
+                styledComponentsStyleTags,
+              }).then(({ shellAfter, shellBefore }) => {
+                if (stopped) return;
+                const pendingScripts: string[] = [];
+                const body = new Transform({
+                  transform(chunk, _encoding, callback) {
+                    try {
+                      if (shellChunkStatus !== ShellChunkStatus.FINISH) {
+                        chunkVec.push(
+                          Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
                         );
+                        /**
+                         * The shell content of App may be splitted by multiple chunks to transform,
+                         * when any node value's size is larger than the React limitation, refer to:
+                         * https://github.com/facebook/react/blob/v18.2.0/packages/react-server/src/ReactServerStreamConfigNode.js#L53.
+                         * So we use the `SHELL_STREAM_END_MARK` to mark the shell content' tail.
+                         *
+                         * The marker can also land in the middle of a chunk that already carries
+                         * suspense-boundary content emitted right after the shell (React's chunk
+                         * boundaries are byte-driven, not render-phase-driven). Concat first so
+                         * we also catch markers that straddle two chunks, then split the buffered
+                         * content at the marker: everything before goes between shellBefore and
+                         * shellAfter; everything after goes out as-is so it lands past the
+                         * closing `</html>` instead of being swallowed inside it.
+                         */
+                        const concatedChunk = Buffer.concat(
+                          chunkVec as any,
+                        ).toString('utf-8');
+                        const markerIndex = concatedChunk.indexOf(
+                          ESCAPED_SHELL_STREAM_END_MARK,
+                        );
+                        if (markerIndex !== -1) {
+                          const beforeMark = concatedChunk.slice(
+                            0,
+                            markerIndex,
+                          );
+                          const afterMark = concatedChunk.slice(
+                            markerIndex + ESCAPED_SHELL_STREAM_END_MARK.length,
+                          );
 
-                        shellChunkStatus = ShellChunkStatus.FINISH;
-                        this.push(`${shellBefore}${beforeMark}${shellAfter}`);
-                        if (afterMark) {
-                          this.push(afterMark);
-                        }
-                        // Flush any pending <script> collected before shell finished
-                        if (pendingScripts.length > 0) {
-                          for (const s of pendingScripts) {
-                            this.push(s);
+                          shellChunkStatus = ShellChunkStatus.FINISH;
+                          this.push(`${shellBefore}${beforeMark}${shellAfter}`);
+                          if (afterMark) {
+                            this.push(afterMark);
+                          }
+                          // Flush any pending <script> collected before shell finished
+                          if (pendingScripts.length > 0) {
+                            for (const s of pendingScripts) {
+                              this.push(s);
+                            }
+                            pendingScripts.length = 0;
                           }
                         }
+                      } else {
+                        this.push(chunk);
                       }
-                    } else {
-                      this.push(chunk);
+                      callback();
+                    } catch (e) {
+                      if (e instanceof Error) {
+                        callback(e);
+                      } else {
+                        callback(
+                          new Error('Received unknown error when streaming'),
+                        );
+                      }
                     }
-                    callback();
-                  } catch (e) {
-                    if (e instanceof Error) {
-                      callback(e);
-                    } else {
-                      callback(
-                        new Error('Received unknown error when streaming'),
-                      );
-                    }
+                  },
+                });
+
+                watch(body);
+                body.once('close', () => {
+                  request.signal.removeEventListener('abort', onAbort);
+                  if (!body.readableEnded)
+                    stop(new Error('SSR response stream was cancelled'));
+                });
+                const passThrough = new PassThrough();
+                watch(passThrough);
+
+                // Transform the Node.js readable stream to a Web ReadableStream
+                // For modern.js depend on hono.js, and we use Web standard
+                const stream = Readable.toWeb(
+                  body,
+                ) as ReadableStream<Uint8Array>;
+                resolve(stream);
+
+                let processedStream: NodeJS.ReadWriteStream = passThrough;
+                extenders.forEach(extender => {
+                  if (extender.processStream) {
+                    processedStream = extender.processStream(processedStream);
+                    watch(processedStream);
                   }
-                },
-              });
+                });
+                let deferredWork = Promise.resolve();
+                processedStream.pipe(body, { end: false });
+                processedStream.once('end', () => {
+                  void deferredWork.then(() => {
+                    if (!stopped) body.end();
+                  }, stop);
+                });
 
-              const passThrough = new PassThrough();
+                // Inject router data scripts, enqueue until shell finished
+                try {
+                  const storageContext = storage.useContext?.();
+                  const activeDeferreds = storageContext?.activeDeferreds;
 
-              // Transform the Node.js readable stream to a Web ReadableStream
-              // For modern.js depend on hono.js, and we use Web standard
-              const stream = Readable.toWeb(body) as ReadableStream<Uint8Array>;
-              resolve(stream);
+                  /**
+                   * activeDeferreds is injected into storageContext by @modern-js/runtime.
+                   * @see packages/toolkit/runtime-utils/src/browser/nestedRoutes.tsx
+                   */
+                  const entries: Array<[string, unknown]> =
+                    activeDeferreds instanceof Map
+                      ? Array.from(activeDeferreds.entries())
+                      : [];
 
-              let processedStream: NodeJS.ReadWriteStream = passThrough;
-              extenders.forEach(extender => {
-                if (extender.processStream) {
-                  processedStream = extender.processStream(processedStream);
+                  if (entries.length > 0) {
+                    const enqueueScript = (s: string) => {
+                      if (stopped || body.destroyed) return;
+                      if (shellChunkStatus === ShellChunkStatus.FINISH) {
+                        body.write(s);
+                      } else {
+                        pendingScripts.push(s);
+                      }
+                    };
+
+                    deferredWork = enqueueFromEntries(
+                      entries,
+                      config.nonce,
+                      enqueueScript,
+                      cancellation.signal,
+                    );
+                    options.work?.track(deferredWork);
+                    void deferredWork.catch(stop);
+                  }
+                } catch (err) {
+                  const monitors = getMonitors();
+                  monitors.error('cannot inject router data script', err);
                 }
+                reactStreamingPipe(passThrough);
               });
-              reactStreamingPipe(passThrough);
-
-              processedStream.pipe(body);
-
-              // Inject router data scripts, enqueue until shell finished
-              try {
-                const storageContext = storage.useContext?.();
-                const activeDeferreds = storageContext?.activeDeferreds;
-
-                /**
-                 * activeDeferreds is injected into storageContext by @modern-js/runtime.
-                 * @see packages/toolkit/runtime-utils/src/browser/nestedRoutes.tsx
-                 */
-                const entries: Array<[string, unknown]> =
-                  activeDeferreds instanceof Map
-                    ? Array.from(activeDeferreds.entries())
-                    : [];
-
-                if (entries.length > 0) {
-                  const enqueueScript = (s: string) => {
-                    if (shellChunkStatus === ShellChunkStatus.FINISH) {
-                      body.write(s);
-                    } else {
-                      pendingScripts.push(s);
-                    }
-                  };
-
-                  enqueueFromEntries(entries, config.nonce, (s: string) =>
-                    enqueueScript(s),
-                  );
-                }
-              } catch (err) {
-                const monitors = getMonitors();
-                monitors.error('cannot inject router data script', err);
-              }
             });
+            options.work?.track(templateWork);
+            void templateWork.catch(stop);
           },
 
           onShellError(error: unknown) {
+            renderingDone();
+            if (stopped) return;
             renderLevel = RenderLevel.CLIENT_RENDER;
-            getTemplates(htmlTemplate, {
+            const templateWork = getTemplates(htmlTemplate, {
               request,
               ssrConfig,
               renderLevel,
@@ -210,19 +290,30 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
               entryName,
               config,
             }).then(({ shellAfter, shellBefore }) => {
+              if (stopped) return;
               const fallbackHtml = `${shellBefore}${shellAfter}`;
 
               const readableStream = getReadableStreamFromString(fallbackHtml);
               resolve(readableStream);
               options?.onShellError?.(error);
+              request.signal.removeEventListener('abort', onAbort);
             });
+            options.work?.track(templateWork);
+            void templateWork.catch(stop);
           },
           onError(error: unknown) {
             renderLevel = RenderLevel.CLIENT_RENDER;
 
-            options?.onError?.(error);
+            try {
+              options?.onError?.(error);
+            } catch (error) {
+              stop(error);
+            }
           },
         },
       );
+      abortReact = abort;
+      request.signal.addEventListener('abort', onAbort, { once: true });
+      if (request.signal.aborted) onAbort();
     });
   };

--- a/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/createReadableStream.worker.ts
@@ -14,6 +14,7 @@ import { getTemplates } from './template';
 
 export const createReadableStreamFromElement: CreateReadableStreamFromElement =
   async (request, rootElement, options) => {
+    request.signal.throwIfAborted();
     let shellChunkStatus = ShellChunkStatus.START;
     const chunkVec: string[] = [];
     const {
@@ -37,6 +38,7 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
     try {
       const readableOriginal = await renderSSRStream(rootElement, {
         request,
+        signal: request.signal,
         nonce: config.nonce,
         rscRoot: rscRoot!,
         routes: runtimeContext.routes,
@@ -50,9 +52,12 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
 
       // A Promise that resolves when all rendering is complete
       // call onAllready, when allReady is resolve.
-      readableOriginal.allReady.then(() => {
+      const allReady = readableOriginal.allReady.then(() => {
         options?.onAllReady?.();
       });
+      options.work?.track(allReady);
+      // The body and allReady may both reject on cancellation.
+      void allReady.catch(() => {});
 
       // However, when a crawler visits your page, or if you're generating the pages at the build time,
       // you might want to let all of the content load first and then produce the final HTML output instead of revealing it progressively.
@@ -73,23 +78,48 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
 
       const reader = readableOriginal.getReader();
 
+      let isClosed = false;
+      const cancellation = new AbortController();
+      const pendingScripts: string[] = [];
+      let cancelling: Promise<void> | undefined;
+      let cancelReader: (reason: unknown) => Promise<void>;
+      const abort = () => {
+        void cancelReader(request.signal.reason).catch(() => {});
+      };
       const stream = new ReadableStream({
         start(controller) {
-          const pendingScripts: string[] = [];
-          let isClosed = false;
+          cancelReader = reason => {
+            if (cancelling) return cancelling;
+            if (isClosed) return Promise.resolve();
+            isClosed = true;
+            cancellation.abort(reason);
+            pendingScripts.length = 0;
+            request.signal.removeEventListener('abort', abort);
+            try {
+              controller.error(reason);
+            } catch {
+              /* Already cancelled. */
+            }
+            cancelling = reader.cancel(reason);
+            options.work?.track(cancelling);
+            return cancelling;
+          };
+          request.signal.addEventListener('abort', abort, { once: true });
+          if (request.signal.aborted) abort();
 
           const safeEnqueue = (chunk: Uint8Array | unknown) => {
             if (isClosed) return;
             try {
               controller.enqueue(chunk as Uint8Array);
-            } catch {
-              isClosed = true;
+            } catch (error) {
+              void cancelReader(error).catch(() => {});
             }
           };
 
           const closeController = () => {
             if (!isClosed) {
               isClosed = true;
+              request.signal.removeEventListener('abort', abort);
               try {
                 controller.close();
               } catch {
@@ -106,6 +136,7 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
           };
 
           const enqueueScript = (script: string) => {
+            if (isClosed) return;
             if (shellChunkStatus === ShellChunkStatus.FINISH) {
               safeEnqueue(encodeForWebStream(script));
             } else {
@@ -124,14 +155,22 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
               ? Array.from(activeDeferreds.entries())
               : [];
 
-          if (entries.length > 0) {
-            enqueueFromEntries(entries, config.nonce, enqueueScript);
-          }
+          const deferredWork = enqueueFromEntries(
+            entries,
+            config.nonce,
+            enqueueScript,
+            cancellation.signal,
+          );
+          options.work?.track(deferredWork);
+          void deferredWork.catch(error => {
+            void cancelReader(error).catch(() => {});
+          });
 
           async function push() {
             try {
               const { done, value } = await reader.read();
               if (done) {
+                await deferredWork;
                 closeController();
                 return;
               }
@@ -175,28 +214,24 @@ export const createReadableStreamFromElement: CreateReadableStreamFromElement =
                 safeEnqueue(value);
               }
 
-              if (!isClosed) push();
+              if (!isClosed) await push();
             } catch (error) {
-              if (!isClosed) {
-                isClosed = true;
-                try {
-                  controller.error(error);
-                } catch {
-                  // Controller already closed
-                }
-              }
+              await cancelReader(error);
             }
           }
-          push();
+          const pumping = push();
+          options.work?.track(pumping);
+          void pumping.catch(error => {
+            void cancelReader(error).catch(() => {});
+          });
         },
         cancel(reason) {
-          reader.cancel(reason).catch(() => {
-            // Ignore cancellation errors
-          });
+          return cancelReader(reason);
         },
       });
       return stream;
     } catch (e) {
+      request.signal.throwIfAborted();
       // Don't log error in `onShellError` callback, since it has been logged in `onError` callback
       const fallbackHtml = `${shellBefore}${shellAfter}`;
       const stream = getReadableStreamFromString(fallbackHtml);

--- a/packages/runtime/plugin-runtime/src/core/server/stream/deferredScript.ts
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/deferredScript.ts
@@ -60,31 +60,43 @@ export function buildDeferredDataScript(
   return `<script async${nonceAttr} data-fn-name="r" data-script-src="modern-run-router-data-fn" data-fn-args='${escaped}' suppressHydrationWarning>${runRouterDataFnStr}</script>`;
 }
 
+/** Cancellation suppresses writes; it does not pretend the underlying tasks stopped. */
 export function enqueueFromEntries(
   entries: Array<[string, unknown]>,
   nonce: string | undefined,
   emit: (script: string) => void,
-): void {
-  entries.forEach(([routeId, value]) => {
-    if (!isDeferredDataLike(value)) return;
-    const pendingKeys = new Set<string>(value.pendingKeys ?? []);
-    pendingKeys.forEach((key: string) => {
+  signal?: AbortSignal,
+): Promise<void> {
+  const tasks: Promise<void>[] = [];
+  for (const [routeId, value] of entries) {
+    if (!isDeferredDataLike(value)) continue;
+    for (const key of new Set(value.pendingKeys ?? [])) {
       const tracked = value.data?.[key];
-      if (isPromiseLike(tracked)) {
-        (tracked as Promise<unknown>).then(
-          (val: unknown) =>
-            emit(buildDeferredDataScript(nonce, [routeId, key, val])),
-          (err: unknown) =>
-            emit(
-              buildDeferredDataScript(nonce, [
-                routeId,
-                key,
-                undefined,
-                toErrorInfo(err),
-              ]),
-            ),
-        );
-      }
-    });
+      if (!isPromiseLike(tracked)) continue;
+      tasks.push(
+        Promise.resolve(tracked).then(
+          val => {
+            if (!signal?.aborted)
+              emit(buildDeferredDataScript(nonce, [routeId, key, val]));
+          },
+          err => {
+            if (!signal?.aborted)
+              emit(
+                buildDeferredDataScript(nonce, [
+                  routeId,
+                  key,
+                  undefined,
+                  toErrorInfo(err),
+                ]),
+              );
+          },
+        ),
+      );
+    }
+  }
+  // One failed serializer/writer must not release ownership of the other tasks.
+  return Promise.allSettled(tasks).then(results => {
+    const failed = results.find(result => result.status === 'rejected');
+    if (failed?.status === 'rejected') throw failed.reason;
   });
 }

--- a/packages/runtime/plugin-runtime/src/core/server/stream/shared.tsx
+++ b/packages/runtime/plugin-runtime/src/core/server/stream/shared.tsx
@@ -1,4 +1,4 @@
-import type { OnError } from '@modern-js/app-tools';
+import type { OnError, RequestHandlerOptions } from '@modern-js/app-tools';
 import { time } from '@modern-js/runtime-utils/time';
 import type {
   ClientManifest as RscClientManifest,
@@ -16,6 +16,7 @@ import { SSRErrors, SSRTimings } from '../tracer';
 import { getSSRConfigByEntry } from '../utils';
 
 export type CreateReadableStreamFromElementOptions = {
+  work?: RequestHandlerOptions['work'];
   runtimeContext: TRuntimeContext;
   config: HandleRequestConfig;
   ssrConfig: SSRConfig;
@@ -154,6 +155,7 @@ export function createRenderStreaming(
     );
 
     const stream = await createReadableStreamFromElement(request, rootElement, {
+      work: options.work,
       config,
       htmlTemplate,
       runtimeContext,

--- a/packages/runtime/plugin-runtime/tests/ssr/fixtures/renderSSRStream.ts
+++ b/packages/runtime/plugin-runtime/tests/ssr/fixtures/renderSSRStream.ts
@@ -1,0 +1,4 @@
+// Exercise real React Web streaming without an RSC bundler runtime in unit tests.
+import { rstest } from '@rstest/core';
+import { renderToReadableStream } from 'react-dom/server.edge';
+export const renderSSRStream = rstest.fn(renderToReadableStream);

--- a/packages/runtime/plugin-runtime/tests/ssr/streamLifecycle.test.tsx
+++ b/packages/runtime/plugin-runtime/tests/ssr/streamLifecycle.test.tsx
@@ -1,0 +1,370 @@
+import type { AddressInfo } from 'node:net';
+import { rstest } from '@rstest/core';
+import type React from 'react';
+import { Suspense, lazy } from 'react';
+import { createNodeServer } from '../../../../server/core/src/adapters/node/node';
+import { createSSRRequestCoordinator } from '../../../../server/core/src/adapters/node/requestCoordinator';
+import { JSX_SHELL_STREAM_END_MARK } from '../../src/common';
+import { createReadableStreamFromElement as nodeRenderer } from '../../src/core/server/stream/createReadableStream';
+import { createReadableStreamFromElement as webRenderer } from '../../src/core/server/stream/createReadableStream.worker';
+import { enqueueFromEntries } from '../../src/core/server/stream/deferredScript';
+import type { CreateReadableStreamFromElementOptions } from '../../src/core/server/stream/shared';
+import { renderSSRStream as webStreamFixture } from './fixtures/renderSSRStream';
+
+const fixture = rstest.hoisted(() => ({
+  templates: rstest.fn(async () => ({
+    shellBefore: '<html>',
+    shellAfter: '</html>',
+  })),
+  activeDeferreds: new Map<string, unknown>(),
+}));
+rstest.mock('../../src/core/server/stream/template', () => ({
+  getTemplates: fixture.templates,
+}));
+rstest.mock('../../src/core/context', () => ({
+  getGlobalInternalRuntimeContext: () => ({
+    hooks: { extendStreamSSR: { call: () => [] } },
+  }),
+}));
+rstest.mock('@modern-js/runtime-utils/node', () => ({
+  storage: { useContext: () => ({ activeDeferreds: fixture.activeDeferreds }) },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+function options(extra: Partial<CreateReadableStreamFromElementOptions> = {}) {
+  return {
+    runtimeContext: {},
+    config: {},
+    ssrConfig: {},
+    htmlTemplate: '',
+    entryName: 'main',
+    onError: () => {},
+    ...extra,
+  } as CreateReadableStreamFromElementOptions;
+}
+const root = (
+  <>
+    <div>shell</div>
+    {JSX_SHELL_STREAM_END_MARK}
+  </>
+);
+const request = (signal?: AbortSignal) =>
+  new Request('http://localhost/', {
+    signal,
+    headers: {
+      'user-agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+    },
+  });
+
+beforeEach(() => {
+  fixture.templates.mockReset();
+  fixture.templates.mockResolvedValue({
+    shellBefore: '<html>',
+    shellAfter: '</html>',
+  });
+  fixture.activeDeferreds.clear();
+});
+
+describe.each([
+  ['Node', nodeRenderer],
+  ['Web', webRenderer],
+] as const)('%s renderer', (_, createReadableStreamFromElement) => {
+  it('drains real React streaming after HTTP disconnect on the same server', async () => {
+    const gate = createSSRRequestCoordinator({
+      maxPendingRequests: 4,
+      requestTimeoutMs: 2000,
+      drainTimeoutMs: 2000,
+    });
+    const producer = deferred<string>();
+    const disconnected = deferred<void>();
+    fixture.activeDeferreds.set('route', {
+      pendingKeys: ['value'],
+      data: { value: producer.promise },
+    });
+    let version = 'old';
+    const server = await createNodeServer(req =>
+      gate.handle(req, async work => {
+        if (new URL(req.url).pathname !== '/stream')
+          return new Response(version);
+        req.signal.addEventListener('abort', () => disconnected.resolve(), {
+          once: true,
+        });
+        return new Response(
+          await createReadableStreamFromElement(req, root, options({ work })),
+        );
+      }),
+    );
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+    const port = (server.address() as AddressInfo).port;
+    const pid = process.pid;
+    const url = `http://127.0.0.1:${port}`;
+    const controller = new AbortController();
+    try {
+      const response = await fetch(`${url}/stream`, {
+        signal: controller.signal,
+      });
+      const reader = response.body!.getReader();
+      expect(new TextDecoder().decode((await reader.read()).value)).toContain(
+        'shell',
+      );
+      controller.abort();
+      await disconnected.promise;
+      const mutate = rstest.fn(async () => {
+        version = 'new';
+      });
+      const update = gate.update(mutate);
+      await new Promise(resolve => setImmediate(resolve));
+      expect(gate.status.activeRequests).toBe(1);
+      expect(mutate).not.toHaveBeenCalled();
+      const next = fetch(url);
+      producer.resolve('finished');
+      await update;
+      expect(await (await next).text()).toBe('new');
+      expect(process.pid).toBe(pid);
+      expect((server.address() as AddressInfo).port).toBe(port);
+    } finally {
+      producer.resolve('finished');
+      controller.abort();
+      server.closeAllConnections();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  it('a cancelled request keeps unfinished template processing leased', async () => {
+    const template = deferred<{ shellBefore: string; shellAfter: string }>();
+    const started = deferred<void>();
+    fixture.templates.mockImplementation(() => {
+      started.resolve();
+      return template.promise;
+    });
+    const gate = createSSRRequestCoordinator({
+      maxPendingRequests: 1,
+      requestTimeoutMs: 1000,
+      drainTimeoutMs: 1000,
+    });
+    const controller = new AbortController();
+    const req = request(controller.signal);
+    const response = gate.handle(
+      req,
+      async work =>
+        new Response(
+          await createReadableStreamFromElement(req, root, options({ work })),
+        ),
+    );
+    // Node rejects early; Web may wait for its template promise before observing cancellation.
+    void response.catch(() => {});
+    await started.promise;
+    controller.abort(new Error('client left'));
+    const mutate = rstest.fn(async () => {});
+    const update = gate.update(mutate);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(mutate).not.toHaveBeenCalled();
+    template.resolve({ shellBefore: '', shellAfter: '' });
+    await expect(response).rejects.toThrow('client left');
+    await expect(update).resolves.toBe(1);
+  });
+  it('rejects template errors instead of leaving the render pending', async () => {
+    fixture.templates.mockRejectedValue(new Error('template failure'));
+    await expect(
+      createReadableStreamFromElement(request(), root, options()),
+    ).rejects.toThrow('template failure');
+  });
+
+  it('rejects fallback template errors too', async () => {
+    fixture.templates.mockRejectedValue(new Error('fallback template failure'));
+    const Broken = () => {
+      throw new Error('shell failure');
+    };
+    await expect(
+      createReadableStreamFromElement(request(), <Broken />, options()),
+    ).rejects.toThrow('fallback template failure');
+  });
+
+  it('reports all-ready independently after the shell was delivered', async () => {
+    const module = deferred<{ default: () => React.ReactNode }>();
+    const Component = lazy(() => module.promise);
+    const allReady = rstest.fn();
+    const stream = await createReadableStreamFromElement(
+      request(),
+      <>
+        <div>shell</div>
+        <main>
+          <Suspense fallback="loading">
+            <Component />
+          </Suspense>
+        </main>
+        {JSX_SHELL_STREAM_END_MARK}
+      </>,
+      options({ onAllReady: allReady }),
+    );
+    const text = new Response(stream).text();
+    expect(allReady).not.toHaveBeenCalled();
+    module.resolve({ default: () => 'finished' });
+    expect(await text).toContain('finished');
+    expect(allReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the body open for deferred scripts after React finishes', async () => {
+    const value = deferred<string>();
+    fixture.activeDeferreds.set('route', {
+      pendingKeys: ['value'],
+      data: { value: value.promise },
+    });
+    const stream = await createReadableStreamFromElement(
+      request(),
+      root,
+      options(),
+    );
+    const reader = stream.getReader();
+    expect((await reader.read()).done).toBe(false);
+    value.resolve('late-value');
+    const chunks: string[] = [];
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      chunks.push(new TextDecoder().decode(chunk.value));
+    }
+    expect(chunks.join('')).toContain('late-value');
+  });
+
+  it('disconnect aborts React but holds updates until independent deferred work settles', async () => {
+    const coordinator = createSSRRequestCoordinator({
+      maxPendingRequests: 2,
+      requestTimeoutMs: 1000,
+      drainTimeoutMs: 1000,
+    });
+    const controller = new AbortController();
+    const value = deferred<string>();
+    const module = deferred<{ default: () => React.ReactNode }>();
+    const Component = lazy(() => module.promise);
+    fixture.activeDeferreds.set('route', {
+      pendingKeys: ['value'],
+      data: { value: value.promise },
+    });
+    const req = request(controller.signal);
+    const response = await coordinator.handle(req, async work => {
+      work.track(module.promise);
+      return new Response(
+        await createReadableStreamFromElement(
+          req,
+          <>
+            <div>shell</div>
+            <main>
+              <Suspense fallback="loading">
+                <Component />
+              </Suspense>
+            </main>
+            {JSX_SHELL_STREAM_END_MARK}
+          </>,
+          options({ work }),
+        ),
+      );
+    });
+    expect(response.status).toBe(200);
+    await response.body!.getReader().read();
+    controller.abort(new Error('client left'));
+    const mutate = rstest.fn(async () => {});
+    const update = coordinator.update(mutate);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(coordinator.status.activeRequests).toBe(1);
+    expect(mutate).not.toHaveBeenCalled();
+    module.resolve({ default: () => 'finished' });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(mutate).not.toHaveBeenCalled();
+    value.resolve('late');
+    await expect(update).resolves.toBe(1);
+  });
+});
+
+it('deferred cancellation suppresses writes without settling underlying work', async () => {
+  const value = deferred<string>();
+  const abort = new AbortController();
+  const emit = rstest.fn();
+  const completion = enqueueFromEntries(
+    [['route', { pendingKeys: ['value'], data: { value: value.promise } }]],
+    undefined,
+    emit,
+    abort.signal,
+  );
+  abort.abort();
+  const settled = rstest.fn();
+  void completion.then(settled);
+  await Promise.resolve();
+  expect(settled).not.toHaveBeenCalled();
+  value.resolve('late');
+  await completion;
+  expect(emit).not.toHaveBeenCalled();
+});
+
+it('one deferred serialization failure still waits for other pending tasks', async () => {
+  const value = deferred<string>();
+  const completion = enqueueFromEntries(
+    [
+      [
+        'route',
+        {
+          pendingKeys: ['broken', 'value'],
+          data: { broken: Promise.resolve(1n), value: value.promise },
+        },
+      ],
+    ],
+    undefined,
+    () => {},
+  );
+  const checked = expect(completion).rejects.toThrow();
+  const settled = rstest.fn();
+  void completion.then(settled, settled);
+  await new Promise(resolve => setImmediate(resolve));
+  expect(settled).not.toHaveBeenCalled();
+  value.resolve('late');
+  await checked;
+});
+
+it('Web cancellation keeps ownership until the original reader cancellation finishes', async () => {
+  const cancelling = deferred<void>();
+  const source = Object.assign(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('shell'));
+      },
+      cancel() {
+        return cancelling.promise;
+      },
+    }),
+    { allReady: Promise.resolve() },
+  );
+  webStreamFixture.mockResolvedValueOnce(source);
+  const gate = createSSRRequestCoordinator({
+    maxPendingRequests: 1,
+    requestTimeoutMs: 1000,
+    drainTimeoutMs: 1000,
+  });
+  const controller = new AbortController();
+  const req = request(controller.signal);
+  await gate.handle(
+    req,
+    async work => new Response(await webRenderer(req, root, options({ work }))),
+  );
+  controller.abort(new Error('client left'));
+  const mutate = rstest.fn(async () => {});
+  const update = gate.update(mutate);
+  await new Promise(resolve => setImmediate(resolve));
+  expect(mutate).not.toHaveBeenCalled();
+  cancelling.resolve();
+  await expect(update).resolves.toBe(1);
+});

--- a/packages/server/core/README.md
+++ b/packages/server/core/README.md
@@ -24,3 +24,8 @@ Please read the [Contributing Guide](https://github.com/web-infra-dev/modern.js/
 ## License
 
 Modern.js is [MIT licensed](https://github.com/web-infra-dev/modern.js/blob/main/LICENSE).
+
+## SSR request coordination
+
+The opt-in Node coordinator and its required renderer completion contract are
+covered in [SSR_REQUEST_COORDINATION.md](./SSR_REQUEST_COORDINATION.md).

--- a/packages/server/core/SSR_REQUEST_COORDINATION.md
+++ b/packages/server/core/SSR_REQUEST_COORDINATION.md
@@ -81,21 +81,27 @@ will connect targeted/full rebuilding. R2 remains open meanwhile.
 
 ## Validation (2026-09-10)
 
-Baseline: Modern `46967f66c0` (`fix/ssr-chunk-loading-global`).
+Baseline: Modern `1340e9c1bc` (`fix/ssr-chunk-loading-global`). Initial work
+used `46967f66c0`; the branch was rebased onto the updated remote, dependencies
+were installed from its frozen lockfile, and the full package tests/build reran.
 
 Commands executed from the Modern repository:
 
 ```sh
+pnpm install --frozen-lockfile --ignore-scripts
 pnpm --filter @modern-js/server-core test -- requestCoordinator.test.ts
 pnpm --filter @modern-js/server-core test
 pnpm --filter @modern-js/server-core build
 pnpm exec biome check packages/server/core/src/adapters/node/requestCoordinator.ts packages/server/core/src/adapters/node/index.ts packages/server/core/tests/adapters/requestCoordinator.test.ts packages/server/core/tests/adapters/requestCoordinator.http.test.ts
-pnpm exec changeset status --output /tmp/modern-coordinator-changeset.json
+pnpm exec changeset status
 git diff --check
 ```
 
 Final package run: 39 tests pass, zero failures/skips; package build and touched
-source/test lint pass. The tests cover queue limits/deadlines/cancellation,
+source/test lint and changeset planning pass. The fixed Modern release group may
+expand the minor release beyond the single package in this changeset. An initial
+Changesets output-file invocation resolved the absolute path under the repository
+and failed; the plain status rerun succeeds. The tests cover queue limits/deadlines/cancellation,
 drain-before-mutation timeout, failed publication and retry, serialized updates,
 self-wait rejection, tracked rejection, body backpressure, and real HTTP streaming
 disconnect. The HTTP test keeps a producer leased after client disconnect, waits

--- a/packages/server/core/SSR_REQUEST_COORDINATION.md
+++ b/packages/server/core/SSR_REQUEST_COORDINATION.md
@@ -11,6 +11,14 @@ out of scope and is not an R2 acceptance gate. Custom producers use the explicit
 work-registration contract below. R3 owns admission before resource selection.
 Do not enable remote mutation around an uninstrumented renderer.**
 
+## Development branches
+
+Modern SSR cache work integrates into `feat/mf-ssr-clear-cache`, created directly
+from `main` at `4af5bf05b6513ee396419fada27f304880c15b67` on 2026-09-10.
+Start subsequent Modern work branches from this integration branch and target all
+related PRs at it. PR #8861 is rebased onto it; the unrelated
+`fix/ssr-chunk-loading-global` commits are not included.
+
 ## Ownership contract
 
 An owner constructs a coordinator with explicit `maxPendingRequests`,
@@ -201,3 +209,28 @@ the work-registration contract, rather than a requirement to discover every
 possible asynchronous side effect. This scope change is documentation-only;
 `git diff --check` was run, and code tests/builds were not repeated because no
 runtime or test behavior changed.
+
+## Integration-base validation (2026-09-10)
+
+The four SSR cache commits were rebased from `1340e9c1bc` onto the new integration
+branch at `4af5bf05b6`. There were no conflicts. The PR retains the same 24-file
+scope, and the custom chunk-loading-global fix from the previous base is absent.
+The integration branch itself starts at main, without those feature commits.
+
+After `pnpm install --frozen-lockfile --ignore-scripts`, all three full package
+`test` and `build` commands listed above were rerun against the main-derived 3.9.0
+dependencies: server-core 42/42, runtime-utils 87/87, runtime 61/61. Builds and
+declarations pass. Also rerun:
+
+```sh
+pnpm exec biome check $(git diff --name-only feat/mf-ssr-clear-cache...HEAD -- '*.ts' '*.tsx' '*.mts')
+pnpm exec changeset status
+git diff --check
+```
+
+The exact strict local-Rspack/Modern baseline command above was rerun with the new
+Modern artifacts: 13/13, no skips/TODOs/failures. The previously recorded
+runtime-utils test-runner listener warning remains. Full framework/builder E2E
+and the MF-wide Cypress suite were not rerun for this base correction; affected
+package tests/builds and the cross-repository artifact regression were used.
+RSC remains outside scope. No release or merge was performed.

--- a/packages/server/core/SSR_REQUEST_COORDINATION.md
+++ b/packages/server/core/SSR_REQUEST_COORDINATION.md
@@ -6,9 +6,10 @@ the HTTP server or restart the process, and introduces no worker orchestration.
 
 **This coordinator is not installed in the default Modern request path. The
 standard Node/Web HTML renderers, nested-route loaders and HTML cache now accept
-and propagate work ownership. R2 remains open for the RSC and custom-producer
-contracts; R3 still owns admission before resource selection. Do not enable remote
-mutation around an uninstrumented renderer.**
+and propagate work ownership. The agreed scope is ordinary HTML SSR; RSC is
+out of scope and is not an R2 acceptance gate. Custom producers use the explicit
+work-registration contract below. R3 owns admission before resource selection.
+Do not enable remote mutation around an uninstrumented renderer.**
 
 ## Ownership contract
 
@@ -87,10 +88,10 @@ requirement; draining a write alone does not invalidate previously cached HTML.
 
 ## Remaining integration boundaries
 
-- RSC uses additional Flight producers, tee branches and payload-injection tasks.
-  These are not covered by the HTML renderer tests or a React HTML all-ready
-  signal. RSC coordinated mutation remains unsupported until that chain has a
-  complete ownership/cancellation contract and compiled integration validation.
+- RSC, Flight producers, tee branches and RSC payload injection are outside this
+  RFC's implementation and acceptance scope, as explicitly agreed on 2026-09-10.
+  They do not block R2 or R3. The scope covers ordinary HTML SSR, including its
+  React streaming, loaders, remote consumption and HTML caches.
 - Extenders can expose their Node stream lifecycle, but arbitrary work hidden
   behind a custom destroy callback or unrelated task is not automatically tracked.
   Custom renderers/producers must register their complete tasks explicitly.
@@ -99,7 +100,7 @@ requirement; draining a write alone does not invalidate previously cached HTML.
   their owner; aborting React cannot cancel their underlying promises. The React
   test intentionally registers its independent lazy-import promise explicitly.
 - R3 must install the gate before selecting resources/loader/renderer, supply work
-  to every owned render/action path, invalidate generation-specific HTML caches,
+  to every owned HTML SSR/loader path, invalidate generation-specific HTML caches,
   and reject unsupported paths before mutation. These changes do not yet switch
   application generations or expose the final MF update API.
 
@@ -155,7 +156,7 @@ that setup failure is not evidence of a product failure.
 
 The HTML stream tests run real React Node and Web rendering with template/context
 fixtures. The Web test alias supplies React Web rendering in place of the RSC
-entry, so these results explicitly do not validate RSC. React 19 waits for a
+entry. RSC validation is outside the agreed scope. React 19 waits for a
 potential document preamble when Suspense is at the root; the streaming fixture
 uses an application DOM container to obtain a real shell before pending content.
 Two real HTTP cases receive the shell, disconnect, keep deferred work leased,
@@ -190,3 +191,13 @@ artifact/HTTP checks do not replace its future E2E acceptance. No publication.
 Final affected-package results: server-core 42/42, runtime-utils 87/87, runtime 61/61; zero failed/skipped tests. All three builds and declaration generation, touched-file Biome, Changesets planning and diff checks pass. The runtime-utils test runner emits a MaxListenersExceededWarning about 11 `modified` listeners; it is recorded rather than suppressed and is not treated as a proven application memory leak or a resolved issue.
 
 A delayed reader-cancellation regression additionally proved that repeated Web cancellation must return the same tracked cancellation promise. The final renderer suite includes 17 lifecycle cases, including this handshake; the final full runtime suite is 61/61.
+
+## Scope decision (2026-09-10)
+
+RSC is explicitly excluded by the user. Continue with ordinary SSR admission,
+application-resource ownership, same-process rebuilding and targeted invalidation.
+Arbitrary unregistered business background work remains an explicit boundary of
+the work-registration contract, rather than a requirement to discover every
+possible asynchronous side effect. This scope change is documentation-only;
+`git diff --check` was run, and code tests/builds were not repeated because no
+runtime or test behavior changed.

--- a/packages/server/core/SSR_REQUEST_COORDINATION.md
+++ b/packages/server/core/SSR_REQUEST_COORDINATION.md
@@ -1,0 +1,112 @@
+# SSR request coordination (R2, opt-in primitive)
+
+`createSSRRequestCoordinator` is exported from `@modern-js/server-core/node`.
+It coordinates one application owner in one Node process. It does not replace
+the HTTP server or restart the process, and introduces no worker orchestration.
+
+**This primitive is not installed in the default Modern request path. R2 is not
+complete until renderers report all outstanding work and cancellation settles
+that work. Do not enable remote mutation around an uninstrumented renderer.**
+
+## Ownership contract
+
+An owner constructs a coordinator with explicit `maxPendingRequests`,
+`requestTimeoutMs` and `drainTimeoutMs`. There are no unmeasured production
+defaults. `handle(request, render)` must wrap selection of the current resources,
+loader and renderer. Selecting a handler before entering the gate can serve a
+stale generation even if the gate itself is correct.
+
+The callback receives `work.track(promise)`. Register the complete promise chain
+for producer/loader work which can outlive the callback or its Response. A tracked
+promise remains leased until it settles, including after disconnect or stream
+cancellation. Register dependent work before its parent work settles; calling
+`track` after the lease finishes is an error. Merely tracking React shell readiness
+or returning a Response is insufficient. Arbitrary unregistered business tasks
+cannot be discovered automatically.
+
+The coordinator also retains transport ownership until the response body reaches
+EOF, errors, or finishes cancellation. The stream wrapper respects backpressure
+and does not pre-read the body. Request disconnect cancels its body reader; that
+only settles transport ownership. It does not settle independently tracked
+producer work. Waiting requests are not rendered and their bodies are not read
+by the coordinator.
+
+`update(publish)` serializes operations without coalescing callers. Each operation
+closes admission, drains existing leases, invokes the callback, then opens
+admission after successful publication. The returned integer is a local serving
+generation count, not a remote version or an MF applied-revision API. The callback
+must complete validation/publication before resolving. Validate inputs before
+calling `update`; the callback may perform irreversible cache mutation.
+
+Drain timeout happens before mutation and restores the preceding serving state.
+A callback failure keeps the application unavailable and returns 503 to waiters
+and new requests. A subsequent explicit update can recover it. The coordinator
+does not promise rollback or timeout an operation which may still be mutating.
+Waiters have independent cancellation and a total deadline across repeated wakes;
+queue overflow/timeout/unavailability produce 503 with Retry-After. Waking
+requests recheck admission before registering a lease.
+
+Calling update from an active request, nesting updates, or entering the gate to
+warm up a generation from its own update is rejected to prevent self-waiting.
+Warm up the unpublished generation directly. AsyncLocalStorage only detects local
+calls in the same context; arbitrary HTTP calls back into the application need
+application-level discipline.
+
+Static/liveness traffic should bypass this application-owner gate. Route-specific
+ownership, readiness policy, and actual Modern resource switching belong to the
+integration phase; this primitive does not infer routes or mutate MF remotes.
+
+## Renderer gaps found in the current code
+
+These are unresolved and prevent treating this primitive as a completed live
+SSR update feature:
+
+- `runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts` only
+  keeps React's `pipe`, does not wire `request.signal` to `abort`, and selects
+  either shell-ready or all-ready as its callback. Default shell streaming does
+  not independently report all producer work complete.
+- Its asynchronous `getTemplates(...).then(...)` paths do not reject the outer
+  promise when template processing fails. They need explicit completion/error
+  handling and stream teardown.
+- `stream/deferredScript.ts` schedules deferred promise callbacks and returns
+  void; these callbacks need tracked completion and protection against writing
+  after cancellation.
+- Stream extenders, loader/RSC work and Web-stream rendering must agree on the
+  completion/abort contract before they are admitted into the coordinated path.
+
+The Node HTTP adapter already propagates response close to the Request's signal;
+the missing renderer handling cannot be replaced by treating that signal as a
+successful drain. R3 will integrate the owner before resource selection and R4
+will connect targeted/full rebuilding. R2 remains open meanwhile.
+
+## Validation (2026-09-10)
+
+Baseline: Modern `46967f66c0` (`fix/ssr-chunk-loading-global`).
+
+Commands executed from the Modern repository:
+
+```sh
+pnpm --filter @modern-js/server-core test -- requestCoordinator.test.ts
+pnpm --filter @modern-js/server-core test
+pnpm --filter @modern-js/server-core build
+pnpm exec biome check packages/server/core/src/adapters/node/requestCoordinator.ts packages/server/core/src/adapters/node/index.ts packages/server/core/tests/adapters/requestCoordinator.test.ts packages/server/core/tests/adapters/requestCoordinator.http.test.ts
+pnpm exec changeset status --output /tmp/modern-coordinator-changeset.json
+git diff --check
+```
+
+Final package run: 39 tests pass, zero failures/skips; package build and touched
+source/test lint pass. The tests cover queue limits/deadlines/cancellation,
+drain-before-mutation timeout, failed publication and retry, serialized updates,
+self-wait rejection, tracked rejection, body backpressure, and real HTTP streaming
+disconnect. The HTTP test keeps a producer leased after client disconnect, waits
+for its explicit completion, and serves the new response on the same PID/port.
+
+An initial test held its first response unread and consequently blocked the next
+drain; the final test consumes it and checks safe serialization. This was a test
+ownership error, not justification to release streams early. No tests were
+weakened to treat shell or disconnect as completion.
+
+Full framework/builder E2E and runtime/Rspack/MF suites are not rerun: this change
+is an opt-in server-core primitive, with no default renderer integration or
+compiler changes. Existing MF baseline tests do not prove this new gate works;
+the real HTTP test above exercises it explicitly. No publish commands were run.

--- a/packages/server/core/SSR_REQUEST_COORDINATION.md
+++ b/packages/server/core/SSR_REQUEST_COORDINATION.md
@@ -4,9 +4,11 @@
 It coordinates one application owner in one Node process. It does not replace
 the HTTP server or restart the process, and introduces no worker orchestration.
 
-**This primitive is not installed in the default Modern request path. R2 is not
-complete until renderers report all outstanding work and cancellation settles
-that work. Do not enable remote mutation around an uninstrumented renderer.**
+**This coordinator is not installed in the default Modern request path. The
+standard Node/Web HTML renderers, nested-route loaders and HTML cache now accept
+and propagate work ownership. R2 remains open for the RSC and custom-producer
+contracts; R3 still owns admission before resource selection. Do not enable remote
+mutation around an uninstrumented renderer.**
 
 ## Ownership contract
 
@@ -56,28 +58,54 @@ Static/liveness traffic should bypass this application-owner gate. Route-specifi
 ownership, readiness policy, and actual Modern resource switching belong to the
 integration phase; this primitive does not infer routes or mutate MF remotes.
 
-## Renderer gaps found in the current code
+## Renderer and loader integration
 
-These are unresolved and prevent treating this primitive as a completed live
-SSR update feature:
+`RenderOptions.work` is forwarded to `RequestHandlerOptions.work` and the stream
+renderer. The runtime request's existing AsyncLocalStorage scope carries it into
+nested-route loaders. This explicitly supplied object avoids introducing a second
+global request context or an MF-wide HTTP gate.
 
-- `runtime/plugin-runtime/src/core/server/stream/createReadableStream.ts` only
-  keeps React's `pipe`, does not wire `request.signal` to `abort`, and selects
-  either shell-ready or all-ready as its callback. Default shell streaming does
-  not independently report all producer work complete.
-- Its asynchronous `getTemplates(...).then(...)` paths do not reject the outer
-  promise when template processing fails. They need explicit completion/error
-  handling and stream teardown.
-- `stream/deferredScript.ts` schedules deferred promise callbacks and returns
-  void; these callbacks need tracked completion and protection against writing
-  after cancellation.
-- Stream extenders, loader/RSC work and Web-stream rendering must agree on the
-  completion/abort contract before they are admitted into the coordinated path.
+Node rendering independently reports React all-ready, rejects normal and fallback
+template errors, forwards Request abort and body cancellation to React, and tears
+down the registered stream chain. It tracks template continuations, React's
+rendering lifetime and each exposed extender stream. Both Node and Web rendering
+keep the output open until deferred scripts settle and suppress writes after
+cancellation. Deferred failures wait for the other registered tasks as well.
 
-The Node HTTP adapter already propagates response close to the Request's signal;
-the missing renderer handling cannot be replaced by treating that signal as a
-successful drain. R3 will integrate the owner before resource selection and R4
-will connect targeted/full rebuilding. R2 remains open meanwhile.
+Nested-route work registers before invoking the business loader/preload, retains
+ownership throughout the loader continuation, and tracks original returned values
+before DeferredData wraps them in a cancellation race. A late task whose request
+lease has ended is rejected before invoking business code. An aborted deferred
+wrapper does not prove its original producer stopped.
+
+The HTML cache forwards cancellation to its input reader, awaits writer
+backpressure, propagates stream errors and waits for asynchronous cache writes.
+Stale-while-revalidate work is registered even though the HTTP caller receives
+cached HTML immediately. An update cannot overtake that old generation's cache
+write. Cache-key invalidation across generations remains an owner integration
+requirement; draining a write alone does not invalidate previously cached HTML.
+
+## Remaining integration boundaries
+
+- RSC uses additional Flight producers, tee branches and payload-injection tasks.
+  These are not covered by the HTML renderer tests or a React HTML all-ready
+  signal. RSC coordinated mutation remains unsupported until that chain has a
+  complete ownership/cancellation contract and compiled integration validation.
+- Extenders can expose their Node stream lifecycle, but arbitrary work hidden
+  behind a custom destroy callback or unrelated task is not automatically tracked.
+  Custom renderers/producers must register their complete tasks explicitly.
+- Nested-route preload imports are tracked. Arbitrary business `React.lazy`,
+  background remote loading and imports outside that path must be registered by
+  their owner; aborting React cannot cancel their underlying promises. The React
+  test intentionally registers its independent lazy-import promise explicitly.
+- R3 must install the gate before selecting resources/loader/renderer, supply work
+  to every owned render/action path, invalidate generation-specific HTML caches,
+  and reject unsupported paths before mutation. These changes do not yet switch
+  application generations or expose the final MF update API.
+
+The Node HTTP adapter already propagates response close to Request.signal. The
+new renderer handling consumes that signal without equating disconnect with a
+successful drain. No deployment worker rotation or process restart is introduced.
 
 ## Validation (2026-09-10)
 
@@ -116,3 +144,49 @@ Full framework/builder E2E and runtime/Rspack/MF suites are not rerun: this chan
 is an opt-in server-core primitive, with no default renderer integration or
 compiler changes. Existing MF baseline tests do not prove this new gate works;
 the real HTTP test above exercises it explicitly. No publish commands were run.
+
+## Follow-up validation: renderer lifecycle (2026-09-10)
+
+The follow-up remains on the same PR/branch; it does not wait for the foundation
+PR to merge. Regression tests first reproduced template hangs and unhandled
+rejections, cache cancellation/error/write races, and premature release of a
+loader continuation. Initial route test setup needed the JSX React binding;
+that setup failure is not evidence of a product failure.
+
+The HTML stream tests run real React Node and Web rendering with template/context
+fixtures. The Web test alias supplies React Web rendering in place of the RSC
+entry, so these results explicitly do not validate RSC. React 19 waits for a
+potential document preamble when Suspense is at the root; the streaming fixture
+uses an application DOM container to obtain a real shell before pending content.
+Two real HTTP cases receive the shell, disconnect, keep deferred work leased,
+and publish new responses on the same PID and port.
+
+Commands for this follow-up (from Modern unless indicated):
+
+```sh
+pnpm --filter @modern-js/runtime exec rstest run tests/ssr/streamLifecycle.test.tsx --reporter verbose --testTimeout 4000
+pnpm --filter @modern-js/runtime-utils exec rstest run tests/universal/routeWork.test.ts --testTimeout 3000
+pnpm --filter @modern-js/server-core exec rstest run tests/plugins/cacheWork.test.ts --testTimeout 3000
+pnpm --filter @modern-js/server-core test
+pnpm --filter @modern-js/runtime-utils test
+pnpm --filter @modern-js/runtime test
+pnpm --filter @modern-js/server-core build
+pnpm --filter @modern-js/runtime-utils build
+pnpm --filter @modern-js/runtime build
+pnpm exec biome check $(git diff --name-only -- '*.ts' '*.tsx' '*.mts') packages/runtime/plugin-runtime/tests/ssr/streamLifecycle.test.tsx packages/runtime/plugin-runtime/tests/ssr/fixtures/renderSSRStream.ts packages/toolkit/runtime-utils/tests/universal/routeWork.test.ts packages/server/core/tests/plugins/cacheWork.test.ts
+pnpm exec changeset status
+git diff --check
+# From /Users/bytedance/outter/core:
+SSR_CACHE_STRICT=1 SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js SSR_CACHE_MODERN_ENTRY=/Users/bytedance/work/modern.js/packages/server/core/dist/cjs/adapters/node/index.js node --test tools/ssr-cache/baseline.test.cjs
+```
+
+The strict local-Rspack/Modern artifact baseline reports 13 tests passing, zero
+skips/TODOs/failures in this invocation. It complements the renderer tests; it does
+not exercise RSC or the not-yet-installed default application owner. Full framework
+and builder E2E and the MF-wide Cypress matrix are not run for this follow-up;
+production-generation switching remains to be integrated, and the targeted
+artifact/HTTP checks do not replace its future E2E acceptance. No publication.
+
+Final affected-package results: server-core 42/42, runtime-utils 87/87, runtime 61/61; zero failed/skipped tests. All three builds and declaration generation, touched-file Biome, Changesets planning and diff checks pass. The runtime-utils test runner emits a MaxListenersExceededWarning about 11 `modified` listeners; it is recorded rather than suppressed and is not treated as a proven application memory leak or a resolved issue.
+
+A delayed reader-cancellation regression additionally proved that repeated Web cancellation must return the same tracked cancellation promise. The final renderer suite includes 17 lifecycle cases, including this handshake; the final full runtime suite is 61/61.

--- a/packages/server/core/src/adapters/node/index.ts
+++ b/packages/server/core/src/adapters/node/index.ts
@@ -27,3 +27,9 @@ export {
   loadServerCliConfig,
   loadCacheConfig,
 } from './helper';
+
+export { createSSRRequestCoordinator } from './requestCoordinator';
+export type {
+  SSRRequestCoordinatorOptions,
+  SSRRequestWork,
+} from './requestCoordinator';

--- a/packages/server/core/src/adapters/node/requestCoordinator.ts
+++ b/packages/server/core/src/adapters/node/requestCoordinator.ts
@@ -1,0 +1,247 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface SSRRequestCoordinatorOptions {
+  maxPendingRequests: number;
+  requestTimeoutMs: number;
+  drainTimeoutMs: number;
+}
+
+export interface SSRRequestWork {
+  /** Register producer/loader work before returning a Response. */
+  track<T>(work: Promise<T>): Promise<T>;
+}
+
+type Phase = 'serving' | 'draining' | 'updating' | 'unavailable';
+type Waiter = { resume: () => void; reject: (reason: Error) => void };
+
+class AdmissionError extends Error {}
+
+/**
+ * Node application-owner primitive. It must wrap resource/handler selection, not
+ * an already captured renderer. Stream producers must register outstanding work.
+ * This does not automatically integrate arbitrary renderers or drain side effects.
+ */
+export function createSSRRequestCoordinator(
+  options: SSRRequestCoordinatorOptions,
+) {
+  const { maxPendingRequests, requestTimeoutMs, drainTimeoutMs } = options;
+  if (!Number.isSafeInteger(maxPendingRequests) || maxPendingRequests < 0)
+    throw new Error('maxPendingRequests must be a non-negative safe integer');
+  for (const timeout of [requestTimeoutMs, drainTimeoutMs]) {
+    if (!Number.isFinite(timeout) || timeout <= 0 || timeout > 2_147_483_647)
+      throw new Error(
+        'Coordinator timeouts must be positive finite timer durations',
+      );
+  }
+  const context = new AsyncLocalStorage<{
+    active: boolean;
+    updating?: boolean;
+  }>();
+  const waiters = new Set<Waiter>();
+  const drainListeners = new Set<() => void>();
+  let phase: Phase = 'serving';
+  let active = 0;
+  let generation = 0;
+  let updates: Promise<unknown> = Promise.resolve();
+
+  const wake = (error?: Error) => {
+    for (const waiter of Array.from(waiters)) {
+      if (error) waiter.reject(error);
+      else waiter.resume();
+    }
+  };
+
+  const waitForAdmission = (signal: AbortSignal, deadline: number) =>
+    new Promise<void>((resolve, reject) => {
+      if (signal.aborted) return reject(signal.reason);
+      if (phase === 'unavailable')
+        return reject(new AdmissionError('SSR application is unavailable'));
+      if (waiters.size >= maxPendingRequests)
+        return reject(new AdmissionError('SSR request queue is full'));
+      const remaining = deadline - Date.now();
+      if (remaining <= 0)
+        return reject(new AdmissionError('SSR request wait timed out'));
+      const finish = (error?: unknown) => {
+        clearTimeout(timer);
+        waiters.delete(waiter);
+        signal.removeEventListener('abort', abort);
+        if (error !== undefined) reject(error);
+        else resolve();
+      };
+      const abort = () => finish(signal.reason);
+      const waiter: Waiter = { resume: () => finish(), reject: finish };
+      const timer = setTimeout(
+        () => finish(new AdmissionError('SSR request wait timed out')),
+        remaining,
+      );
+      waiters.add(waiter);
+      signal.addEventListener('abort', abort, { once: true });
+    });
+
+  const drain = () =>
+    new Promise<void>((resolve, reject) => {
+      if (active === 0) return resolve();
+      const finish = () => {
+        clearTimeout(timer);
+        drainListeners.delete(finish);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        drainListeners.delete(finish);
+        reject(new Error('SSR drain timed out before mutation'));
+      }, drainTimeoutMs);
+      drainListeners.add(finish);
+    });
+
+  return {
+    get status() {
+      return {
+        phase,
+        generation,
+        activeRequests: active,
+        pendingRequests: waiters.size,
+      };
+    },
+
+    async handle(
+      request: Request,
+      render: (work: SSRRequestWork) => Promise<Response>,
+    ): Promise<Response> {
+      if (
+        context.getStore()?.active &&
+        (context.getStore()?.updating || phase !== 'serving')
+      )
+        throw new Error(
+          'Cannot wait on SSR admission from its active request or update',
+        );
+      const deadline = Date.now() + requestTimeoutMs;
+      try {
+        // Waking is only a notification: another update may have closed admission.
+        while (phase !== 'serving')
+          await waitForAdmission(request.signal, deadline);
+        request.signal.throwIfAborted();
+      } catch (error) {
+        if (error instanceof AdmissionError)
+          return new Response(error.message, {
+            status: 503,
+            headers: { 'Retry-After': '1' },
+          });
+        throw error;
+      }
+      // No await between checking admission and acquiring the lease.
+      active++;
+      const lease = { active: true };
+      let pending = 1;
+      const release = () => {
+        if (--pending !== 0) return;
+        lease.active = false;
+        active--;
+        if (active === 0)
+          for (const finish of Array.from(drainListeners)) finish();
+      };
+      const work: SSRRequestWork = {
+        track<T>(task: Promise<T>) {
+          if (!lease.active)
+            throw new Error('Cannot register work on a completed SSR request');
+          pending++;
+          // Both success and failure settle work; neither implies response success.
+          task.then(release, release);
+          return task;
+        },
+      };
+      return context.run(lease, async () => {
+        try {
+          const response = await render(work);
+          if (!response.body) return response;
+          const reader = response.body.getReader();
+          pending++;
+          let ended = false;
+          const finish = () => {
+            if (ended) return;
+            ended = true;
+            request.signal.removeEventListener('abort', abort);
+            release();
+          };
+          // Disconnect settles only transport ownership. Registered producer work
+          // still holds the lease until its own cancellation/completion handshake.
+          const abort = () => {
+            void reader.cancel(request.signal.reason).then(finish, finish);
+          };
+          request.signal.addEventListener('abort', abort, { once: true });
+          if (request.signal.aborted) abort();
+          const body = new ReadableStream<Uint8Array>(
+            {
+              async pull(controller) {
+                try {
+                  const chunk = await reader.read();
+                  if (chunk.done) {
+                    controller.close();
+                    finish();
+                  } else controller.enqueue(chunk.value);
+                } catch (error) {
+                  controller.error(error);
+                  finish();
+                }
+              },
+              async cancel(reason) {
+                try {
+                  await reader.cancel(reason);
+                } finally {
+                  finish();
+                }
+              },
+            },
+            { highWaterMark: 0 },
+          );
+          return new Response(body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          });
+        } finally {
+          release();
+        }
+      });
+    },
+
+    /** Serialize updates. A mutation failure stays closed; retry explicitly. */
+    update(publish: () => Promise<void>): Promise<number> {
+      if (context.getStore()?.active)
+        return Promise.reject(
+          new Error(
+            context.getStore()?.updating
+              ? 'Cannot nest SSR updates'
+              : 'Cannot update SSR from a request being drained',
+          ),
+        );
+      const operation = updates.then(async () => {
+        const previous = phase;
+        phase = 'draining';
+        try {
+          await drain();
+        } catch (error) {
+          phase = previous;
+          if (phase === 'serving') wake();
+          throw error;
+        }
+        phase = 'updating';
+        const publication = { active: true, updating: true };
+        try {
+          await context.run(publication, publish);
+          generation++;
+          phase = 'serving';
+          wake();
+          return generation;
+        } catch (error) {
+          phase = 'unavailable';
+          wake(new AdmissionError('SSR application update failed'));
+          throw error;
+        } finally {
+          publication.active = false;
+        }
+      });
+      updates = operation.catch(() => {});
+      return operation;
+    },
+  };
+}

--- a/packages/server/core/src/adapters/node/requestCoordinator.ts
+++ b/packages/server/core/src/adapters/node/requestCoordinator.ts
@@ -1,14 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { SSRRequestWork } from '../../types/requestHandler';
+export type { SSRRequestWork } from '../../types/requestHandler';
 
 export interface SSRRequestCoordinatorOptions {
   maxPendingRequests: number;
   requestTimeoutMs: number;
   drainTimeoutMs: number;
-}
-
-export interface SSRRequestWork {
-  /** Register producer/loader work before returning a Response. */
-  track<T>(work: Promise<T>): Promise<T>;
 }
 
 type Phase = 'serving' | 'draining' | 'updating' | 'unavailable';

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -140,6 +140,7 @@ export async function createRender({
       loaderContext,
       contextForceCSR,
       reporter,
+      work,
     },
   ) => {
     const forMatchpathname = matchPathname ?? getPathname(req);
@@ -231,6 +232,7 @@ export async function createRender({
       onError,
       onTiming,
       reporter,
+      work,
     };
 
     if (fallbackReason) {

--- a/packages/server/core/src/plugins/render/ssrCache.ts
+++ b/packages/server/core/src/plugins/render/ssrCache.ts
@@ -59,50 +59,56 @@ async function processCache({
     const writer = stream.writable.getWriter();
 
     let html = '';
-    const push = () =>
-      reader.read().then(({ done, value }) => {
-        if (done) {
-          const match = ZERO_RENDER_LEVEL.test(html) || NO_SSR_CACHE.test(html);
-          // case 1: We should not cache the html, if we can match the html is downgrading.
-          // case 2: We should not cache the html, if the user's code contains <NoSSRCache>.
-          if (match) {
-            writer.close();
-            return;
-          }
-          const current = Date.now();
-          const cache: CacheStruct = {
-            val: html,
-            cursor: current,
-          };
+    let cancelled = false;
+    const cancel = async (reason: unknown) => {
+      cancelled = true;
+      await reader.cancel(reason);
+    };
+    // A cancelled consumer may leave the producer blocked in reader.read().
+    const downstream = writer.closed.catch(cancel);
+    requestHandlerOptions.work?.track(downstream);
+    void downstream.catch(() => {});
+    const onAbort = () => {
+      void Promise.allSettled([
+        cancel(request.signal.reason),
+        writer.abort(request.signal.reason),
+      ]);
+    };
+    request.signal.addEventListener('abort', onAbort, { once: true });
+    if (request.signal.aborted) onAbort();
 
-          container.set(key, JSON.stringify(cache), { ttl }).catch(() => {
-            if (onError) {
-              onError(
-                `[render-cache] set cache failed, key: ${key}, value: ${JSON.stringify(
-                  cache,
-                )}`,
-              );
-            } else {
-              console.error(
-                `[render-cache] set cache failed, key: ${key}, value: ${JSON.stringify(
-                  cache,
-                )}`,
-              );
-            }
-          });
-
-          writer.close();
-          return;
+    const pumping = (async () => {
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (cancelled) return;
+          if (done) break;
+          html += decoder.decode(value, { stream: true });
+          await writer.write(value);
         }
-
-        const content = decoder.decode(value);
-        html += content;
-
-        writer.write(value);
-        push();
-      });
-
-    push();
+        html += decoder.decode();
+        if (!ZERO_RENDER_LEVEL.test(html) && !NO_SSR_CACHE.test(html)) {
+          const cache: CacheStruct = { val: html, cursor: Date.now() };
+          try {
+            await container.set(key, JSON.stringify(cache), { ttl });
+          } catch (error) {
+            if (onError) onError(error, 'render-cache');
+            else
+              console.error(
+                `[render-cache] set cache failed, key: ${key}`,
+                error,
+              );
+          }
+        }
+        await writer.close();
+      } catch (error) {
+        await Promise.allSettled([cancel(error), writer.abort(error)]);
+      } finally {
+        request.signal.removeEventListener('abort', onAbort);
+      }
+    })();
+    requestHandlerOptions.work?.track(pumping);
+    void pumping.catch(() => {});
 
     cacheStatus && response.headers.set(X_RENDER_CACHE, cacheStatus);
 
@@ -246,7 +252,7 @@ export async function getCacheResult(
       // the cache is stale while revalidate
 
       // we shouldn't await this promise.
-      processCache({
+      const refreshing = processCache({
         key,
         request,
         requestHandler,
@@ -256,6 +262,14 @@ export async function getCacheResult(
       }).then(async response => {
         // For cache the readableStream, we need confirm the response is consume,
         await response.text();
+      });
+      requestHandlerOptions.work?.track(refreshing);
+      void refreshing.catch(error => {
+        try {
+          onError?.(error, 'render-cache');
+        } catch {
+          /* Reporting must not create an unhandled background rejection. */
+        }
       });
 
       const cacheStatus: CacheStatus = 'stale';

--- a/packages/server/core/src/plugins/render/ssrRender.ts
+++ b/packages/server/core/src/plugins/render/ssrRender.ts
@@ -23,6 +23,7 @@ import { createRequestHandlerConfig } from './utils';
 
 // TODO: It's a type combine by RenderOptions and CreateRenderOptions, improve it.
 export interface SSRRenderOptions {
+  work?: RequestHandlerOptions['work'];
   pwd: string;
   html: string;
   routeInfo: ServerRoute;
@@ -70,6 +71,7 @@ export async function ssrRender(
     onError,
     onTiming,
     reporter,
+    work,
   }: SSRRenderOptions,
 ): Promise<Response> {
   const { entryName } = routeInfo;
@@ -98,6 +100,7 @@ export async function ssrRender(
   const config = createRequestHandlerConfig(userConfig);
 
   const requestHandlerOptions: RequestHandlerOptions = {
+    work,
     resource: {
       route: routeInfo,
       loadableStats,

--- a/packages/server/core/src/types/render.ts
+++ b/packages/server/core/src/types/render.ts
@@ -9,10 +9,12 @@ import type {
   ServerManifest as RscServerManifest,
 } from '@modern-js/types';
 import type { NodeRequest } from '@modern-js/types/server';
+import type { SSRRequestWork } from './requestHandler';
 import type { ServerManifest } from './server';
 
 // TODO: combine some field with RequestHandlerOptions
 export interface RenderOptions {
+  work?: SSRRequestWork;
   monitors: Monitors;
 
   loaderContext?: Map<string, unknown>;

--- a/packages/server/core/src/types/requestHandler.ts
+++ b/packages/server/core/src/types/requestHandler.ts
@@ -35,7 +35,15 @@ export type OnError = (err: unknown, key?: string) => void;
 
 export type OnTiming = (name: string, dur: number) => void;
 
+export interface SSRRequestWork {
+  /** Hold the request until the complete producer promise settles. */
+  track<T>(work: Promise<T>): Promise<T>;
+}
+
 export type RequestHandlerOptions = {
+  /** Framework producer work that may outlive the response or disconnect. */
+  work?: SSRRequestWork;
+
   resource: Resource;
 
   config: RequestHandlerConfig;

--- a/packages/server/core/tests/adapters/requestCoordinator.http.test.ts
+++ b/packages/server/core/tests/adapters/requestCoordinator.http.test.ts
@@ -1,0 +1,75 @@
+import type { AddressInfo } from 'node:net';
+import { createNodeServer } from '../../src/adapters/node/node';
+import { createSSRRequestCoordinator } from '../../src/adapters/node/requestCoordinator';
+
+it('keeps a disconnected producer leased and publishes on the same HTTP server', async () => {
+  const gate = createSSRRequestCoordinator({
+    maxPendingRequests: 4,
+    requestTimeoutMs: 2000,
+    drainTimeoutMs: 2000,
+  });
+  let finishProducer!: () => void;
+  const producer = new Promise<void>(resolve => {
+    finishProducer = resolve;
+  });
+  let cancelled!: () => void;
+  const cancellation = new Promise<void>(resolve => {
+    cancelled = resolve;
+  });
+  let version = 'old';
+  const server = await createNodeServer(req =>
+    gate.handle(req, async work => {
+      if (new URL(req.url).pathname === '/stream') {
+        work.track(producer);
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('shell'));
+            },
+            cancel() {
+              cancelled();
+            },
+          }),
+        );
+      }
+      return new Response(version);
+    }),
+  );
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const port = (server.address() as AddressInfo).port;
+  const pid = process.pid;
+  const url = `http://127.0.0.1:${port}`;
+  const abort = new AbortController();
+  try {
+    const stream = await fetch(`${url}/stream`, { signal: abort.signal });
+    const reader = stream.body!.getReader();
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe('shell');
+    abort.abort();
+    await cancellation;
+    expect(gate.status.activeRequests).toBe(1);
+    let mutated = false;
+    const update = gate.update(async () => {
+      mutated = true;
+      version = 'new';
+    });
+    await new Promise<void>(resolve => setImmediate(resolve));
+    const next = fetch(url);
+    expect(mutated).toBe(false);
+    finishProducer();
+    await update;
+    expect(await (await next).text()).toBe('new');
+    expect((server.address() as AddressInfo).port).toBe(port);
+    expect(process.pid).toBe(pid);
+  } finally {
+    finishProducer();
+    abort.abort();
+    server.closeAllConnections();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});

--- a/packages/server/core/tests/adapters/requestCoordinator.test.ts
+++ b/packages/server/core/tests/adapters/requestCoordinator.test.ts
@@ -1,0 +1,289 @@
+import { createSSRRequestCoordinator } from '../../src/adapters/node/requestCoordinator';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+const tick = () => new Promise<void>(resolve => setImmediate(resolve));
+const request = () => new Request('http://localhost/');
+const coordinator = (overrides = {}) =>
+  createSSRRequestCoordinator({
+    maxPendingRequests: 2,
+    requestTimeoutMs: 1000,
+    drainTimeoutMs: 1000,
+    ...overrides,
+  });
+
+it('drains the old response and selects the published handler after waking', async () => {
+  const gate = coordinator();
+  const stream = new TransformStream<Uint8Array>();
+  const writer = stream.writable.getWriter();
+  const old = await gate.handle(
+    request(),
+    async () => new Response(stream.readable),
+  );
+  const text = old.text();
+  await writer.write(new TextEncoder().encode('old'));
+  let current = 'old';
+  let published = false;
+  const update = gate.update(async () => {
+    published = true;
+    current = 'new';
+  });
+  await tick();
+  const next = gate.handle(request(), async () => new Response(current));
+  expect(published).toBe(false);
+  expect(gate.status.pendingRequests).toBe(1);
+  await writer.close();
+  expect(await text).toBe('old');
+  expect(await update).toBe(1);
+  expect(await (await next).text()).toBe('new');
+  expect(gate.status.activeRequests).toBe(0);
+});
+
+it('keeps producer work leased after the body ends or is cancelled', async () => {
+  for (const cancel of [false, true]) {
+    const gate = coordinator();
+    const producer = deferred();
+    const response = await gate.handle(request(), async work => {
+      work.track(producer.promise);
+      return new Response('shell');
+    });
+    if (cancel) await response.body!.cancel();
+    else expect(await response.text()).toBe('shell');
+    const update = gate.update(async () => {});
+    await tick();
+    expect(gate.status.phase).toBe('draining');
+    expect(gate.status.activeRequests).toBe(1);
+    producer.resolve();
+    await update;
+    expect(gate.status.activeRequests).toBe(0);
+  }
+});
+
+it('disconnect does not release unsettled producer work', async () => {
+  const gate = coordinator();
+  const abort = new AbortController();
+  const producer = deferred();
+  let cancelled = false;
+  await gate.handle(
+    new Request('http://localhost/', { signal: abort.signal }),
+    async work => {
+      work.track(producer.promise);
+      return new Response(
+        new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+        }),
+      );
+    },
+  );
+  abort.abort();
+  await tick();
+  expect(cancelled).toBe(true);
+  expect(gate.status.activeRequests).toBe(1);
+  producer.resolve();
+  await tick();
+  expect(gate.status.activeRequests).toBe(0);
+});
+
+it('times out draining before mutation and resumes the old application', async () => {
+  const gate = coordinator({ drainTimeoutMs: 20 });
+  const producer = deferred();
+  await gate.handle(request(), async work => {
+    work.track(producer.promise);
+    return new Response(null, { status: 204 });
+  });
+  let mutated = false;
+  await expect(
+    gate.update(async () => {
+      mutated = true;
+    }),
+  ).rejects.toThrow('before mutation');
+  expect(mutated).toBe(false);
+  expect(gate.status.generation).toBe(0);
+  expect(
+    await (
+      await gate.handle(request(), async () => new Response('old'))
+    ).text(),
+  ).toBe('old');
+  producer.resolve();
+});
+
+it('bounds the queue and removes only the cancelled waiter', async () => {
+  const gate = coordinator({ maxPendingRequests: 1 });
+  const publish = deferred();
+  const update = gate.update(() => publish.promise);
+  await tick();
+  const abort = new AbortController();
+  const waiting = gate.handle(
+    new Request('http://localhost/', { signal: abort.signal }),
+    async () => new Response('unused'),
+  );
+  const reason = new Error('disconnected');
+  const rejected = expect(waiting).rejects.toBe(reason);
+  // Check overflow before cancellation; the update itself must remain pending.
+  const overflow = await gate.handle(
+    request(),
+    async () => new Response('unused'),
+  );
+  expect(overflow.status).toBe(503);
+  abort.abort(reason);
+  await rejected;
+  expect(gate.status.pendingRequests).toBe(0);
+  expect(gate.status.phase).toBe('updating');
+  publish.resolve();
+  await update;
+});
+
+it('times out an individual waiter without cancelling the update', async () => {
+  const gate = coordinator({ requestTimeoutMs: 20 });
+  const publish = deferred();
+  const update = gate.update(() => publish.promise);
+  await tick();
+  const response = await gate.handle(
+    request(),
+    async () => new Response('unused'),
+  );
+  expect(response.status).toBe(503);
+  expect(response.headers.get('Retry-After')).toBe('1');
+  expect(gate.status.pendingRequests).toBe(0);
+  expect(gate.status.phase).toBe('updating');
+  publish.resolve();
+  await update;
+});
+
+it('stays unavailable after mutation failure and supports an explicit retry', async () => {
+  const gate = coordinator();
+  const publish = deferred();
+  const update = gate.update(() => publish.promise);
+  const observed = expect(update).rejects.toThrow('mutation failed');
+  await tick();
+  const waiting = gate.handle(request(), async () => new Response('partial'));
+  publish.reject(new Error('mutation failed'));
+  await observed;
+  expect((await waiting).status).toBe(503);
+  expect(gate.status.phase).toBe('unavailable');
+  expect(gate.status.generation).toBe(0);
+  expect(
+    (await gate.handle(request(), async () => new Response('partial'))).status,
+  ).toBe(503);
+  await gate.update(async () => {});
+  expect(
+    await (
+      await gate.handle(request(), async () => new Response('recovered'))
+    ).text(),
+  ).toBe('recovered');
+});
+
+it('serializes updates without coalescing their outcomes or admitting stale handlers', async () => {
+  const gate = coordinator();
+  const first = deferred();
+  const second = deferred();
+  const order: number[] = [];
+  const one = gate.update(async () => {
+    order.push(1);
+    await first.promise;
+  });
+  const two = gate.update(async () => {
+    order.push(2);
+    await second.promise;
+  });
+  await tick();
+  const waiting = gate.handle(
+    request(),
+    async () => new Response(String(gate.status.generation)),
+  );
+  const received = waiting.then(response => response.text());
+  first.resolve();
+  expect(await one).toBe(1);
+  await tick();
+  expect(order).toEqual([1, 2]);
+  // A wake from the first publication must recheck the second update's gate.
+  expect(gate.status.phase).toBe('updating');
+  second.resolve();
+  expect(await two).toBe(2);
+  expect(['1', '2']).toContain(await received);
+});
+
+it('rejects self-draining updates and ignores an unrelated coordinator context', async () => {
+  const gate = coordinator();
+  const other = coordinator();
+  const response = await gate.handle(request(), async () => {
+    await expect(gate.update(async () => {})).rejects.toThrow(
+      'request being drained',
+    );
+    await other.update(async () => {});
+    return new Response('ok');
+  });
+  expect(await response.text()).toBe('ok');
+});
+
+it('settles rejected tracked work without leaking a lease or swallowing render errors', async () => {
+  const gate = coordinator();
+  const producer = deferred();
+  await expect(
+    gate.handle(request(), async work => {
+      work.track(producer.promise);
+      throw new Error('render failed');
+    }),
+  ).rejects.toThrow('render failed');
+  expect(gate.status.activeRequests).toBe(1);
+  producer.reject(new Error('producer failed'));
+  await gate.update(async () => {});
+  expect(gate.status.activeRequests).toBe(0);
+});
+
+it('does not read a queued request body or select its handler before admission', async () => {
+  const gate = coordinator();
+  const publish = deferred();
+  const update = gate.update(() => publish.promise);
+  await tick();
+  let reads = 0;
+  let calls = 0;
+  const body = new ReadableStream(
+    {
+      pull(controller) {
+        reads++;
+        controller.close();
+      },
+    },
+    { highWaterMark: 0 },
+  );
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    body,
+    duplex: 'half',
+  } as RequestInit);
+  const response = gate.handle(req, async () => {
+    calls++;
+    await req.text();
+    return new Response('ok');
+  });
+  await tick();
+  expect(reads).toBe(0);
+  expect(calls).toBe(0);
+  publish.resolve();
+  await update;
+  expect(await (await response).text()).toBe('ok');
+  expect(calls).toBe(1);
+});
+
+it('rejects nested updates and gated warmup instead of waiting on itself', async () => {
+  const gate = coordinator();
+  await gate.update(async () => {
+    await expect(gate.update(async () => {})).rejects.toThrow(
+      'nest SSR updates',
+    );
+    await expect(
+      gate.handle(request(), async () => new Response('warmup')),
+    ).rejects.toThrow('active request or update');
+  });
+  expect(gate.status.generation).toBe(1);
+});

--- a/packages/server/core/tests/plugins/cacheWork.test.ts
+++ b/packages/server/core/tests/plugins/cacheWork.test.ts
@@ -1,0 +1,104 @@
+import { rstest } from '@rstest/core';
+import { createSSRRequestCoordinator } from '../../src/adapters/node/requestCoordinator';
+import { getCacheResult } from '../../src/plugins/render/ssrCache';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+it('holds stale revalidation through the asynchronous cache write', async () => {
+  const coordinator = createSSRRequestCoordinator({
+    maxPendingRequests: 1,
+    requestTimeoutMs: 1000,
+    drainTimeoutMs: 1000,
+  });
+  const writing = deferred<void>();
+  const written = deferred<void>();
+  const container = {
+    get: async () => JSON.stringify({ val: 'stale', cursor: Date.now() - 200 }),
+    set: async () => {
+      writing.resolve();
+      await written.promise;
+      return container;
+    },
+    has: async () => true,
+    delete: async () => true,
+  };
+  const request = new Request('http://localhost/');
+  const response = await coordinator.handle(request, work =>
+    getCacheResult(request, {
+      cacheControl: { maxAge: 100, staleWhileRevalidate: 1000 },
+      container,
+      requestHandler: async () => new Response('fresh'),
+      requestHandlerOptions: { work } as any,
+    }),
+  );
+  expect(await response.text()).toBe('stale');
+  await writing.promise;
+  const mutate = rstest.fn(async () => {});
+  const update = coordinator.update(mutate);
+  await new Promise(resolve => setImmediate(resolve));
+  expect(mutate).not.toHaveBeenCalled();
+  written.resolve();
+  await expect(update).resolves.toBe(1);
+});
+
+it('response cancellation cancels the cache producer stream', async () => {
+  const cancelled = rstest.fn();
+  const container = {
+    get: async () => undefined,
+    set: rstest.fn(),
+    has: async () => false,
+    delete: async () => false,
+  };
+  const request = new Request('http://localhost/');
+  const response = await getCacheResult(request, {
+    cacheControl: { maxAge: 100, staleWhileRevalidate: 1000 },
+    container,
+    requestHandler: async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('shell'));
+          },
+          cancel: cancelled,
+        }),
+      ),
+    requestHandlerOptions: {} as any,
+  });
+  const reader = response.body!.getReader();
+  await reader.read();
+  await reader.cancel();
+  await new Promise(resolve => setImmediate(resolve));
+  expect(cancelled).toHaveBeenCalledTimes(1);
+  expect(container.set).not.toHaveBeenCalled();
+});
+
+it('a stream failure rejects the cache response body without writing a partial cache', async () => {
+  const container = {
+    get: async () => undefined,
+    set: rstest.fn(),
+    has: async () => false,
+    delete: async () => false,
+  };
+  const request = new Request('http://localhost/');
+  const response = await getCacheResult(request, {
+    cacheControl: { maxAge: 100, staleWhileRevalidate: 1000 },
+    container,
+    requestHandler: async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(new Error('render failed'));
+          },
+        }),
+      ),
+    requestHandlerOptions: {} as any,
+  });
+  await expect(response.text()).rejects.toThrow('render failed');
+  expect(container.set).not.toHaveBeenCalled();
+});

--- a/packages/toolkit/runtime-utils/src/browser/nestedRoutes.tsx
+++ b/packages/toolkit/runtime-utils/src/browser/nestedRoutes.tsx
@@ -142,44 +142,89 @@ function isPlainObject(value: any): value is Record<string, any> {
   );
 }
 
+async function getRequestWork() {
+  if (typeof document !== 'undefined') return undefined;
+  try {
+    return (await getAsyncLocalStorage())?.useContext()?.work;
+  } catch {
+    return undefined;
+  }
+}
+
+function holdRequestWork(work: Awaited<ReturnType<typeof getRequestWork>>) {
+  let finish = () => {};
+  if (work) {
+    const running = new Promise<void>(done => {
+      finish = done;
+    });
+    // Reject an expired lease before invoking any business code.
+    work.track(running);
+  }
+  return finish;
+}
+
 function createLoader(route: NestedRoute): LoaderFunction {
   const { loader } = route;
   if (loader) {
     return async (args: LoaderFunctionArgs) => {
-      if (typeof route.lazyImport === 'function') {
-        route.lazyImport();
-      }
-      const end = time();
-      const res = await loader(args);
-      let activeDeferreds = null;
-      if (typeof document === 'undefined') {
-        activeDeferreds = (await getAsyncLocalStorage())?.useContext()
-          ?.activeDeferreds as Map<string, DeferredData>;
-      } else {
-        activeDeferreds = originalActiveDeferreds;
-      }
-      if (isPlainObject(res)) {
-        const deferredData = privateDefer(res);
-        activeDeferreds.set(route.id!, deferredData);
-      }
+      const work =
+        typeof document === 'undefined' ? await getRequestWork() : undefined;
+      const finish = holdRequestWork(work);
+      try {
+        if (typeof route.lazyImport === 'function') {
+          const importing = route.lazyImport();
+          if (importing) work?.track(Promise.resolve(importing));
+        }
+        const end = time();
+        const loading = Promise.resolve(loader(args));
+        work?.track(loading);
+        const res = await loading;
+        // Track originals before DeferredData wraps them in a cancellation race.
+        if (isPlainObject(res) && work) {
+          work.track(Promise.allSettled(Object.values(res)));
+        }
+        let activeDeferreds = null;
+        if (typeof document === 'undefined') {
+          activeDeferreds = (await getAsyncLocalStorage())?.useContext()
+            ?.activeDeferreds as Map<string, DeferredData>;
+        } else {
+          activeDeferreds = originalActiveDeferreds;
+        }
+        if (isPlainObject(res)) {
+          const deferredData = privateDefer(res);
+          activeDeferreds.set(route.id!, deferredData);
+        }
 
-      const cost = end();
-      if (typeof document === 'undefined') {
-        const storage = await getAsyncLocalStorage();
-        storage
-          ?.useContext()
-          .monitors?.timing(
-            `${LOADER_REPORTER_NAME}-${route.id?.replace(/\//g, '_')}`,
-            cost,
-          );
+        const cost = end();
+        if (typeof document === 'undefined') {
+          const storage = await getAsyncLocalStorage();
+          storage
+            ?.useContext()
+            .monitors?.timing(
+              `${LOADER_REPORTER_NAME}-${route.id?.replace(/\//g, '_')}`,
+              cost,
+            );
+        }
+        return res;
+      } finally {
+        finish();
       }
-      return res;
     };
   } else {
     return () => {
-      if (typeof route.lazyImport === 'function') {
-        route.lazyImport();
+      if (typeof document === 'undefined') {
+        return getRequestWork().then(work => {
+          const finish = holdRequestWork(work);
+          try {
+            const importing = route.lazyImport?.();
+            if (importing) work?.track(Promise.resolve(importing));
+            return null;
+          } finally {
+            finish();
+          }
+        });
       }
+      route.lazyImport?.();
       return null;
     };
   }

--- a/packages/toolkit/runtime-utils/src/universal/async_storage.server.ts
+++ b/packages/toolkit/runtime-utils/src/universal/async_storage.server.ts
@@ -55,6 +55,7 @@ const storage = createStorage<{
     headers: Record<string, string>;
     status: number;
   };
+  work?: { track<T>(work: Promise<T>): Promise<T> };
   activeDeferreds?: Map<string, unknown>;
   serverPayload?: unknown;
 }>();

--- a/packages/toolkit/runtime-utils/tests/universal/routeWork.test.ts
+++ b/packages/toolkit/runtime-utils/tests/universal/routeWork.test.ts
@@ -1,0 +1,138 @@
+import { rstest } from '@rstest/core';
+import React from 'react';
+beforeEach(() => {
+  rstest.stubGlobal('React', React);
+});
+afterEach(() => {
+  rstest.unstubAllGlobals();
+});
+import type { DeferredData } from '../../src/browser/deferreds';
+import { transformNestedRoutes } from '../../src/browser/nestedRoutes';
+import { storage } from '../../src/universal/async_storage.server';
+
+rstest.mock('../../src/universal/async_storage', () => ({
+  getAsyncLocalStorage: async () => storage,
+}));
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+function scope() {
+  const pending = new Set<Promise<unknown>>();
+  const work = {
+    track<T>(promise: Promise<T>) {
+      pending.add(promise);
+      void promise.then(
+        () => pending.delete(promise),
+        () => pending.delete(promise),
+      );
+      return promise;
+    },
+  };
+  return {
+    pending,
+    context: { work, activeDeferreds: new Map<string, DeferredData>() },
+  };
+}
+function loader(route: Record<string, unknown>) {
+  return transformNestedRoutes([{ id: 'route', path: '/', ...route } as any])[0]
+    .loader as (args: any) => Promise<unknown>;
+}
+
+it('tracks route preloading even without a data loader', async () => {
+  const imported = deferred<unknown>();
+  const { pending, context } = scope();
+  await storage.run(context, () =>
+    loader({ lazyImport: () => imported.promise })({}),
+  );
+  expect(pending.has(imported.promise)).toBe(true);
+  imported.resolve({});
+  await imported.promise;
+  expect(pending.size).toBe(0);
+});
+
+it('tracks the original deferred value after its cancellation wrapper rejects', async () => {
+  const value = deferred<string>();
+  const { pending, context } = scope();
+  await storage.run(context, () =>
+    loader({ loader: async () => ({ value: value.promise }) })({}),
+  );
+  context.activeDeferreds.get('route')!.cancel();
+  await new Promise(resolve => setImmediate(resolve));
+  expect(pending.size).toBeGreaterThan(0);
+  value.resolve('done');
+  await new Promise(resolve => setImmediate(resolve));
+  expect(pending.size).toBe(0);
+});
+
+it('a rejected loader does not release its unfinished route import', async () => {
+  const imported = deferred<unknown>();
+  const { pending, context } = scope();
+  await expect(
+    storage.run(context, () =>
+      loader({
+        lazyImport: () => imported.promise,
+        loader: async () => {
+          throw new Error('loader failed');
+        },
+      })({}),
+    ),
+  ).rejects.toThrow('loader failed');
+  expect(pending.has(imported.promise)).toBe(true);
+  imported.resolve({});
+  await imported.promise;
+  expect(pending.size).toBe(0);
+});
+
+it('rejects a late route task before starting business code', async () => {
+  const preload = rstest.fn();
+  const data = rstest.fn();
+  const context = {
+    activeDeferreds: new Map(),
+    work: {
+      track() {
+        throw new Error('request completed');
+      },
+    },
+  };
+  await expect(
+    storage.run(context, () =>
+      loader({ lazyImport: preload, loader: data })({}),
+    ),
+  ).rejects.toThrow('request completed');
+  expect(preload).not.toHaveBeenCalled();
+  expect(data).not.toHaveBeenCalled();
+});
+
+it('keeps loader continuation leased while registering returned deferred values', async () => {
+  let active = 0;
+  const value = deferred<string>();
+  const context = {
+    activeDeferreds: new Map(),
+    work: {
+      track<T>(promise: Promise<T>) {
+        if (active === -1) throw new Error('lease already released');
+        active++;
+        void promise.then(
+          () => {
+            if (--active === 0) active = -1;
+          },
+          () => {
+            if (--active === 0) active = -1;
+          },
+        );
+        return promise;
+      },
+    },
+  };
+  await storage.run(context, () =>
+    loader({ loader: async () => ({ value: value.promise }) })({}),
+  );
+  expect(active).toBeGreaterThan(0);
+  value.resolve('done');
+  await new Promise(resolve => setImmediate(resolve));
+  expect(active).toBe(-1);
+});


### PR DESCRIPTION
## Summary

Add an opt-in Node request coordinator that bounds waiting requests, tracks outstanding work and drains it before serialized publication. Returning a Response, producing a React shell or disconnecting the client does not release unfinished producer work. Drain timeout occurs before mutation; failed publication keeps admission closed until an explicit retry.

Connect the optional work context through the render pipeline into standard Node/Web HTML rendering and nested-route loaders. Forward abort to React, handle normal/fallback template failures, retain deferred scripts until completion, and await the actual Web reader cancellation handshake. Track original loader values before DeferredData races them against cancellation, and reject expired route work before starting business code. Track SSR cache revalidation and asynchronous writes, propagate stream failures/cancellation, and respect backpressure.

The agreed scope is ordinary HTML SSR. RSC, Flight and RSC payload tasks are explicitly out of scope and do not block R2 or R3. Custom/business producers use the explicit work-registration contract; automatically discovering arbitrary background side effects is not an acceptance requirement. The default application-owner gate and generation switching are not installed; these remain owner integration work. The Web unit fixture exercises real React HTML streaming. Generation-specific HTML cache invalidation belongs to owner integration. Do not enable production remote mutation based on these tests alone. Full contracts, remaining boundaries and exact commands are in packages/server/core/SSR_REQUEST_COORDINATION.md.

Validation rerun after the rebase and `pnpm install --frozen-lockfile --ignore-scripts` on main-derived Modern 3.9.0 dependencies: server-core 42/42, runtime-utils 87/87 and runtime 61/61 full package tests pass; all three builds/declarations, touched-file Biome, Changesets planning, diff checks and commit hooks pass. The 17 renderer lifecycle cases include real HTTP Node/Web disconnect/drain/publication on the same PID/port and delayed reader cancellation. The strict local Rspack 2.2.2 + Modern artifact baseline reports 13/13, zero failures/skips/TODOs. The runtime-utils test process reports a MaxListenersExceededWarning for modified listeners; it was recorded, not suppressed. Full framework/builder E2E and MF-wide Cypress were not run; production owner integration remains outstanding. RSC acceptance is outside the user-confirmed scope. The base-correction follow-up reran all three package test/build commands, Biome, Changesets planning, git diff --check and the strict local-Rspack/Modern artifact baseline. Exact commands and skipped checks are recorded in the validation document. No publication.

## Related Links

MF R1 adapter lifecycle: https://github.com/module-federation/core/pull/5052

RFC: https://bytedance.larkoffice.com/docx/I8VZdLKxPoI85NxNTkrcX2Zmnuf

Targets `feat/mf-ssr-clear-cache`, created directly from `main` at `4af5bf05b6513ee396419fada27f304880c15b67`. All subsequent Modern SSR cache work branches and PRs use this integration branch. The four feature commits were rebased onto it; the old chunk-loading-global fix is excluded. The PR retains its 24-file scope.

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.