### PR TITLE
test: isolate pure ESM integration apps

### DIFF
--- a/tests/integration/pure-esm-project/tests/deploy.test.ts
+++ b/tests/integration/pure-esm-project/tests/deploy.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { execa, fs as fse } from '@modern-js/utils';
 import {
+  createIsolatedTestApp,
   getPort,
   killApp,
   modernBuild,
@@ -39,30 +40,11 @@ describe('deploy', () => {
   let appDir: string;
 
   beforeAll(async () => {
-    appDir = await fse.mkdtemp(
-      path.join(path.dirname(sourceAppDir), '.pure-esm-deploy-'),
-    );
-    await fse.copy(sourceAppDir, appDir, {
-      filter: src => {
-        const relative = path.relative(sourceAppDir, src);
-        if (!relative) {
-          return true;
-        }
-        const [firstSegment] = relative.split(path.sep);
-        return ![
-          'node_modules',
-          'dist',
-          'dist-deploy',
-          '.output',
-          'tests',
-        ].includes(firstSegment);
-      },
-    });
-    await fse.ensureSymlink(
-      path.join(sourceAppDir, 'node_modules'),
-      path.join(appDir, 'node_modules'),
-      'dir',
-    );
+    appDir = (
+      await createIsolatedTestApp(sourceAppDir, {
+        prefix: '.pure-esm-deploy-',
+      })
+    ).appDir;
 
     await modernBuild(appDir, [], {
       env: {

--- a/tests/integration/pure-esm-project/tests/index.test.ts
+++ b/tests/integration/pure-esm-project/tests/index.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { fs as fse } from '@modern-js/utils';
 import puppeteer, { type Browser, type Page } from 'puppeteer';
 import {
+  createIsolatedTestApp,
   getPort,
   killApp,
   launchApp,
@@ -18,31 +19,9 @@ const sourceAppDir = path.resolve(__dirname, '../');
 dns.setDefaultResultOrder('ipv4first');
 
 async function createIsolatedAppDir() {
-  const appDir = await fse.mkdtemp(
-    path.join(path.dirname(sourceAppDir), '.pure-esm-index-'),
-  );
-
-  await fse.copy(sourceAppDir, appDir, {
-    filter: src => {
-      const relative = path.relative(sourceAppDir, src);
-      if (!relative) {
-        return true;
-      }
-      const [firstSegment] = relative.split(path.sep);
-      return ![
-        'node_modules',
-        'dist',
-        'dist-deploy',
-        '.output',
-        'tests',
-      ].includes(firstSegment);
-    },
+  const { appDir } = await createIsolatedTestApp(sourceAppDir, {
+    prefix: '.pure-esm-index-',
   });
-  await fse.ensureSymlink(
-    path.join(sourceAppDir, 'node_modules'),
-    path.join(appDir, 'node_modules'),
-    'dir',
-  );
 
   return appDir;
 }


### PR DESCRIPTION
## Summary

- Reuse `createIsolatedTestApp` for the pure-ESM deploy and app integration tests.
- Keep temporary app dependencies linked while giving each app its own `.modern-js` and `.cache` state, preventing concurrent build/dev interference.

## Related Links

- Fixes the pure-ESM framework-test CI timeout caused by shared generated state.

## Checklist

- [ ] I have added changeset via `pnpm run change` (test-only change).
- [ ] I have updated the documentation (not applicable).
- [ ] I have added tests to cover my changes (existing concurrent fixture suite verifies the change).

## Verification

- `pnpm exec biome check tests/integration/pure-esm-project/tests/deploy.test.ts tests/integration/pure-esm-project/tests/index.test.ts`
- `pnpm --dir tests exec rstest integration/pure-esm-project/tests`