### PR TITLE
feat(server): publish rebuilt SSR application resources

### DIFF
--- a/.changeset/ssr-application-generation.md
+++ b/.changeset/ssr-application-generation.md
@@ -1,0 +1,7 @@
+---
+"@modern-js/server-core": minor
+"@modern-js/prod-server": minor
+"@modern-js/plugin-data-loader": patch
+---
+
+Add opt-in process-local SSR application resource publication before request middleware, with bounded admission, validated CommonJS resource rebuilding and generation-specific HTML cache keys. Propagate request work into standalone data loaders. Keep the listening HTTP server while updates drain and publish, and keep SSR unavailable after failed preparation until an explicit retry.

--- a/packages/cli/plugin-data-loader/src/runtime/index.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/index.ts
@@ -98,6 +98,7 @@ export const handleRequest: ServerLoaderBundle['handleRequest'] = async ({
       monitors,
       request,
       activeDeferreds,
+      work: context.work,
     },
     async () => {
       const routes = transformNestedRoutes(routesConfig);
@@ -136,6 +137,7 @@ export const handleRequest: ServerLoaderBundle['handleRequest'] = async ({
             // @ts-ignore
             deferredData,
             request.signal,
+            context.work,
           );
           const init = deferredData.init || {};
           if (init.status && isRedirectResponse(init.status)) {

--- a/packages/cli/plugin-data-loader/src/runtime/response.ts
+++ b/packages/cli/plugin-data-loader/src/runtime/response.ts
@@ -13,6 +13,7 @@ import type {
   TrackedPromise,
 } from '@modern-js/runtime-utils/browser';
 import { serializeJson } from '@modern-js/runtime-utils/node';
+import type { SSRRequestWork } from '@modern-js/server-core/node';
 
 function isTrackedPromise(value: any): value is TrackedPromise {
   return (
@@ -24,56 +25,93 @@ const DEFERRED_VALUE_PLACEHOLDER_PREFIX = '__deferred_promise:';
 export function createDeferredReadableStream(
   deferredData: DeferredData,
   signal: AbortSignal,
-): any {
+  work?: SSRRequestWork,
+): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
-  const stream = new ReadableStream({
-    async start(controller: any) {
-      const criticalData: any = {};
-
-      const preresolvedKeys: string[] = [];
-      for (const [key, value] of Object.entries(deferredData.data)) {
-        if (isTrackedPromise(value)) {
-          criticalData[key] = `${DEFERRED_VALUE_PLACEHOLDER_PREFIX}${key}`;
-          if (
-            typeof value._data !== 'undefined' ||
-            typeof value._error !== 'undefined'
-          ) {
-            preresolvedKeys.push(key);
-          }
-        } else {
-          criticalData[key] = value;
+  let cancel = () => {};
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      let settle!: () => void;
+      const completion = new Promise<void>(resolve => {
+        settle = resolve;
+      });
+      work?.track(completion);
+      let ended = false;
+      let unsubscribe = () => {};
+      const finish = () => {
+        if (ended) return;
+        ended = true;
+        unsubscribe();
+        signal.removeEventListener('abort', abort);
+        settle();
+      };
+      const fail = (reason: unknown) => {
+        if (ended) return;
+        finish();
+        controller.error(reason);
+        deferredData.cancel();
+      };
+      const abort = () => fail(signal.reason);
+      cancel = () => {
+        finish();
+        deferredData.cancel();
+      };
+      signal.addEventListener('abort', abort, { once: true });
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      try {
+        const criticalData: Record<string, unknown> = {};
+        const preresolvedKeys: string[] = [];
+        for (const [key, value] of Object.entries(deferredData.data)) {
+          if (isTrackedPromise(value)) {
+            criticalData[key] = `${DEFERRED_VALUE_PLACEHOLDER_PREFIX}${key}`;
+            if (
+              typeof value._data !== 'undefined' ||
+              typeof value._error !== 'undefined'
+            )
+              preresolvedKeys.push(key);
+          } else criticalData[key] = value;
         }
-      }
-
-      // Send the critical data
-      controller.enqueue(encoder.encode(`${JSON.stringify(criticalData)}\n\n`));
-
-      for (const preresolvedKey of preresolvedKeys) {
-        enqueueTrackedPromise(
-          controller,
-          encoder,
-          preresolvedKey,
-          deferredData.data[preresolvedKey] as TrackedPromise,
+        controller.enqueue(
+          encoder.encode(`${JSON.stringify(criticalData)}\n\n`),
         );
-      }
-
-      const unsubscribe = deferredData.subscribe((aborted, settledKey) => {
-        if (settledKey) {
+        for (const key of preresolvedKeys)
           enqueueTrackedPromise(
             controller,
             encoder,
-            settledKey,
-            deferredData.data[settledKey] as TrackedPromise,
+            key,
+            deferredData.data[key] as TrackedPromise,
           );
-        }
-      });
-      await deferredData.resolveData(signal);
-      unsubscribe();
-      controller.close();
+        const update = (aborted: boolean, key?: string) => {
+          if (ended) return;
+          try {
+            if (key)
+              enqueueTrackedPromise(
+                controller,
+                encoder,
+                key,
+                deferredData.data[key] as TrackedPromise,
+              );
+            if (aborted || deferredData.done) {
+              controller.close();
+              finish();
+            }
+          } catch (error) {
+            fail(error);
+          }
+        };
+        unsubscribe = deferredData.subscribe(update);
+        update(false);
+      } catch (error) {
+        fail(error);
+      }
+    },
+    cancel() {
+      cancel();
     },
   });
-
-  return stream;
 }
 
 function enqueueTrackedPromise(

--- a/packages/cli/plugin-data-loader/tests/requestWork.test.ts
+++ b/packages/cli/plugin-data-loader/tests/requestWork.test.ts
@@ -1,0 +1,134 @@
+import { storage } from '@modern-js/runtime-utils/node';
+import { handleRequest } from '../src/runtime';
+
+it('keeps the application work scope in standalone loader requests', async () => {
+  const tracked = new Set<Promise<unknown>>();
+  const work = {
+    track<T>(task: Promise<T>) {
+      tracked.add(task);
+      void task.then(
+        () => tracked.delete(task),
+        () => tracked.delete(task),
+      );
+      return task;
+    },
+  };
+  let release!: () => void;
+  const pending = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  const response = await handleRequest({
+    request: new Request('http://localhost/?__loader=page'),
+    serverRoutes: [{ urlPath: '/', entryName: 'main' }] as any,
+    routes: [
+      {
+        id: 'page',
+        path: '/',
+        loader: () => {
+          expect(storage.useContext().work).toBe(work);
+          storage.useContext().work!.track(pending);
+          return new Response('loader');
+        },
+      },
+    ] as any,
+    context: { monitors: { timing() {} } as any, work },
+  });
+  expect(await response!.text()).toBe('loader');
+  expect(tracked.has(pending)).toBe(true);
+  release();
+  await pending;
+  expect(tracked.size).toBe(0);
+});
+
+it('settles the deferred response producer on cancellation without cancelling original work', async () => {
+  const { createDeferredReadableStream } = await import(
+    '../src/runtime/response'
+  );
+  const { DeferredData } = await import('@modern-js/runtime-utils/browser');
+  let resolve!: (value: string) => void;
+  const original = new Promise<string>(done => {
+    resolve = done;
+  });
+  const tasks = new Set<Promise<unknown>>();
+  const work = {
+    track<T>(task: Promise<T>) {
+      tasks.add(task);
+      void task.then(
+        () => tasks.delete(task),
+        () => tasks.delete(task),
+      );
+      return task;
+    },
+  };
+  work.track(original);
+  const data = new DeferredData({ value: original });
+  const stream = createDeferredReadableStream(
+    data,
+    new AbortController().signal,
+    work,
+  );
+  const reader = stream.getReader();
+  await reader.read();
+  expect(tasks.size).toBe(2);
+  await reader.cancel();
+  await new Promise(done => setImmediate(done));
+  expect(tasks.size).toBe(1);
+  resolve('late');
+  await new Promise(done => setImmediate(done));
+  expect(tasks.size).toBe(0);
+});
+
+it('still observes abort after one deferred field has settled', async () => {
+  const { createDeferredReadableStream } = await import(
+    '../src/runtime/response'
+  );
+  const { DeferredData } = await import('@modern-js/runtime-utils/browser');
+  let first!: (value: string) => void;
+  let second!: (value: string) => void;
+  const data = new DeferredData({
+    first: new Promise<string>(done => {
+      first = done;
+    }),
+    second: new Promise<string>(done => {
+      second = done;
+    }),
+  });
+  const abort = new AbortController();
+  const reader = createDeferredReadableStream(data, abort.signal).getReader();
+  await reader.read();
+  first('ready');
+  await reader.read();
+  abort.abort(new Error('disconnect'));
+  await expect(reader.read()).rejects.toThrow('disconnect');
+  second('late');
+  await new Promise(done => setImmediate(done));
+});
+
+it('rejects deferred serialization errors and settles the response work', async () => {
+  const { createDeferredReadableStream } = await import(
+    '../src/runtime/response'
+  );
+  const { DeferredData } = await import('@modern-js/runtime-utils/browser');
+  let release!: (value: bigint) => void;
+  const data = new DeferredData({
+    value: new Promise<bigint>(done => {
+      release = done;
+    }),
+  });
+  let completion!: Promise<void>;
+  const work = {
+    track<T>(task: Promise<T>) {
+      completion = task as Promise<void>;
+      return task;
+    },
+  };
+  const reader = createDeferredReadableStream(
+    data,
+    new AbortController().signal,
+    work,
+  ).getReader();
+  await reader.read();
+  release(1n);
+  await expect(reader.read()).rejects.toThrow();
+  await completion;
+});

--- a/packages/server/core/SSR_REQUEST_COORDINATION.md
+++ b/packages/server/core/SSR_REQUEST_COORDINATION.md
@@ -1,15 +1,64 @@
-# SSR request coordination (R2, opt-in primitive)
+# SSR request coordination and application publication (R2 / R3)
 
 `createSSRRequestCoordinator` is exported from `@modern-js/server-core/node`.
 It coordinates one application owner in one Node process. It does not replace
 the HTTP server or restart the process, and introduces no worker orchestration.
 
-**This coordinator is not installed in the default Modern request path. The
-standard Node/Web HTML renderers, nested-route loaders and HTML cache now accept
-and propagate work ownership. The agreed scope is ordinary HTML SSR; RSC is
-out of scope and is not an R2 acceptance gate. Custom producers use the explicit
-work-registration contract below. R3 owns admission before resource selection.
-Do not enable remote mutation around an uninstrumented renderer.**
+`createProdServer({ ssrApplication })` now installs an opt-in application owner
+before resource selection and all direct/plugin request middleware. Without this
+option the existing request path is retained. Ordinary HTML SSR and standalone
+data loaders are supported; RSC is outside scope. This is the application rebuild
+path, not the final MF update API or static dependency planner.
+
+## Application publication (R3)
+
+`SSRResourceApplicationOptions` requires the three coordinator limits and an
+`onReady(application)` callback. The callback receives `status` and
+`update(invalidate)`. The control plane invokes update outside request handling.
+The application owner drains existing work, awaits the bundler/remote invalidator,
+awaits `dispose(previousResources)`, reloads the declared CommonJS render/loader
+roots, rereads templates and JSON manifests, creates a fresh renderer, validates
+entry handlers and optional loader bundles, and publishes all resources together.
+The HTTP server, port, process, server plugins and logical MF instance remain.
+
+The invalidator owns transitive bundler state and remote changes; `dispose` owns
+adapter detachment and application-owned cleanup. They must preserve shared
+factories and support explicit retries. `dispose` must release all live adapters
+owned by this application, including adapters installed by an unsuccessful create;
+a failed create invokes it again before reporting the error. It must not dispose
+other applications or the persistent MF control plane. Modern only evicts declared
+application roots using canonical `require.resolve` keys. It does not walk and
+delete every Node dependency or automatically undo business globals/listeners.
+
+New requests choose templates, manifest, renderer and work context after admission.
+Each publication also gets a unique HTML-cache namespace (including custom keys
+and custom cache containers); old values expire by their existing TTL and cannot
+be served by the new generation. Namespaces are process-local, so separate owners
+no longer reuse each other's HTML cache entries when this mode is enabled.
+No cache backend flush or broad Node cache deletion is performed.
+
+An optional `validate(resources)` checks the unpublished generation directly.
+It must await its complete validation work and must not call back through gated
+HTTP requests. Concurrent entry preparation settles before failure is reported.
+Missing/invalid SSR handlers, templates, existing loader bundles and malformed
+JSON manifests reject publication. Native ESM application entry roots are rejected;
+Modern's own ESM distribution may still load the explicitly CommonJS app roots.
+After a mutation/preparation failure SSR stays unavailable until an explicit retry;
+there is no rollback promise or artificial mutation timeout.
+
+`bypass(request)` may return a Response directly for trusted static/liveness
+handlers. Returning undefined enters normal admission. The bypass cannot fall
+through to application middleware and must not access application-owned resources.
+Without an explicit bypass, requests (including static/API routes) are admitted
+through this application-wide owner. Scope-based admission remains R4. A readiness
+handler can consult `status`; liveness must not imply readiness during failed
+publication. No guessed production queue/time-limit defaults are introduced.
+
+The MF adapter and final remote-update API will compose these hooks. The production
+artifact test already supplies the real companion runtime's adapter disposal and
+remove/register operations, including failed-candidate cleanup. R4 still adds the
+static dependency planner and selective path; R5 owns API migration; R6 remains
+responsible for the complete deployment/hydration/load/resource acceptance matrix.
 
 ## Development branches
 
@@ -91,8 +140,8 @@ The HTML cache forwards cancellation to its input reader, awaits writer
 backpressure, propagates stream errors and waits for asynchronous cache writes.
 Stale-while-revalidate work is registered even though the HTTP caller receives
 cached HTML immediately. An update cannot overtake that old generation's cache
-write. Cache-key invalidation across generations remains an owner integration
-requirement; draining a write alone does not invalidate previously cached HTML.
+write. The opt-in application owner isolates HTML cache keys across generations; draining
+a write alone would not invalidate previously cached HTML.
 
 ## Remaining integration boundaries
 
@@ -107,10 +156,9 @@ requirement; draining a write alone does not invalidate previously cached HTML.
   background remote loading and imports outside that path must be registered by
   their owner; aborting React cannot cancel their underlying promises. The React
   test intentionally registers its independent lazy-import promise explicitly.
-- R3 must install the gate before selecting resources/loader/renderer, supply work
-  to every owned HTML SSR/loader path, invalidate generation-specific HTML caches,
-  and reject unsupported paths before mutation. These changes do not yet switch
-  application generations or expose the final MF update API.
+- R3 now supplies admission, work propagation and application-resource publication
+  when explicitly enabled. The final MF update API and static selective planner
+  remain separate integration work.
 
 The Node HTTP adapter already propagates response close to Request.signal. The
 new renderer handling consumes that signal without equating disconnect with a
@@ -234,3 +282,69 @@ runtime-utils test-runner listener warning remains. Full framework/builder E2E
 and the MF-wide Cypress suite were not rerun for this base correction; affected
 package tests/builds and the cross-repository artifact regression were used.
 RSC remains outside scope. No release or merge was performed.
+
+
+## R3 verification (2026-09-10)
+
+The current branch starts at integration commit `3d6b2f910d` (merged #8861) and
+continues targeting `feat/mf-ssr-clear-cache`. Tests exercise real ServerBase and
+createProdServer request chains, not only the coordinator primitive. The CJS
+artifact tests are explicit commands after build, outside the Rstest module loader.
+On macOS, a first experiment used a noncanonical temporary-directory cache key;
+using `require.resolve` fixes that defect. The owner now performs this itself.
+
+The production MF test exposed an additional cross-layer bug: a dynamic registration
+name can differ from the provider name in `Shared.from`, and dynamic remotes have
+no compile-time remoteInfos. Both runtime-core and the bundler cleanup hook must
+resolve this ownership from the runtime registration/resolved container metadata.
+Without the companion MF repair the strict shared-identity assertions fail even
+though the earlier 13-case baseline passes. The assertions were kept. No Rspack
+source or dependency lockfiles were changed for this repair.
+
+Commands (Modern repository unless indicated):
+
+```sh
+pnpm --filter @modern-js/server-core exec rstest run tests/adapters/application.test.ts
+pnpm --filter @modern-js/plugin-data-loader exec rstest run tests/requestWork.test.ts
+pnpm --filter @modern-js/server-core test
+pnpm --filter @modern-js/plugin-data-loader test
+pnpm --filter @modern-js/server-core build
+pnpm --filter @modern-js/plugin-data-loader build
+pnpm --filter @modern-js/prod-server build
+node --test packages/server/core/tests/application.http.test.cjs
+NODE_ENV=production SSR_CACHE_RSPACK_ENTRY=/Users/bytedance/outter/rspack/packages/rspack/dist/index.js SSR_CACHE_MF_ROOT=/Users/bytedance/outter/core node --test packages/server/core/tests/application.mf.test.cjs
+pnpm exec biome check $(git diff --cached --name-only -- '*.ts' '*.tsx' '*.mts' '*.cjs')
+pnpm exec changeset status
+git diff --check
+```
+
+The native HTTP tests cover new-resource selection, cached HTML isolation, loader
+replacement, direct/pre middleware admission, same PID/port, invalid publication,
+retry, native ESM rejection, and waiting for concurrent entry initialization.
+The MF artifact test compiles v1/v2/v3 before serving, then updates without host
+recompilation or recreating the HTTP server. It asserts queued HTTP requests get
+the new version, host/provider shared references remain identical, the logical
+MF instance is reused, old/failed adapters are detached, one current adapter remains,
+and a business global written by v1 still exists. Failed warmup yields 503 and a
+successful explicit retry restores v3.
+
+Standalone loader regressions also cover its work context, cancelled deferred
+responses, abort after one field settled, and serialization failure. Response
+subscription completion does not settle an independent original business Promise.
+
+Full framework/builder E2E, browser hydration/Cypress, load tests and RSC are not
+included in this R3 run. RSC is explicitly excluded; the other broad acceptance
+checks remain R6 rather than being represented as passed. The prod-server package
+has no unit-test suite; its actual createProdServer entry is exercised above.
+No publish commands are run. Exact final counts are recorded with the PR.
+
+
+Final R3 results: server-core 46/46; plugin-data-loader 10 passed and one existing
+skipped case (`should return directly when routeId not exist`). All three affected
+package builds and declarations pass. Native HTTP artifacts: 3/3; production MF
+artifact: 1/1; prior strict Rspack/Modern baseline: 13/13, with no skips/TODOs.
+The companion MF repair passes runtime-core 138/138 and bundler runtime 122/122.
+Its repository-wide Prettier gate still reports 683 existing/generated or unrelated
+user-dirty files; its changed files pass. This is recorded rather than broad-formatting
+the workspace. The production MF test requires both companion repository paths and
+fails if they are omitted; it is not silently skipped by the package unit runner.

--- a/packages/server/core/src/adapters/node/application.ts
+++ b/packages/server/core/src/adapters/node/application.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  Middleware,
+  Render,
+  ServerEnv,
+  ServerManifest,
+} from '../../types';
+import {
+  type SSRRequestCoordinatorOptions,
+  createSSRRequestCoordinator,
+} from './requestCoordinator';
+
+export interface SSRApplicationResources {
+  templates: Record<string, string>;
+  serverManifest: ServerManifest;
+  render: Render;
+}
+
+export interface SSRApplicationOptions extends SSRRequestCoordinatorOptions {
+  load: (rebuilding: boolean) => Promise<SSRApplicationResources>;
+  /** Release generation-owned adapters/state; must be safe to retry after failure. */
+  dispose?: (resources: SSRApplicationResources) => Promise<void>;
+  /** Must respond directly; bypass handlers cannot fall through into application code. */
+  bypass?: (request: Request) => Promise<Response | undefined>;
+}
+
+/** One process-local resource owner. Module invalidation belongs to its bundler adapter. */
+export async function createSSRApplication(options: SSRApplicationOptions) {
+  const coordinator = createSSRRequestCoordinator(options);
+  let resources = await options.load(false);
+  let cacheNamespace = randomUUID();
+  const middleware: Middleware<ServerEnv> = async (c, next) => {
+    const bypass = await options.bypass?.(c.req.raw);
+    if (bypass) return bypass;
+    const response = await coordinator.handle(c.req.raw, async work => {
+      // Admission must precede all resource selection, including captured promises.
+      c.set('templates', resources.templates);
+      c.set('serverManifest', resources.serverManifest);
+      c.set('ssrRender', resources.render);
+      c.set('ssrWork', work);
+      c.set('ssrCacheNamespace', cacheNamespace);
+      await next();
+      return c.res;
+    });
+    c.res = response;
+    return response;
+  };
+  return {
+    middleware,
+    get status() {
+      return coordinator.status;
+    },
+    /** Called only by the control plane; invalidate must detach/reset owned bundler state. */
+    update(invalidate: () => Promise<void>) {
+      if (typeof invalidate !== 'function')
+        return Promise.reject(
+          new TypeError('An owned module invalidator is required'),
+        );
+      return coordinator.update(async () => {
+        await invalidate();
+        await options.dispose?.(resources);
+        let candidate: SSRApplicationResources;
+        try {
+          candidate = await options.load(true);
+        } catch (error) {
+          // The owner must also release any adapters created by a failed load.
+          try {
+            await options.dispose?.(resources);
+          } catch (cleanupError) {
+            throw new AggregateError(
+              [error, cleanupError],
+              'SSR preparation and cleanup failed',
+            );
+          }
+          throw error;
+        }
+        resources = candidate;
+        cacheNamespace = randomUUID();
+      });
+    },
+  };
+}
+export type SSRApplication = Awaited<ReturnType<typeof createSSRApplication>>;

--- a/packages/server/core/src/adapters/node/index.ts
+++ b/packages/server/core/src/adapters/node/index.ts
@@ -33,3 +33,12 @@ export type {
   SSRRequestCoordinatorOptions,
   SSRRequestWork,
 } from './requestCoordinator';
+
+export { createSSRApplication } from './application';
+export type {
+  SSRApplication,
+  SSRApplicationOptions,
+  SSRApplicationResources,
+} from './application';
+
+export type { SSRResourceApplicationOptions } from './plugins/resource';

--- a/packages/server/core/src/adapters/node/plugins/resource.ts
+++ b/packages/server/core/src/adapters/node/plugins/resource.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import path from 'path';
 import { fileReader } from '@modern-js/runtime-utils/fileReader';
 import type { Monitors, ServerRoute } from '@modern-js/types';
@@ -11,6 +12,7 @@ import {
   compatibleRequire,
   isProd,
 } from '@modern-js/utils';
+import { getRenderHandler } from '../../../plugins/render/inject';
 import type {
   Middleware,
   MiddlewareHandler,
@@ -19,8 +21,25 @@ import type {
   ServerPlugin,
 } from '../../../types';
 import { uniqueKeyByRoute } from '../../../utils';
+import {
+  type SSRApplication,
+  type SSRApplicationOptions,
+  type SSRApplicationResources,
+  createSSRApplication,
+} from '../application';
 
-export async function getHtmlTemplates(pwd: string, routes: ServerRoute[]) {
+export interface SSRResourceApplicationOptions
+  extends Omit<SSRApplicationOptions, 'load'> {
+  onReady: (application: SSRApplication) => void;
+  /** Validate unpublished resources directly, without re-entering HTTP admission. */
+  validate?: (resources: SSRApplicationResources) => Promise<void>;
+}
+
+export async function getHtmlTemplates(
+  pwd: string,
+  routes: ServerRoute[],
+  options: { fresh?: boolean } = {},
+) {
   // Only process routes with entryName, which are HTML template routes.
   // Public static file routes don't have entryName and shouldn't be processed here.
   const htmlRoutes = routes.filter(route => route.entryName);
@@ -30,7 +49,9 @@ export async function getHtmlTemplates(pwd: string, routes: ServerRoute[]) {
       let html: string | undefined;
       try {
         const htmlPath = path.join(pwd, route.entryPath);
-        html = (await fileReader.readFile(htmlPath, 'utf-8'))?.toString();
+        html = options.fresh
+          ? await fs.readFile(htmlPath, 'utf-8')
+          : (await fileReader.readFile(htmlPath, 'utf-8'))?.toString();
       } catch (e) {
         // ignore error
       }
@@ -59,15 +80,50 @@ export function injectTemplates(
   };
 }
 
-const loadBundle = async (filepath: string, monitors?: Monitors) => {
+async function assertCommonJS(filepath: string) {
+  if (filepath.endsWith('.cjs')) return;
+  if (filepath.endsWith('.mjs'))
+    throw new Error(
+      `Native ESM application entries cannot be reloaded: ${filepath}`,
+    );
+  let directory = path.dirname(filepath);
+  for (;;) {
+    const packagePath = path.join(directory, 'package.json');
+    if (await fs.pathExists(packagePath)) {
+      if ((await fs.readJSON(packagePath)).type === 'module')
+        throw new Error(
+          `Native ESM application entries cannot be reloaded: ${filepath}`,
+        );
+      return;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) return;
+    directory = parent;
+  }
+}
+
+const loadBundle = async (
+  filepath: string,
+  monitors?: Monitors,
+  reloadable = false,
+) => {
   if (!(await fs.pathExists(filepath))) {
     return undefined;
   }
 
   try {
+    if (reloadable) {
+      // Use the Node CJS cache even when Modern itself is served from ESM.
+      const resolved = createRequire(path.resolve(filepath)).resolve(
+        path.resolve(filepath),
+      );
+      await assertCommonJS(resolved);
+      return createRequire(resolved)(resolved);
+    }
     const module = await compatibleRequire(filepath, false);
     return module;
   } catch (e) {
+    if (reloadable) throw e;
     if (monitors) {
       monitors.error(
         `Load ${filepath} bundle failed, error = %s`,
@@ -88,11 +144,12 @@ export async function getServerManifest(
   pwd: string,
   routes: ServerRoute[],
   monitors?: Monitors,
+  options: { reloadable?: boolean } = {},
 ): Promise<ServerManifest> {
   const loaderBundles: Record<string, any> = {};
   const renderBundles: Record<string, any> = {};
 
-  await Promise.all(
+  const loaded = await Promise.allSettled(
     routes
       .filter(route => Boolean(route.bundle))
       .map(async route => {
@@ -104,9 +161,22 @@ export async function getServerManifest(
           `${entryName}-server-loaders.js`,
         );
 
-        const renderBundle = await loadBundle(renderBundlePath, monitors);
-        const loaderBundle = await loadBundle(loaderBundlePath, monitors);
-
+        const renderBundle = await loadBundle(
+          renderBundlePath,
+          monitors,
+          options.reloadable,
+        );
+        if (
+          options.reloadable &&
+          route.isSSR &&
+          typeof (await renderBundle?.requestHandler) !== 'function'
+        )
+          throw new Error(`Invalid SSR entry: ${entryName}`);
+        const loaderBundle = await loadBundle(
+          loaderBundlePath,
+          monitors,
+          options.reloadable,
+        );
         renderBundle && (renderBundles[entryName] = renderBundle);
         loaderBundle &&
           (loaderBundles[entryName] = loaderBundle?.loadModules
@@ -115,21 +185,37 @@ export async function getServerManifest(
       }),
   );
 
+  const errors = loaded.filter(result => result.status === 'rejected');
+  if (errors.length)
+    throw new AggregateError(
+      errors.map(result => result.reason),
+      'SSR bundle preparation failed',
+    );
+  const readManifest = async (filename: string) => {
+    try {
+      return await (options.reloadable
+        ? fs.readJSON(filename)
+        : compatibleRequire(filename));
+    } catch (error) {
+      if (
+        options.reloadable &&
+        (error as NodeJS.ErrnoException).code !== 'ENOENT'
+      )
+        throw error;
+      return {};
+    }
+  };
   const loadableUri = path.join(pwd, LOADABLE_STATS_FILE);
 
-  const loadableStats = await compatibleRequire(loadableUri).catch(_ => ({}));
+  const loadableStats = await readManifest(loadableUri);
 
   const routesManifestUri = path.join(pwd, ROUTE_MANIFEST_FILE);
 
-  const routeManifest = await compatibleRequire(routesManifestUri).catch(
-    _ => ({}),
-  );
+  const routeManifest = await readManifest(routesManifestUri);
 
   const nestedRoutesJsonPath = path.join(pwd, NESTED_ROUTE_SPEC_FILE);
 
-  const nestedRoutesJson = await compatibleRequire(nestedRoutesJsonPath).catch(
-    _ => ({}),
-  );
+  const nestedRoutesJson = await readManifest(nestedRoutesJsonPath);
 
   return {
     loaderBundles,
@@ -215,16 +301,112 @@ export const injectRscManifestPlugin = (enableRsc: boolean): ServerPlugin => ({
   },
 });
 
-export const injectResourcePlugin = (): ServerPlugin => ({
+export const injectResourcePlugin = (
+  applicationOptions?: SSRResourceApplicationOptions,
+): ServerPlugin => ({
   name: '@modern-js/plugin-inject-resource',
 
   setup(api) {
-    api.onPrepare(() => {
+    api.onPrepare(async () => {
       const {
         middlewares,
         routes,
         distDirectory: pwd,
       } = api.getServerContext();
+
+      if (applicationOptions) {
+        const context = api.getServerContext();
+        if (
+          api.getServerConfig().server?.rsc ||
+          routes.some(route => route.isRSC)
+        ) {
+          throw new Error(
+            'SSR application updates support ordinary HTML SSR only',
+          );
+        }
+        if (!context.getRenderOptions || !context.serverBase) {
+          throw new Error(
+            'SSR application requires the Modern render and server owners',
+          );
+        }
+        const application = await createSSRApplication({
+          ...applicationOptions,
+          load: async rebuilding => {
+            if (rebuilding) {
+              // These are the declared application roots. The invalidator owns
+              // transitive bundler/module state and must preserve shared modules.
+              for (const route of routes) {
+                if (!route.bundle) continue;
+                const roots = [
+                  path.resolve(pwd!, route.bundle),
+                  path.resolve(
+                    pwd!,
+                    SERVER_BUNDLE_DIRECTORY,
+                    `${route.entryName || MAIN_ENTRY_NAME}-server-loaders.js`,
+                  ),
+                ];
+                for (const filename of roots) {
+                  if (!(await fs.pathExists(filename))) continue;
+                  const require = createRequire(filename);
+                  delete require.cache[require.resolve(filename)];
+                }
+              }
+            }
+            // allSettled prevents a failed loader from abandoning concurrent preparation.
+            const loaded = await Promise.allSettled([
+              getHtmlTemplates(pwd!, routes, { fresh: true }),
+              getServerManifest(pwd!, routes, undefined, { reloadable: true }),
+              getRenderHandler(context.getRenderOptions),
+            ]);
+            const failures = loaded.filter(
+              result => result.status === 'rejected',
+            );
+            if (failures.length)
+              throw new AggregateError(
+                failures.map(result => result.reason),
+                'SSR resource preparation failed',
+              );
+            const value = <T>(result: PromiseSettledResult<T>): T => {
+              if (result.status === 'rejected') throw result.reason;
+              return result.value;
+            };
+            const templates = value(loaded[0]);
+            const serverManifest = value(loaded[1]);
+            const render = value(loaded[2]);
+            for (const route of routes) {
+              if (!route.entryName) continue;
+              if (!templates[uniqueKeyByRoute(route)])
+                throw new Error(`Missing SSR template: ${route.entryName}`);
+              if (!route.isSSR) continue;
+              const handler =
+                await serverManifest.renderBundles?.[route.entryName]
+                  ?.requestHandler;
+              if (typeof handler !== 'function')
+                throw new Error(`Invalid SSR entry: ${route.entryName}`);
+              const loaderPath = path.join(
+                pwd!,
+                SERVER_BUNDLE_DIRECTORY,
+                `${route.entryName}-server-loaders.js`,
+              );
+              if (await fs.pathExists(loaderPath)) {
+                if (
+                  typeof serverManifest.loaderBundles?.[route.entryName]
+                    ?.handleRequest !== 'function'
+                )
+                  throw new Error(`Invalid SSR loader: ${route.entryName}`);
+              }
+            }
+            const resources = { templates, serverManifest, render };
+            await applicationOptions.validate?.(resources);
+            return resources;
+          },
+        });
+        // Mounted before ServerBase installs plugin middlewares, including custom
+        // pre/render middleware. Those must not capture resources before admission.
+        context.serverBase.setRequestMiddleware(application.middleware);
+        applicationOptions.onReady(application);
+        return;
+      }
 
       // In Production, should warmup server bundles on prepare.
       let htmlTemplatePromise: ReturnType<typeof getHtmlTemplates> | undefined;

--- a/packages/server/core/src/plugins/render/dataHandler.ts
+++ b/packages/server/core/src/plugins/render/dataHandler.ts
@@ -12,6 +12,7 @@ export const dataHandler = async (
     onTiming,
     serverManifest,
     loaderContext,
+    work,
   }: SSRRenderOptions & {
     serverRoutes: ServerRoute[];
   },
@@ -30,6 +31,7 @@ export const dataHandler = async (
     context: {
       monitors,
       loaderContext,
+      work,
     },
     onTiming,
     onError,

--- a/packages/server/core/src/plugins/render/index.ts
+++ b/packages/server/core/src/plugins/render/index.ts
@@ -109,7 +109,9 @@ function createRenderHandler(
     const request = c.req.raw;
     const nodeReq = c.env.node?.req;
 
-    const res = await render(request, {
+    const res = await (c.get('ssrRender') || render)(request, {
+      work: c.get('ssrWork'),
+      cacheNamespace: c.get('ssrCacheNamespace'),
       nodeReq,
       monitors,
       templates,

--- a/packages/server/core/src/plugins/render/render.ts
+++ b/packages/server/core/src/plugins/render/render.ts
@@ -141,6 +141,7 @@ export async function createRender({
       contextForceCSR,
       reporter,
       work,
+      cacheNamespace,
     },
   ) => {
     const forMatchpathname = matchPathname ?? getPathname(req);
@@ -233,6 +234,7 @@ export async function createRender({
       onTiming,
       reporter,
       work,
+      cacheNamespace,
     };
 
     if (fallbackReason) {

--- a/packages/server/core/src/plugins/render/ssrCache.ts
+++ b/packages/server/core/src/plugins/render/ssrCache.ts
@@ -201,6 +201,7 @@ export function matchCacheControl(
 }
 
 export interface GetCacheResultOptions {
+  cacheNamespace?: string;
   cacheControl: CacheControl;
   requestHandler: RequestHandler;
   requestHandlerOptions: RequestHandlerOptions;
@@ -219,7 +220,11 @@ export async function getCacheResult(
   } = options;
   const { onError } = requestHandlerOptions;
 
-  const key = computedKey(request, cacheControl);
+  const computed = computedKey(request, cacheControl);
+  const key =
+    options.cacheNamespace === undefined
+      ? computed
+      : JSON.stringify(['modern-ssr', options.cacheNamespace, computed]);
 
   let value: string | undefined;
   try {

--- a/packages/server/core/src/plugins/render/ssrRender.ts
+++ b/packages/server/core/src/plugins/render/ssrRender.ts
@@ -24,6 +24,7 @@ import { createRequestHandlerConfig } from './utils';
 // TODO: It's a type combine by RenderOptions and CreateRenderOptions, improve it.
 export interface SSRRenderOptions {
   work?: RequestHandlerOptions['work'];
+  cacheNamespace?: string;
   pwd: string;
   html: string;
   routeInfo: ServerRoute;
@@ -72,6 +73,7 @@ export async function ssrRender(
     onTiming,
     reporter,
     work,
+    cacheNamespace,
   }: SSRRenderOptions,
 ): Promise<Response> {
   const { entryName } = routeInfo;
@@ -134,6 +136,7 @@ export async function ssrRender(
   if (cacheControl && shouldUseCache(request)) {
     response = await getCacheResult(request, {
       cacheControl,
+      cacheNamespace,
       container: cacheConfig?.container,
       requestHandler: requestHandler!,
       requestHandlerOptions,

--- a/packages/server/core/src/serverBase.ts
+++ b/packages/server/core/src/serverBase.ts
@@ -26,6 +26,8 @@ export class ServerBase<E extends Env = any> {
 
   private app: Hono<E>;
 
+  private requestMiddleware?: MiddlewareHandler<E>;
+
   private plugins: ServerPlugin[] = [];
 
   private serverContext: ServerContext | null = null;
@@ -35,6 +37,9 @@ export class ServerBase<E extends Env = any> {
 
     this.app = new Hono<E>();
     this.app.use('*', run);
+    this.app.use('*', (context, next) =>
+      this.requestMiddleware ? this.requestMiddleware(context, next) : next(),
+    );
   }
 
   /**
@@ -62,6 +67,13 @@ export class ServerBase<E extends Env = any> {
     this.#applyMiddlewares();
 
     return this;
+  }
+
+  /** Install one outer request owner before both direct routes and plugin middleware. */
+  setRequestMiddleware(middleware: MiddlewareHandler<E>) {
+    if (this.requestMiddleware)
+      throw new Error('A request owner is already installed');
+    this.requestMiddleware = middleware;
   }
 
   addPlugins(plugins: ServerPlugin[]) {

--- a/packages/server/core/src/types/render.ts
+++ b/packages/server/core/src/types/render.ts
@@ -15,6 +15,7 @@ import type { ServerManifest } from './server';
 // TODO: combine some field with RequestHandlerOptions
 export interface RenderOptions {
   work?: SSRRequestWork;
+  cacheNamespace?: string;
   monitors: Monitors;
 
   loaderContext?: Map<string, unknown>;

--- a/packages/server/core/src/types/server.ts
+++ b/packages/server/core/src/types/server.ts
@@ -18,6 +18,7 @@ import type {
   OnTiming,
   RequestHandlerOptions,
   Resource,
+  SSRRequestWork,
 } from './requestHandler';
 
 export type RequestHandler = (
@@ -33,6 +34,7 @@ export type ServerLoaderBundle = {
     routes: NestedRoute[];
     context: {
       monitors: Monitors;
+      work?: SSRRequestWork;
       reporter?: Reporter;
       loaderContext?: Map<string, unknown>;
     };
@@ -71,6 +73,9 @@ export type ServerManifest = {
 };
 
 type ServerVariables = {
+  ssrWork?: SSRRequestWork;
+  ssrCacheNamespace?: string;
+  ssrRender?: import('./render').Render;
   /** @deprecated */
   logger: Logger;
 

--- a/packages/server/core/tests/adapters/application.test.ts
+++ b/packages/server/core/tests/adapters/application.test.ts
@@ -1,0 +1,121 @@
+import { rstest } from '@rstest/core';
+import { Hono } from 'hono';
+import { createSSRApplication } from '../../src/adapters/node/application';
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+const limits = {
+  maxPendingRequests: 2,
+  requestTimeoutMs: 1000,
+  drainTimeoutMs: 1000,
+};
+
+it('selects fresh resources after admission and drains registered work after response completion', async () => {
+  let version = 'old';
+  const load = rstest.fn(async () => ({
+    templates: { main: version },
+    serverManifest: {},
+    render: async () => new Response(version),
+  }));
+  const application = await createSSRApplication({ ...limits, load });
+  const app = new Hono();
+  app.use('*', application.middleware);
+  const outstanding = deferred();
+  app.get('/', c => {
+    if (c.get('templates').main === 'old')
+      c.get('ssrWork').track(outstanding.promise);
+    return c.text(c.get('templates').main);
+  });
+  expect(await (await app.request('/')).text()).toBe('old');
+  const mutation = rstest.fn(async () => {
+    version = 'new';
+  });
+  const update = application.update(mutation);
+  await tick();
+  const queued = app.request('/');
+  await tick();
+  expect(mutation).not.toHaveBeenCalled();
+  expect(load).toHaveBeenCalledTimes(1);
+  outstanding.resolve();
+  await expect(update).resolves.toBe(1);
+  expect(await (await queued).text()).toBe('new');
+  expect(load).toHaveBeenCalledTimes(2);
+});
+
+it('failed resource preparation stays closed and retry publishes a fresh cache namespace', async () => {
+  let fail = false;
+  const application = await createSSRApplication({
+    ...limits,
+    load: async () => {
+      if (fail) throw new Error('invalid bundle');
+      return {
+        templates: {},
+        serverManifest: {},
+        render: async () => new Response('ok'),
+      };
+    },
+  });
+  const app = new Hono();
+  app.use('*', application.middleware);
+  app.get('/', c => c.text(c.get('ssrCacheNamespace')));
+  const before = await (await app.request('/')).text();
+  await expect(
+    application.update(async () => {
+      fail = true;
+    }),
+  ).rejects.toThrow('invalid bundle');
+  expect((await app.request('/')).status).toBe(503);
+  await expect(
+    application.update(async () => {
+      fail = false;
+    }),
+  ).resolves.toBe(1);
+  expect(await (await app.request('/')).text()).not.toBe(before);
+});
+
+it('explicit bypass responds without touching application resources during update', async () => {
+  const application = await createSSRApplication({
+    ...limits,
+    bypass: async request =>
+      new URL(request.url).pathname === '/live'
+        ? new Response('alive')
+        : undefined,
+    load: async () => ({
+      templates: {},
+      serverManifest: {},
+      render: async () => new Response('ok'),
+    }),
+  });
+  const app = new Hono();
+  app.use('*', application.middleware);
+  const business = rstest.fn(c => c.text('app'));
+  app.get('*', business);
+  const wait = deferred();
+  const update = application.update(() => wait.promise);
+  await tick();
+  expect(await (await app.request('/live')).text()).toBe('alive');
+  expect(business).not.toHaveBeenCalled();
+  wait.resolve();
+  await update;
+});
+
+it('rejects an invalid update callback without closing admission', async () => {
+  const application = await createSSRApplication({
+    ...limits,
+    load: async () => ({
+      templates: {},
+      serverManifest: {},
+      render: async () => new Response('ok'),
+    }),
+  });
+  await expect(application.update(undefined as any)).rejects.toThrow(
+    'invalidator',
+  );
+  expect(application.status.phase).toBe('serving');
+});

--- a/packages/server/core/tests/application.http.test.cjs
+++ b/packages/server/core/tests/application.http.test.cjs
@@ -1,0 +1,274 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { mkdtemp, writeFile, rm, mkdir } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { once } = require('node:events');
+const { cleanRequireCache } = require('@modern-js/utils');
+const {
+  createServerBase,
+  createDefaultPlugins,
+  renderPlugin,
+} = require('../dist/cjs');
+const {
+  injectResourcePlugin,
+  createNodeServer,
+  getServerManifest,
+} = require('../dist/cjs/adapters/node');
+const getDefaultConfig = () => ({
+  html: {},
+  output: {},
+  source: {},
+  tools: {},
+  server: {},
+  bff: {},
+  dev: {},
+  security: {},
+});
+const getDefaultAppContext = () => ({ apiDirectory: '', lambdaDirectory: '' });
+
+test('rebuilds real Modern SSR and loader entries, skips old HTML cache, and keeps the HTTP server', async () => {
+  const pwd = await mkdtemp(path.join(tmpdir(), 'modern-owner-'));
+  const entry = path.join(pwd, 'entry.cjs');
+  const loader = path.join(pwd, 'bundles/main-server-loaders.js');
+  const write = async version => {
+    await writeFile(
+      entry,
+      `exports.requestHandler = async (req, options) => new Response(${JSON.stringify(version)} + ':' + Boolean(options.work));`,
+    );
+    await writeFile(
+      loader,
+      `exports.handleRequest = async ({context}) => new Response(${JSON.stringify(version)} + ':loader:' + Boolean(context.work)); exports.routes = [];`,
+    );
+  };
+  await mkdir(path.dirname(loader));
+  await writeFile(path.join(pwd, 'index.html'), '<html>template</html>');
+  await write('v1');
+  const config = getDefaultConfig();
+  config.server = { ssr: true };
+  let application;
+  let preCalls = 0;
+  const server = createServerBase({
+    pwd,
+    config,
+    appContext: getDefaultAppContext(),
+    routes: [
+      {
+        urlPath: '/',
+        entryName: 'main',
+        entryPath: 'index.html',
+        bundle: 'entry.cjs',
+        isSSR: true,
+      },
+    ],
+  });
+  server.use('*', async (_, next) => {
+    preCalls++;
+    await next();
+  });
+  server.addPlugins([
+    ...createDefaultPlugins({
+      cacheConfig: {
+        strategy: { maxAge: 100000, staleWhileRevalidate: 100000 },
+      },
+    }),
+    {
+      name: 'pre-business',
+      setup(api) {
+        api.onPrepare(() => {
+          api.getServerContext().middlewares.push({
+            name: 'pre-business',
+            order: 'pre',
+            handler: async (_, next) => {
+              preCalls++;
+              await next();
+            },
+          });
+        });
+      },
+    },
+    injectResourcePlugin({
+      maxPendingRequests: 3,
+      requestTimeoutMs: 1000,
+      drainTimeoutMs: 1000,
+      onReady(value) {
+        application = value;
+      },
+      bypass: async request =>
+        new URL(request.url).pathname === '/live'
+          ? new Response('alive')
+          : undefined,
+    }),
+    renderPlugin(),
+  ]);
+  let nodeServer;
+  try {
+    await server.init();
+    nodeServer = await createNodeServer(server.handle);
+    nodeServer.listen(0, '127.0.0.1');
+    await once(nodeServer, 'listening');
+    const address = nodeServer.address();
+    const base = `http://127.0.0.1:${address.port}`;
+    const pid = process.pid;
+    assert.equal(await (await fetch(base)).text(), 'v1:true');
+    assert.equal((await fetch(base)).headers.get('x-render-cache'), 'hit');
+    assert.equal(
+      await (await fetch(`${base}/?__loader=main`)).text(),
+      'v1:loader:true',
+    );
+    let release;
+    const wait = new Promise(resolve => {
+      release = resolve;
+    });
+    let entered;
+    const entryReady = new Promise(resolve => {
+      entered = resolve;
+    });
+    const update = application.update(async () => {
+      entered();
+      await wait;
+      await write('v2');
+      // Exact owned CommonJS roots only. MF adapter invalidation is a separate layer.
+      // Modern evicts declared application roots after invalidation and disposal.
+    });
+    await entryReady;
+    const before = preCalls;
+    const queued = fetch(base);
+    assert.equal(await (await fetch(`${base}/live`)).text(), 'alive');
+    assert.equal(preCalls, before);
+    release();
+    assert.equal(await update, 1);
+    const fresh = await queued;
+    assert.equal(await fresh.text(), 'v2:true');
+    assert.equal(fresh.headers.get('x-render-cache'), 'miss');
+    assert.equal(
+      await (await fetch(`${base}/?__loader=main`)).text(),
+      'v2:loader:true',
+    );
+    assert.deepEqual(nodeServer.address(), address);
+    assert.equal(process.pid, pid);
+    await assert.rejects(
+      application.update(async () => {
+        await writeFile(entry, 'exports.requestHandler = 42;');
+        cleanRequireCache([require.resolve(entry)]);
+      }),
+      error =>
+        error instanceof AggregateError &&
+        error.errors.some(
+          nested =>
+            nested instanceof AggregateError &&
+            nested.errors.some(reason =>
+              /Invalid SSR entry/.test(reason.message),
+            ),
+        ),
+    );
+    assert.equal((await fetch(base)).status, 503);
+    await application.update(async () => {
+      await write('v3');
+      // Modern evicts declared application roots after invalidation and disposal.
+    });
+    assert.equal(await (await fetch(base)).text(), 'v3:true');
+  } finally {
+    nodeServer?.closeAllConnections();
+    if (nodeServer?.listening)
+      await new Promise((resolve, reject) =>
+        nodeServer.close(error => (error ? reject(error) : resolve())),
+      );
+    cleanRequireCache([require.resolve(entry)]);
+    cleanRequireCache([require.resolve(loader)]);
+    await rm(pwd, { recursive: true, force: true });
+  }
+});
+
+test('rejects native ESM application entries before serving or mutation', async () => {
+  const pwd = await mkdtemp(path.join(tmpdir(), 'modern-owner-esm-'));
+  await writeFile(path.join(pwd, 'index.html'), '<html/>');
+  await writeFile(
+    path.join(pwd, 'entry.mjs'),
+    'export const requestHandler = () => new Response("esm");',
+  );
+  let ready = false;
+  const server = createServerBase({
+    pwd,
+    config: getDefaultConfig(),
+    appContext: getDefaultAppContext(),
+    routes: [
+      {
+        urlPath: '/',
+        entryName: 'main',
+        entryPath: 'index.html',
+        bundle: 'entry.mjs',
+        isSSR: true,
+      },
+    ],
+  });
+  server.addPlugins([
+    ...createDefaultPlugins(),
+    injectResourcePlugin({
+      maxPendingRequests: 1,
+      requestTimeoutMs: 1000,
+      drainTimeoutMs: 1000,
+      onReady() {
+        ready = true;
+      },
+    }),
+    renderPlugin(),
+  ]);
+  try {
+    await assert.rejects(
+      server.init(),
+      error =>
+        error instanceof AggregateError &&
+        error.errors.some(
+          nested =>
+            nested instanceof AggregateError &&
+            nested.errors.some(reason => /Native ESM/.test(reason.message)),
+        ),
+    );
+    assert.equal(ready, false);
+  } finally {
+    await rm(pwd, { recursive: true, force: true });
+  }
+});
+
+test('a failed entry waits for other asynchronous entry initialization before rejecting', async () => {
+  const pwd = await mkdtemp(path.join(tmpdir(), 'modern-owner-drain-'));
+  const pendingPath = path.join(pwd, 'pending.cjs');
+  const failedPath = path.join(pwd, 'failed.cjs');
+  await writeFile(
+    pendingPath,
+    'exports.requestHandler = new Promise(resolve => { exports.ready = () => resolve(() => new Response("ready")); });',
+  );
+  await writeFile(failedPath, 'exports.requestHandler = 42;');
+  let settled = false;
+  const loading = getServerManifest(
+    pwd,
+    [
+      { entryName: 'failed', bundle: 'failed.cjs', isSSR: true },
+      { entryName: 'pending', bundle: 'pending.cjs', isSSR: true },
+    ],
+    undefined,
+    { reloadable: true },
+  );
+  const outcome = loading.then(
+    () => {
+      settled = true;
+    },
+    error => {
+      settled = true;
+      return error;
+    },
+  );
+  try {
+    await new Promise(resolve => setTimeout(resolve, 20));
+    assert.equal(settled, false);
+    require(pendingPath).ready();
+    assert.ok((await outcome) instanceof AggregateError);
+  } finally {
+    cleanRequireCache([
+      require.resolve(pendingPath),
+      require.resolve(failedPath),
+    ]);
+    await rm(pwd, { recursive: true, force: true });
+  }
+});

--- a/packages/server/core/tests/application.mf.test.cjs
+++ b/packages/server/core/tests/application.mf.test.cjs
@@ -1,0 +1,252 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { tmpdir } = require('node:os');
+const { pathToFileURL } = require('node:url');
+const { once } = require('node:events');
+const { createProdServer } = require('../../prod-server/dist/cjs');
+
+test('production server rebuilds dynamic MF remotes v1/v2/v3 with one control plane', async () => {
+  assert.ok(
+    process.env.SSR_CACHE_RSPACK_ENTRY,
+    'Set the companion Rspack artifact entry',
+  );
+  assert.ok(
+    process.env.SSR_CACHE_MF_ROOT,
+    'Set the companion MF repository root',
+  );
+  const { rspack, container } = await import(
+    pathToFileURL(process.env.SSR_CACHE_RSPACK_ENTRY).href
+  );
+  const root = await fs.realpath(
+    await fs.mkdtemp(path.join(tmpdir(), 'modern-mf-owner-')),
+  );
+  const out = path.join(root, 'dist');
+  const implementation = path.join(
+    process.env.SSR_CACHE_MF_ROOT,
+    'packages/runtime-tools',
+  );
+  const write = (name, value) => fs.writeFile(path.join(root, name), value);
+  await write('shared.js', 'export default { identity: "shared" };');
+  for (const version of ['v1', 'v2', 'v3']) {
+    await write(
+      `${version}.js`,
+      `${version === 'v1' ? 'globalThis.__modernOwnerMarker = "persist";' : ''} import shared from 'shared-lib'; export { shared }; export default '${version}';`,
+    );
+  }
+  await write(
+    'dynamic.js',
+    'let saved; export async function render() { saved ||= await __webpack_require__.federation.instance.loadRemote("dynamic/Value"); return new Response(saved.default); }',
+  );
+  await write(
+    'host.js',
+    'export const req = __webpack_require__; export const share = () => import("shared-lib"); export const requestHandler = import("./dynamic").then(m => m.render);',
+  );
+  await write(
+    'plugin.js',
+    "module.exports=()=>({name:'local-entry',loadEntry({remoteInfo}) { return __non_webpack_require__(remoteInfo.entry); }});",
+  );
+  const common = {
+    context: root,
+    target: 'node',
+    mode: 'production',
+    devtool: false,
+    optimization: { minimize: false, concatenateModules: false },
+    output: {
+      path: out,
+      library: { type: 'commonjs2' },
+      filename: '[name].cjs',
+      chunkFilename: '[name].cjs',
+    },
+  };
+  const configs = ['v1', 'v2', 'v3'].map(version => ({
+    ...common,
+    entry: {},
+    output: { ...common.output, uniqueName: version },
+    plugins: [
+      new container.ModuleFederationPlugin({
+        name: version,
+        implementation,
+        filename: `${version}.cjs`,
+        library: { type: 'commonjs-module' },
+        exposes: { './Value': `./${version}.js` },
+        shared: {
+          'shared-lib': {
+            import: './shared.js',
+            version: '1.0.0',
+            singleton: true,
+          },
+        },
+      }),
+    ],
+  }));
+  configs.push({
+    ...common,
+    entry: { host: './host.js' },
+    output: { ...common.output, uniqueName: 'modern-owner-host' },
+    plugins: [
+      new container.ModuleFederationPlugin({
+        name: 'modern-owner-host',
+        implementation,
+        shared: {
+          'shared-lib': {
+            import: false,
+            requiredVersion: false,
+            singleton: true,
+          },
+        },
+        remotes: { remote: { external: `v1@${path.join(out, 'v1.cjs')}` } },
+        runtimePlugins: [path.join(root, 'plugin.js')],
+      }),
+    ],
+  });
+  const compiler = rspack(configs);
+  try {
+    await new Promise((resolve, reject) =>
+      compiler.run((error, stats) =>
+        error
+          ? reject(error)
+          : stats.hasErrors()
+            ? reject(new Error(stats.toString({ all: false, errors: true })))
+            : resolve(),
+      ),
+    );
+  } finally {
+    await new Promise((resolve, reject) =>
+      compiler.close(error => (error ? reject(error) : resolve())),
+    );
+  }
+  await fs.writeFile(path.join(out, 'index.html'), '<html>template</html>');
+  const adapters = Symbol.for('module-federation.clear-cache.adapters');
+  let application;
+  let instance;
+  let disposals = 0;
+  let failValidation = false;
+  const server = await createProdServer({
+    pwd: out,
+    serverConfigPath: path.join(out, 'missing-server-config'),
+    appContext: { apiDirectory: '', lambdaDirectory: '' },
+    config: {
+      html: {},
+      output: {},
+      source: {},
+      tools: {},
+      server: { ssr: true },
+      bff: {},
+      dev: {},
+      security: {},
+    },
+    routes: [
+      {
+        urlPath: '/',
+        entryName: 'main',
+        entryPath: 'index.html',
+        bundle: 'host.cjs',
+        isSSR: true,
+      },
+    ],
+    ssrApplication: {
+      maxPendingRequests: 4,
+      requestTimeoutMs: 5000,
+      drainTimeoutMs: 5000,
+      onReady(value) {
+        application = value;
+      },
+      async validate(resources) {
+        const next =
+          resources.serverManifest.renderBundles.main.req.federation.instance;
+        if (instance) assert.equal(next, instance);
+        else instance = next;
+        assert.equal(instance[adapters].bindings.size, 1);
+        if (failValidation) throw new Error('warmup failed');
+      },
+      async dispose() {
+        for (const req of Array.from(instance[adapters]?.bindings || []))
+          req.federation.disposeClearCache();
+        disposals++;
+        assert.equal(instance[adapters], undefined);
+      },
+    },
+  });
+  const remote = version => ({
+    name: 'dynamic',
+    entry: path.join(out, `${version}.cjs`),
+    type: 'commonjs-module',
+    entryGlobalName: version,
+  });
+  instance.registerRemotes([remote('v1')]);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  const pid = process.pid;
+  const url = `http://127.0.0.1:${address.port}`;
+  try {
+    assert.equal(await (await fetch(url)).text(), 'v1');
+    const shared = (await require(path.join(out, 'host.cjs')).share()).default;
+    assert.equal((await instance.loadRemote('dynamic/Value')).shared, shared);
+    for (const version of ['v2', 'v3']) {
+      let release;
+      const wait = new Promise(resolve => {
+        release = resolve;
+      });
+      let entered;
+      const closed = new Promise(resolve => {
+        entered = resolve;
+      });
+      const updating = application.update(async () => {
+        entered();
+        await wait;
+        await instance.removeRemote('dynamic');
+        instance.registerRemotes([remote(version)]);
+      });
+      await closed;
+      const queued = fetch(url);
+      // Wait for real HTTP admission, not a timer-based assumption about fetch scheduling.
+      const deadline = Date.now() + 3000;
+      while (application.status.pendingRequests === 0 && Date.now() < deadline)
+        await new Promise(resolve => setTimeout(resolve, 5));
+      assert.equal(application.status.pendingRequests, 1);
+      release();
+      await updating;
+      assert.equal(await (await queued).text(), version);
+      const hostShared = (await require(path.join(out, 'host.cjs')).share())
+        .default;
+      assert.equal(hostShared, shared);
+      assert.equal((await instance.loadRemote('dynamic/Value')).shared, shared);
+      assert.equal(globalThis.__modernOwnerMarker, 'persist');
+      assert.deepEqual(server.address(), address);
+      assert.equal(process.pid, pid);
+    }
+    assert.equal(disposals, 2);
+    assert.equal(application.status.generation, 2);
+    failValidation = true;
+    await assert.rejects(
+      application.update(async () => {}),
+      /warmup failed/,
+    );
+    assert.equal(
+      instance[adapters],
+      undefined,
+      'failed candidate adapters must be released',
+    );
+    assert.equal((await fetch(url)).status, 503);
+    failValidation = false;
+    await application.update(async () => {});
+    assert.equal(await (await fetch(url)).text(), 'v3');
+    assert.equal(instance[adapters].bindings.size, 1);
+    assert.equal(
+      (await require(path.join(out, 'host.cjs')).share()).default,
+      shared,
+    );
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve, reject) =>
+      server.close(error => (error ? reject(error) : resolve())),
+    );
+    for (const req of Array.from(instance[adapters]?.bindings || []))
+      req.federation.disposeClearCache();
+    delete globalThis.__modernOwnerMarker;
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/server/prod-server/src/apply.ts
+++ b/packages/server/prod-server/src/apply.ts
@@ -94,7 +94,7 @@ export async function applyPlugins(
     }),
     injectConfigMiddlewarePlugin(middlewares, renderMiddlewares),
     ...(options.plugins || []),
-    injectResourcePlugin(),
+    injectResourcePlugin(options.ssrApplication),
     injectRscManifestPlugin(enableRsc),
     serverStaticPlugin(),
     faviconPlugin(),

--- a/packages/server/prod-server/src/types.ts
+++ b/packages/server/prod-server/src/types.ts
@@ -3,10 +3,12 @@ import type {
   ServerBaseOptions,
   ServerPlugin,
 } from '@modern-js/server-core';
+import type { SSRResourceApplicationOptions } from '@modern-js/server-core/node';
 import type { Reporter } from '@modern-js/types';
 import type { Logger } from '@modern-js/utils';
 
 interface ProdServerExtraOptions {
+  ssrApplication?: SSRResourceApplicationOptions;
   serverConfigPath: string;
   plugins?: ServerPlugin[];
 }


### PR DESCRIPTION
## Summary

Add opt-in `createProdServer({ ssrApplication })` integration for same-process SSR application publication. Admission now precedes direct/plugin middleware and resource selection. Updates drain requests and producer work, run the owned invalidator/disposer, reload declared CommonJS render/loader roots, validate fresh resources and publish a new renderer and HTML-cache namespace. Failed preparation cleans candidate adapters and keeps SSR unavailable until an explicit retry; the HTTP server and logical MF control plane remain.

Also propagate work into standalone data loaders and settle their deferred response subscriptions on cancellation, abort and serialization failure. Static/liveness bypass is an explicit direct-response hook; unconfigured routes remain behind the application-wide gate. Native ESM application roots are rejected. RSC is excluded.

The real production test found a shared-factory identity bug in both MF cleanup layers. **Use with companion [module-federation/core #5053](https://github.com/module-federation/core/pull/5053)**. With that repair, compiled dynamic remotes v1/v2/v3 pass on one PID/port with queued requests using new handlers, strict host/provider shared identity, adapter detachment, preserved business globals and failed-warmup recovery. The test compiles before serving; updates do not rerun serve or compile the host.

Validation: server-core 46/46; data-loader 10 passed plus one pre-existing skipped test; three affected package builds/declarations; native HTTP artifact tests 3/3; production MF artifact 1/1; prior strict local Rspack/Modern baseline 13/13; Biome, Changesets and commit hooks pass. The companion MF suites pass 138/138 and 122/122. Its full Prettier gate reports 683 existing/generated or unrelated dirty files; touched files pass. Full framework/builder/browser-hydration, Cypress and load/heap endurance are not claimed complete and remain RFC R6. Exact commands and limitations: `packages/server/core/SSR_REQUEST_COORDINATION.md`.

This is R3's application rebuild path. R4 selective planning and R5 final MF update API/migration are still pending; no release is performed.

## Related Links

- Continues #8861 from `feat/mf-ssr-clear-cache` at `3d6b2f910d`.
- [Companion MF repair #5053](https://github.com/module-federation/core/pull/5053)
- [SSR cache RFC and roadmap](https://bytedance.larkoffice.com/docx/I8VZdLKxPoI85NxNTkrcX2Zmnuf)

## Checklist

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
